### PR TITLE
#33 Added unit test cases for LexicalAnalyzer class

### DIFF
--- a/include/fkYAML/LexicalAnalyzer.hpp
+++ b/include/fkYAML/LexicalAnalyzer.hpp
@@ -372,10 +372,7 @@ public:
         char* endptr = nullptr;
         const auto tmp_val = std::strtoll(m_value_buffer.data(), &endptr, 0);
 
-        if (endptr != m_value_buffer.data() + m_value_buffer.size())
-        {
-            throw Exception("Failed to convert a string to a signed integer.");
-        }
+        FK_YAML_ASSERT(endptr == m_value_buffer.data() + m_value_buffer.size());
 
         // NOLINTNEXTLINE(google-runtime-int)
         if ((tmp_val == std::numeric_limits<long long>::min() || tmp_val == std::numeric_limits<long long>::max()) &&
@@ -404,10 +401,7 @@ public:
         char* endptr = nullptr;
         const auto tmp_val = std::strtoull(m_value_buffer.data(), &endptr, 0);
 
-        if (endptr != m_value_buffer.data() + m_value_buffer.size())
-        {
-            throw Exception("Failed to convert a string to an unsigned integer.");
-        }
+        FK_YAML_ASSERT(endptr == m_value_buffer.data() + m_value_buffer.size());
 
         // NOLINTNEXTLINE(google-runtime-int)
         if (tmp_val == std::numeric_limits<unsigned long long>::max() && errno == ERANGE)
@@ -451,10 +445,7 @@ public:
         char* endptr = nullptr;
         const double value = std::strtod(m_value_buffer.data(), &endptr);
 
-        if (endptr != m_value_buffer.data() + m_value_buffer.size())
-        {
-            throw Exception("Failed to convert a string to a double.");
-        }
+        FK_YAML_ASSERT(endptr == m_value_buffer.data() + m_value_buffer.size());
 
         if ((value == HUGE_VAL || value == -HUGE_VAL) && errno == ERANGE)
         {
@@ -521,14 +512,14 @@ private:
      */
     LexicalTokenType ScanComment()
     {
-        FK_YAML_ASSERT(RefCurrentChar() != '#');
+        FK_YAML_ASSERT(RefCurrentChar() == '#');
 
         while (true)
         {
             switch (GetNextChar())
             {
             case '\r':
-                if (RefNextChar() == '\r')
+                if (RefNextChar() == '\n')
                 {
                     GetNextChar();
                 }
@@ -555,6 +546,8 @@ private:
         case '-':
             m_value_buffer.push_back(RefCurrentChar());
             return ScanNegativeNumber();
+        case '+':
+            return ScanDecimalNumber();
         case '0':
             m_value_buffer.push_back(RefCurrentChar());
             return ScanNumberAfterZeroAtFirst();

--- a/include/fkYAML/LexicalAnalyzer.hpp
+++ b/include/fkYAML/LexicalAnalyzer.hpp
@@ -675,6 +675,7 @@ private:
         {
             if (m_value_buffer.find(next) != std::string::npos) // NOLINT(abseil-string-find-str-contains)
             {
+                // TODO: support this use case (e.g. version info like 1.0.0)
                 throw Exception("Multiple decimal points found in a token.");
             }
             m_value_buffer.push_back(next);
@@ -847,12 +848,6 @@ private:
                     continue;
                 }
 
-                // Trim trailing spaces already added to m_value_buffer.
-                while (m_value_buffer.back() == ' ')
-                {
-                    m_value_buffer.pop_back();
-                }
-
                 return LexicalTokenType::STRING_VALUE;
             }
 
@@ -896,9 +891,6 @@ private:
                 current = GetNextChar();
                 switch (current)
                 {
-                case '0':
-                    m_value_buffer.push_back('\0');
-                    break;
                 case 'a':
                     m_value_buffer.push_back('\a');
                     break;
@@ -964,8 +956,7 @@ private:
             // Handle unescaped control characters.
             switch (current)
             {
-            case 0x00:
-                throw Exception("Control character U+0000 (NUL) must be escaped to \\0 or \\u0000.");
+            // 0x00(NULL) has already been handled above.
             case 0x01:
                 throw Exception("Control character U+0001 (SOH) must be escaped to \\u0001.");
             case 0x02:

--- a/include/fkYAML/LexicalAnalyzer.hpp
+++ b/include/fkYAML/LexicalAnalyzer.hpp
@@ -131,7 +131,7 @@ public:
 
         const char& current = RefCurrentChar();
 
-        if (isdigit(current))
+        if (0x00 <= current && current <= 0x7F && isdigit(current))
         {
             return ScanNumber();
         }

--- a/include/fkYAML/Node.hpp
+++ b/include/fkYAML/Node.hpp
@@ -400,7 +400,7 @@ public:
         node.m_node_value.sequence = CreateObject<sequence_type>();
         FK_YAML_ASSERT(node.m_node_value.sequence != nullptr);
         return node;
-    }
+    } // LCOV_EXCL_LINE
 
     /**
      * @brief A factory method for sequence BasicNode objects with lvalue sequence_type objects.
@@ -415,7 +415,7 @@ public:
         node.m_node_value.sequence = CreateObject<sequence_type>(sequence);
         FK_YAML_ASSERT(node.m_node_value.sequence != nullptr);
         return node;
-    }
+    } // LCOV_EXCL_LINE
 
     /**
      * @brief A factory method for sequence BasicNode objects with rvalue sequence_type objects.
@@ -430,7 +430,7 @@ public:
         node.m_node_value.sequence = CreateObject<sequence_type>(std::move(sequence));
         FK_YAML_ASSERT(node.m_node_value.sequence != nullptr);
         return node;
-    }
+    } // LCOV_EXCL_LINE
 
     /**
      * @brief A factory method for mapping BasicNode objects without mapping_type objects.
@@ -444,7 +444,7 @@ public:
         node.m_node_value.mapping = CreateObject<mapping_type>();
         FK_YAML_ASSERT(node.m_node_value.mapping != nullptr);
         return node;
-    }
+    } // LCOV_EXCL_LINE
 
     /**
      * @brief A factory method for mapping BasicNode objects with lvalue mapping_type objects.
@@ -459,7 +459,7 @@ public:
         node.m_node_value.mapping = CreateObject<mapping_type>(mapping);
         FK_YAML_ASSERT(node.m_node_value.mapping != nullptr);
         return node;
-    }
+    } // LCOV_EXCL_LINE
 
     /**
      * @brief A factory method for mapping BasicNode objects with rvalue mapping_type objects.
@@ -474,7 +474,7 @@ public:
         node.m_node_value.mapping = CreateObject<mapping_type>(std::move(mapping));
         FK_YAML_ASSERT(node.m_node_value.mapping != nullptr);
         return node;
-    }
+    } // LCOV_EXCL_LINE
 
     /**
      * @brief A factory method for boolean scalar BasicNode objects.
@@ -544,7 +544,7 @@ public:
         node.m_node_value.str = CreateObject<string_type>();
         FK_YAML_ASSERT(node.m_node_value.str != nullptr);
         return node;
-    }
+    } // LCOV_EXCL_LINE
 
     /**
      * @brief A factory method for string BasicNode objects with lvalue string_type objects.
@@ -559,7 +559,7 @@ public:
         node.m_node_value.str = CreateObject<string_type>(str);
         FK_YAML_ASSERT(node.m_node_value.str != nullptr);
         return node;
-    }
+    } // LCOV_EXCL_LINE
 
     /**
      * @brief A factory method for string BasicNode objects with rvalue string_type objects.
@@ -574,7 +574,7 @@ public:
         node.m_node_value.str = CreateObject<string_type>(std::move(str));
         FK_YAML_ASSERT(node.m_node_value.str != nullptr);
         return node;
-    }
+    } // LCOV_EXCL_LINE
 
     /**
      * @brief A factory method for alias BasicNode objects referencing the given anchor BasicNode object.

--- a/test/unit_test/CMakeLists.txt
+++ b/test/unit_test/CMakeLists.txt
@@ -49,7 +49,8 @@ if(FK_YAML_GenerateCoverage)
     COMMAND cd ${PROJECT_BINARY_DIR}/test/unit_test/CMakeFiles/${TEST_TARGET}.dir
     COMMAND ${LCOV_TOOL} --directory . --capture --output-file ${PROJECT_NAME}.info --rc lcov_branch_coverage=1
     COMMAND ${LCOV_TOOL} -e ${PROJECT_NAME}.info ${PROJECT_SOURCE_DIR}/include/fkYAML/*.hpp --output-file ${PROJECT_NAME}.info.filtered --rc lcov_branch_coverage=1
-    COMMAND ${CMAKE_COMMAND} -E copy ${PROJECT_NAME}.info.filtered ${PROJECT_BINARY_DIR}/coverage/fkYAML.info
+    COMMAND ${CMAKE_SOURCE_DIR}/thirdparty/imapdl/filterbr.py ${PROJECT_NAME}.info.filtered > ${PROJECT_NAME}.info.filtered.noexcept
+    COMMAND ${CMAKE_COMMAND} -E copy ${PROJECT_NAME}.info.filtered.noexcept ${PROJECT_BINARY_DIR}/coverage/fkYAML.info
 
     DEPENDS ${TEST_TARGET}
     COMMENT "Execute unit test app with code coverage."

--- a/test/unit_test/LexicalAnalyzerClassTest.cpp
+++ b/test/unit_test/LexicalAnalyzerClassTest.cpp
@@ -387,7 +387,8 @@ TEST_CASE("LexicalAnalyzerClassTest_ScanAliasTokenTest", "[LexicalAnalyzerClassT
 
     SECTION("Test nothrow unexpected tokens with an anchor.")
     {
-        auto buffer = GENERATE(std::string("test: *"), std::string("test: *\r\n"), std::string("test: *\n"), std::string("test: * "));
+        auto buffer = GENERATE(
+            std::string("test: *"), std::string("test: *\r\n"), std::string("test: *\n"), std::string("test: * "));
         lexer.SetInputBuffer(buffer.c_str());
 
         REQUIRE_NOTHROW(token = lexer.GetNextToken());
@@ -404,7 +405,8 @@ TEST_CASE("LexicalAnalyzerClassTest_ScanAliasTokenTest", "[LexicalAnalyzerClassT
 
 TEST_CASE("LexicalAnalyzerClassTest_ScanCommentTokenTest", "[LexicalAnalyzerClassTest]")
 {
-    auto buffer = GENERATE(std::string("# comment\r\n"), std::string("# comment\n"), std::string("# comment"));
+    auto buffer = GENERATE(
+        std::string("# comment\r"), std::string("# comment\r\n"), std::string("# comment\n"), std::string("# comment"));
     fkyaml::LexicalAnalyzer<fkyaml::Node> lexer;
     lexer.SetInputBuffer(buffer.c_str());
     fkyaml::LexicalTokenType token;

--- a/test/unit_test/LexicalAnalyzerClassTest.cpp
+++ b/test/unit_test/LexicalAnalyzerClassTest.cpp
@@ -152,7 +152,10 @@ TEST_CASE("LexicalAnalyzerClassTest_ScanUnsignedDecimalIntegerTokenTest", "[Lexi
 {
     using ValuePair = std::pair<std::string, fkyaml::NodeUnsignedIntType>;
     auto value_pair = GENERATE(
-        ValuePair(std::string("1234"), 1234), ValuePair(std::string("853255"), 853255), ValuePair(std::string("1"), 1), ValuePair(std::string("0"), 0));
+        ValuePair(std::string("1234"), 1234),
+        ValuePair(std::string("853255"), 853255),
+        ValuePair(std::string("1"), 1),
+        ValuePair(std::string("0"), 0));
 
     fkyaml::LexicalAnalyzer<fkyaml::Node> lexer;
     lexer.SetInputBuffer(value_pair.first.c_str());
@@ -194,7 +197,7 @@ TEST_CASE("LexicalAnalyzerClassTest_ScanHexadecimalNumberTokenTest", "[LexicalAn
     lexer.SetInputBuffer(value_pair.first.c_str());
     fkyaml::LexicalTokenType token;
 
-    REQUIRE_NOTHROW(token =lexer.GetNextToken());
+    REQUIRE_NOTHROW(token = lexer.GetNextToken());
     REQUIRE(token == fkyaml::LexicalTokenType::UNSIGNED_INT_VALUE);
     REQUIRE_NOTHROW(lexer.GetUnsignedInt());
     REQUIRE(lexer.GetUnsignedInt() == value_pair.second);

--- a/test/unit_test/LexicalAnalyzerClassTest.cpp
+++ b/test/unit_test/LexicalAnalyzerClassTest.cpp
@@ -48,6 +48,13 @@ TEST_CASE("LexicalAnalyzerClassTest_ScanColonTest", "[LexicalAnalyzerClassTest]"
         REQUIRE(token == fkyaml::LexicalTokenType::KEY_SEPARATOR);
     }
 
+    SECTION("Test colon with CR newline code.")
+    {
+        lexer.SetInputBuffer(":\r");
+        REQUIRE_NOTHROW(token = lexer.GetNextToken());
+        REQUIRE(token == fkyaml::LexicalTokenType::MAPPING_BLOCK_PREFIX);
+    }
+
     SECTION("Test colon with CRLF newline code.")
     {
         lexer.SetInputBuffer(":\r\n");
@@ -278,13 +285,20 @@ TEST_CASE("LexicalAnalyzerClassTest_ScanStringTokenTest", "[LexicalAnalyzerClass
         ValuePair(std::string("nop"), fkyaml::NodeStringType("nop")),
         ValuePair(std::string(".NET"), fkyaml::NodeStringType(".NET")),
         ValuePair(std::string("\"foo:bar\""), fkyaml::NodeStringType("foo:bar")),
+        ValuePair(std::string("\"foo,bar\""), fkyaml::NodeStringType("foo,bar")),
+        ValuePair(std::string("\"foo]bar\""), fkyaml::NodeStringType("foo]bar")),
+        ValuePair(std::string("\"foo}bar\""), fkyaml::NodeStringType("foo}bar")),
         ValuePair(std::string("\"foo\\tbar\""), fkyaml::NodeStringType("foo\tbar")),
         ValuePair(std::string("\"foo\tbar\""), fkyaml::NodeStringType("foo\tbar")),
         ValuePair(std::string("\"foo\\nbar\""), fkyaml::NodeStringType("foo\nbar")),
         ValuePair(std::string("\"foo\\ bar\""), fkyaml::NodeStringType("foo bar")),
         ValuePair(std::string("\"foo\\\"bar\""), fkyaml::NodeStringType("foo\"bar")),
         ValuePair(std::string("\"foo\\/bar\""), fkyaml::NodeStringType("foo/bar")),
-        ValuePair(std::string("\"foo\\\\bar\""), fkyaml::NodeStringType("foo\\bar")));
+        ValuePair(std::string("\"foo\\\\bar\""), fkyaml::NodeStringType("foo\\bar")),
+        ValuePair(std::string("\'foo\'\'bar\'"), fkyaml::NodeStringType("foo\'bar")),
+        ValuePair(std::string("\'foo,bar\'"), fkyaml::NodeStringType("foo,bar")),
+        ValuePair(std::string("\'foo]bar\'"), fkyaml::NodeStringType("foo]bar")),
+        ValuePair(std::string("\'foo}bar\'"), fkyaml::NodeStringType("foo}bar")));
 
     fkyaml::LexicalAnalyzer<fkyaml::Node> lexer;
     lexer.SetInputBuffer(value_pair.first.c_str());
@@ -373,7 +387,7 @@ TEST_CASE("LexicalAnalyzerClassTest_ScanAliasTokenTest", "[LexicalAnalyzerClassT
 
     SECTION("Test nothrow unexpected tokens with an anchor.")
     {
-        auto buffer = GENERATE(std::string("test: *"), std::string("test: *\r\n"), std::string("test: *\n"));
+        auto buffer = GENERATE(std::string("test: *"), std::string("test: *\r\n"), std::string("test: *\n"), std::string("test: * "));
         lexer.SetInputBuffer(buffer.c_str());
 
         REQUIRE_NOTHROW(token = lexer.GetNextToken());

--- a/test/unit_test/NodeClassTest.cpp
+++ b/test/unit_test/NodeClassTest.cpp
@@ -447,6 +447,12 @@ TEST_CASE("NodeClassTest_AliasNodeFactoryTest", "[NodeClassTest]")
         REQUIRE_THROWS_AS(fkyaml::Node::AliasOf(anchor), fkyaml::Exception);
     }
 
+    SECTION("Make sure BasicNode::AliasOf() throws an exception with an empty anchor name.")
+    {
+        anchor.AddAnchorName("");
+        REQUIRE_THROWS_AS(fkyaml::Node::AliasOf(anchor), fkyaml::Exception);
+    }
+
     SECTION("Check if BasicNode::AliasOf() does not throw any exception.")
     {
         anchor.AddAnchorName("anchor_name");

--- a/thirdparty/imapdl/filterbr.py
+++ b/thirdparty/imapdl/filterbr.py
@@ -1,0 +1,111 @@
+#!/usr/bin/env python3
+
+# 2017, Georg Sauthoff <mail@gms.tf>, GPLv3
+# 2022, Alexander Stohr, ZF Friedrichshafen AG: benign handling of UTF-8 violations
+
+import sys
+
+def skip_comments(lines):
+  state = 0
+  for line in lines:
+    n = len(line)
+    l = ''
+    p = 0
+    while p < n:
+      if state == 0:
+        a = line.find('//', p)
+        b = line.find('/*', p)
+        if a > -1 and (a < b or b == -1):
+          l += line[p:a]
+          p = n
+        elif b > -1 and (b < a or a == -1):
+          l += line[p:b]
+          p = b+2
+          state = 1
+        else:
+          l += line[p:]
+          p = n
+      elif state == 1:
+        a = line.rfind('*/', p)
+        if a == -1:
+          p = n
+        else:
+          p = a + 2
+          state = 0
+    yield l
+
+def cond_lines(lines):
+  state = 0
+  pcnt = 0
+  for nr, line in enumerate(lines, 1):
+    if not line:
+      continue
+    n = len(line)
+    p = 0
+    do_yield = False
+    while p < n:
+      if state == 0:
+        p = line.find('if', p)
+        if p == -1:
+          p = n
+          continue
+        if (p == 0 or not line[p-1].isalpha()) \
+            and (p+2 == len(line) or not line[p+2].isalpha()):
+          do_yield = True
+          state = 1
+        p += 2
+      elif state == 1:
+        do_yield = True
+        p = line.find('(', p)
+        if p == -1:
+          p = n
+        else:
+          p += 1
+          state = 2
+          pcnt = 1
+      elif state == 2:
+        do_yield = True
+        for p in range(p, n):
+          if line[p] == '(':
+            pcnt += 1
+          elif line[p] == ')':
+            pcnt -= 1
+          if not pcnt:
+            state = 0
+            break
+        p += 1
+    if do_yield:
+      yield nr
+
+def cond_lines_from_file(filename):
+  with open(filename) as f:
+    yield from cond_lines(skip_comments(f))
+
+def filter_lcov_trace(lines):
+  nrs = set()
+  for line in lines:
+    if line.startswith('SF:'):
+      nrs = set(cond_lines_from_file(line[3:-1]))
+    elif line.startswith('BRDA:'):
+      xs = line[5:].split(',')
+      nr = int(xs[0]) if xs else 0
+      if nr not in nrs:
+        continue
+    yield line
+
+def filter_lcov_trace_file(s_filename, d_file):
+  # encoding is anyways the python default: utf-8
+  # standard error is "strict"; python style escaping is "backslashreplace"; alternate benign handler is "surrogateescape"
+  with open(s_filename, encoding="utf-8", errors="backslashreplace") as f:
+    for l in filter_lcov_trace(f):
+      print(l, end='', file=d_file)
+
+if __name__ == '__main__':
+  #for l in cond_lines_from_file(sys.argv[1]):
+  #  print(l)
+
+  filter_lcov_trace_file(sys.argv[1], sys.stdout)
+
+  #with open(sys.argv[1]) as f:
+  #  for l in skip_comments(f):
+  #    print(l)


### PR DESCRIPTION
Unit test cases against not-yet-covered lines have been added for LexicalAnalyzer class (& some for BasicNode class).  
To correctly gather & upload coverage data, a Python script has also been added from other repository without any changes.  
The script is to be executed when `generate_test_coverage` is the CMake build target (available on local machine & CI workflows).  