### PR TITLE
#8 support clang format & clang tidy

### DIFF
--- a/.clang-format
+++ b/.clang-format
@@ -1,0 +1,222 @@
+---
+Language:        Cpp
+# BasedOnStyle:  Microsoft
+AccessModifierOffset: -4
+AlignAfterOpenBracket: AlwaysBreak
+AlignArrayOfStructures: None
+AlignConsecutiveAssignments:
+  Enabled:         false
+  AcrossEmptyLines: false
+  AcrossComments:  false
+  AlignCompound:   false
+  PadOperators:    true
+AlignConsecutiveBitFields:
+  Enabled:         false
+  AcrossEmptyLines: false
+  AcrossComments:  false
+  AlignCompound:   false
+  PadOperators:    false
+AlignConsecutiveDeclarations:
+  Enabled:         false
+  AcrossEmptyLines: false
+  AcrossComments:  false
+  AlignCompound:   false
+  PadOperators:    false
+AlignConsecutiveMacros:
+  Enabled:         false
+  AcrossEmptyLines: false
+  AcrossComments:  false
+  AlignCompound:   false
+  PadOperators:    false
+AlignEscapedNewlines: Right
+AlignOperands:   Align
+AlignTrailingComments:
+  Kind:            Always
+  OverEmptyLines:  0
+AllowAllArgumentsOnNextLine: true
+AllowAllParametersOfDeclarationOnNextLine: true
+AllowShortBlocksOnASingleLine: Never
+AllowShortCaseLabelsOnASingleLine: false
+AllowShortEnumsOnASingleLine: false
+AllowShortFunctionsOnASingleLine: None
+AllowShortIfStatementsOnASingleLine: Never
+AllowShortLambdasOnASingleLine: All
+AllowShortLoopsOnASingleLine: false
+AlwaysBreakAfterDefinitionReturnType: None
+AlwaysBreakAfterReturnType: None
+AlwaysBreakBeforeMultilineStrings: false
+AlwaysBreakTemplateDeclarations: true
+AttributeMacros:
+  - __capability
+BinPackArguments: false
+BinPackParameters: true
+BitFieldColonSpacing: Both
+BraceWrapping:
+  AfterCaseLabel:  false
+  AfterClass:      true
+  AfterControlStatement: Always
+  AfterEnum:       true
+  AfterExternBlock: true
+  AfterFunction:   true
+  AfterNamespace:  true
+  AfterObjCDeclaration: true
+  AfterStruct:     true
+  AfterUnion:      true
+  BeforeCatch:     true
+  BeforeElse:      true
+  BeforeLambdaBody: false
+  BeforeWhile:     false
+  IndentBraces:    false
+  SplitEmptyFunction: true
+  SplitEmptyRecord: true
+  SplitEmptyNamespace: true
+BreakAfterAttributes: Never
+BreakAfterJavaFieldAnnotations: false
+BreakArrays:     true
+BreakBeforeBinaryOperators: None
+BreakBeforeConceptDeclarations: Always
+BreakBeforeBraces: Custom
+BreakBeforeInlineASMColon: OnlyMultiline
+BreakBeforeTernaryOperators: true
+BreakConstructorInitializers: BeforeColon
+BreakInheritanceList: BeforeColon
+BreakStringLiterals: true
+ColumnLimit:     120
+CommentPragmas:  '^ IWYU pragma:'
+CompactNamespaces: false
+ConstructorInitializerAllOnOneLineOrOnePerLine: true
+ConstructorInitializerIndentWidth: 4
+ContinuationIndentWidth: 4
+Cpp11BracedListStyle: true
+DerivePointerAlignment: false
+DisableFormat:   false
+EmptyLineAfterAccessModifier: Never
+EmptyLineBeforeAccessModifier: LogicalBlock
+ExperimentalAutoDetectBinPacking: false
+FixNamespaceComments: true
+ForEachMacros:
+  - foreach
+  - Q_FOREACH
+  - BOOST_FOREACH
+IfMacros:
+  - KJ_IF_MAYBE
+IncludeBlocks:   Preserve
+IncludeCategories:
+  - Regex:           '^"(llvm|llvm-c|clang|clang-c)/'
+    Priority:        2
+    SortPriority:    0
+    CaseSensitive:   false
+  - Regex:           '^(<|"(gtest|gmock|isl|json)/)'
+    Priority:        3
+    SortPriority:    0
+    CaseSensitive:   false
+  - Regex:           '.*'
+    Priority:        1
+    SortPriority:    0
+    CaseSensitive:   false
+IncludeIsMainRegex: '(Test)?$'
+IncludeIsMainSourceRegex: ''
+IndentAccessModifiers: false
+IndentCaseBlocks: false
+IndentCaseLabels: false
+IndentExternBlock: AfterExternBlock
+IndentGotoLabels: true
+IndentPPDirectives: None
+IndentRequiresClause: true
+IndentWidth:     4
+IndentWrappedFunctionNames: false
+InsertBraces:    false
+InsertNewlineAtEOF: false
+InsertTrailingCommas: None
+IntegerLiteralSeparator:
+  Binary:          0
+  Decimal:         0
+  Hex:             0
+JavaScriptQuotes: Leave
+JavaScriptWrapImports: true
+KeepEmptyLinesAtTheStartOfBlocks: true
+LambdaBodyIndentation: Signature
+LineEnding:      DeriveLF
+MacroBlockBegin: ''
+MacroBlockEnd:   ''
+MaxEmptyLinesToKeep: 1
+NamespaceIndentation: None
+ObjCBinPackProtocolList: Auto
+ObjCBlockIndentWidth: 2
+ObjCBreakBeforeNestedBlockParam: true
+ObjCSpaceAfterProperty: false
+ObjCSpaceBeforeProtocolList: true
+PackConstructorInitializers: Never
+PenaltyBreakAssignment: 2
+PenaltyBreakBeforeFirstCallParameter: 19
+PenaltyBreakComment: 300
+PenaltyBreakFirstLessLess: 120
+PenaltyBreakOpenParenthesis: 0
+PenaltyBreakString: 1000
+PenaltyBreakTemplateDeclaration: 10
+PenaltyExcessCharacter: 1000000
+PenaltyIndentedWhitespace: 0
+PenaltyReturnTypeOnItsOwnLine: 1000
+PointerAlignment: Left
+PPIndentWidth:   -1
+QualifierAlignment: Leave
+ReferenceAlignment: Pointer
+ReflowComments:  true
+RemoveBracesLLVM: false
+RemoveSemicolon: false
+RequiresClausePosition: OwnLine
+RequiresExpressionIndentation: OuterScope
+SeparateDefinitionBlocks: Leave
+ShortNamespaceLines: 1
+SortIncludes:    CaseSensitive
+SortJavaStaticImport: Before
+SortUsingDeclarations: LexicographicNumeric
+SpaceAfterCStyleCast: false
+SpaceAfterLogicalNot: false
+SpaceAfterTemplateKeyword: true
+SpaceAroundPointerQualifiers: Default
+SpaceBeforeAssignmentOperators: true
+SpaceBeforeCaseColon: false
+SpaceBeforeCpp11BracedList: true
+SpaceBeforeCtorInitializerColon: true
+SpaceBeforeInheritanceColon: true
+SpaceBeforeParens: ControlStatements
+SpaceBeforeParensOptions:
+  AfterControlStatements: true
+  AfterForeachMacros: true
+  AfterFunctionDefinitionName: false
+  AfterFunctionDeclarationName: false
+  AfterIfMacros:   true
+  AfterOverloadedOperator: false
+  AfterRequiresInClause: false
+  AfterRequiresInExpression: false
+  BeforeNonEmptyParentheses: false
+SpaceBeforeRangeBasedForLoopColon: true
+SpaceBeforeSquareBrackets: false
+SpaceInEmptyBlock: false
+SpaceInEmptyParentheses: false
+SpacesBeforeTrailingComments: 1
+SpacesInAngles:  Never
+SpacesInConditionalStatement: false
+SpacesInContainerLiterals: true
+SpacesInCStyleCastParentheses: false
+SpacesInLineCommentPrefix:
+  Minimum:         1
+  Maximum:         -1
+SpacesInParentheses: false
+SpacesInSquareBrackets: false
+Standard:        Latest
+StatementAttributeLikeMacros:
+  - Q_EMIT
+StatementMacros:
+  - Q_UNUSED
+  - QT_REQUIRE_VERSION
+TabWidth:        4
+UseTab:          Never
+WhitespaceSensitiveMacros:
+  - BOOST_PP_STRINGIZE
+  - CF_SWIFT_NAME
+  - NS_SWIFT_NAME
+  - PP_STRINGIZE
+  - STRINGIZE
+...

--- a/.clang-tidy
+++ b/.clang-tidy
@@ -1,0 +1,35 @@
+---
+Checks: '*,
+         -altera-struct-pack-align,
+         -altera-unroll-loops,
+         -cppcoreguidelines-pro-type-union-access,
+         -fuchsia-overloaded-operator,
+         -llvm-header-guard,
+         -llvmlibc-*,
+         -misc-no-recursion,
+         -modernize-use-trailing-return-type,
+         -readability-identifier-length,
+         -readability-redundant-access-specifiers'
+WarningsAsErrors: '*'
+HeaderFilterRegex: ''
+CheckOptions:
+  - { key: hicpp-special-member-functions.AllowSoleDefaultDtor, value: 1 }
+  - { key: modernize-use-nullptr.NullMacros, value: 'NULL' }
+
+  - { key: readability-identifier-naming.ClassCase, value: CamelCase }
+  - { key: readability-identifier-naming.StructCase, value: CamelCase }
+  - { key: readability-identifier-naming.UnionCase, value: CamelCase }
+  - { key: readability-identifier-naming.EnumCase, value: CamelCase }
+  - { key: readability-identifier-naming.FunctionCase, value: CamelCase }
+  - { key: readability-identifier-naming.ClassMemberCase, value: lower_case }
+  - { key: readability-identifier-naming.ClassMemberPrefix, value: s_ }
+  - { key: readability-identifier-naming.PrivateMemberCase, value: lower_case }
+  - { key: readability-identifier-naming.PrivateMemberPrefix, value: m_ }
+  - { key: readability-identifier-naming.VariableCase, value: lower_case }
+  - { key: readability-identifier-naming.ParameterCase, value: lower_case }
+  - { key: readability-identifier-naming.ConstantParameterCase, value: lower_case }
+  - { key: readability-identifier-naming.ConstantCase, value: UPPER_CASE }
+  - { key: readability-identifier-naming.FunctionCase, value: CamelCase }
+  - { key: readability-identifier-naming.TemplateParameter, value: CamelCase }
+  - { key: readability-identifier-naming.Namespace, value: lower_case }
+...

--- a/.github/workflows/clang_format_check.yml
+++ b/.github/workflows/clang_format_check.yml
@@ -26,4 +26,5 @@ jobs:
     - name: Run clang-format style check
       uses: jidicula/clang-format-action@v4.11.0
       with:
+        clang-format-version: '16'
         check-path: include/fkYAML

--- a/.github/workflows/clang_format_check.yml
+++ b/.github/workflows/clang_format_check.yml
@@ -1,0 +1,29 @@
+name: Clang_Format_Check
+
+on:
+  push:
+    paths:
+      - '**.hpp'
+      - '**.cpp'
+  pull_request:
+    branches: [ "main", "develop" ]
+
+env:
+  # Customize the CMake build type here (Release, Debug, RelWithDebInfo, etc.)
+  BUILD_TYPE: Debug
+
+jobs:
+  format-check:
+    # The CMake configure and build commands are platform agnostic and should work equally well on Windows or Mac.
+    # You can convert this to a matrix build if you need cross-platform coverage.
+    # See: https://docs.github.com/en/free-pro-team@latest/actions/learn-github-actions/managing-complex-workflows#using-a-build-matrix
+    timeout-minutes: 10
+    runs-on: ubuntu-latest
+
+    steps:
+    - uses: actions/checkout@v3
+
+    - name: Run clang-format style check
+      uses: jidicula/clang-format-action@v4.11.0
+      with:
+        check-path: include/fkYAML

--- a/.github/workflows/cmake_debug.yml
+++ b/.github/workflows/cmake_debug.yml
@@ -40,7 +40,7 @@ jobs:
     - name: Configure CMake
       # Configure CMake in a 'build' subdirectory. `CMAKE_BUILD_TYPE` is only required if you are using a single-configuration generator such as make.
       # See https://cmake.org/cmake/help/latest/variable/CMAKE_BUILD_TYPE.html?highlight=cmake_build_type
-      run: cmake -B ${{github.workspace}}/build -DCMAKE_BUILD_TYPE=${{env.BUILD_TYPE}}
+      run: cmake -B ${{github.workspace}}/build -DCMAKE_BUILD_TYPE=${{env.BUILD_TYPE}} -DFK_YAML_CI=ON
 
     - name: Build
       # Build your program with the given configuration

--- a/.github/workflows/cmake_package_debug.yml
+++ b/.github/workflows/cmake_package_debug.yml
@@ -40,7 +40,7 @@ jobs:
     - name: Configure CMake
       # Configure CMake in a 'build' subdirectory. `CMAKE_BUILD_TYPE` is only required if you are using a single-configuration generator such as make.
       # See https://cmake.org/cmake/help/latest/variable/CMAKE_BUILD_TYPE.html?highlight=cmake_build_type
-      run: cmake -B ${{github.workspace}}/build -DCMAKE_BUILD_TYPE=${{env.BUILD_TYPE}} -DCMAKE_INSTALL_PREFIX="${{github.workspace}}/build/package"
+      run: cmake -B ${{github.workspace}}/build -DCMAKE_BUILD_TYPE=${{env.BUILD_TYPE}} -DCMAKE_INSTALL_PREFIX="${{github.workspace}}/build/package" -DFK_YAML_CI=ON
 
     - name: Install
       # Build your program with the given configuration

--- a/.github/workflows/cmake_package_release.yml
+++ b/.github/workflows/cmake_package_release.yml
@@ -40,7 +40,7 @@ jobs:
     - name: Configure CMake
       # Configure CMake in a 'build' subdirectory. `CMAKE_BUILD_TYPE` is only required if you are using a single-configuration generator such as make.
       # See https://cmake.org/cmake/help/latest/variable/CMAKE_BUILD_TYPE.html?highlight=cmake_build_type
-      run: cmake -B ${{github.workspace}}/build -DCMAKE_BUILD_TYPE=${{env.BUILD_TYPE}} -DCMAKE_INSTALL_PREFIX="${{github.workspace}}/build/package"
+      run: cmake -B ${{github.workspace}}/build -DCMAKE_BUILD_TYPE=${{env.BUILD_TYPE}} -DCMAKE_INSTALL_PREFIX="${{github.workspace}}/build/package" -DFK_YAML_CI=ON
 
     - name: Install
       # Build your program with the given configuration

--- a/.github/workflows/cmake_release.yml
+++ b/.github/workflows/cmake_release.yml
@@ -40,7 +40,7 @@ jobs:
     - name: Configure CMake
       # Configure CMake in a 'build' subdirectory. `CMAKE_BUILD_TYPE` is only required if you are using a single-configuration generator such as make.
       # See https://cmake.org/cmake/help/latest/variable/CMAKE_BUILD_TYPE.html?highlight=cmake_build_type
-      run: cmake -B ${{github.workspace}}/build -DCMAKE_BUILD_TYPE=${{env.BUILD_TYPE}}
+      run: cmake -B ${{github.workspace}}/build -DCMAKE_BUILD_TYPE=${{env.BUILD_TYPE}} -DFK_YAML_CI=ON
 
     - name: Build
       # Build your program with the given configuration

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -27,6 +27,17 @@ endif()
 option(FK_YAML_BuildTests "Build the unit tests when FK_YAML_BUILD_TEST is enabled or if this library is the main target." ${FK_YAML_BUILD_TEST_INIT})
 option(FK_YAML_Install    "Install CMake targets during install step." ${FK_YAML_IS_MAIN_PROJECT})
 
+if (FK_YAML_RUN_CLANG_FORMAT)
+  set(FK_YAML_RUN_CLANG_FORMAT_INIT ON)
+else()
+  if(FK_YAML_IS_MAIN_PROJECT)
+    set(FK_YAML_RUN_CLANG_FORMAT_INIT ON)
+  else()
+    set(FK_YAML_RUN_CLANG_FORMAT_INIT OFF)
+  endif()
+endif()
+option(FK_YAML_RunClangFormat "Run clang-format when FK_YAML_RUN_CLANG_FORMAT is enabled or if this library is the main target." ${FK_YAML_RUN_CLANG_FORMAT_INIT})
+
 #
 # Configurations.
 #
@@ -44,6 +55,18 @@ set(FK_YAML_CMAKE_VERSION_CONFIG_FILE  "${FK_YAML_CMAKE_CONFIG_DIR}/${PROJECT_NA
 set(FK_YAML_CMAKE_PROJECT_CONFIG_FILE  "${FK_YAML_CMAKE_CONFIG_DIR}/${PROJECT_NAME}Config.cmake")
 set(FK_YAML_CMAKE_PROJECT_TARGETS_FILE "${FK_YAML_CMAKE_CONFIG_DIR}/${PROJECT_NAME}Targets.cmake")
 set(FK_YAML_PKGCONFIG_INSTALL_DIR      "${CMAKE_INSTALL_DATADIR}/pkgconfig")
+
+#
+# Run clang-format if enabled.
+#
+
+if(FK_YAML_RunClangFormat)
+  include(${CMAKE_CURRENT_SOURCE_DIR}/cmake/RunClangFormat.cmake)
+  run_clang_format(
+    ${FK_YAML_TARGET_NAME}
+    "${CMAKE_CURRENT_SOURCE_DIR}/include/fkYAML/*.hpp"
+  )
+endif()
 
 #
 # Create target and add include path.

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -27,15 +27,21 @@ endif()
 option(FK_YAML_BuildTests "Build the unit tests when FK_YAML_BUILD_TEST is enabled or if this library is the main target." ${FK_YAML_BUILD_TEST_INIT})
 option(FK_YAML_Install    "Install CMake targets during install step." ${FK_YAML_IS_MAIN_PROJECT})
 
-if (FK_YAML_RUN_CLANG_FORMAT)
+if(FK_YAML_RUN_CLANG_FORMAT)
   set(FK_YAML_RUN_CLANG_FORMAT_INIT ON)
 else()
-  if(FK_YAML_IS_MAIN_PROJECT)
+  if(FK_YAML_IS_MAIN_PROJECT AND NOT DEFINED )
     set(FK_YAML_RUN_CLANG_FORMAT_INIT ON)
   else()
     set(FK_YAML_RUN_CLANG_FORMAT_INIT OFF)
   endif()
 endif()
+
+# disable execution of clang-format during CI.
+if(FK_YAML_CI)
+  set(FK_YAML_RUN_CLANG_FORMAT_INIT OFF)
+endif()
+
 option(FK_YAML_RunClangFormat "Run clang-format when FK_YAML_RUN_CLANG_FORMAT is enabled or if this library is the main target." ${FK_YAML_RUN_CLANG_FORMAT_INIT})
 
 #

--- a/cmake/RunClangFormat.cmake
+++ b/cmake/RunClangFormat.cmake
@@ -8,6 +8,7 @@ function(run_clang_format target pattern)
     add_custom_target(
       ${target_for_clang_format}
       ALL
+      COMMAND "${CLANG_FORMAT_EXE}" --version
       COMMAND "${CLANG_FORMAT_EXE}" ${pattern} -i -style=file
     )
   else()

--- a/cmake/RunClangFormat.cmake
+++ b/cmake/RunClangFormat.cmake
@@ -1,0 +1,16 @@
+find_program(CLANG_FORMAT_EXE clang-format)
+
+function(run_clang_format target pattern)
+  if(CLANG_FORMAT_EXE)
+    message(STATUS "Runs clang-format for ${target}. pattern: ${pattern}")
+    message(STATUS "clang-format location: ${CLANG_FORMAT_EXE}")
+    set(target_for_clang_format "run_clang_format_for_${target}")
+    add_custom_target(
+      ${target_for_clang_format}
+      ALL
+      COMMAND "${CLANG_FORMAT_EXE}" ${pattern} -i -style=file
+    )
+  else()
+    message(FATAL "Failed to find clang-format.exe")
+  endif()
+endfunction()

--- a/include/fkYAML/Exception.hpp
+++ b/include/fkYAML/Exception.hpp
@@ -17,12 +17,9 @@ namespace fkyaml
 class Exception : public std::exception
 {
 public:
-    Exception()
-        : m_error_msg("")
-    {
-    }
+    Exception() = default;
 
-    Exception(const char* msg)
+    explicit Exception(const char* msg)
         : m_error_msg(msg)
     {
     }

--- a/include/fkYAML/Exception.hpp
+++ b/include/fkYAML/Exception.hpp
@@ -1,6 +1,6 @@
 /**
  * Exception.hpp - implementation of custom exception classes.
- * 
+ *
  * Copyright (c) 2023 fktn
  * Distributed under the MIT License (https://opensource.org/licenses/MIT)
  */
@@ -37,6 +37,6 @@ private:
     std::string m_error_msg;
 };
 
-}
+} // namespace fkyaml
 
 #endif /* FK_YAML_EXCEPTION_HPP_ */

--- a/include/fkYAML/Iterator.hpp
+++ b/include/fkYAML/Iterator.hpp
@@ -63,42 +63,25 @@ private:
         MAPPING,
     };
 
-    union IteratorHolder
+    using NonConstValueType = typename std::remove_const<ValueType>::type;
+
+    struct IteratorHolder
     {
-        IteratorHolder()
-            : sequence_iterator()
-        {
-        }
-
-        IteratorHolder(const typename ValueType::sequence_type::iterator& itr) noexcept
-            : sequence_iterator(itr)
-        {
-        }
-
-        IteratorHolder(const typename ValueType::mapping_type::iterator& itr) noexcept
-            : mapping_iterator(itr)
-        {
-        }
-
-        ~IteratorHolder()
-        {
-        }
-
-        typename ValueType::sequence_type::iterator sequence_iterator;
-        typename ValueType::mapping_type::iterator mapping_iterator;
+        typename NonConstValueType::sequence_type::iterator sequence_iterator {};
+        typename NonConstValueType::mapping_type::iterator mapping_iterator {};
     };
 
 public:
-    Iterator(SequenceIteratorTag, const typename ValueType::sequence_type::iterator& itr) noexcept
-        : m_inner_iterator_type(InnerIteratorType::SEQUENCE),
-          m_iterator_holder(itr)
+    Iterator(SequenceIteratorTag /* unused */, const typename ValueType::sequence_type::iterator& itr) noexcept
+        : m_inner_iterator_type(InnerIteratorType::SEQUENCE)
     {
+        m_iterator_holder.sequence_iterator = itr;
     }
 
-    Iterator(MappingIteratorTag, const typename ValueType::mapping_type::iterator& itr) noexcept
-        : m_inner_iterator_type(InnerIteratorType::MAPPING),
-          m_iterator_holder(itr)
+    Iterator(MappingIteratorTag /* unused */, const typename ValueType::mapping_type::iterator& itr) noexcept
+        : m_inner_iterator_type(InnerIteratorType::MAPPING)
     {
+          m_iterator_holder.mapping_iterator = itr;
     }
 
     Iterator(const Iterator& other) noexcept
@@ -129,12 +112,10 @@ public:
         }
     }
 
-    ~Iterator()
-    {
-    }
+    ~Iterator() = default;
 
 public:
-    Iterator& operator=(const Iterator& other) noexcept
+    Iterator& operator=(const Iterator& other) noexcept // NOLINT(cert-oop54-cpp)
     {
         if (&other == this)
         {
@@ -213,6 +194,13 @@ public:
         return *this;
     }
 
+    Iterator operator+(difference_type i) const
+    {
+        auto result = *this;
+        result += i;
+        return result;
+    }
+
     Iterator& operator++() noexcept
     {
         switch (m_inner_iterator_type)
@@ -227,14 +215,7 @@ public:
         return *this;
     }
 
-    Iterator operator+(difference_type i) const
-    {
-        auto result = *this;
-        result += i;
-        return result;
-    }
-
-    Iterator operator++(int) & noexcept
+    Iterator operator++(int) & noexcept // NOLINT(cert-dcl21-cpp)
     {
         auto result = *this;
         ++(*this);
@@ -267,7 +248,7 @@ public:
         return *this;
     }
 
-    Iterator operator--(int) & noexcept
+    Iterator operator--(int) & noexcept // NOLINT(cert-dcl21-cpp)
     {
         auto result = *this;
         --(*this);

--- a/include/fkYAML/Iterator.hpp
+++ b/include/fkYAML/Iterator.hpp
@@ -1,6 +1,6 @@
 /**
  * Iterator.hpp - Implementation of the YAML node iterator.
- * 
+ *
  * Copyright (c) 2023 fktn
  * Distributed under the MIT License (https://opensource.org/licenses/MIT)
  */
@@ -8,16 +8,20 @@
 #ifndef FK_YAML_ITERATOR_HPP_
 #define FK_YAML_ITERATOR_HPP_
 
-#include <iterator>
 #include <cstddef>
+#include <iterator>
 
 #include "fkYAML/Exception.hpp"
 
 namespace fkyaml
 {
 
-struct SequenceIteratorTag {};
-struct MappingIteratorTag {};
+struct SequenceIteratorTag
+{
+};
+struct MappingIteratorTag
+{
+};
 
 template <typename ValueType>
 struct IteratorTraits
@@ -81,7 +85,7 @@ private:
         }
 
         typename ValueType::sequence_type::iterator sequence_iterator;
-        typename ValueType::mapping_type::iterator  mapping_iterator;
+        typename ValueType::mapping_type::iterator mapping_iterator;
     };
 
 public:
@@ -230,7 +234,7 @@ public:
         return result;
     }
 
-    Iterator operator++(int)& noexcept
+    Iterator operator++(int) & noexcept
     {
         auto result = *this;
         ++(*this);
@@ -263,7 +267,7 @@ public:
         return *this;
     }
 
-    Iterator operator--(int)& noexcept
+    Iterator operator--(int) & noexcept
     {
         auto result = *this;
         --(*this);
@@ -329,6 +333,6 @@ private:
     mutable IteratorHolder m_iterator_holder;
 };
 
-} // fkyaml
+} // namespace fkyaml
 
 #endif /* FK_YAML_ITERATOR_HPP_ */

--- a/include/fkYAML/Iterator.hpp
+++ b/include/fkYAML/Iterator.hpp
@@ -81,7 +81,7 @@ public:
     Iterator(MappingIteratorTag /* unused */, const typename ValueType::mapping_type::iterator& itr) noexcept
         : m_inner_iterator_type(InnerIteratorType::MAPPING)
     {
-          m_iterator_holder.mapping_iterator = itr;
+        m_iterator_holder.mapping_iterator = itr;
     }
 
     Iterator(const Iterator& other) noexcept

--- a/include/fkYAML/Iterator.hpp
+++ b/include/fkYAML/Iterator.hpp
@@ -19,6 +19,7 @@ namespace fkyaml
 struct SequenceIteratorTag
 {
 };
+
 struct MappingIteratorTag
 {
 };

--- a/include/fkYAML/Node.hpp
+++ b/include/fkYAML/Node.hpp
@@ -21,7 +21,8 @@
 #include "fkYAML/Iterator.hpp"
 #include "fkYAML/NodeType.hpp"
 
-namespace fkyaml {
+namespace fkyaml
+{
 
 class Node
 {

--- a/include/fkYAML/Node.hpp
+++ b/include/fkYAML/Node.hpp
@@ -21,8 +21,7 @@
 #include "fkYAML/Iterator.hpp"
 #include "fkYAML/NodeType.hpp"
 
-namespace fkyaml
-{
+namespace fkyaml {
 
 class Node
 {

--- a/include/fkYAML/Node.hpp
+++ b/include/fkYAML/Node.hpp
@@ -273,8 +273,6 @@ public:
     }
 
 public:
-    // factory methods
-
     static Node Sequence(const sequence_type& sequence)
     {
         Node node;

--- a/include/fkYAML/Node.hpp
+++ b/include/fkYAML/Node.hpp
@@ -192,7 +192,7 @@ public:
     {
     }
 
-    Node(const Node& rhs) 
+    Node(const Node& rhs)
         : m_node_type(rhs.m_node_type)
     {
         switch (m_node_type)
@@ -664,7 +664,7 @@ public:
         using std::swap;
         swap(m_node_type, rhs.m_node_type);
 
-        NodeValue tmp{};
+        NodeValue tmp {};
         std::memcpy(&tmp, &m_node_value, sizeof(NodeValue));
         std::memcpy(&m_node_value, &rhs.m_node_value, sizeof(NodeValue));
         std::memcpy(&rhs.m_node_value, &tmp, sizeof(NodeValue));
@@ -675,9 +675,9 @@ public:
         switch (m_node_type)
         {
         case NodeType::SEQUENCE:
-            return { fkyaml::SequenceIteratorTag(), m_node_value.sequence->begin() };
+            return {fkyaml::SequenceIteratorTag(), m_node_value.sequence->begin()};
         case NodeType::MAPPING:
-            return { fkyaml::MappingIteratorTag(), m_node_value.mapping->begin() };
+            return {fkyaml::MappingIteratorTag(), m_node_value.mapping->begin()};
         default:
             throw Exception("The target node is neither of sequence nor mapping types.");
         }
@@ -693,9 +693,9 @@ public:
         switch (m_node_type)
         {
         case NodeType::SEQUENCE:
-            return { fkyaml::SequenceIteratorTag(), m_node_value.sequence->begin() };
+            return {fkyaml::SequenceIteratorTag(), m_node_value.sequence->begin()};
         case NodeType::MAPPING:
-            return { fkyaml::MappingIteratorTag(), m_node_value.mapping->begin() };
+            return {fkyaml::MappingIteratorTag(), m_node_value.mapping->begin()};
         default:
             throw Exception("The target node is neither of sequence nor mapping types.");
         }
@@ -711,9 +711,9 @@ public:
         switch (m_node_type)
         {
         case NodeType::SEQUENCE:
-            return { fkyaml::SequenceIteratorTag(), m_node_value.sequence->end() };
+            return {fkyaml::SequenceIteratorTag(), m_node_value.sequence->end()};
         case NodeType::MAPPING:
-            return { fkyaml::MappingIteratorTag(), m_node_value.mapping->end() };
+            return {fkyaml::MappingIteratorTag(), m_node_value.mapping->end()};
         default:
             throw Exception("The target node is neither of sequence nor mapping types.");
         }
@@ -729,9 +729,9 @@ public:
         switch (m_node_type)
         {
         case NodeType::SEQUENCE:
-            return { fkyaml::SequenceIteratorTag(), m_node_value.sequence->end() };
+            return {fkyaml::SequenceIteratorTag(), m_node_value.sequence->end()};
         case NodeType::MAPPING:
-            return { fkyaml::MappingIteratorTag(), m_node_value.mapping->end() };
+            return {fkyaml::MappingIteratorTag(), m_node_value.mapping->end()};
         default:
             throw Exception("The target node is neither of sequence nor mapping types.");
         }
@@ -744,7 +744,7 @@ public:
 
 private:
     NodeType m_node_type;
-    NodeValue m_node_value{};
+    NodeValue m_node_value {};
 };
 
 using NodeSequenceType = typename Node::sequence_type;

--- a/include/fkYAML/Node.hpp
+++ b/include/fkYAML/Node.hpp
@@ -1,6 +1,6 @@
 /**
  * Node.hpp - Implementation of YAML node data structure.
- * 
+ *
  * Copyright (c) 2023 fktn
  * Distributed under the MIT License (https://opensource.org/licenses/MIT)
  */
@@ -11,15 +11,15 @@
 #include <cassert>
 #include <cstdint>
 #include <cstring>
-#include <string>
 #include <memory>
+#include <string>
 #include <type_traits>
 #include <unordered_map>
 #include <vector>
 
 #include "fkYAML/Exception.hpp"
-#include "fkYAML/NodeType.hpp"
 #include "fkYAML/Iterator.hpp"
+#include "fkYAML/NodeType.hpp"
 
 namespace fkyaml
 {
@@ -30,16 +30,17 @@ public:
     using iterator = Iterator<Node>;
     using const_iterator = Iterator<const Node>;
 
-    using sequence_type     = std::vector<Node>;
-    using mapping_type      = std::unordered_map<std::string, Node>;
-    using boolean_type      = bool;
-    using signed_int_type   = int64_t;
+    using sequence_type = std::vector<Node>;
+    using mapping_type = std::unordered_map<std::string, Node>;
+    using boolean_type = bool;
+    using signed_int_type = int64_t;
     using unsigned_int_type = uint64_t;
     using float_number_type = double;
-    using string_type       = std::string;
+    using string_type = std::string;
 
 private:
-    union NodeValue {
+    union NodeValue
+    {
         NodeValue()
         {
         }
@@ -81,7 +82,8 @@ private:
 
         NodeValue(const sequence_type& seq) noexcept
             : sequence(CreateObject<sequence_type>(seq))
-        {}
+        {
+        }
 
         NodeValue& operator=(const sequence_type& seq) noexcept
         {
@@ -91,7 +93,8 @@ private:
 
         NodeValue(sequence_type&& seq) noexcept
             : sequence(CreateObject<sequence_type>(std::move(seq)))
-        {}
+        {
+        }
 
         NodeValue& operator=(sequence_type&& seq) noexcept
         {
@@ -101,7 +104,8 @@ private:
 
         NodeValue(const mapping_type& map) noexcept
             : mapping(CreateObject<mapping_type>(map))
-        {}
+        {
+        }
 
         NodeValue& operator=(const mapping_type& map) noexcept
         {
@@ -111,7 +115,8 @@ private:
 
         NodeValue(mapping_type&& map) noexcept
             : mapping(CreateObject<mapping_type>(std::move(map)))
-        {}
+        {
+        }
 
         NodeValue& operator=(mapping_type&& map) noexcept
         {
@@ -121,7 +126,8 @@ private:
 
         NodeValue(const boolean_type bool_val) noexcept
             : boolean(bool_val)
-        {}
+        {
+        }
 
         NodeValue& operator=(const boolean_type bool_val) noexcept
         {
@@ -131,7 +137,8 @@ private:
 
         NodeValue(const signed_int_type int_val) noexcept
             : signed_int(int_val)
-        {}
+        {
+        }
 
         NodeValue& operator=(const signed_int_type int_val) noexcept
         {
@@ -141,7 +148,8 @@ private:
 
         NodeValue(const unsigned_int_type uint_val) noexcept
             : unsigned_int(uint_val)
-        {}
+        {
+        }
 
         NodeValue& operator=(const unsigned_int_type uint_val) noexcept
         {
@@ -162,7 +170,8 @@ private:
 
         NodeValue(const string_type& str_val) noexcept
             : str(CreateObject<string_type>(str_val))
-        {}
+        {
+        }
 
         NodeValue& operator=(const string_type& str_val) noexcept
         {
@@ -172,7 +181,8 @@ private:
 
         NodeValue(string_type&& str_val) noexcept
             : str(CreateObject<string_type>(std::move(str_val)))
-        {}
+        {
+        }
 
         NodeValue& operator=(string_type&& str_val) noexcept
         {
@@ -207,7 +217,10 @@ private:
 
                     if (current_node.IsSequence())
                     {
-                        std::move(current_node.m_node_value.sequence->begin(), current_node.m_node_value.sequence->end(), std::back_inserter(stack));
+                        std::move(
+                            current_node.m_node_value.sequence->begin(),
+                            current_node.m_node_value.sequence->end(),
+                            std::back_inserter(stack));
                         current_node.m_node_value.sequence->clear();
                     }
                     else if (current_node.IsMapping())
@@ -240,13 +253,13 @@ private:
             }
         }
 
-        sequence_type*   sequence;
-        mapping_type*    mapping;
-        boolean_type     boolean;
-        signed_int_type   signed_int;
+        sequence_type* sequence;
+        mapping_type* mapping;
+        boolean_type boolean;
+        signed_int_type signed_int;
         unsigned_int_type unsigned_int;
         float_number_type float_val;
-        string_type*     str;
+        string_type* str;
     };
 
 private:
@@ -257,8 +270,7 @@ private:
         using AllocTraitsType = std::allocator_traits<AllocType>;
 
         AllocType alloc;
-        auto deleter = [&](ObjType* obj)
-        {
+        auto deleter = [&](ObjType* obj) {
             AllocTraitsType::destroy(alloc, obj);
             AllocTraitsType::deallocate(alloc, obj, 1);
         };
@@ -273,7 +285,8 @@ private:
     template <typename ObjType>
     static void DestroyObject(ObjType* obj) noexcept
     {
-        if (!obj) return;
+        if (!obj)
+            return;
 
         std::allocator<ObjType> alloc;
         std::allocator_traits<decltype(alloc)>::destroy(alloc, obj);
@@ -765,9 +778,9 @@ public:
         swap(m_node_type, rhs.m_node_type);
 
         NodeValue tmp;
-        std::memcpy(&tmp,              &m_node_value,     sizeof(NodeValue));
-        std::memcpy(&m_node_value,     &rhs.m_node_value, sizeof(NodeValue));
-        std::memcpy(&rhs.m_node_value, &tmp,           sizeof(NodeValue));
+        std::memcpy(&tmp, &m_node_value, sizeof(NodeValue));
+        std::memcpy(&m_node_value, &rhs.m_node_value, sizeof(NodeValue));
+        std::memcpy(&rhs.m_node_value, &tmp, sizeof(NodeValue));
     }
 
     iterator Begin()
@@ -845,17 +858,17 @@ private:
     }
 
 private:
-    NodeType  m_node_type;
+    NodeType m_node_type;
     NodeValue m_node_value;
 };
 
-using NodeSequenceType    = typename Node::sequence_type;
-using NodeMappingType     = typename Node::mapping_type;
-using NodeBooleanType     = typename Node::boolean_type;
-using NodeSignedIntType   = typename Node::signed_int_type;
+using NodeSequenceType = typename Node::sequence_type;
+using NodeMappingType = typename Node::mapping_type;
+using NodeBooleanType = typename Node::boolean_type;
+using NodeSignedIntType = typename Node::signed_int_type;
 using NodeUnsignedIntType = typename Node::unsigned_int_type;
 using NodeFloatNumberType = typename Node::float_number_type;
-using NodeStringType      = typename Node::string_type;
+using NodeStringType = typename Node::string_type;
 
 } // namespace fkyaml
 
@@ -864,8 +877,7 @@ namespace std
 
 template <>
 inline void swap<fkyaml::Node>(fkyaml::Node& lhs, fkyaml::Node& rhs) noexcept(
-    std::is_nothrow_move_constructible<fkyaml::Node>::value
-    && std::is_nothrow_move_assignable<fkyaml::Node>::value)
+    std::is_nothrow_move_constructible<fkyaml::Node>::value&& std::is_nothrow_move_assignable<fkyaml::Node>::value)
 {
     lhs.Swap(rhs);
 }

--- a/include/fkYAML/NodeType.hpp
+++ b/include/fkYAML/NodeType.hpp
@@ -1,6 +1,6 @@
 /**
  * NodeType.hpp - Definitions of YAML node data types.
- * 
+ *
  * Copyright (c) 2023 fktn
  * Distributed under the MIT License (https://opensource.org/licenses/MIT)
  */

--- a/test/node_class_test/NodeClassTest.cpp
+++ b/test/node_class_test/NodeClassTest.cpp
@@ -1,6 +1,6 @@
 /**
  * NodeClassTest.cpp - implementation of test functions for the Node class
- * 
+ *
  * Copyright (c) 2023 fktn
  * Distributed under the MIT License (https://opensource.org/licenses/MIT)
  */
@@ -48,8 +48,9 @@ int NodeClassTest::SequenceNodeFactoryTest()
             std::fprintf(
                 stderr,
                 "type error of the sequence node value. index=%d, expectation=%d, actual=%d\n",
-                i, static_cast<int>(fkyaml::NodeType::NULL_OBJECT), static_cast<int>(node[i].Type())
-            );
+                i,
+                static_cast<int>(fkyaml::NodeType::NULL_OBJECT),
+                static_cast<int>(node[i].Type()));
             return -1;
         }
     }
@@ -59,7 +60,8 @@ int NodeClassTest::SequenceNodeFactoryTest()
 
 int NodeClassTest::MappingNodeFactoryTest()
 {
-    fkyaml::Node node = fkyaml::Node::Mapping(fkyaml::NodeMappingType{{std::string("test"), fkyaml::Node::BooleanScalar(true)}});
+    fkyaml::Node node =
+        fkyaml::Node::Mapping(fkyaml::NodeMappingType {{std::string("test"), fkyaml::Node::BooleanScalar(true)}});
 
     if (!node.IsMapping())
     {
@@ -78,8 +80,9 @@ int NodeClassTest::MappingNodeFactoryTest()
         std::fprintf(
             stderr,
             "type error of the mapping node value. key=%s, expectation=%d, actual=%d\n",
-            "test", static_cast<int>(fkyaml::NodeType::BOOLEAN), static_cast<int>(node.Type())
-        );
+            "test",
+            static_cast<int>(fkyaml::NodeType::BOOLEAN),
+            static_cast<int>(node.Type()));
         return -1;
     }
 
@@ -88,8 +91,9 @@ int NodeClassTest::MappingNodeFactoryTest()
         std::fprintf(
             stderr,
             "value error of the mapping node value. key=%s, expectation=%s, actual=%s\n",
-            "test", "true", node["test"].ToBoolean() ? "true" : "false"
-        );
+            "test",
+            "true",
+            node["test"].ToBoolean() ? "true" : "false");
         return -1;
     }
 
@@ -108,7 +112,8 @@ int NodeClassTest::BoolNodeFactoryTest()
 
     if (node.ToBoolean() != true)
     {
-        std::fprintf(stderr, "node value error. expectation=%s, actual=%s\n", "true", node.ToBoolean() ? "true" : "false");
+        std::fprintf(
+            stderr, "node value error. expectation=%s, actual=%s\n", "true", node.ToBoolean() ? "true" : "false");
         return -1;
     }
 
@@ -146,7 +151,8 @@ int NodeClassTest::UnsignedIntNodeFactoryTest()
 
     if (node.ToUnsignedInteger() != 255ULL)
     {
-        std::fprintf(stderr, "node value error. expectation=%llu, actual=%" PRIu64 "\n", 255ULL, node.ToUnsignedInteger());
+        std::fprintf(
+            stderr, "node value error. expectation=%llu, actual=%" PRIu64 "\n", 255ULL, node.ToUnsignedInteger());
         return -1;
     }
 
@@ -200,15 +206,15 @@ int NodeClassTest::StringNodeFactoryTest()
 
 int NodeClassTest::SequenceForLoopTest()
 {
-    fkyaml::Node node = fkyaml::Node::Sequence({ fkyaml::Node::SignedIntegerScalar(0), fkyaml::Node::SignedIntegerScalar(1), fkyaml::Node::SignedIntegerScalar(2) });
+    fkyaml::Node node = fkyaml::Node::Sequence(
+        {fkyaml::Node::SignedIntegerScalar(0),
+         fkyaml::Node::SignedIntegerScalar(1),
+         fkyaml::Node::SignedIntegerScalar(2)});
 
     if (!node.IsSequence() || node.Size() != 3)
     {
         std::fprintf(
-            stderr,
-            "node initialization failure. type=%d, size=%zu\n",
-            static_cast<int>(node.Type()), node.Size()
-        );
+            stderr, "node initialization failure. type=%d, size=%zu\n", static_cast<int>(node.Type()), node.Size());
         return -1;
     }
 
@@ -220,8 +226,8 @@ int NodeClassTest::SequenceForLoopTest()
             std::fprintf(
                 stderr,
                 "value type of the target sequence node is invalid. expectation=%d, actual=%d\n",
-                static_cast<int>(fkyaml::NodeType::SIGNED_INTEGER), static_cast<int>(item.Type())
-            );
+                static_cast<int>(fkyaml::NodeType::SIGNED_INTEGER),
+                static_cast<int>(item.Type()));
             return -1;
         }
 
@@ -230,8 +236,8 @@ int NodeClassTest::SequenceForLoopTest()
             std::fprintf(
                 stderr,
                 "value of the target sequence node is invalid. expectation=%" PRId64 ", actual=%" PRId64 "\n",
-                value, item.ToSignedInteger()
-            );
+                value,
+                item.ToSignedInteger());
             return -1;
         }
 
@@ -243,15 +249,15 @@ int NodeClassTest::SequenceForLoopTest()
 
 int NodeClassTest::ConstSequenceForLoopTest()
 {
-    const fkyaml::Node node = fkyaml::Node::Sequence({ fkyaml::Node::SignedIntegerScalar(0), fkyaml::Node::SignedIntegerScalar(1), fkyaml::Node::SignedIntegerScalar(2) });
+    const fkyaml::Node node = fkyaml::Node::Sequence(
+        {fkyaml::Node::SignedIntegerScalar(0),
+         fkyaml::Node::SignedIntegerScalar(1),
+         fkyaml::Node::SignedIntegerScalar(2)});
 
     if (!node.IsSequence() || node.Size() != 3)
     {
         std::fprintf(
-            stderr,
-            "node initialization failure. type=%d, size=%zu\n",
-            static_cast<int>(node.Type()), node.Size()
-        );
+            stderr, "node initialization failure. type=%d, size=%zu\n", static_cast<int>(node.Type()), node.Size());
         return -1;
     }
 
@@ -263,8 +269,8 @@ int NodeClassTest::ConstSequenceForLoopTest()
             std::fprintf(
                 stderr,
                 "value type of the target sequence node is invalid. expectation=%d, actual=%d\n",
-                static_cast<int>(fkyaml::NodeType::SIGNED_INTEGER), static_cast<int>(item.Type())
-            );
+                static_cast<int>(fkyaml::NodeType::SIGNED_INTEGER),
+                static_cast<int>(item.Type()));
             return -1;
         }
 
@@ -273,8 +279,8 @@ int NodeClassTest::ConstSequenceForLoopTest()
             std::fprintf(
                 stderr,
                 "value of the target sequence node is invalid. expectation=%" PRId64 ", actual=%" PRId64 "\n",
-                value, item.ToSignedInteger()
-            );
+                value,
+                item.ToSignedInteger());
             return -1;
         }
 

--- a/test/node_class_test/NodeClassTest.hpp
+++ b/test/node_class_test/NodeClassTest.hpp
@@ -1,6 +1,6 @@
 /**
  * NodeClassTest.hpp - declaration of test functions for the Node class
- * 
+ *
  * Copyright (c) 2023 fktn
  * Distributed under the MIT License (https://opensource.org/licenses/MIT)
  */

--- a/test/node_class_test/main.cpp
+++ b/test/node_class_test/main.cpp
@@ -1,6 +1,6 @@
 /**
  * main.cpp - implementation of the entry point of the unit test application.
- * 
+ *
  * Copyright (c) 2023 fktn
  * Distributed under the MIT License (https://opensource.org/licenses/MIT)
  */
@@ -14,18 +14,17 @@
 
 #include "NodeClassTest.hpp"
 
-static const std::unordered_map<uint32_t, int(*)()> NODE_TEST_CASE_MAP
-{
-    { 0x0000, NodeClassTest::DefaultCtorTest },
-    { 0x0001, NodeClassTest::SequenceNodeFactoryTest },
-    { 0x0002, NodeClassTest::MappingNodeFactoryTest },
-    { 0x0003, NodeClassTest::BoolNodeFactoryTest },
-    { 0x0004, NodeClassTest::SignedIntNodeFactoryTest },
-    { 0x0005, NodeClassTest::UnsignedIntNodeFactoryTest },
-    { 0x0006, NodeClassTest::FloatNumberNodeFactoryTest },
-    { 0x0007, NodeClassTest::StringNodeFactoryTest },
-    { 0x0008, NodeClassTest::SequenceForLoopTest },
-    { 0x0009, NodeClassTest::ConstSequenceForLoopTest },
+static const std::unordered_map<uint32_t, int (*)()> NODE_TEST_CASE_MAP {
+    {0x0000, NodeClassTest::DefaultCtorTest},
+    {0x0001, NodeClassTest::SequenceNodeFactoryTest},
+    {0x0002, NodeClassTest::MappingNodeFactoryTest},
+    {0x0003, NodeClassTest::BoolNodeFactoryTest},
+    {0x0004, NodeClassTest::SignedIntNodeFactoryTest},
+    {0x0005, NodeClassTest::UnsignedIntNodeFactoryTest},
+    {0x0006, NodeClassTest::FloatNumberNodeFactoryTest},
+    {0x0007, NodeClassTest::StringNodeFactoryTest},
+    {0x0008, NodeClassTest::SequenceForLoopTest},
+    {0x0009, NodeClassTest::ConstSequenceForLoopTest},
 };
 
 int main(int argc, char* argv[])


### PR DESCRIPTION
This library now supports clang-format & clang-tidy.  
clang-format-16 & clang-tidy-16 are checked in my develop environment on Windows10 Home edition.  
Other versions may be currently unsupported, so further investigation may be necessary.  

clang-format is also supported while executing GitHub Actions, but clang-tidy is not.  
As for clang-tidy, implementation will be done in another issue later on.  