### PR TITLE
#61 Support YAML version directives

### DIFF
--- a/include/fkYAML/Deserializer.hpp
+++ b/include/fkYAML/Deserializer.hpp
@@ -87,6 +87,8 @@ public:
         string_type anchor_name {};
         bool needs_anchor_impl = false;
 
+        string_type yaml_version {};
+
         LexicalTokenType type = m_lexer.GetNextToken();
         while (type != LexicalTokenType::END_OF_BUFFER)
         {
@@ -146,7 +148,19 @@ public:
                 break;
             }
             case LexicalTokenType::COMMENT_PREFIX:
-            case LexicalTokenType::DIRECTIVE_PREFIX:
+                break;
+            case LexicalTokenType::YAML_VER_DIRECTIVE: {
+                if (!yaml_version.empty())
+                {
+                    throw Exception("YAML version cannot be specified more than once in the same YAML document.");
+                }
+                yaml_version = m_lexer.GetYamlVersion();
+                break;
+            }
+            case LexicalTokenType::TAG_DIRECTIVE:
+                // TODO: implement tag directive deserialization.
+            case LexicalTokenType::INVALID_DIRECTIVE:
+                // TODO: should output a warning log. Currently just ignore this case.
                 break;
             case LexicalTokenType::SEQUENCE_BLOCK_PREFIX:
                 if (p_current_node->IsNull())

--- a/include/fkYAML/Deserializer.hpp
+++ b/include/fkYAML/Deserializer.hpp
@@ -87,7 +87,7 @@ public:
         string_type anchor_name {};
         bool needs_anchor_impl = false;
 
-        string_type yaml_version {};
+        YamlVersionType yaml_version {YamlVersionType::VER_1_2};
 
         LexicalTokenType type = m_lexer.GetNextToken();
         while (type != LexicalTokenType::END_OF_BUFFER)
@@ -107,9 +107,11 @@ public:
                     p_current_node->operator[](0) = BasicNodeType::Mapping();
                     node_stack.emplace_back(p_current_node);
                     p_current_node = &(p_current_node->operator[](0));
+                    p_current_node->SetVersion(yaml_version);
                     p_current_node->ToMapping().emplace(tmp_str, BasicNodeType());
                     node_stack.emplace_back(p_current_node);
                     p_current_node = &(p_current_node->operator[](tmp_str));
+                    p_current_node->SetVersion(yaml_version);
                 }
                 break;
             case LexicalTokenType::VALUE_SEPARATOR:
@@ -140,6 +142,7 @@ public:
                 if (p_current_node->IsSequence())
                 {
                     p_current_node->ToSequence().emplace_back(BasicNodeType::AliasOf(anchor_table.at(anchor_name)));
+                    p_current_node->ToSequence().back().SetVersion(yaml_version);
                     anchor_name.clear();
                     break;
                 }
@@ -150,11 +153,9 @@ public:
             case LexicalTokenType::COMMENT_PREFIX:
                 break;
             case LexicalTokenType::YAML_VER_DIRECTIVE: {
-                if (!yaml_version.empty())
-                {
-                    throw Exception("YAML version cannot be specified more than once in the same YAML document.");
-                }
-                yaml_version = m_lexer.GetYamlVersion();
+                FK_YAML_ASSERT(p_current_node == &root);
+                yaml_version = ConvertToVersionType(m_lexer.GetYamlVersion());
+                p_current_node->SetVersion(yaml_version);
                 break;
             }
             case LexicalTokenType::TAG_DIRECTIVE:
@@ -166,6 +167,7 @@ public:
                 if (p_current_node->IsNull())
                 {
                     *p_current_node = BasicNodeType::Sequence();
+                    p_current_node->SetVersion(yaml_version);
                     break;
                 }
                 if (p_current_node->IsMapping())
@@ -179,6 +181,7 @@ public:
                     // for the second or later mapping items in a sequence node.
                     node_stack.back()->ToSequence().emplace_back(BasicNodeType::Mapping());
                     p_current_node = &(node_stack.back()->ToSequence().back());
+                    p_current_node->SetVersion(yaml_version);
                     break;
                 }
                 if (!p_current_node->IsSequence())
@@ -192,6 +195,7 @@ public:
                     throw Exception("Cannot assign a sequence value as a key.");
                 }
                 *p_current_node = BasicNodeType::Sequence();
+                p_current_node->SetVersion(yaml_version);
                 break;
             case LexicalTokenType::SEQUENCE_FLOW_END:
                 if (!p_current_node->IsSequence())
@@ -207,6 +211,7 @@ public:
                     throw Exception("Cannot assign a mapping value as a key.");
                 }
                 *p_current_node = BasicNodeType::Mapping();
+                p_current_node->SetVersion(yaml_version);
                 break;
             case LexicalTokenType::MAPPING_FLOW_BEGIN:
                 if (p_current_node->IsMapping())
@@ -214,6 +219,7 @@ public:
                     throw Exception("Cannot assign a mapping value as a key.");
                 }
                 *p_current_node = BasicNodeType::Mapping();
+                p_current_node->SetVersion(yaml_version);
                 break;
             case LexicalTokenType::MAPPING_FLOW_END:
                 if (!p_current_node->IsMapping())
@@ -236,8 +242,13 @@ public:
                 if (p_current_node->IsSequence())
                 {
                     p_current_node->ToSequence().emplace_back();
+                    p_current_node->ToSequence().back().SetVersion(yaml_version);
+                    break;
                 }
 
+                p_current_node->SetVersion(yaml_version);
+                p_current_node = node_stack.back();
+                node_stack.pop_back();
                 break;
             case LexicalTokenType::BOOLEAN_VALUE:
                 if (p_current_node->IsMapping())
@@ -248,6 +259,7 @@ public:
                 if (p_current_node->IsSequence())
                 {
                     p_current_node->ToSequence().emplace_back(BasicNodeType::BooleanScalar(m_lexer.GetBoolean()));
+                    p_current_node->ToSequence().back().SetVersion(yaml_version);
                     if (needs_anchor_impl)
                     {
                         p_current_node->ToSequence().back().AddAnchorName(anchor_name);
@@ -255,20 +267,20 @@ public:
                         needs_anchor_impl = false;
                         anchor_name.clear();
                     }
+                    break;
                 }
-                else // a scalar node
+                // a scalar node
+                *p_current_node = BasicNodeType::BooleanScalar(m_lexer.GetBoolean());
+                p_current_node->SetVersion(yaml_version);
+                if (needs_anchor_impl)
                 {
-                    *p_current_node = BasicNodeType::BooleanScalar(m_lexer.GetBoolean());
-                    if (needs_anchor_impl)
-                    {
-                        p_current_node->AddAnchorName(anchor_name);
-                        anchor_table[anchor_name] = *p_current_node;
-                        needs_anchor_impl = false;
-                        anchor_name.clear();
-                    }
-                    p_current_node = node_stack.back();
-                    node_stack.pop_back();
+                    p_current_node->AddAnchorName(anchor_name);
+                    anchor_table[anchor_name] = *p_current_node;
+                    needs_anchor_impl = false;
+                    anchor_name.clear();
                 }
+                p_current_node = node_stack.back();
+                node_stack.pop_back();
                 break;
             case LexicalTokenType::SIGNED_INT_VALUE:
                 if (p_current_node->IsMapping())
@@ -280,6 +292,7 @@ public:
                 {
                     p_current_node->ToSequence().emplace_back(
                         BasicNodeType::SignedIntegerScalar(m_lexer.GetSignedInt()));
+                    p_current_node->ToSequence().back().SetVersion(yaml_version);
                     if (needs_anchor_impl)
                     {
                         p_current_node->ToSequence().back().AddAnchorName(anchor_name);
@@ -287,20 +300,20 @@ public:
                         needs_anchor_impl = false;
                         anchor_name.clear();
                     }
+                    break;
                 }
-                else // a scalar node
+                // a scalar node
+                *p_current_node = BasicNodeType::SignedIntegerScalar(m_lexer.GetSignedInt());
+                p_current_node->SetVersion(yaml_version);
+                if (needs_anchor_impl)
                 {
-                    *p_current_node = BasicNodeType::SignedIntegerScalar(m_lexer.GetSignedInt());
-                    if (needs_anchor_impl)
-                    {
-                        p_current_node->AddAnchorName(anchor_name);
-                        anchor_table[anchor_name] = *p_current_node;
-                        needs_anchor_impl = false;
-                        anchor_name.clear();
-                    }
-                    p_current_node = node_stack.back();
-                    node_stack.pop_back();
+                    p_current_node->AddAnchorName(anchor_name);
+                    anchor_table[anchor_name] = *p_current_node;
+                    needs_anchor_impl = false;
+                    anchor_name.clear();
                 }
+                p_current_node = node_stack.back();
+                node_stack.pop_back();
                 break;
             case LexicalTokenType::UNSIGNED_INT_VALUE:
                 if (p_current_node->IsMapping())
@@ -312,6 +325,7 @@ public:
                 {
                     p_current_node->ToSequence().emplace_back(
                         BasicNodeType::UnsignedIntegerScalar(m_lexer.GetUnsignedInt()));
+                    p_current_node->ToSequence().back().SetVersion(yaml_version);
                     if (needs_anchor_impl)
                     {
                         p_current_node->ToSequence().back().AddAnchorName(anchor_name);
@@ -319,20 +333,19 @@ public:
                         needs_anchor_impl = false;
                         anchor_name.clear();
                     }
+                    break;
                 }
-                else
+                // a scalar node
+                *p_current_node = BasicNodeType::UnsignedIntegerScalar(m_lexer.GetUnsignedInt());
+                if (needs_anchor_impl)
                 {
-                    *p_current_node = BasicNodeType::UnsignedIntegerScalar(m_lexer.GetUnsignedInt());
-                    if (needs_anchor_impl)
-                    {
-                        p_current_node->AddAnchorName(anchor_name);
-                        anchor_table[anchor_name] = *p_current_node;
-                        needs_anchor_impl = false;
-                        anchor_name.clear();
-                    }
-                    p_current_node = node_stack.back();
-                    node_stack.pop_back();
+                    p_current_node->AddAnchorName(anchor_name);
+                    anchor_table[anchor_name] = *p_current_node;
+                    needs_anchor_impl = false;
+                    anchor_name.clear();
                 }
+                p_current_node = node_stack.back();
+                node_stack.pop_back();
                 break;
             case LexicalTokenType::FLOAT_NUMBER_VALUE:
                 if (p_current_node->IsMapping())
@@ -344,6 +357,7 @@ public:
                 {
                     p_current_node->ToSequence().emplace_back(
                         BasicNodeType::FloatNumberScalar(m_lexer.GetFloatNumber()));
+                    p_current_node->ToSequence().back().SetVersion(yaml_version);
                     if (needs_anchor_impl)
                     {
                         p_current_node->ToSequence().back().AddAnchorName(anchor_name);
@@ -351,20 +365,20 @@ public:
                         needs_anchor_impl = false;
                         anchor_name.clear();
                     }
+                    break;
                 }
-                else // a scalar
+                // a scalar node
+                *p_current_node = BasicNodeType::FloatNumberScalar(m_lexer.GetFloatNumber());
+                p_current_node->SetVersion(yaml_version);
+                if (needs_anchor_impl)
                 {
-                    *p_current_node = BasicNodeType::FloatNumberScalar(m_lexer.GetFloatNumber());
-                    if (needs_anchor_impl)
-                    {
-                        p_current_node->AddAnchorName(anchor_name);
-                        anchor_table[anchor_name] = *p_current_node;
-                        needs_anchor_impl = false;
-                        anchor_name.clear();
-                    }
-                    p_current_node = node_stack.back();
-                    node_stack.pop_back();
+                    p_current_node->AddAnchorName(anchor_name);
+                    anchor_table[anchor_name] = *p_current_node;
+                    needs_anchor_impl = false;
+                    anchor_name.clear();
                 }
+                p_current_node = node_stack.back();
+                node_stack.pop_back();
                 break;
             case LexicalTokenType::STRING_VALUE:
                 if (p_current_node->IsMapping())
@@ -377,6 +391,7 @@ public:
                 if (p_current_node->IsSequence())
                 {
                     p_current_node->ToSequence().emplace_back(BasicNodeType::StringScalar(m_lexer.GetString()));
+                    p_current_node->ToSequence().back().SetVersion(yaml_version);
                     if (needs_anchor_impl)
                     {
                         p_current_node->ToSequence().back().AddAnchorName(anchor_name);
@@ -388,6 +403,7 @@ public:
                 }
                 // a scalar node
                 *p_current_node = BasicNodeType::StringScalar(m_lexer.GetString());
+                p_current_node->SetVersion(yaml_version);
                 if (needs_anchor_impl)
                 {
                     p_current_node->AddAnchorName(anchor_name);
@@ -406,6 +422,22 @@ public:
         }
 
         return root;
+    }
+
+private:
+    /**
+     * @brief Convert a YAML version string to YAMLVersionType object.
+     *
+     * @param version_str A YAML version string.
+     * @return YamlVersionType A converted YAMLVersionType object.
+     */
+    YamlVersionType ConvertToVersionType(const string_type& version_str) const noexcept
+    {
+        if (version_str == "1.1")
+        {
+            return YamlVersionType::VER_1_1;
+        }
+        return YamlVersionType::VER_1_2;
     }
 
 private:

--- a/include/fkYAML/LexicalAnalyzer.hpp
+++ b/include/fkYAML/LexicalAnalyzer.hpp
@@ -831,10 +831,21 @@ private:
 
         for (;; current = GetNextChar())
         {
+            if (current == ' ')
+            {
+                if (!needs_last_double_quote && !needs_last_single_quote)
+                {
+                    return LexicalTokenType::STRING_VALUE;
+                }
+                m_value_buffer.push_back(current);
+                continue;
+            }
+
             if (current == '\"')
             {
                 if (needs_last_double_quote)
                 {
+                    GetNextChar();
                     return LexicalTokenType::STRING_VALUE;
                 }
 

--- a/include/fkYAML/LexicalAnalyzer.hpp
+++ b/include/fkYAML/LexicalAnalyzer.hpp
@@ -435,7 +435,7 @@ public:
 
     /**
      * @brief Get the YAML version specification.
-     * 
+     *
      * @return const string_type& A YAML version specification.
      */
     const string_type& GetYamlVersion() const
@@ -502,7 +502,7 @@ private:
     /**
      * @brief Scan directives starting with the prefix '%'
      * @note Currently, only %YAML directive is supported. If not, returns invalid or throws an exception.
-     * 
+     *
      * @return LexicalTokenType The lexical token type for directives.
      */
     LexicalTokenType ScanDirective()
@@ -544,7 +544,7 @@ private:
     /**
      * @brief Scan a YAML version directive.
      * @note Only 1.1 and 1.2 are supported. If not, throws an exception.
-     * 
+     *
      * @return LexicalTokenType The lexical token type for YAML version directives.
      */
     LexicalTokenType ScanYamlVersionDirective()

--- a/include/fkYAML/LexicalAnalyzer.hpp
+++ b/include/fkYAML/LexicalAnalyzer.hpp
@@ -490,22 +490,8 @@ private:
     {
         FK_YAML_ASSERT(RefCurrentChar() == '#');
 
-        while (true)
-        {
-            switch (GetNextChar())
-            {
-            case '\r':
-                if (RefNextChar() == '\n')
-                {
-                    GetNextChar();
-                }
-            case '\n':
-            case '\0':
-                return LexicalTokenType::COMMENT_PREFIX;
-            default:
-                break;
-            }
-        }
+        SkipUntilLineEnd();
+        return LexicalTokenType::COMMENT_PREFIX;
     }
 
     LexicalTokenType ScanDirective()
@@ -517,23 +503,8 @@ private:
         case 'T': {
             if (GetNextChar() != 'A' || GetNextChar() != 'G')
             {
-                while (true)
-                {
-                    // skip reading until the end of input buffer or the next line.
-                    switch (RefCurrentChar())
-                    {
-                    case '\r':
-                        if (RefNextChar() == '\n')
-                        {
-                            GetNextChar();
-                        }
-                    case '\n':
-                        GetNextChar();
-                    case '\0':
-                        return LexicalTokenType::INVALID_DIRECTIVE;
-                    }
-                    GetNextChar();
-                }
+                SkipUntilLineEnd();
+                return LexicalTokenType::INVALID_DIRECTIVE;
             }
             if (GetNextChar() != ' ')
             {
@@ -545,23 +516,8 @@ private:
         case 'Y':
             if (GetNextChar() != 'A' || GetNextChar() != 'M' || GetNextChar() != 'L')
             {
-                while (true)
-                {
-                    // skip reading until the next line or the end of input buffer.
-                    switch (RefCurrentChar())
-                    {
-                    case '\r':
-                        if (RefNextChar() == '\n')
-                        {
-                            GetNextChar();
-                        }
-                    case '\n':
-                        GetNextChar();
-                    case '\0':
-                        return LexicalTokenType::INVALID_DIRECTIVE;
-                    }
-                    GetNextChar();
-                }
+                SkipUntilLineEnd();
+                return LexicalTokenType::INVALID_DIRECTIVE;
             }
             if (GetNextChar() != ' ')
             {
@@ -569,23 +525,8 @@ private:
             }
             return ScanYamlVersionDirective();
         default:
-            while (true)
-            {
-                // skip reading until the next line or the end of input buffer.
-                switch (RefCurrentChar())
-                {
-                case '\r':
-                    if (RefNextChar() == '\n')
-                    {
-                        GetNextChar();
-                    }
-                case '\n':
-                    GetNextChar();
-                case '\0':
-                    return LexicalTokenType::INVALID_DIRECTIVE;
-                }
-                GetNextChar();
-            }
+            SkipUntilLineEnd();
+            return LexicalTokenType::INVALID_DIRECTIVE;
         }
     }
 
@@ -1218,6 +1159,26 @@ private:
             case '\r':
                 break;
             default:
+                return;
+            }
+            GetNextChar();
+        }
+    }
+
+    void SkipUntilLineEnd()
+    {
+        while (true)
+        {
+            switch (RefCurrentChar())
+            {
+            case '\r':
+                if (RefNextChar() == '\n')
+                {
+                    GetNextChar();
+                }
+            case '\n':
+                GetNextChar();
+            case '\0':
                 return;
             }
             GetNextChar();

--- a/include/fkYAML/LexicalAnalyzer.hpp
+++ b/include/fkYAML/LexicalAnalyzer.hpp
@@ -433,6 +433,11 @@ public:
         return m_value_buffer;
     }
 
+    /**
+     * @brief Get the YAML version specification.
+     * 
+     * @return const string_type& A YAML version specification.
+     */
     const string_type& GetYamlVersion() const
     {
         FK_YAML_ASSERT(!m_value_buffer.empty() && m_value_buffer.size() == 3);
@@ -494,6 +499,12 @@ private:
         return LexicalTokenType::COMMENT_PREFIX;
     }
 
+    /**
+     * @brief Scan directives starting with the prefix '%'
+     * @note Currently, only %YAML directive is supported. If not, returns invalid or throws an exception.
+     * 
+     * @return LexicalTokenType The lexical token type for directives.
+     */
     LexicalTokenType ScanDirective()
     {
         FK_YAML_ASSERT(RefCurrentChar() == '%');
@@ -530,6 +541,12 @@ private:
         }
     }
 
+    /**
+     * @brief Scan a YAML version directive.
+     * @note Only 1.1 and 1.2 are supported. If not, throws an exception.
+     * 
+     * @return LexicalTokenType The lexical token type for YAML version directives.
+     */
     LexicalTokenType ScanYamlVersionDirective()
     {
         m_value_buffer.clear();
@@ -1165,6 +1182,9 @@ private:
         }
     }
 
+    /**
+     * @brief Skip reading in the current line.
+     */
     void SkipUntilLineEnd()
     {
         while (true)

--- a/include/fkYAML/LexicalAnalyzer.hpp
+++ b/include/fkYAML/LexicalAnalyzer.hpp
@@ -646,18 +646,15 @@ private:
             return (ret == LexicalTokenType::FLOAT_NUMBER_VALUE) ? ret : LexicalTokenType::SIGNED_INT_VALUE;
         }
 
-        if (next == '.')
+        const std::string tmp_str = m_input_buffer.substr(m_position_info.total_read_char_counts, 4);
+        if (tmp_str == ".inf" || tmp_str == ".Inf" || tmp_str == ".INF")
         {
-            const std::string tmp_str = m_input_buffer.substr(m_position_info.total_read_char_counts, 4);
-            if (tmp_str == ".inf" || tmp_str == ".Inf" || tmp_str == ".INF")
+            m_value_buffer += tmp_str;
+            for (int i = 0; i < 4; ++i)
             {
-                m_value_buffer += tmp_str;
-                for (int i = 0; i < 4; ++i)
-                {
-                    GetNextChar();
-                }
-                return LexicalTokenType::FLOAT_NUMBER_VALUE;
+                GetNextChar();
             }
+            return LexicalTokenType::FLOAT_NUMBER_VALUE;
         }
         throw Exception("Invalid character found in a negative number token."); // LCOV_EXCL_LINE
     }

--- a/include/fkYAML/Node.hpp
+++ b/include/fkYAML/Node.hpp
@@ -21,6 +21,7 @@
 #include "fkYAML/Exception.hpp"
 #include "fkYAML/Iterator.hpp"
 #include "fkYAML/NodeType.hpp"
+#include "fkYAML/YAMLVersionType.hpp"
 
 /**
  * @namespace fkyaml
@@ -583,7 +584,7 @@ public:
      * @param anchor_node An anchor node to be referenced by the newly constructed BasicNode object.
      * @return BasicNode A constructed BasicNode object of alias type.
      */
-    static BasicNode AliasOf(BasicNode& anchor_node)
+    static BasicNode AliasOf(const BasicNode& anchor_node)
     {
         if (!anchor_node.m_anchor_name || anchor_node.m_anchor_name->empty())
         {
@@ -938,6 +939,26 @@ public:
         default:
             return false;
         }
+    }
+
+    /**
+     * @brief Get the YAML version specification for this BasicNode object.
+     *
+     * @return YamlVersionType The YAML version specification.
+     */
+    YamlVersionType GetVersion() const noexcept
+    {
+        return m_yaml_version_type;
+    }
+
+    /**
+     * @brief Set the YAML version specification for this BasicNode object.
+     *
+     * @param version The YAML version specification.
+     */
+    void SetVersion(const YamlVersionType version) noexcept
+    {
+        m_yaml_version_type = version;
     }
 
     /**
@@ -1380,6 +1401,8 @@ public:
 private:
     /** The current node value type. */
     NodeType m_node_type {NodeType::NULL_OBJECT};
+    /** The YAML version specification. */
+    YamlVersionType m_yaml_version_type {YamlVersionType::VER_1_2};
     /** The current node value. */
     NodeValue m_node_value {};
     /** The anchor name for this node. */

--- a/include/fkYAML/Node.hpp
+++ b/include/fkYAML/Node.hpp
@@ -279,7 +279,8 @@ public:
      * @param[in] rhs A BasicNode object to be copied with.
      */
     BasicNode(const BasicNode& rhs)
-        : m_node_type(rhs.m_node_type)
+        : m_node_type(rhs.m_node_type),
+          m_yaml_version_type(rhs.m_yaml_version_type)
     {
         switch (m_node_type)
         {
@@ -329,7 +330,8 @@ public:
      */
     BasicNode(BasicNode&& rhs) noexcept // NOLINT(bugprone-exception-escape)
         : m_node_type(rhs.m_node_type),
-          m_anchor_name(rhs.m_anchor_name)
+          m_anchor_name(rhs.m_anchor_name),
+          m_yaml_version_type(rhs.m_yaml_version_type)
     {
         switch (m_node_type)
         {
@@ -373,6 +375,7 @@ public:
         }
 
         rhs.m_node_type = NodeType::NULL_OBJECT;
+        rhs.m_yaml_version_type = YamlVersionType::VER_1_2;
         rhs.m_node_value.mapping = nullptr;
         rhs.m_anchor_name = nullptr;
     }
@@ -1253,6 +1256,7 @@ public:
     {
         using std::swap;
         swap(m_node_type, rhs.m_node_type);
+        swap(m_yaml_version_type, rhs.m_yaml_version_type);
 
         NodeValue tmp {};
         std::memcpy(&tmp, &m_node_value, sizeof(NodeValue));

--- a/include/fkYAML/NodeType.hpp
+++ b/include/fkYAML/NodeType.hpp
@@ -9,6 +9,8 @@
 #ifndef FK_YAML_NODE_TYPE_HPP_
 #define FK_YAML_NODE_TYPE_HPP_
 
+#include <cstdint>
+
 /**
  * @namespace fkyaml
  * @brief namespace for fkYAML library.
@@ -20,7 +22,7 @@ namespace fkyaml
  * @enum NodeType
  * @brief Definition of node value types.
  */
-enum class NodeType
+enum class NodeType : std::uint32_t
 {
     SEQUENCE,         //!< sequence value type
     MAPPING,          //!< mapping value type

--- a/include/fkYAML/YAMLVersionType.hpp
+++ b/include/fkYAML/YAMLVersionType.hpp
@@ -1,0 +1,29 @@
+/**
+ * @file YAMLVersionType.hpp
+ * @brief Definitions of YAML version specification types.
+ *
+ * Copyright (c) 2023 fktn
+ * Distributed under the MIT License (https://opensource.org/licenses/MIT)
+ */
+
+#ifndef FK_YAML_YAML_VERSION_TYPE_HPP_
+#define FK_YAML_YAML_VERSION_TYPE_HPP_
+
+#include <cstdint>
+
+/**
+ * @namespace fkyaml
+ * @brief namespace for fkYAML library.
+ */
+namespace fkyaml
+{
+
+enum class YamlVersionType : std::uint32_t
+{
+    VER_1_1, //!< YAML version 1.1
+    VER_1_2, //!< YAML version 1.2
+};
+
+}; // namespace fkyaml
+
+#endif /* FK_YAML_YAML_VERSION_TYPE_HPP_ */

--- a/include/fkYAML/YAMLVersionType.hpp
+++ b/include/fkYAML/YAMLVersionType.hpp
@@ -18,6 +18,10 @@
 namespace fkyaml
 {
 
+/**
+ * @enum YamlVersionType
+ * @brief Definition of YAML version types.
+ */
 enum class YamlVersionType : std::uint32_t
 {
     VER_1_1, //!< YAML version 1.1

--- a/test/unit_test/DeserializerClassTest.cpp
+++ b/test/unit_test/DeserializerClassTest.cpp
@@ -9,6 +9,14 @@
 
 #include "fkYAML/Deserializer.hpp"
 
+TEST_CASE("DeserializerClassTest_InputStringTest", "[DeserializerClassTest]")
+{
+    fkyaml::Deserializer deserializer;
+
+    REQUIRE_NOTHROW(deserializer.Deserialize("test: hoge"));
+    REQUIRE_THROWS_AS(deserializer.Deserialize(nullptr), fkyaml::Exception);
+}
+
 TEST_CASE("DeserializerClassTest_DeserializeBlockSequenceTest", "[DeserializerClassTest]")
 {
     fkyaml::Deserializer deserializer;
@@ -492,6 +500,35 @@ TEST_CASE("DeserializerClassTest_DeserializeFlowMappingTest", "[DeserializerClas
         REQUIRE_NOTHROW(test_pi_node.ToFloatNumber());
         REQUIRE(test_pi_node.ToFloatNumber() == 3.14);
     }
+}
+
+TEST_CASE("DeserializerClassTest_DeserializeInputWithCommentTest", "[DeserializerClassTest]")
+{
+    fkyaml::Deserializer deserializer;
+    fkyaml::Node root;
+
+    REQUIRE_NOTHROW(root = deserializer.Deserialize("foo: one # comment\nbar: true\npi: 3.14"));
+
+    REQUIRE(root.IsMapping());
+    REQUIRE(root.Size() == 3);
+
+    REQUIRE_NOTHROW(root["foo"]);
+    fkyaml::Node& foo_node = root["foo"];
+    REQUIRE(foo_node.IsString());
+    REQUIRE_NOTHROW(foo_node.ToString());
+    REQUIRE(foo_node.ToString().compare("one") == 0);
+
+    REQUIRE_NOTHROW(root["bar"]);
+    fkyaml::Node& bar_node = root["bar"];
+    REQUIRE(bar_node.IsBoolean());
+    REQUIRE_NOTHROW(bar_node.ToBoolean());
+    REQUIRE(bar_node.ToBoolean() == true);
+
+    REQUIRE_NOTHROW(root["pi"]);
+    fkyaml::Node& pi_node = root["pi"];
+    REQUIRE(pi_node.IsFloatNumber());
+    REQUIRE_NOTHROW(pi_node.ToFloatNumber());
+    REQUIRE(pi_node.ToFloatNumber() == 3.14);
 }
 
 TEST_CASE("DeserializerClassTest_DeserializeYAMLVerDirectiveTest", "[DeserializerClassTest]")

--- a/test/unit_test/DeserializerClassTest.cpp
+++ b/test/unit_test/DeserializerClassTest.cpp
@@ -494,6 +494,39 @@ TEST_CASE("DeserializerClassTest_DeserializeFlowMappingTest", "[DeserializerClas
     }
 }
 
+TEST_CASE("DeserializerClassTest_DeserializeYAMLVerDirectiveTest", "[DeserializerClassTest]")
+{
+    fkyaml::Deserializer deserializer;
+    fkyaml::Node root;
+
+    REQUIRE_NOTHROW(root = deserializer.Deserialize("%YAML 1.1\nfoo: one\nbar: true\npi: 3.14"));
+
+    REQUIRE(root.GetVersion() == fkyaml::YamlVersionType::VER_1_1);
+    REQUIRE(root.IsMapping());
+    REQUIRE(root.Size() == 3);
+
+    REQUIRE_NOTHROW(root["foo"]);
+    fkyaml::Node& foo_node = root["foo"];
+    REQUIRE(root.GetVersion() == fkyaml::YamlVersionType::VER_1_1);
+    REQUIRE(foo_node.IsString());
+    REQUIRE_NOTHROW(foo_node.ToString());
+    REQUIRE(foo_node.ToString().compare("one") == 0);
+
+    REQUIRE_NOTHROW(root["bar"]);
+    fkyaml::Node& bar_node = root["bar"];
+    REQUIRE(root.GetVersion() == fkyaml::YamlVersionType::VER_1_1);
+    REQUIRE(bar_node.IsBoolean());
+    REQUIRE_NOTHROW(bar_node.ToBoolean());
+    REQUIRE(bar_node.ToBoolean() == true);
+
+    REQUIRE_NOTHROW(root["pi"]);
+    fkyaml::Node& pi_node = root["pi"];
+    REQUIRE(root.GetVersion() == fkyaml::YamlVersionType::VER_1_1);
+    REQUIRE(pi_node.IsFloatNumber());
+    REQUIRE_NOTHROW(pi_node.ToFloatNumber());
+    REQUIRE(pi_node.ToFloatNumber() == 3.14);
+}
+
 TEST_CASE("DeserializerClassTest_DeserializeNoMachingAnchorTest", "[DeserializerClassTest]")
 {
     fkyaml::Deserializer deserializer;

--- a/test/unit_test/LexicalAnalyzerClassTest.cpp
+++ b/test/unit_test/LexicalAnalyzerClassTest.cpp
@@ -346,6 +346,14 @@ TEST_CASE("LexicalAnalyzerClassTest_ScanNaNTokenTest", "[LexicalAnalyzerClassTes
     }
 }
 
+TEST_CASE("LexicalAnalyzerClassTest_ScanInvalidNumberTokenTest", "[LexicalAnalyzerClassTest]")
+{
+    auto buffer = GENERATE(std::string("-.test"), std::string("1.0.0"));
+    fkyaml::LexicalAnalyzer<fkyaml::Node> lexer;
+    lexer.SetInputBuffer(buffer.c_str());
+    REQUIRE_THROWS_AS(lexer.GetNextToken(), fkyaml::Exception);
+}
+
 TEST_CASE("LexicalAnalyzerClassTest_ScanStringTokenTest", "[LexicalAnalyzerClassTest]")
 {
     using ValuePair = std::pair<std::string, fkyaml::NodeStringType>;

--- a/test/unit_test/LexicalAnalyzerClassTest.cpp
+++ b/test/unit_test/LexicalAnalyzerClassTest.cpp
@@ -364,6 +364,7 @@ TEST_CASE("LexicalAnalyzerClassTest_ScanStringTokenTest", "[LexicalAnalyzerClass
         ValuePair(std::string("nop"), fkyaml::NodeStringType("nop")),
         ValuePair(std::string(".NET"), fkyaml::NodeStringType(".NET")),
         ValuePair(std::string("foo:bar"), fkyaml::NodeStringType("foo:bar")),
+        ValuePair(std::string("\"foo bar\""), fkyaml::NodeStringType("foo bar")),
         ValuePair(std::string("\"foo:bar\""), fkyaml::NodeStringType("foo:bar")),
         ValuePair(std::string("\"foo,bar\""), fkyaml::NodeStringType("foo,bar")),
         ValuePair(std::string("\"foo]bar\""), fkyaml::NodeStringType("foo]bar")),
@@ -382,6 +383,7 @@ TEST_CASE("LexicalAnalyzerClassTest_ScanStringTokenTest", "[LexicalAnalyzerClass
         ValuePair(std::string("\"foo\\/bar\""), fkyaml::NodeStringType("foo/bar")),
         ValuePair(std::string("\"foo\\\\bar\""), fkyaml::NodeStringType("foo\\bar")),
         ValuePair(std::string("\"\\x30\\x2B\\x6d\""), fkyaml::NodeStringType("0+m")),
+        ValuePair(std::string("\'foo bar\'"), fkyaml::NodeStringType("foo bar")),
         ValuePair(std::string("\'foo\'\'bar\'"), fkyaml::NodeStringType("foo\'bar")),
         ValuePair(std::string("\'foo,bar\'"), fkyaml::NodeStringType("foo,bar")),
         ValuePair(std::string("\'foo]bar\'"), fkyaml::NodeStringType("foo]bar")),
@@ -670,7 +672,7 @@ TEST_CASE("LexicalAnalyzerClassTest_ScanKeyFloatNumberValuePairTokenTest", "[Lex
 TEST_CASE("LexicalAnalyzerClassTest_ScanKeyStringValuePairTokenTest", "[LexicalAnalyzerClassTest]")
 {
     fkyaml::LexicalAnalyzer<fkyaml::Node> lexer;
-    lexer.SetInputBuffer("test: some value");
+    lexer.SetInputBuffer("test: \"some value\"");
     fkyaml::LexicalTokenType token;
 
     REQUIRE_NOTHROW(token = lexer.GetNextToken());

--- a/test/unit_test/NodeClassTest.cpp
+++ b/test/unit_test/NodeClassTest.cpp
@@ -1306,6 +1306,29 @@ TEST_CASE("NodeClassTest_SizeGetterTest", "[NodeClassTest]")
 }
 
 //
+// test cases for YAML version property getter/setter
+//
+
+TEST_CASE("NodeClassTest_SetVersionTest", "[NodeClassTest]")
+{
+    fkyaml::Node node;
+    node.SetVersion(fkyaml::YamlVersionType::VER_1_1);
+    REQUIRE(node.GetVersion() == fkyaml::YamlVersionType::VER_1_1);
+
+    node.SetVersion(fkyaml::YamlVersionType::VER_1_2);
+    REQUIRE(node.GetVersion() == fkyaml::YamlVersionType::VER_1_2);
+}
+
+TEST_CASE("NodeClassTest_GetVersionTest", "[NodeClassTest]")
+{
+    fkyaml::Node node;
+    REQUIRE(node.GetVersion() == fkyaml::YamlVersionType::VER_1_2);
+
+    node.SetVersion(fkyaml::YamlVersionType::VER_1_1);
+    REQUIRE(node.GetVersion() == fkyaml::YamlVersionType::VER_1_1);
+}
+
+//
 // test cases for anchor name property checker/getter/setter
 //
 


### PR DESCRIPTION
Lexical analysis/deserialization of YAML version directives are supported in fkYAML library.  
The supported YAML versions are 1.1 and 1.2.(The library defaults to 1.2 without any specification.)  
Each Node objects can be used to reference YAML version used in deserialization.  
Tag directives are currently not supported, but will be implemented in the near future PR.  
