### PR TITLE
#57 Added static/runtime assertion checks

### DIFF
--- a/include/fkYAML/Assert.hpp
+++ b/include/fkYAML/Assert.hpp
@@ -1,0 +1,22 @@
+/**
+ * @file Assert.hpp
+ * @brief Definition of assertion for fkYAML library implementation.
+ *
+ * Copyright (c) 2023 fktn
+ * Distributed under the MIT License (https://opensource.org/licenses/MIT)
+ */
+
+#ifndef FK_YAML_ASSERT_HPP_
+#define FK_YAML_ASSERT_HPP_
+
+// if FK_YAML_ASSERT is not user-defined. apply the default assert impl.
+#ifndef FK_YAML_ASSERT
+#ifndef NDEBUG
+#include <cassert>
+#define FK_YAML_ASSERT(x) assert(x)
+#else
+#define FK_YAML_ASSERT(x)
+#endif
+#endif
+
+#endif /* FK_YAML_ASSERT_HPP_ */

--- a/include/fkYAML/Deserializer.hpp
+++ b/include/fkYAML/Deserializer.hpp
@@ -12,6 +12,7 @@
 #include "fkYAML/Exception.hpp"
 #include "fkYAML/LexicalAnalyzer.hpp"
 #include "fkYAML/Node.hpp"
+#include "fkYAML/NodeTypeTraits.hpp"
 
 #ifndef FK_YAML_DESERIALIZER_HPP_
 #define FK_YAML_DESERIALIZER_HPP_
@@ -37,6 +38,8 @@ namespace fkyaml
 template <typename BasicNodeType = Node>
 class BasicDeserializer
 {
+    static_assert(is_basic_node<BasicNodeType>::value, "BasicDeserializer only accepts (const) BasicNode<...>");
+
     /** A type for sequence node value containers. */
     using sequence_type = typename BasicNodeType::sequence_type;
     /** A type for mapping node value containers. */

--- a/include/fkYAML/Iterator.hpp
+++ b/include/fkYAML/Iterator.hpp
@@ -13,6 +13,7 @@
 #include <iterator>
 
 #include "fkYAML/Exception.hpp"
+#include "fkYAML/NodeTypeTraits.hpp"
 
 /**
  * @namespace fkyaml
@@ -117,6 +118,8 @@ public:
 private:
     /** A type of non-const version of iterated elements. */
     using NonConstValueType = typename std::remove_const<ValueType>::type;
+
+    static_assert(is_basic_node<NonConstValueType>::value, "Iterator only accepts (const) BasicNode<...>");
 
     /**
      * @struct IteratorHolder

--- a/include/fkYAML/LexicalAnalyzer.hpp
+++ b/include/fkYAML/LexicalAnalyzer.hpp
@@ -19,6 +19,7 @@
 
 #include "fkYAML/Assert.hpp"
 #include "fkYAML/Exception.hpp"
+#include "fkYAML/NodeTypeTraits.hpp"
 
 /**
  * @namespace fkyaml
@@ -64,6 +65,8 @@ template <typename BasicNodeType>
 class LexicalAnalyzer
 {
 private:
+    static_assert(is_basic_node<BasicNodeType>::value, "LexicalAnalyzer only accepts (const) BasicNode<...>");
+
     using char_traits_type = std::char_traits<char>;
     using char_int_type = typename char_traits_type::int_type;
 

--- a/include/fkYAML/LexicalAnalyzer.hpp
+++ b/include/fkYAML/LexicalAnalyzer.hpp
@@ -17,6 +17,7 @@
 #include <string>
 #include <vector>
 
+#include "fkYAML/Assert.hpp"
 #include "fkYAML/Exception.hpp"
 
 /**
@@ -323,10 +324,7 @@ public:
      */
     std::nullptr_t GetNull() const
     {
-        if (m_value_buffer.empty())
-        {
-            throw Exception("Value storage is empty.");
-        }
+        FK_YAML_ASSERT(!m_value_buffer.empty());
 
         if (m_value_buffer == "null" || m_value_buffer == "Null" || m_value_buffer == "NULL" || m_value_buffer == "~")
         {
@@ -344,10 +342,7 @@ public:
      */
     boolean_type GetBoolean() const
     {
-        if (m_value_buffer.empty())
-        {
-            throw Exception("Value storage is empty.");
-        }
+        FK_YAML_ASSERT(!m_value_buffer.empty());
 
         if (m_value_buffer == "true" || m_value_buffer == "True" || m_value_buffer == "TRUE")
         {
@@ -369,10 +364,7 @@ public:
      */
     signed_int_type GetSignedInt() const
     {
-        if (m_value_buffer.empty())
-        {
-            throw Exception("Value storage is empty.");
-        }
+        FK_YAML_ASSERT(!m_value_buffer.empty());
 
         char* endptr = nullptr;
         const auto tmp_val = std::strtoll(m_value_buffer.data(), &endptr, 0);
@@ -404,10 +396,7 @@ public:
      */
     unsigned_int_type GetUnsignedInt() const
     {
-        if (m_value_buffer.empty())
-        {
-            throw Exception("Value storage is empty.");
-        }
+        FK_YAML_ASSERT(!m_value_buffer.empty());
 
         char* endptr = nullptr;
         const auto tmp_val = std::strtoull(m_value_buffer.data(), &endptr, 0);
@@ -438,10 +427,7 @@ public:
      */
     float_number_type GetFloatNumber() const
     {
-        if (m_value_buffer.empty())
-        {
-            throw Exception("Value storage is empty.");
-        }
+        FK_YAML_ASSERT(!m_value_buffer.empty());
 
         if (m_value_buffer == ".inf" || m_value_buffer == ".Inf" || m_value_buffer == ".INF")
         {
@@ -532,10 +518,7 @@ private:
      */
     LexicalTokenType ScanComment()
     {
-        if (RefCurrentChar() != '#')
-        {
-            throw Exception("Not the beginning of a comment section.");
-        }
+        FK_YAML_ASSERT(RefCurrentChar() != '#');
 
         while (true)
         {
@@ -1088,6 +1071,7 @@ private:
      */
     const char& RefCurrentChar() const noexcept
     {
+        FK_YAML_ASSERT(m_position_info.total_read_char_counts <= m_input_buffer.size());
         return m_input_buffer[m_position_info.total_read_char_counts];
     }
 
@@ -1098,6 +1082,7 @@ private:
      */
     const char& RefNextChar() const noexcept
     {
+        FK_YAML_ASSERT(m_position_info.total_read_char_counts + 1 <= m_input_buffer.size());
         return m_input_buffer[m_position_info.total_read_char_counts + 1];
     }
 
@@ -1108,6 +1093,8 @@ private:
      */
     const char& GetNextChar() noexcept
     {
+        FK_YAML_ASSERT(m_position_info.total_read_char_counts + 1 <= m_input_buffer.size());
+
         const char current = m_input_buffer[m_position_info.total_read_char_counts];
         const char& next = m_input_buffer[++m_position_info.total_read_char_counts];
         ++m_position_info.read_char_counts_in_line;
@@ -1153,6 +1140,7 @@ private:
         }
 
         size_t pos = m_position_info.total_read_char_counts - 1;
+        FK_YAML_ASSERT(pos < m_input_buffer.size());
         uint32_t indent_width = 0;
         while (pos > 0 && m_input_buffer[pos] != '\r' && m_input_buffer[pos] != '\n')
         {

--- a/include/fkYAML/Node.hpp
+++ b/include/fkYAML/Node.hpp
@@ -9,7 +9,6 @@
 #ifndef FK_YAML_NODE_HPP_
 #define FK_YAML_NODE_HPP_
 
-#include <cassert>
 #include <cstdint>
 #include <cstring>
 #include <map>
@@ -18,6 +17,7 @@
 #include <type_traits>
 #include <vector>
 
+#include "fkYAML/Assert.hpp"
 #include "fkYAML/Exception.hpp"
 #include "fkYAML/Iterator.hpp"
 #include "fkYAML/NodeType.hpp"
@@ -231,7 +231,7 @@ private:
         std::unique_ptr<ObjType, decltype(deleter)> object(AllocTraitsType::allocate(alloc, 1), deleter);
         AllocTraitsType::construct(alloc, object.get(), std::forward<ArgTypes>(args)...);
 
-        assert(object != nullptr);
+        FK_YAML_ASSERT(object != nullptr);
         return object.release();
     }
 
@@ -284,9 +284,11 @@ public:
         {
         case NodeType::SEQUENCE:
             m_node_value.sequence = CreateObject<sequence_type>(*(rhs.m_node_value.sequence));
+            FK_YAML_ASSERT(m_node_value.sequence != nullptr);
             break;
         case NodeType::MAPPING:
             m_node_value.mapping = CreateObject<mapping_type>(*(rhs.m_node_value.mapping));
+            FK_YAML_ASSERT(m_node_value.mapping != nullptr);
             break;
         case NodeType::NULL_OBJECT:
             m_node_value.mapping = nullptr;
@@ -305,6 +307,7 @@ public:
             break;
         case NodeType::STRING:
             m_node_value.str = CreateObject<string_type>(*(rhs.m_node_value.str));
+            FK_YAML_ASSERT(m_node_value.str != nullptr);
             break;
         default:                                               // LCOV_EXCL_LINE
             throw Exception("Not supported node value type."); // LCOV_EXCL_LINE
@@ -314,6 +317,7 @@ public:
         {
             DestroyObject<std::string>(m_anchor_name);
             m_anchor_name = CreateObject<std::string>(*(rhs.m_anchor_name));
+            FK_YAML_ASSERT(m_anchor_name != nullptr);
         }
     }
 
@@ -329,15 +333,18 @@ public:
         switch (m_node_type)
         {
         case NodeType::SEQUENCE:
+            FK_YAML_ASSERT(rhs.m_node_value.sequence != nullptr);
             m_node_value.sequence = rhs.m_node_value.sequence;
             rhs.m_node_value.sequence = nullptr;
             break;
         case NodeType::MAPPING:
+            FK_YAML_ASSERT(rhs.m_node_value.mapping != nullptr);
             m_node_value.mapping = rhs.m_node_value.mapping;
             rhs.m_node_value.mapping = nullptr;
             break;
         case NodeType::NULL_OBJECT:
-            m_node_value.mapping = rhs.m_node_value.mapping = nullptr;
+            FK_YAML_ASSERT(rhs.m_node_value.mapping == nullptr);
+            m_node_value.mapping = rhs.m_node_value.mapping;
             break;
         case NodeType::BOOLEAN:
             m_node_value.boolean = rhs.m_node_value.boolean;
@@ -356,6 +363,7 @@ public:
             rhs.m_node_value.float_val = static_cast<float_number_type>(0.0);
             break;
         case NodeType::STRING:
+            FK_YAML_ASSERT(rhs.m_node_value.str != nullptr);
             m_node_value.str = rhs.m_node_value.str;
             rhs.m_node_value.str = nullptr;
             break;
@@ -390,6 +398,7 @@ public:
         BasicNode node;
         node.m_node_type = NodeType::SEQUENCE;
         node.m_node_value.sequence = CreateObject<sequence_type>();
+        FK_YAML_ASSERT(node.m_node_value.sequence != nullptr);
         return node;
     }
 
@@ -404,6 +413,7 @@ public:
         BasicNode node;
         node.m_node_type = NodeType::SEQUENCE;
         node.m_node_value.sequence = CreateObject<sequence_type>(sequence);
+        FK_YAML_ASSERT(node.m_node_value.sequence != nullptr);
         return node;
     }
 
@@ -418,6 +428,7 @@ public:
         BasicNode node;
         node.m_node_type = NodeType::SEQUENCE;
         node.m_node_value.sequence = CreateObject<sequence_type>(std::move(sequence));
+        FK_YAML_ASSERT(node.m_node_value.sequence != nullptr);
         return node;
     }
 
@@ -431,6 +442,7 @@ public:
         BasicNode node;
         node.m_node_type = NodeType::MAPPING;
         node.m_node_value.mapping = CreateObject<mapping_type>();
+        FK_YAML_ASSERT(node.m_node_value.mapping != nullptr);
         return node;
     }
 
@@ -445,6 +457,7 @@ public:
         BasicNode node;
         node.m_node_type = NodeType::MAPPING;
         node.m_node_value.mapping = CreateObject<mapping_type>(mapping);
+        FK_YAML_ASSERT(node.m_node_value.mapping != nullptr);
         return node;
     }
 
@@ -459,6 +472,7 @@ public:
         BasicNode node;
         node.m_node_type = NodeType::MAPPING;
         node.m_node_value.mapping = CreateObject<mapping_type>(std::move(mapping));
+        FK_YAML_ASSERT(node.m_node_value.mapping != nullptr);
         return node;
     }
 
@@ -528,6 +542,7 @@ public:
         BasicNode node;
         node.m_node_type = NodeType::STRING;
         node.m_node_value.str = CreateObject<string_type>();
+        FK_YAML_ASSERT(node.m_node_value.str != nullptr);
         return node;
     }
 
@@ -542,6 +557,7 @@ public:
         BasicNode node;
         node.m_node_type = NodeType::STRING;
         node.m_node_value.str = CreateObject<string_type>(str);
+        FK_YAML_ASSERT(node.m_node_value.str != nullptr);
         return node;
     }
 
@@ -556,6 +572,7 @@ public:
         BasicNode node;
         node.m_node_type = NodeType::STRING;
         node.m_node_value.str = CreateObject<string_type>(std::move(str));
+        FK_YAML_ASSERT(node.m_node_value.str != nullptr);
         return node;
     }
 
@@ -615,6 +632,8 @@ public:
             throw Exception("The target node is not of a sequence type.");
         }
 
+        FK_YAML_ASSERT(m_node_value.sequence != nullptr);
+        FK_YAML_ASSERT(index < m_node_value.sequence->size());
         return m_node_value.sequence->operator[](index);
     }
 
@@ -631,6 +650,8 @@ public:
             throw Exception("The target node is not of a sequence type.");
         }
 
+        FK_YAML_ASSERT(m_node_value.sequence != nullptr);
+        FK_YAML_ASSERT(index < m_node_value.sequence->size());
         return m_node_value.sequence->operator[](index);
     }
 
@@ -647,6 +668,7 @@ public:
             throw Exception("The target node is not of a mapping type.");
         }
 
+        FK_YAML_ASSERT(m_node_value.mapping != nullptr);
         return m_node_value.mapping->operator[](key);
     }
 
@@ -663,6 +685,7 @@ public:
             throw Exception("The target node is not of a mapping type.");
         }
 
+        FK_YAML_ASSERT(m_node_value.mapping != nullptr);
         return m_node_value.mapping->operator[](key);
     }
 
@@ -679,6 +702,7 @@ public:
             throw Exception("The target node is not of a mapping type.");
         }
 
+        FK_YAML_ASSERT(m_node_value.mapping != nullptr);
         return m_node_value.mapping->operator[](std::move(key));
     }
 
@@ -695,6 +719,7 @@ public:
             throw Exception("The target node is not of a mapping type.");
         }
 
+        FK_YAML_ASSERT(m_node_value.mapping != nullptr);
         return m_node_value.mapping->operator[](std::move(key));
     }
 
@@ -837,10 +862,13 @@ public:
         switch (m_node_type)
         {
         case NodeType::SEQUENCE:
+            FK_YAML_ASSERT(m_node_value.sequence != nullptr);
             return m_node_value.sequence->empty();
         case NodeType::MAPPING:
+            FK_YAML_ASSERT(m_node_value.mapping != nullptr);
             return m_node_value.mapping->empty();
         case NodeType::STRING:
+            FK_YAML_ASSERT(m_node_value.str != nullptr);
             return m_node_value.str->empty();
         default:
             throw Exception("The target node is not of a container type.");
@@ -857,10 +885,13 @@ public:
         switch (m_node_type)
         {
         case NodeType::SEQUENCE:
+            FK_YAML_ASSERT(m_node_value.sequence != nullptr);
             return m_node_value.sequence->size();
         case NodeType::MAPPING:
+            FK_YAML_ASSERT(m_node_value.mapping != nullptr);
             return m_node_value.mapping->size();
         case NodeType::STRING:
+            FK_YAML_ASSERT(m_node_value.str != nullptr);
             return m_node_value.str->size();
         default:
             throw Exception("The target node is not of a container type.");
@@ -879,6 +910,7 @@ public:
         switch (m_node_type)
         {
         case NodeType::MAPPING: {
+            FK_YAML_ASSERT(m_node_value.mapping != nullptr);
             mapping_type& map = *m_node_value.mapping;
             return map.find(key) != map.end();
         }
@@ -899,6 +931,7 @@ public:
         switch (m_node_type)
         {
         case NodeType::MAPPING: {
+            FK_YAML_ASSERT(m_node_value.mapping != nullptr);
             mapping_type& map = *m_node_value.mapping;
             return map.find(std::move(key)) != map.end();
         }
@@ -944,6 +977,7 @@ public:
     {
         DestroyObject<std::string>(m_anchor_name);
         m_anchor_name = CreateObject<std::string>(anchor_name);
+        FK_YAML_ASSERT(m_anchor_name != nullptr);
     }
 
     /**
@@ -956,6 +990,7 @@ public:
     {
         DestroyObject<std::string>(m_anchor_name);
         m_anchor_name = CreateObject<std::string>(std::move(anchor_name));
+        FK_YAML_ASSERT(m_anchor_name != nullptr);
     }
 
     /**
@@ -971,6 +1006,7 @@ public:
             throw Exception("The target node is not of a sequence type.");
         }
 
+        FK_YAML_ASSERT(m_node_value.sequence != nullptr);
         return *(m_node_value.sequence);
     }
 
@@ -987,6 +1023,7 @@ public:
             throw Exception("The target node is not of a sequence type.");
         }
 
+        FK_YAML_ASSERT(m_node_value.sequence != nullptr);
         return *(m_node_value.sequence);
     }
 
@@ -1003,6 +1040,7 @@ public:
             throw Exception("The target node is not of a mapping type.");
         }
 
+        FK_YAML_ASSERT(m_node_value.mapping != nullptr);
         return *(m_node_value.mapping);
     }
 
@@ -1019,6 +1057,7 @@ public:
             throw Exception("The target node is not of a mapping type.");
         }
 
+        FK_YAML_ASSERT(m_node_value.mapping != nullptr);
         return *(m_node_value.mapping);
     }
 
@@ -1163,6 +1202,7 @@ public:
             throw Exception("The target node is not of a string type.");
         }
 
+        FK_YAML_ASSERT(m_node_value.str != nullptr);
         return *(m_node_value.str);
     }
 
@@ -1179,6 +1219,7 @@ public:
             throw Exception("The target node is not of a string type.");
         }
 
+        FK_YAML_ASSERT(m_node_value.str != nullptr);
         return *(m_node_value.str);
     }
 
@@ -1211,8 +1252,10 @@ public:
         switch (m_node_type)
         {
         case NodeType::SEQUENCE:
+            FK_YAML_ASSERT(m_node_value.sequence != nullptr);
             return {fkyaml::SequenceIteratorTag(), m_node_value.sequence->begin()};
         case NodeType::MAPPING:
+            FK_YAML_ASSERT(m_node_value.mapping != nullptr);
             return {fkyaml::MappingIteratorTag(), m_node_value.mapping->begin()};
         default:
             throw Exception("The target node is neither of sequence nor mapping types.");
@@ -1243,8 +1286,10 @@ public:
         switch (m_node_type)
         {
         case NodeType::SEQUENCE:
+            FK_YAML_ASSERT(m_node_value.sequence != nullptr);
             return {fkyaml::SequenceIteratorTag(), m_node_value.sequence->begin()};
         case NodeType::MAPPING:
+            FK_YAML_ASSERT(m_node_value.mapping != nullptr);
             return {fkyaml::MappingIteratorTag(), m_node_value.mapping->begin()};
         default:
             throw Exception("The target node is neither of sequence nor mapping types.");
@@ -1275,8 +1320,10 @@ public:
         switch (m_node_type)
         {
         case NodeType::SEQUENCE:
+            FK_YAML_ASSERT(m_node_value.sequence != nullptr);
             return {fkyaml::SequenceIteratorTag(), m_node_value.sequence->end()};
         case NodeType::MAPPING:
+            FK_YAML_ASSERT(m_node_value.mapping != nullptr);
             return {fkyaml::MappingIteratorTag(), m_node_value.mapping->end()};
         default:
             throw Exception("The target node is neither of sequence nor mapping types.");
@@ -1307,8 +1354,10 @@ public:
         switch (m_node_type)
         {
         case NodeType::SEQUENCE:
+            FK_YAML_ASSERT(m_node_value.sequence != nullptr);
             return {fkyaml::SequenceIteratorTag(), m_node_value.sequence->end()};
         case NodeType::MAPPING:
+            FK_YAML_ASSERT(m_node_value.mapping != nullptr);
             return {fkyaml::MappingIteratorTag(), m_node_value.mapping->end()};
         default:
             throw Exception("The target node is neither of sequence nor mapping types.");

--- a/include/fkYAML/NodeTypeTraits.hpp
+++ b/include/fkYAML/NodeTypeTraits.hpp
@@ -1,0 +1,41 @@
+/**
+ * @file NodeTypeTraits.hpp
+ * @brief Implementation of YAML node data type traits.
+ *
+ * Copyright (c) 2023 fktn
+ * Distributed under the MIT License (https://opensource.org/licenses/MIT)
+ */
+
+#ifndef FK_YAML_NODE_TYPE_TRAITS_HPP_
+#define FK_YAML_NODE_TYPE_TRAITS_HPP_
+
+#include <type_traits>
+
+namespace fkyaml
+{
+
+// forward declaration for fkyaml::BasicNode<...>
+template <
+    template <typename, typename...> class SequenceType, template <typename, typename, typename...> class MappingType,
+    typename BooleanType, typename SignedIntegerType, typename UnsignedIntegerType, typename FloatNumberType,
+    typename StringType>
+class BasicNode;
+
+template <typename T>
+struct is_basic_node : std::false_type
+{
+};
+
+template <
+    template <typename, typename...> class SequenceType, template <typename, typename, typename...> class MappingType,
+    typename BooleanType, typename SignedIntegerType, typename UnsignedIntegerType, typename FloatNumberType,
+    typename StringType>
+struct is_basic_node<BasicNode<
+    SequenceType, MappingType, BooleanType, SignedIntegerType, UnsignedIntegerType, FloatNumberType, StringType>>
+    : std::true_type
+{
+};
+
+} // namespace fkyaml
+
+#endif /* FK_YAML_NODE_TYPE_TRAITS_HPP_ */


### PR DESCRIPTION
Some static/runtime assertion checks have been added to fkYAML library to enhance its testability at compile-time/runtime.  
Runtime assertions can be customized by users by defining their own FK_YAML_ASSERT implementation before including each fkYAML header file.  
