### PR TITLE
#14 Support clang-tidy on CI

### DIFF
--- a/.github/workflows/ubuntu.yml
+++ b/.github/workflows/ubuntu.yml
@@ -46,4 +46,4 @@ jobs:
       run: cmake -B ${{github.workspace}}/build_clang_tidy
 
     - name: Clang-Tidy check
-      run: cmake --build ${{github.workflow}}/build_clang_tidy --target run_clang_tidy
+      run: cmake --build ${{github.workspace}}/build_clang_tidy --target run_clang_tidy

--- a/.github/workflows/ubuntu.yml
+++ b/.github/workflows/ubuntu.yml
@@ -11,7 +11,7 @@ on:
   workflow_dispatch:
 
 jobs:
-  build:
+  ubuntu-latest:
     timeout-minutes: 10
     runs-on: ubuntu-latest
     strategy:
@@ -32,3 +32,18 @@ jobs:
     - name: Test
       working-directory: ${{github.workspace}}/build_${{matrix.build_type}}
       run: ctest -C ${{matrix.build_type}} --output-on-failure
+
+  ci-clang_tidy_check:
+    timeout-minutes: 10
+    runs-on: ubuntu-latest
+
+    steps:
+    - uses: actions/checkout@v3
+      with:
+        submodules: recursive
+
+    - name: Configure CMake
+      run: cmake -B ${{github.workspace}}/build_clang_tidy
+
+    - name: Clang-Tidy check
+      run: cmake --build ${{github.workflow}}/build_clang_tidy --target run_clang_tidy

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -56,9 +56,20 @@ else()
   endif()
 endif()
 
+if(FK_YAML_RUN_CLANG_TIDY)
+  set(FK_YAML_RUN_CLANG_TIDY_INIT ON)
+else()
+  if(FK_YAML_IS_MAIN_PROJECT)
+    set(FK_YAML_RUN_CLANG_TIDY_INIT ON)
+  else()
+    set(FK_YAML_RUN_CLANG_TIDY_INIT OFF)
+  endif()
+endif()
+
 if(FK_YAML_CI)
-  # disable execution of clang-format during CI.
+  # disable execution of clang-format/clang-tidy by default during CI.
   set(FK_YAML_RUN_CLANG_FORMAT_INIT OFF)
+  set(FK_YAML_RUN_CLANG_TIDY_INIT OFF)
 endif()
 
 option(FK_YAML_BuildTests     "Build the unit tests when FK_YAML_BUILD_TEST is enabled or if this library is the main target." ${FK_YAML_BUILD_TEST_INIT})
@@ -67,8 +78,9 @@ option(FK_YAML_GenerateCoverage "Build the unit tests with code coverage data if
 option(FK_YAML_Install        "Install CMake targets during install step." ${FK_YAML_IS_MAIN_PROJECT})
 option(FK_YAML_RunDoxygen     "Generate API documentation with doxygen." ${FK_YAML_RUN_DOXYGEN_INIT})
 option(FK_YAML_RunClangFormat "Run clang-format when FK_YAML_RUN_CLANG_FORMAT is enabled or if this library is the main target." ${FK_YAML_RUN_CLANG_FORMAT_INIT})
+option(FK_YAML_RunClangTidy   "Run clang-tidy when FK_YAML_RUN_CLANG_TIDY is enabled or if this library is the main target." ${FK_YAML_RUN_CLANG_TIDY_INIT})
 
-if(FK_YAML_BuildTests OR FK_YAML_RunClangFormat)
+if(FK_YAML_BuildTests OR FK_YAML_RunClangFormat OR FK_YAML_RunClangTidy)
   set(CMAKE_MODULE_PATH "${CMAKE_CURRENT_SOURCE_DIR}/cmake")
   if(FK_YAML_BuildTests)
     set(CMAKE_MODULE_PATH "${CMAKE_MODULE_PATH};${CMAKE_CURRENT_SOURCE_DIR}/thirdparty/catch2/contrib")
@@ -102,18 +114,6 @@ set(FK_YAML_CMAKE_PROJECT_TARGETS_FILE "${FK_YAML_CMAKE_CONFIG_DIR}/${PROJECT_NA
 set(FK_YAML_PKGCONFIG_INSTALL_DIR      "${CMAKE_INSTALL_DATADIR}/pkgconfig")
 
 #
-# Run clang-format if enabled.
-#
-
-if(FK_YAML_RunClangFormat)
-  include(RunClangFormat)
-  run_clang_format(
-    ${FK_YAML_TARGET_NAME}
-    "${CMAKE_CURRENT_SOURCE_DIR}/include/fkYAML/*.hpp"
-  )
-endif()
-
-#
 # Create target and add include path.
 #
 
@@ -127,6 +127,24 @@ target_include_directories(
   $<INSTALL_INTERFACE:${FK_YAML_INCLUDE_INSTALL_DIR}>
 )
 
+# configure clang-format if enabled.
+if(FK_YAML_RunClangFormat)
+  set(FK_YAML_ClangFormatTargetPrefix "run_clang_format_for_")
+  include(RunClangFormat)
+  run_clang_format(
+    ${FK_YAML_TARGET_NAME}
+    "${CMAKE_CURRENT_SOURCE_DIR}/include/fkYAML/*.hpp"
+  )
+endif()
+
+# Configure clang-tidy if enabled.
+# **DO NOT** put the following lines before configuring clang-format for fkYAML library sources
+# to make sure that correctly formatted source files will be tested by clang-tidy.
+if(FK_YAML_RunClangTidy)
+  add_subdirectory(clang_tidy)
+  add_dependencies(ClangTidyHelper "${FK_YAML_ClangFormatTargetPrefix}${FK_YAML_TARGET_NAME}")
+endif()
+
 #
 # Install a pkg-config file, so other tools can find this library.
 #
@@ -135,6 +153,8 @@ configure_file(
   "${CMAKE_CURRENT_SOURCE_DIR}/cmake/pkg-config.pc.in"
   "${CMAKE_CURRENT_BINARY_DIR}/${PROJECT_NAME}.pc"
 )
+
+add_custom_target(build_library ALL DEPENDS ${FK_YAML_TARGET_NAME})
 
 #
 # Create and configure the unit test target.

--- a/clang_tidy/CMakeLists.txt
+++ b/clang_tidy/CMakeLists.txt
@@ -1,0 +1,15 @@
+find_program(CLANG_TIDY_EXE NAMES clang-tidy REQUIRED)
+execute_process(COMMAND ${CLANG_TIDY_EXE} --version OUTPUT_VARIABLE CLANG_TIDY_VERSION ERROR_VARIABLE CLANG_TIDY_VERSION)
+string(REGEX MATCH "[0-9]+(\\.[0-9]+)+" CLANG_TIDY_VERSION "${CLANG_TIDY_VERSION}")
+message(STATUS "Found clang-tidy. location: ${CLANG_TIDY_EXE} version: ${CLANG_TIDY_VERSION}")
+
+set(CMAKE_CXX_CLANG_TIDY "${CLANG_TIDY_EXE};-header-filter=../*")
+set(CMAKE_EXPORT_COMPILE_COMMANDS ON)
+
+add_executable(ClangTidyHelper ClangTidyHelper.cpp)
+target_include_directories(ClangTidyHelper PUBLIC ${FK_YAML_INCLUDE_BUILD_DIR})
+target_compile_options(ClangTidyHelper PUBLIC -O0) # no optimization
+
+add_custom_target(run_clang_tidy DEPENDS ClangTidyHelper)
+
+add_dependencies(${FK_YAML_TARGET_NAME} run_clang_tidy)

--- a/clang_tidy/ClangTidyHelper.cpp
+++ b/clang_tidy/ClangTidyHelper.cpp
@@ -1,0 +1,14 @@
+#include "fkYAML/Assert.hpp"
+#include "fkYAML/Deserializer.hpp"
+#include "fkYAML/Exception.hpp"
+#include "fkYAML/Iterator.hpp"
+#include "fkYAML/LexicalAnalyzer.hpp"
+#include "fkYAML/Node.hpp"
+#include "fkYAML/NodeType.hpp"
+#include "fkYAML/NodeTypeTraits.hpp"
+
+// This is just a dummy main function for compilation.
+int main()
+{
+    return 0;
+}

--- a/cmake/RunClangFormat.cmake
+++ b/cmake/RunClangFormat.cmake
@@ -1,16 +1,24 @@
-find_program(CLANG_FORMAT_EXE clang-format)
+find_program(CLANG_FORMAT_EXE clang-format REQUIRED)
+execute_process(COMMAND ${CLANG_FORMAT_EXE} --version OUTPUT_VARIABLE CLANG_FORMAT_VERSION ERROR_VARIABLE CLANG_FORMAT_VERSION)
+string(REGEX MATCH "[0-9]+(\\.[0-9]+)+" CLANG_FORMAT_VERSION "${CLANG_FORMAT_VERSION}")
+message(STATUS "Found clang-format. location: ${CLANG_FORMAT_EXE} version: ${CLANG_FORMAT_VERSION}")
+
+add_custom_target(run_clang_format)
 
 function(run_clang_format target pattern)
   if(CLANG_FORMAT_EXE)
     message(STATUS "Runs clang-format for ${target}. pattern: ${pattern}")
-    message(STATUS "clang-format location: ${CLANG_FORMAT_EXE}")
-    set(target_for_clang_format "run_clang_format_for_${target}")
+    set(target_for_clang_format "${FK_YAML_ClangFormatTargetPrefix}${target}")
     add_custom_target(
       ${target_for_clang_format}
-      ALL
       COMMAND "${CLANG_FORMAT_EXE}" --version
       COMMAND "${CLANG_FORMAT_EXE}" ${pattern} -i -style=file
+      WORKING_DIRECTORY "${PROJECT_SOURCE_DIR}"
     )
+    # make sure that clang-format is executed before building target sources.
+    add_dependencies(${target} ${target_for_clang_format})
+    # enables running clang-format without building any applications.
+    add_dependencies(run_clang_format ${target_for_clang_format})
   else()
     message(FATAL "Failed to find clang-format.exe")
   endif()

--- a/include/fkYAML/Assert.hpp
+++ b/include/fkYAML/Assert.hpp
@@ -13,9 +13,9 @@
 #ifndef FK_YAML_ASSERT
 #ifndef NDEBUG
 #include <cassert>
-#define FK_YAML_ASSERT(x) assert(x)
+#define FK_YAML_ASSERT(x) assert(x) // NOLINT(cppcoreguidelines-macro-usage)
 #else
-#define FK_YAML_ASSERT(x)
+#define FK_YAML_ASSERT(x) // NOLINT(cppcoreguidelines-macro-usage)
 #endif
 #endif
 

--- a/include/fkYAML/Deserializer.hpp
+++ b/include/fkYAML/Deserializer.hpp
@@ -38,7 +38,7 @@ namespace fkyaml
 template <typename BasicNodeType = Node>
 class BasicDeserializer
 {
-    static_assert(is_basic_node<BasicNodeType>::value, "BasicDeserializer only accepts (const) BasicNode<...>");
+    static_assert(IsBasicNode<BasicNodeType>::value, "BasicDeserializer only accepts (const) BasicNode<...>");
 
     /** A type for sequence node value containers. */
     using sequence_type = typename BasicNodeType::sequence_type;
@@ -79,12 +79,12 @@ public:
 
         m_lexer.SetInputBuffer(source);
         BasicNodeType root = BasicNodeType::Mapping();
-        std::vector<BasicNodeType*> node_stack;
-        std::unordered_map<string_type, BasicNodeType> anchor_table;
+        std::vector<BasicNodeType*> node_stack {};
+        std::unordered_map<string_type, BasicNodeType> anchor_table {};
 
         BasicNodeType* p_current_node = &root;
 
-        string_type anchor_name;
+        string_type anchor_name {};
         bool needs_anchor_impl = false;
 
         LexicalTokenType type = m_lexer.GetNextToken();

--- a/include/fkYAML/Iterator.hpp
+++ b/include/fkYAML/Iterator.hpp
@@ -119,7 +119,7 @@ private:
     /** A type of non-const version of iterated elements. */
     using NonConstValueType = typename std::remove_const<ValueType>::type;
 
-    static_assert(is_basic_node<NonConstValueType>::value, "Iterator only accepts (const) BasicNode<...>");
+    static_assert(IsBasicNode<NonConstValueType>::value, "Iterator only accepts (const) BasicNode<...>");
 
     /**
      * @struct IteratorHolder
@@ -161,7 +161,7 @@ public:
      *
      * @param other An Iterator object to be copied with.
      */
-    Iterator(const Iterator& other) noexcept
+    Iterator(const Iterator& other) noexcept // NOLINT(bugprone-exception-escape)
         : m_inner_iterator_type(other.m_inner_iterator_type)
     {
         switch (m_inner_iterator_type)
@@ -182,7 +182,7 @@ public:
      *
      * @param other An Iterator object to be moved from.
      */
-    Iterator(Iterator&& other) noexcept
+    Iterator(Iterator&& other) noexcept // NOLINT(bugprone-exception-escape)
         : m_inner_iterator_type(other.m_inner_iterator_type)
     {
         switch (m_inner_iterator_type)
@@ -207,7 +207,7 @@ public:
      * @param rhs An Iterator object to be copied with.
      * @return Iterator& Reference to this Iterator object.
      */
-    Iterator& operator=(const Iterator& rhs) noexcept // NOLINT(cert-oop54-cpp)
+    Iterator& operator=(const Iterator& rhs) noexcept // NOLINT(cert-oop54-cpp,bugprone-exception-escape)
     {
         if (&rhs == this)
         {
@@ -236,7 +236,7 @@ public:
      * @param rhs An Iterator object to be moved from.
      * @return Iterator& Reference to this Iterator object.
      */
-    Iterator& operator=(Iterator&& rhs) noexcept
+    Iterator& operator=(Iterator&& rhs) noexcept // NOLINT(bugprone-exception-escape)
     {
         if (&rhs == this)
         {
@@ -264,7 +264,7 @@ public:
      *
      * @return pointer A pointer to the Node object internally referenced by the actual iterator object.
      */
-    pointer operator->() noexcept
+    pointer operator->() noexcept // NOLINT(bugprone-exception-escape)
     {
         switch (m_inner_iterator_type)
         {
@@ -282,7 +282,7 @@ public:
      *
      * @return reference Reference to the Node object internally referenced by the actual iterator object.
      */
-    reference operator*() noexcept
+    reference operator*() noexcept // NOLINT(bugprone-exception-escape)
     {
         switch (m_inner_iterator_type)
         {
@@ -301,7 +301,7 @@ public:
      * @param i The difference from this Iterator object with which it moves forward.
      * @return Iterator& Reference to this Iterator object.
      */
-    Iterator& operator+=(difference_type i)
+    Iterator& operator+=(difference_type i) noexcept // NOLINT(bugprone-exception-escape)
     {
         switch (m_inner_iterator_type)
         {
@@ -323,7 +323,7 @@ public:
      * @param i The difference from this Iterator object.
      * @return Iterator An Iterator object which has been added @a i.
      */
-    Iterator operator+(difference_type i) const
+    Iterator operator+(difference_type i) const noexcept
     {
         auto result = *this;
         result += i;
@@ -335,7 +335,7 @@ public:
      *
      * @return Iterator& Reference to this Iterator object.
      */
-    Iterator& operator++() noexcept
+    Iterator& operator++() noexcept // NOLINT(bugprone-exception-escape)
     {
         switch (m_inner_iterator_type)
         {
@@ -369,7 +369,7 @@ public:
      * @param i The difference from this Iterator object with which it moves backward.
      * @return Iterator& Reference to this Iterator object.
      */
-    Iterator& operator-=(difference_type i)
+    Iterator& operator-=(difference_type i) noexcept // NOLINT(bugprone-exception-escape)
     {
         return operator+=(-i);
     }
@@ -380,7 +380,7 @@ public:
      * @param i The difference from this Iterator object.
      * @return Iterator An Iterator object from which has been subtracted @ i.
      */
-    Iterator operator-(difference_type i)
+    Iterator operator-(difference_type i) noexcept
     {
         auto result = *this;
         result -= i;
@@ -392,7 +392,7 @@ public:
      *
      * @return Iterator& Reference to this Iterator object.
      */
-    Iterator& operator--() noexcept
+    Iterator& operator--() noexcept // NOLINT(bugprone-exception-escape)
     {
         switch (m_inner_iterator_type)
         {
@@ -537,7 +537,7 @@ public:
         }
     }
 
-    reference Value() noexcept
+    reference Value() noexcept // NOLINT(bugprone-exception-escape)
     {
         return operator*();
     }

--- a/include/fkYAML/LexicalAnalyzer.hpp
+++ b/include/fkYAML/LexicalAnalyzer.hpp
@@ -65,7 +65,7 @@ template <typename BasicNodeType>
 class LexicalAnalyzer
 {
 private:
-    static_assert(is_basic_node<BasicNodeType>::value, "LexicalAnalyzer only accepts (const) BasicNode<...>");
+    static_assert(IsBasicNode<BasicNodeType>::value, "LexicalAnalyzer only accepts (const) BasicNode<...>");
 
     using char_traits_type = std::char_traits<char>;
     using char_int_type = typename char_traits_type::int_type;

--- a/include/fkYAML/Node.hpp
+++ b/include/fkYAML/Node.hpp
@@ -326,7 +326,7 @@ public:
      *
      * @param[in] rhs A BasicNode object to be moved from.
      */
-    BasicNode(BasicNode&& rhs) noexcept
+    BasicNode(BasicNode&& rhs) noexcept // NOLINT(bugprone-exception-escape)
         : m_node_type(rhs.m_node_type),
           m_anchor_name(rhs.m_anchor_name)
     {

--- a/include/fkYAML/NodeTypeTraits.hpp
+++ b/include/fkYAML/NodeTypeTraits.hpp
@@ -22,7 +22,7 @@ template <
 class BasicNode;
 
 template <typename T>
-struct is_basic_node : std::false_type
+struct IsBasicNode : std::false_type
 {
 };
 
@@ -30,7 +30,7 @@ template <
     template <typename, typename...> class SequenceType, template <typename, typename, typename...> class MappingType,
     typename BooleanType, typename SignedIntegerType, typename UnsignedIntegerType, typename FloatNumberType,
     typename StringType>
-struct is_basic_node<BasicNode<
+struct IsBasicNode<BasicNode<
     SequenceType, MappingType, BooleanType, SignedIntegerType, UnsignedIntegerType, FloatNumberType, StringType>>
     : std::true_type
 {

--- a/test/unit_test/CMakeLists.txt
+++ b/test/unit_test/CMakeLists.txt
@@ -16,13 +16,6 @@ add_sanitizer_flags(${FK_YAML_RunSanitizers})
 
 set(TEST_TARGET "fkYAMLUnitTest")
 
-if(${FK_YAML_RunClangFormat})
-  run_clang_format(
-    ${TEST_TARGET}
-    "${CMAKE_CURRENT_SOURCE_DIR}/*.cpp"
-  )
-endif()
-
 add_executable(${TEST_TARGET}
   ExceptionClassTest.cpp
   NodeClassTest.cpp
@@ -31,6 +24,27 @@ add_executable(${TEST_TARGET}
   DeserializerClassTest.cpp
   main.cpp
 )
+
+target_include_directories(${TEST_TARGET} PRIVATE
+  ${PROJECT_SOURCE_DIR}/include
+  ${CMAKE_CURRENT_SOURCE_DIR}
+)
+
+target_link_libraries(${TEST_TARGET}
+  Catch2::Catch2
+)
+
+include(Catch)
+catch_discover_tests(${TEST_TARGET})
+
+add_dependencies(${TEST_TARGET} build_library)
+
+if(${FK_YAML_RunClangFormat})
+  run_clang_format(
+    ${TEST_TARGET}
+    "${CMAKE_CURRENT_SOURCE_DIR}/*.cpp"
+  )
+endif()
 
 if(FK_YAML_GenerateCoverage)
   target_compile_options(${TEST_TARGET} PRIVATE
@@ -56,15 +70,3 @@ if(FK_YAML_GenerateCoverage)
     COMMENT "Execute unit test app with code coverage."
   )
 endif()
-
-target_include_directories(${TEST_TARGET} PRIVATE
-  ${PROJECT_SOURCE_DIR}/include
-  ${CMAKE_CURRENT_SOURCE_DIR}
-)
-
-target_link_libraries(${TEST_TARGET}
-  Catch2::Catch2
-)
-
-include(Catch)
-catch_discover_tests(${TEST_TARGET})


### PR DESCRIPTION
Clang-tidy is supported in CMake scripts for fkYAML library.  
It is configured to be running:
- when fkYAML library is the main CMake target (specify `-DFK_YAML_RunClangTidy=OFF` to disable this configuration)
- or when source code changes detected by GitHub Actions.  

