### PR TITLE
#64 add self-hosted runner for GitHub Actions

### DIFF
--- a/.github/workflows/ubuntu.yml
+++ b/.github/workflows/ubuntu.yml
@@ -65,8 +65,8 @@ jobs:
           cmake --build ${{github.workspace}}/build_compiler_tests --target ci_test_compiler_g++-10
           cmake --build ${{github.workspace}}/build_compiler_tests --target ci_test_compiler_g++-11
           cmake --build ${{github.workspace}}/build_compiler_tests --target ci_test_compiler_g++-12
-          cmake --build ${{github.workspace}}/build_compiler_tests --target ci_test_compiler_clang-11
-          cmake --build ${{github.workspace}}/build_compiler_tests --target ci_test_compiler_clang-12
-          cmake --build ${{github.workspace}}/build_compiler_tests --target ci_test_compiler_clang-13
-          cmake --build ${{github.workspace}}/build_compiler_tests --target ci_test_compiler_clang-14
-          cmake --build ${{github.workspace}}/build_compiler_tests --target ci_test_compiler_clang-15
+          cmake --build ${{github.workspace}}/build_compiler_tests --target ci_test_compiler_clang++-11
+          cmake --build ${{github.workspace}}/build_compiler_tests --target ci_test_compiler_clang++-12
+          cmake --build ${{github.workspace}}/build_compiler_tests --target ci_test_compiler_clang++-13
+          cmake --build ${{github.workspace}}/build_compiler_tests --target ci_test_compiler_clang++-14
+          cmake --build ${{github.workspace}}/build_compiler_tests --target ci_test_compiler_clang++-15

--- a/.github/workflows/ubuntu.yml
+++ b/.github/workflows/ubuntu.yml
@@ -48,7 +48,7 @@ jobs:
     - name: Clang-Tidy check
       run: cmake --build ${{github.workspace}}/build_clang_tidy --target run_clang_tidy
 
-  variout-compiler-tests:
+  various-compiler-tests:
     runs-on: self-hosted
 
     steps:

--- a/.github/workflows/ubuntu.yml
+++ b/.github/workflows/ubuntu.yml
@@ -47,3 +47,26 @@ jobs:
 
     - name: Clang-Tidy check
       run: cmake --build ${{github.workspace}}/build_clang_tidy --target run_clang_tidy
+
+  variout-compiler-tests:
+    runs-on: self-hosted
+
+    steps:
+      - uses: actions/checkout@v3
+        with:
+          submodules: recursive
+
+      - name: Configure CMake
+        run: cmake -B ${{github.workspace}}/build_compiler_tests
+
+      - name: Run builds & tests
+        run: |
+          cmake --build ${{github.workspace}}/build_compiler_tests --target ci_test_compiler_g++-9
+          cmake --build ${{github.workspace}}/build_compiler_tests --target ci_test_compiler_g++-10
+          cmake --build ${{github.workspace}}/build_compiler_tests --target ci_test_compiler_g++-11
+          cmake --build ${{github.workspace}}/build_compiler_tests --target ci_test_compiler_g++-12
+          cmake --build ${{github.workspace}}/build_compiler_tests --target ci_test_compiler_clang-11
+          cmake --build ${{github.workspace}}/build_compiler_tests --target ci_test_compiler_clang-12
+          cmake --build ${{github.workspace}}/build_compiler_tests --target ci_test_compiler_clang-13
+          cmake --build ${{github.workspace}}/build_compiler_tests --target ci_test_compiler_clang-14
+          cmake --build ${{github.workspace}}/build_compiler_tests --target ci_test_compiler_clang-15

--- a/.github/workflows/ubuntu.yml
+++ b/.github/workflows/ubuntu.yml
@@ -57,7 +57,7 @@ jobs:
           submodules: recursive
 
       - name: Configure CMake
-        run: cmake -B ${{github.workspace}}/build_compiler_tests
+        run: cmake -B ${{github.workspace}}/build_compiler_tests -DFK_YAML_CI=ON
 
       - name: Run builds & tests
         run: |

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -80,7 +80,7 @@ option(FK_YAML_RunDoxygen     "Generate API documentation with doxygen." ${FK_YA
 option(FK_YAML_RunClangFormat "Run clang-format when FK_YAML_RUN_CLANG_FORMAT is enabled or if this library is the main target." ${FK_YAML_RUN_CLANG_FORMAT_INIT})
 option(FK_YAML_RunClangTidy   "Run clang-tidy when FK_YAML_RUN_CLANG_TIDY is enabled or if this library is the main target." ${FK_YAML_RUN_CLANG_TIDY_INIT})
 
-if(FK_YAML_BuildTests OR FK_YAML_RunClangFormat OR FK_YAML_RunClangTidy)
+if(FK_YAML_BuildTests OR FK_YAML_RunClangFormat OR FK_YAML_RunClangTidy OR FK_YAML_CI)
   set(CMAKE_MODULE_PATH "${CMAKE_CURRENT_SOURCE_DIR}/cmake")
   if(FK_YAML_BuildTests)
     set(CMAKE_MODULE_PATH "${CMAKE_MODULE_PATH};${CMAKE_CURRENT_SOURCE_DIR}/thirdparty/catch2/contrib")
@@ -143,6 +143,11 @@ endif()
 if(FK_YAML_RunClangTidy)
   add_subdirectory(clang_tidy)
   add_dependencies(ClangTidyHelper "${FK_YAML_ClangFormatTargetPrefix}${FK_YAML_TARGET_NAME}")
+endif()
+
+# Configure targets for CI.
+if(FK_YAML_CI)
+  include(ci)
 endif()
 
 #

--- a/cmake/ci.cmake
+++ b/cmake/ci.cmake
@@ -1,6 +1,6 @@
 # find necessary tools
 
-foreach(COMPILER g++-9 g++-10 g++-11 g++-12 clang-11 clang-12 clang-13 clang-14 clang-15)
+foreach(COMPILER g++-9 g++-10 g++-11 g++-12 clang++-11 clang++-12 clang++-13 clang++-14 clang++-15)
   find_program(COMPILER_TOOL NAMES ${COMPILER})
   if(COMPILER_TOOL)
     add_custom_target(ci_test_compiler_${COMPILER}

--- a/cmake/ci.cmake
+++ b/cmake/ci.cmake
@@ -1,0 +1,15 @@
+# find necessary tools
+
+foreach(COMPILER g++-9 g++-10 g++-11 g++-12 clang-11 clang-12 clang-13 clang-14 clang-15)
+  find_program(COMPILER_TOOL NAMES ${COMPILER})
+  if(COMPILER_TOOL)
+    add_custom_target(ci_test_compiler_${COMPILER}
+      COMMAND CXX=${COMPILER} ${CMAKE_COMMAND} -DCMAKE_BUILD_TYPE=Debug -GNinja -DFK_YAML_CI=ON
+        -S${PROJECT_SOURCE_DIR} -B${PROJECT_BINARY_DIR}/build_compiler_${COMPILER}
+      COMMAND ${CMAKE_COMMAND} --build ${PROJECT_BINARY_DIR}/build_compiler_${COMPILER}
+      COMMAND cd ${PROJECT_BINARY_DIR}/build_compiler_${COMPILER} && ${CMAKE_CTEST_COMMAND} -C Debug --output-on-failure
+      COMMENT "Compile and test with ${COMPILER}"
+    )
+  endif()
+  unset(COMPILER_TOOL CACHE)
+endforeach()


### PR DESCRIPTION
Script contents have been modified to support self-hosted runner of GitHub Actions.  
The self-hosted runner is a private project which contains various tools(compilers, linters, testers etc) to execute more compilicated tests during GitHub Actions.  