### PR TITLE
#28 add sanitizers to unit test app

### DIFF
--- a/.github/workflows/cmake_debug.yml
+++ b/.github/workflows/cmake_debug.yml
@@ -24,17 +24,17 @@ jobs:
         os: [ubuntu-latest, windows-latest, macos-latest]
         include:
           - os: ubuntu-latest
-            artifact_name: fkYAML_linux_x64.tgz
+            run_sanitizers: ON
           - os: windows-latest
-            artifact_name: fkYAML_windows_x64.zip
+            run_sanitizers: OFF
           - os: macos-latest
-            artifact_name: fkYAML_mac_darwin.tgz
+            run_sanitizers: OFF
 
     steps:
     - uses: actions/checkout@v3
 
     - name: Configure CMake
-      run: cmake -B ${{github.workspace}}/build -DCMAKE_BUILD_TYPE=${{env.BUILD_TYPE}} -DFK_YAML_CI=ON
+      run: cmake -B ${{github.workspace}}/build -DCMAKE_BUILD_TYPE=${{env.BUILD_TYPE}} -DFK_YAML_CI=ON -DFK_YAML_RUN_SANITIZER=${{matrix.run_sanitizer}}
 
     - name: Build
       run: cmake --build ${{github.workspace}}/build --config ${{env.BUILD_TYPE}}

--- a/.github/workflows/cmake_release.yml
+++ b/.github/workflows/cmake_release.yml
@@ -24,17 +24,17 @@ jobs:
         os: [ubuntu-latest, windows-latest, macos-latest]
         include:
           - os: ubuntu-latest
-            artifact_name: fkYAML_linux_x64.tgz
+            run_sanitizers: ON
           - os: windows-latest
-            artifact_name: fkYAML_windows_x64.zip
+            run_sanitizers: OFF
           - os: macos-latest
-            artifact_name: fkYAML_mac_darwin.tgz
+            run_sanitizers: OFF
 
     steps:
     - uses: actions/checkout@v3
 
     - name: Configure CMake
-      run: cmake -B ${{github.workspace}}/build -DCMAKE_BUILD_TYPE=${{env.BUILD_TYPE}} -DFK_YAML_CI=ON
+      run: cmake -B ${{github.workspace}}/build -DCMAKE_BUILD_TYPE=${{env.BUILD_TYPE}} -DFK_YAML_CI=ON -DFK_YAML_RUN_SANITIZERS=${{matrix.run_sanitizers}}
 
     - name: Build
       run: cmake --build ${{github.workspace}}/build --config ${{env.BUILD_TYPE}}

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -48,8 +48,6 @@ else()
 endif()
 
 if(FK_YAML_CI)
-  # enable sanitizers during CI.
-  set(FK_YAML_RUN_SANITIZERS_INIT ON)
   # disable execution of clang-format during CI.
   set(FK_YAML_RUN_CLANG_FORMAT_INIT OFF)
 endif()

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -24,32 +24,45 @@ if(FK_YAML_IS_MAIN_PROJECT OR FK_YAML_BUILD_TEST)
 else()
   set(FK_YAML_BUILD_TEST_INIT OFF)
 endif()
-option(FK_YAML_BuildTests "Build the unit tests when FK_YAML_BUILD_TEST is enabled or if this library is the main target." ${FK_YAML_BUILD_TEST_INIT})
-option(FK_YAML_Install    "Install CMake targets during install step." ${FK_YAML_IS_MAIN_PROJECT})
+
+if(FK_YAML_RUN_SANITIZERS)
+  set(FK_YAML_RUN_SANITIZERS_INIT ON)
+else()
+  set(FK_YAML_RUN_SANITIZERS_INIT OFF)
+endif()
 
 if(FK_YAML_RUN_DOXYGEN)
   set(FK_YAML_RUN_DOXYGEN_INIT ON)
 else()
   set(FK_YAML_RUN_DOXYGEN_INIT OFF)
 endif()
-option(FK_YAML_RunDoxygen "Generate API documentation with doxygen" ${FK_YAML_RUN_DOXYGEN_INIT})
 
 if(FK_YAML_RUN_CLANG_FORMAT)
   set(FK_YAML_RUN_CLANG_FORMAT_INIT ON)
 else()
-  if(FK_YAML_IS_MAIN_PROJECT AND NOT DEFINED )
+  if(FK_YAML_IS_MAIN_PROJECT)
     set(FK_YAML_RUN_CLANG_FORMAT_INIT ON)
   else()
     set(FK_YAML_RUN_CLANG_FORMAT_INIT OFF)
   endif()
 endif()
 
-# disable execution of clang-format during CI.
 if(FK_YAML_CI)
+  # enable sanitizers during CI.
+  set(FK_YAML_RUN_SANITIZERS_INIT ON)
+  # disable execution of clang-format during CI.
   set(FK_YAML_RUN_CLANG_FORMAT_INIT OFF)
 endif()
 
+option(FK_YAML_BuildTests     "Build the unit tests when FK_YAML_BUILD_TEST is enabled or if this library is the main target." ${FK_YAML_BUILD_TEST_INIT})
+option(FK_YAML_RunSanitizers  "Build the unit tests with sanitizers if FK_YAML_RUN_SANITIZERS is enabled" ${FK_YAML_RUN_SANITIZERS_INIT})
+option(FK_YAML_Install        "Install CMake targets during install step." ${FK_YAML_IS_MAIN_PROJECT})
+option(FK_YAML_RunDoxygen     "Generate API documentation with doxygen" ${FK_YAML_RUN_DOXYGEN_INIT})
 option(FK_YAML_RunClangFormat "Run clang-format when FK_YAML_RUN_CLANG_FORMAT is enabled or if this library is the main target." ${FK_YAML_RUN_CLANG_FORMAT_INIT})
+
+if(FK_YAML_BuildTests OR FK_YAML_RunClangFormat)
+  set(CMAKE_MODULE_PATH "${CMAKE_CURRENT_SOURCE_DIR}/cmake")
+endif()
 
 #
 # Configurations.
@@ -75,7 +88,7 @@ set(FK_YAML_PKGCONFIG_INSTALL_DIR      "${CMAKE_INSTALL_DATADIR}/pkgconfig")
 #
 
 if(FK_YAML_RunClangFormat)
-  include(${CMAKE_CURRENT_SOURCE_DIR}/cmake/RunClangFormat.cmake)
+  include(RunClangFormat)
   run_clang_format(
     ${FK_YAML_TARGET_NAME}
     "${CMAKE_CURRENT_SOURCE_DIR}/include/fkYAML/*.hpp"
@@ -111,6 +124,7 @@ configure_file(
 
 if(FK_YAML_BuildTests)
   include(CTest)
+  include(AddSanitizers)
   enable_testing()
   add_subdirectory(test)
 endif()

--- a/cmake/AddSanitizers.cmake
+++ b/cmake/AddSanitizers.cmake
@@ -1,0 +1,45 @@
+function(add_sanitizer_flags ENABLED)
+  if(NOT ${ENABLED})
+    message(STATUS "Sanitizers deactivated.")
+    return()
+  endif()
+
+  if(CMAKE_CXX_COMPILER_ID MATCHES "CLANG" OR CMAKE_CXX_COMPILER_ID MATCHES "GNU")
+    # Common compile/link options for sanitizers
+    add_compile_options("-fno-omit-frame-pointer")
+    add_link_options("-fno-omit-frame-pointer")
+
+    # AddressSanitizer
+    add_compile_options("-fsanitize=address")
+    add_link_options("-fsanitize=address")
+
+    # UndefinedBehaviorSanitizer
+    add_compile_options("-fsanitize=undefined")
+    add_link_options("-fsanitize=undefined")
+
+    # option to detect out-of-bounds access
+    add_compile_options("-fsanitize=bounds")
+    add_link_options("-fsanitize=bounds")
+
+    if(CMAKE_CXX_COMPILER_ID MATCHES "CLANG")
+      # MemorySanitizer
+      add_compile_options("-fsanitize=memory")
+      add_link_options("-fsanitize=memory")
+
+      add_compile_options("-fsanitize=integer")
+      add_link_options("-fsanitize=integer")
+
+      add_compile_options("-fsanitize=nullability")
+      add_link_options("-fsanitize=nullability")
+
+      # option to print a verbose error report and exit the program
+      add_compile_options("-fno-sanitize-recover=all")
+      add_link_options("-fno-sanitize-recover=all")
+    endif()
+  elseif(CMAKE_CXX_COMPILER_ID MATCHES "MSVC")
+    message(STATUS "No sanitizers enabled for MSVC compiler&linker")
+  else()
+    message(ERROR "Compiler not supported for sanitizers.")
+  endif()
+
+endfunction()

--- a/cmake/AddSanitizers.cmake
+++ b/cmake/AddSanitizers.cmake
@@ -4,7 +4,7 @@ function(add_sanitizer_flags ENABLED)
     return()
   endif()
 
-  if(CMAKE_CXX_COMPILER_ID MATCHES "CLANG" OR CMAKE_CXX_COMPILER_ID MATCHES "GNU")
+  if(CMAKE_CXX_COMPILER_ID MATCHES "Clang" OR CMAKE_CXX_COMPILER_ID MATCHES "GNU")
     # Common compile/link options for sanitizers
     add_compile_options("-fno-omit-frame-pointer")
     add_link_options("-fno-omit-frame-pointer")
@@ -21,11 +21,7 @@ function(add_sanitizer_flags ENABLED)
     add_compile_options("-fsanitize=bounds")
     add_link_options("-fsanitize=bounds")
 
-    if(CMAKE_CXX_COMPILER_ID MATCHES "CLANG")
-      # MemorySanitizer
-      add_compile_options("-fsanitize=memory")
-      add_link_options("-fsanitize=memory")
-
+    if(CMAKE_CXX_COMPILER_ID MATCHES "Clang")
       add_compile_options("-fsanitize=integer")
       add_link_options("-fsanitize=integer")
 

--- a/test/unit_test/CMakeLists.txt
+++ b/test/unit_test/CMakeLists.txt
@@ -12,8 +12,7 @@ else()
 endif()
 set(CMAKE_CXX_STANDARD 11)
 
-# add_sanitizer_flags(${FK_YAML_RunSanitizers})
-add_sanitizer_flags(ON)
+add_sanitizer_flags(${FK_YAML_RunSanitizers})
 
 set(TEST_TARGET "fkYAMLUnitTest")
 

--- a/test/unit_test/CMakeLists.txt
+++ b/test/unit_test/CMakeLists.txt
@@ -12,6 +12,9 @@ else()
 endif()
 set(CMAKE_CXX_STANDARD 11)
 
+# add_sanitizer_flags(${FK_YAML_RunSanitizers})
+add_sanitizer_flags(ON)
+
 set(TEST_TARGET "fkYAMLUnitTest")
 
 add_executable(${TEST_TARGET}

--- a/test/unit_test/main.cpp
+++ b/test/unit_test/main.cpp
@@ -16,7 +16,7 @@
 #include "LexicalAnalyzerTest.hpp"
 #include "NodeClassTest.hpp"
 
-static const std::unordered_map<uint32_t, int (*)()> TEST_CASE_MAP {
+static const std::unordered_map<unsigned long, int (*)()> TEST_CASE_MAP {
     {0x0000, NodeClassTest::DefaultCtorTest},
     {0x0001, NodeClassTest::SequenceTypeCtorTest},
     {0x0002, NodeClassTest::MappingTypeCtorTest},
@@ -153,7 +153,7 @@ int main(int argc, char* argv[])
 
     errno = 0;
 
-    uint32_t test_id = std::strtoul(argv[1], nullptr, 0);
+    unsigned long test_id = std::strtoul(argv[1], nullptr, 0);
     if ((test_id == 0 || test_id == ULONG_MAX) && errno == ERANGE)
     {
         std::fprintf(stderr, "Failed to retrieve test case id.");


### PR DESCRIPTION
A new build option to build the unit test app with some sanitizers has been added.  
To enable sanitizers, add `-DFK_YAML_RUN_SANITIZERS=ON` when configuring fkYAML library with CMake.  
Currently, this option is executed only on ubuntu during GitHub Actions.  