### PR TITLE
Feature/42 add key check api to basicnode

### DIFF
--- a/.github/workflows/coverage.yml
+++ b/.github/workflows/coverage.yml
@@ -21,7 +21,7 @@ jobs:
 
     - name: Generate coverage
       run: |
-        sudo apt install lcov
+        sudo apt-get install -y lcov
         CXX=g++ cmake -B ${{github.workspace}}/build_coverage -DCMAKE_BUILD_TYPE=Debug -DFK_YAML_CI=ON -DFK_YAML_CODE_COVERAGE=ON
         cmake --build ${{github.workspace}}/build_coverage --config Debug --target generate_test_coverage
 

--- a/include/fkYAML/Node.hpp
+++ b/include/fkYAML/Node.hpp
@@ -972,6 +972,36 @@ public:
         }
     }
 
+    bool Contains(const std::string& key) const
+    {
+        switch (m_node_type)
+        {
+        case NodeType::MAPPING: {
+            mapping_type& map = *m_node_value.mapping;
+            return map.find(key) != map.end();
+        }
+        case NodeType::ALIAS:
+            return m_node_value.anchor->Contains(key);
+        default:
+            return false;
+        }
+    }
+
+    bool Contains(std::string&& key) const
+    {
+        switch (m_node_type)
+        {
+        case NodeType::MAPPING: {
+            mapping_type& map = *m_node_value.mapping;
+            return map.find(std::move(key)) != map.end();
+        }
+        case NodeType::ALIAS:
+            return m_node_value.anchor->Contains(std::move(key));
+        default:
+            return false;
+        }
+    }
+
     /**
      * @brief Check whether or not this BasicNode object has already had any anchor name.
      *

--- a/include/fkYAML/Node.hpp
+++ b/include/fkYAML/Node.hpp
@@ -972,6 +972,13 @@ public:
         }
     }
 
+    /**
+     * @brief Check whether or not this BasicNode object has a given key in its inner mapping Node value.
+     *
+     * @param key A lvalue key object.
+     * @return true If this BasicNode object has a given key.
+     * @return false If this BasicNode object does not have a given key.
+     */
     bool Contains(const std::string& key) const
     {
         switch (m_node_type)
@@ -987,6 +994,13 @@ public:
         }
     }
 
+    /**
+     * @brief Check whether or not this BasicNode object has a given key in its inner mapping Node value.
+     *
+     * @param key A rvalue key object.
+     * @return true If this BasicNode object has a given key.
+     * @return false If this BasicNode object does not have a given key.
+     */
     bool Contains(std::string&& key) const
     {
         switch (m_node_type)

--- a/test/unit_test/NodeClassTest.cpp
+++ b/test/unit_test/NodeClassTest.cpp
@@ -1160,6 +1160,80 @@ TEST_CASE("NodeClassTest_IsEmptyTest", "[NodeClassTest]")
 }
 
 //
+// test cases for mapping key existence checker
+//
+
+TEST_CASE("NodeClassTest_ContainsTest", "[NodeClassTest]")
+{
+    SECTION("Test mapping node.")
+    {
+        fkyaml::Node node = fkyaml::Node::Mapping({{"test", fkyaml::Node()}});
+        std::string key = "test";
+
+        SECTION("Test non-alias mapping node with lvalue key.")
+        {
+            REQUIRE(node.Contains(key));
+        }
+
+        SECTION("Test alias mapping node with lvalue key.")
+        {
+            node.AddAnchorName("anchor_name");
+            fkyaml::Node alias = fkyaml::Node::AliasOf(node);
+            REQUIRE(node.Contains(key));
+        }
+
+        SECTION("Test non-alias mapping node with rvalue key.")
+        {
+            REQUIRE(node.Contains(std::move(key)));
+        }
+
+        SECTION("Test alias mapping node with rvalue key.")
+        {
+            node.AddAnchorName("anchor_name");
+            fkyaml::Node alias = fkyaml::Node::AliasOf(node);
+            REQUIRE(node.Contains(std::move(key)));
+        }
+    }
+
+    SECTION("Test non-mapping node.")
+    {
+        auto node = GENERATE(
+            fkyaml::Node::Sequence(),
+            fkyaml::Node(),
+            fkyaml::Node::BooleanScalar(false),
+            fkyaml::Node::SignedIntegerScalar(0),
+            fkyaml::Node::UnsignedIntegerScalar(0),
+            fkyaml::Node::FloatNumberScalar(0.0),
+            fkyaml::Node::StringScalar());
+        std::string key = "test";
+
+        SECTION("Test non-alias non-mapping node with lvalue key.")
+        {
+            REQUIRE_FALSE(node.Contains(key));
+        }
+
+        SECTION("Test alias non-mapping node with lvalue key.")
+        {
+            node.AddAnchorName("anchor_name");
+            fkyaml::Node alias = fkyaml::Node::AliasOf(node);
+            REQUIRE_FALSE(alias.Contains(key));
+        }
+
+        SECTION("Test non-alias non-mapping node with rvalue key.")
+        {
+            REQUIRE_FALSE(node.Contains(std::move(key)));
+        }
+
+        SECTION("Test alias non-mapping node with rvalue key.")
+        {
+            node.AddAnchorName("anchor_name");
+            fkyaml::Node alias = fkyaml::Node::AliasOf(node);
+            REQUIRE_FALSE(alias.Contains(std::move(key)));
+        }
+    }
+}
+
+//
 // test cases for container size getter
 //
 


### PR DESCRIPTION
A BasicNode API to check key existence in the inner mapping Node value, has been added.  
Some unit test cases for the new BasicNode API have also been implemented.  
