### PR TITLE
#54 add unit tests for Exception class

### DIFF
--- a/include/fkYAML/Exception.hpp
+++ b/include/fkYAML/Exception.hpp
@@ -37,8 +37,11 @@ public:
      * @param msg An error description message.
      */
     explicit Exception(const char* msg)
-        : m_error_msg(msg)
     {
+        if (msg)
+        {
+            m_error_msg = msg;
+        }
     }
 
 public:
@@ -54,7 +57,7 @@ public:
 
 private:
     /** An error message holder. */
-    std::string m_error_msg;
+    std::string m_error_msg{};
 };
 
 } // namespace fkyaml

--- a/include/fkYAML/Exception.hpp
+++ b/include/fkYAML/Exception.hpp
@@ -57,7 +57,7 @@ public:
 
 private:
     /** An error message holder. */
-    std::string m_error_msg{};
+    std::string m_error_msg {};
 };
 
 } // namespace fkyaml

--- a/test/unit_test/CMakeLists.txt
+++ b/test/unit_test/CMakeLists.txt
@@ -24,6 +24,7 @@ if(${FK_YAML_RunClangFormat})
 endif()
 
 add_executable(${TEST_TARGET}
+  ExceptionClassTest.cpp
   NodeClassTest.cpp
   IteratorClassTest.cpp
   LexicalAnalyzerClassTest.cpp

--- a/test/unit_test/CMakeLists.txt
+++ b/test/unit_test/CMakeLists.txt
@@ -49,8 +49,7 @@ if(FK_YAML_GenerateCoverage)
     COMMAND cd ${PROJECT_BINARY_DIR}/test/unit_test/CMakeFiles/${TEST_TARGET}.dir
     COMMAND ${LCOV_TOOL} --directory . --capture --output-file ${PROJECT_NAME}.info --rc lcov_branch_coverage=1
     COMMAND ${LCOV_TOOL} -e ${PROJECT_NAME}.info ${PROJECT_SOURCE_DIR}/include/fkYAML/*.hpp --output-file ${PROJECT_NAME}.info.filtered --rc lcov_branch_coverage=1
-    COMMAND ${LCOV_TOOL} -r ${PROJECT_NAME}.info.filtered /usr/include/* --output-file ${PROJECT_NAME}.info.filtered.stl_excluded --rc lcov_branch_coverage=1
-    COMMAND ${CMAKE_COMMAND} -E copy ${PROJECT_NAME}.info.filtered.stl_excluded ${PROJECT_BINARY_DIR}/coverage/fkYAML.info
+    COMMAND ${CMAKE_COMMAND} -E copy ${PROJECT_NAME}.info.filtered ${PROJECT_BINARY_DIR}/coverage/fkYAML.info
 
     DEPENDS ${TEST_TARGET}
     COMMENT "Execute unit test app with code coverage."

--- a/test/unit_test/ExceptionClassTest.cpp
+++ b/test/unit_test/ExceptionClassTest.cpp
@@ -28,6 +28,8 @@ TEST_CASE("ExceptionClassTest_CtorWithMessageTest", "[ExceptionClassTest]")
 
     SECTION("Test null message.")
     {
-        REQUIRE_THROWS(fkyaml::Exception(nullptr));
+        const char* message = nullptr;
+        fkyaml::Exception exception(message);
+        REQUIRE(std::string(exception.what()).empty());
     }
 }

--- a/test/unit_test/ExceptionClassTest.cpp
+++ b/test/unit_test/ExceptionClassTest.cpp
@@ -19,7 +19,15 @@ TEST_CASE("ExceptionClassTest_DefaultCtorTest", "[ExceptionClassTest]")
 
 TEST_CASE("ExceptionClassTest_CtorWithMessageTest", "[ExceptionClassTest]")
 {
-    const char* message = "test error message.";
-    fkyaml::Exception exception(message);
-    REQUIRE(std::string(exception.what()).compare(message) == 0);
+    SECTION("Test non-null message.")
+    {
+        const char* message = "test error message.";
+        fkyaml::Exception exception(message);
+        REQUIRE(std::string(exception.what()).compare(message) == 0);
+    }
+
+    SECTION("Test null message.")
+    {
+        REQUIRE_THROWS(fkyaml::Exception(nullptr));
+    }
 }

--- a/test/unit_test/ExceptionClassTest.cpp
+++ b/test/unit_test/ExceptionClassTest.cpp
@@ -1,0 +1,25 @@
+/**
+ * ExceptionClassTest.cpp - implementation of test functions for the Exception class
+ *
+ * Copyright (c) 2023 fktn
+ * Distributed under the MIT License (https://opensource.org/licenses/MIT)
+ */
+
+#include <cstring>
+
+#include "catch2/catch.hpp"
+
+#include "fkYAML/Exception.hpp"
+
+TEST_CASE("ExceptionClassTest_DefaultCtorTest", "[ExceptionClassTest]")
+{
+    fkyaml::Exception exception;
+    REQUIRE(std::string(exception.what()).empty());
+}
+
+TEST_CASE("ExceptionClassTest_CtorWithMessageTest", "[ExceptionClassTest]")
+{
+    const char* message = "test error message.";
+    fkyaml::Exception exception(message);
+    REQUIRE(std::string(exception.what()).compare(message) == 0);
+}


### PR DESCRIPTION
Some unit test cases have been added for Exception class APIs.  
Currently, I have no idea to ignore STL implementation when generating coverage information, and the branch coverage will therefore be fixed after the solution for the above is found.  
