### PR TITLE
#45 add code coverage job

### DIFF
--- a/.github/workflows/coverage.yml
+++ b/.github/workflows/coverage.yml
@@ -1,0 +1,31 @@
+name: Coverage
+
+on:
+  push:
+    branches: [ main, develop ]
+  pull_request:
+  workflow_dispatch:
+
+
+jobs:
+  coverage:
+    timeout-minutes: 10
+    runs-on: ubuntu-latest
+
+    steps:
+    - uses: actions/checkout@v3
+      with:
+        submodules: recursive
+
+    - name: Generate coverage
+      run: |
+        sudo apt install lcov
+        CXX=g++ cmake -B ${{github.workspace}}/build_coverage -DCMAKE_BUILD_TYPE=Debug -DFK_YAML_CI=ON -DFK_YAML_CODE_COVERAGE=ON
+        cmake --build ${{github.workspace}}/build_coverage --config Debug --target generate_test_coverage
+
+    - name: Upload coverage to Coveralls
+      uses: coverallsapp/github-action@v2
+      with:
+        github-token: ${{secrets.GITHUB_TOKEN}}
+        file: ${{github.workspace}}/build_coverage/coverage/fkYAML.info
+        format: lcov

--- a/.github/workflows/ubuntu.yml
+++ b/.github/workflows/ubuntu.yml
@@ -41,7 +41,7 @@ jobs:
     - name: Generate coverage
       run: |
         sudo apt install lcov
-        CXX=g++ cmake -B ${{github.workspace}}/build_coverage -DCMAKE_BUILD_TYPE=Debug -DFK_YAML_CI=ON -DFK_YAML_CODE_COVERAGE_ON
+        CXX=g++ cmake -B ${{github.workspace}}/build_coverage -DCMAKE_BUILD_TYPE=Debug -DFK_YAML_CI=ON -DFK_YAML_CODE_COVERAGE=ON
         cmake --build ${{github.workspace}}/build_coverage --config Debug --target generate_test_coverage
 
     - name: Upload coverage to Coveralls

--- a/.github/workflows/ubuntu.yml
+++ b/.github/workflows/ubuntu.yml
@@ -38,6 +38,10 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
+    - uses: actions/checkout@v3
+      with:
+        submodules: recursive
+
     - name: Generate coverage
       run: |
         sudo apt install lcov

--- a/.github/workflows/ubuntu.yml
+++ b/.github/workflows/ubuntu.yml
@@ -53,3 +53,4 @@ jobs:
       with:
         github-token: ${{secrets.GITHUB_TOKEN}}
         file: ${{github.workspace}}/build_coverage/test/unit_test/fkYAML.info.filtered
+        format: lcov

--- a/.github/workflows/ubuntu.yml
+++ b/.github/workflows/ubuntu.yml
@@ -32,25 +32,3 @@ jobs:
     - name: Test
       working-directory: ${{github.workspace}}/build_${{matrix.build_type}}
       run: ctest -C ${{matrix.build_type}} --output-on-failure
-
-  coverage:
-    timeout-minutes: 10
-    runs-on: ubuntu-latest
-
-    steps:
-    - uses: actions/checkout@v3
-      with:
-        submodules: recursive
-
-    - name: Generate coverage
-      run: |
-        sudo apt install lcov
-        CXX=g++ cmake -B ${{github.workspace}}/build_coverage -DCMAKE_BUILD_TYPE=Debug -DFK_YAML_CI=ON -DFK_YAML_CODE_COVERAGE=ON
-        cmake --build ${{github.workspace}}/build_coverage --config Debug --target generate_test_coverage
-
-    - name: Upload coverage to Coveralls
-      uses: coverallsapp/github-action@v2
-      with:
-        github-token: ${{secrets.GITHUB_TOKEN}}
-        file: ${{github.workspace}}/build_coverage/test/unit_test/fkYAML.info.filtered
-        format: lcov

--- a/.github/workflows/ubuntu.yml
+++ b/.github/workflows/ubuntu.yml
@@ -52,4 +52,4 @@ jobs:
       uses: coverallsapp/github-action@v2
       with:
         github-token: ${{secrets.GITHUB_TOKEN}}
-        file: ${{github.workspace}}/build_coverage/test/unittest/fkYAML.info.filtered
+        file: ${{github.workspace}}/build_coverage/test/unit_test/fkYAML.info.filtered

--- a/.github/workflows/ubuntu.yml
+++ b/.github/workflows/ubuntu.yml
@@ -32,3 +32,20 @@ jobs:
     - name: Test
       working-directory: ${{github.workspace}}/build_${{matrix.build_type}}
       run: ctest -C ${{matrix.build_type}} --output-on-failure
+
+  coverage:
+    timeout-minutes: 10
+    runs-on: ubuntu-latest
+
+    steps:
+    - name: Generate coverage
+      run: |
+        sudo apt install lcov
+        CXX=g++ cmake -B ${{github.workspace}}/build_coverage -DCMAKE_BUILD_TYPE=Debug -DFK_YAML_CI=ON -DFK_YAML_CODE_COVERAGE_ON
+        cmake --build ${{github.workspace}}/build_coverage --config Debug --target generate_test_coverage
+
+    - name: Upload coverage to Coveralls
+      uses: coverallsapp/github-action@v2
+      with:
+        github-token: ${{secrets.GITHUB_TOKEN}}
+        file: ${{github.workspace}}/build_coverage/test/unittest/fkYAML.info.filtered

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -31,6 +31,15 @@ else()
   set(FK_YAML_RUN_SANITIZERS_INIT OFF)
 endif()
 
+if(FK_YAML_CODE_COVERAGE)
+  # Code coverage data depends on unit test app.
+  # So force build it.
+  set(FK_YAML_BUILD_TEST_INIT ON)
+  set(FK_YAML_CODE_COVERAGE_INIT ON)
+else()
+  set(FK_YAML_CODE_COVERAGE_INIT OFF)
+endif()
+
 if(FK_YAML_RUN_DOXYGEN)
   set(FK_YAML_RUN_DOXYGEN_INIT ON)
 else()
@@ -53,9 +62,10 @@ if(FK_YAML_CI)
 endif()
 
 option(FK_YAML_BuildTests     "Build the unit tests when FK_YAML_BUILD_TEST is enabled or if this library is the main target." ${FK_YAML_BUILD_TEST_INIT})
-option(FK_YAML_RunSanitizers  "Build the unit tests with sanitizers if FK_YAML_RUN_SANITIZERS is enabled" ${FK_YAML_RUN_SANITIZERS_INIT})
+option(FK_YAML_RunSanitizers  "Build the unit tests with sanitizers if FK_YAML_RUN_SANITIZERS is enabled." ${FK_YAML_RUN_SANITIZERS_INIT})
+option(FK_YAML_GenerateCoverage "Build the unit tests with code coverage data if FK_YAML_CODE_COVERAGE is enabled." ${FK_YAML_CODE_COVERAGE_INIT})
 option(FK_YAML_Install        "Install CMake targets during install step." ${FK_YAML_IS_MAIN_PROJECT})
-option(FK_YAML_RunDoxygen     "Generate API documentation with doxygen" ${FK_YAML_RUN_DOXYGEN_INIT})
+option(FK_YAML_RunDoxygen     "Generate API documentation with doxygen." ${FK_YAML_RUN_DOXYGEN_INIT})
 option(FK_YAML_RunClangFormat "Run clang-format when FK_YAML_RUN_CLANG_FORMAT is enabled or if this library is the main target." ${FK_YAML_RUN_CLANG_FORMAT_INIT})
 
 if(FK_YAML_BuildTests OR FK_YAML_RunClangFormat)
@@ -63,6 +73,13 @@ if(FK_YAML_BuildTests OR FK_YAML_RunClangFormat)
   if(FK_YAML_BuildTests)
     set(CMAKE_MODULE_PATH "${CMAKE_MODULE_PATH};${CMAKE_CURRENT_SOURCE_DIR}/thirdparty/catch2/contrib")
   endif()
+endif()
+
+if(FK_YAML_GenerateCoverage)
+  find_program(LCOV_TOOL NAMES lcov REQUIRED)
+  execute_process(COMMAND ${LCOV_TOOL} --version OUTPUT_VARIABLE LCOV_TOOL_VERSION ERROR_VARIABLE LCOV_TOOL_VERSION)
+  string(REGEX MATCH "[0-9]+(\\.[0-9]+)+" LCOV_TOOL_VERSION "${LCOV_TOOL_VERSION}")
+  message(STATUS "lcov ${LCOV_TOOL_VERSION} (${LCOV_TOOL})")
 endif()
 
 #

--- a/README.md
+++ b/README.md
@@ -1,6 +1,7 @@
 [![Ubuntu](https://github.com/fktn-k/fkYAML/workflows/Ubuntu/badge.svg)](https://github.com/fktn-k/fkYAML/actions?query=workflow%3AUbuntu)
 [![Windows](https://github.com/fktn-k/fkYAML/workflows/Windows/badge.svg)](https://github.com/fktn-k/fkYAML/actions?query=workflow%3AWindows)
 [![macOS](https://github.com/fktn-k/fkYAML/workflows/macOS/badge.svg)](https://github.com/fktn-k/fkYAML/actions?query=workflow%3AmacOS)
+[![Coverage Status](https://coveralls.io/repos/github/fktn-k/fkYAML/badge.svg?branch=develop)](https://coveralls.io/github/fktn-k/fkYAML?branch=develop)
 [![CodeQL](https://github.com/fktn-k/fkYAML/workflows/CodeQL/badge.svg)](https://github.com/fktn-k/fkYAML/actions?query=workflow%3ACodeQL)
 
 # fkYAML

--- a/test/unit_test/CMakeLists.txt
+++ b/test/unit_test/CMakeLists.txt
@@ -47,7 +47,7 @@ if(FK_YAML_GenerateCoverage)
     COMMAND cd ${PROJECT_BINARY_DIR}/test/unit_test/CMakeFiles/${TEST_TARGET}.dir
     COMMAND ${LCOV_TOOL} --directory . --capture --output-file ${PROJECT_NAME}.info --rc lcov_branch_coverage=1
     COMMAND ${LCOV_TOOL} -e ${PROJECT_NAME}.info ${PROJECT_SOURCE_DIR}/include/fkYAML/*.hpp --output-file ${PROJECT_NAME}.info.filtered --rc lcov_branch_coverage=1
-    # COMMAND genhtml --title "fkYAML -- A C++ header-only YAML library" --legend --demangle-cpp --output-directory html --show-details --branch-coverage ${PROJECT_NAME}.info.filtered
+    COMMAND ${CMAKE_COMMAND} -E copy ${PROJECT_NAME}.info.filtered ${PROJECT_BINARY_DIR}/coverage/fkYAML.info
 
     DEPENDS ${TEST_TARGET}
     COMMENT "Execute unit test app with code coverage."

--- a/test/unit_test/CMakeLists.txt
+++ b/test/unit_test/CMakeLists.txt
@@ -30,6 +30,30 @@ add_executable(${TEST_TARGET}
   main.cpp
 )
 
+if(FK_YAML_GenerateCoverage)
+  target_compile_options(${TEST_TARGET} PRIVATE
+    -O0        # no optimization
+    -g         # generate debug info
+    --coverage # set all required flags to generate code coverage data
+  )
+  if(CMAKE_VERSION VERSION_GREATER_EQUAL 3.13)
+    target_link_options(${TEST_TARGET} PRIVATE --coverage)
+  else()
+    target_link_libraries(${TEST_TARGET} PRIVATE --coverage)
+  endif()
+
+  add_custom_target(generate_test_coverage
+    COMMAND ${CMAKE_CTEST_COMMAND} -C ${CMAKE_BUILD_TYPE} --output-on-failure
+    COMMAND cd ${PROJECT_BINARY_DIR}/test/unit_test/CMakeFiles/${TEST_TARGET}.dir
+    COMMAND ${LCOV_TOOL} --directory . --capture --output-file ${PROJECT_NAME}.info --rc lcov_branch_coverage=1
+    COMMAND ${LCOV_TOOL} -e ${PROJECT_NAME}.info ${PROJECT_SOURCE_DIR}/include/fkYAML/*.hpp --output-file ${PROJECT_NAME}.info.filtered --rc lcov_branch_coverage=1
+    # COMMAND genhtml --title "fkYAML -- A C++ header-only YAML library" --legend --demangle-cpp --output-directory html --show-details --branch-coverage ${PROJECT_NAME}.info.filtered
+
+    DEPENDS ${TEST_TARGET}
+    COMMENT "Execute unit test app with code coverage."
+  )
+endif()
+
 target_include_directories(${TEST_TARGET} PRIVATE
   ${PROJECT_SOURCE_DIR}/include
   ${CMAKE_CURRENT_SOURCE_DIR}


### PR DESCRIPTION
The test code coverage has been introduced to both CMake target & GitHub Actions' workflow job.  
This project will use Coveralls as a code coverage service.  
The current coverage on develop branch will be displayed on top of the README.md.  
The coverage rate will be growing upto 100% as much fastly as possible.  