### PR TITLE
#85 change integer scalar data type to int64_t only

### DIFF
--- a/include/fkYAML/Deserializer.hpp
+++ b/include/fkYAML/Deserializer.hpp
@@ -46,10 +46,8 @@ class BasicDeserializer
     using mapping_type = typename BasicNodeType::mapping_type;
     /** A type for boolean node values. */
     using boolean_type = typename BasicNodeType::boolean_type;
-    /** A type for signed integer node values. */
-    using signed_int_type = typename BasicNodeType::signed_int_type;
-    /** A type for unsigned integer node values. */
-    using unsigned_int_type = typename BasicNodeType::unsigned_int_type;
+    /** A type for integer node values. */
+    using integer_type = typename BasicNodeType::integer_type;
     /** A type for float number node values. */
     using float_number_type = typename BasicNodeType::float_number_type;
     /** A type for string node values. */
@@ -282,7 +280,7 @@ public:
                 p_current_node = node_stack.back();
                 node_stack.pop_back();
                 break;
-            case LexicalTokenType::SIGNED_INT_VALUE:
+            case LexicalTokenType::INTEGER_VALUE:
                 if (p_current_node->IsMapping())
                 {
                     throw Exception("Cannot assign a signed integer as a key.");
@@ -290,8 +288,7 @@ public:
 
                 if (p_current_node->IsSequence())
                 {
-                    p_current_node->ToSequence().emplace_back(
-                        BasicNodeType::SignedIntegerScalar(m_lexer.GetSignedInt()));
+                    p_current_node->ToSequence().emplace_back(BasicNodeType::IntegerScalar(m_lexer.GetInteger()));
                     p_current_node->ToSequence().back().SetVersion(yaml_version);
                     if (needs_anchor_impl)
                     {
@@ -303,40 +300,8 @@ public:
                     break;
                 }
                 // a scalar node
-                *p_current_node = BasicNodeType::SignedIntegerScalar(m_lexer.GetSignedInt());
+                *p_current_node = BasicNodeType::IntegerScalar(m_lexer.GetInteger());
                 p_current_node->SetVersion(yaml_version);
-                if (needs_anchor_impl)
-                {
-                    p_current_node->AddAnchorName(anchor_name);
-                    anchor_table[anchor_name] = *p_current_node;
-                    needs_anchor_impl = false;
-                    anchor_name.clear();
-                }
-                p_current_node = node_stack.back();
-                node_stack.pop_back();
-                break;
-            case LexicalTokenType::UNSIGNED_INT_VALUE:
-                if (p_current_node->IsMapping())
-                {
-                    throw Exception("Cannot assign an unsigned integer as a key.");
-                }
-
-                if (p_current_node->IsSequence())
-                {
-                    p_current_node->ToSequence().emplace_back(
-                        BasicNodeType::UnsignedIntegerScalar(m_lexer.GetUnsignedInt()));
-                    p_current_node->ToSequence().back().SetVersion(yaml_version);
-                    if (needs_anchor_impl)
-                    {
-                        p_current_node->ToSequence().back().AddAnchorName(anchor_name);
-                        anchor_table[anchor_name] = p_current_node->ToSequence().back();
-                        needs_anchor_impl = false;
-                        anchor_name.clear();
-                    }
-                    break;
-                }
-                // a scalar node
-                *p_current_node = BasicNodeType::UnsignedIntegerScalar(m_lexer.GetUnsignedInt());
                 if (needs_anchor_impl)
                 {
                     p_current_node->AddAnchorName(anchor_name);

--- a/include/fkYAML/LexicalAnalyzer.hpp
+++ b/include/fkYAML/LexicalAnalyzer.hpp
@@ -51,8 +51,7 @@ enum class LexicalTokenType
     MAPPING_FLOW_END,      //!< the character for mapping end `}`
     NULL_VALUE,            //!< a null value found. use GetNull() to get a value.
     BOOLEAN_VALUE,         //!< a boolean value found. use GetBoolean() to get a value.
-    SIGNED_INT_VALUE,      //!< a signed integer value found. use GetSignedInt() to get a value.
-    UNSIGNED_INT_VALUE,    //!< an unsigned integer value found. use GetUnsignedInt() to get a value.
+    INTEGER_VALUE,         //!< an integer value found. use GetInteger() to get a value.
     FLOAT_NUMBER_VALUE,    //!< a float number value found. use GetFloatNumber() to get a value.
     STRING_VALUE,          //!< the character for string begin `"` or any character except the above ones
 };
@@ -74,8 +73,7 @@ private:
 
 public:
     using boolean_type = typename BasicNodeType::boolean_type;
-    using signed_int_type = typename BasicNodeType::signed_int_type;
-    using unsigned_int_type = typename BasicNodeType::unsigned_int_type;
+    using integer_type = typename BasicNodeType::integer_type;
     using float_number_type = typename BasicNodeType::float_number_type;
     using string_type = typename BasicNodeType::string_type;
 
@@ -357,11 +355,11 @@ public:
     }
 
     /**
-     * @brief Convert from string to signed integer and get the converted value.
+     * @brief Convert from string to integer and get the converted value.
      *
-     * @return signed_int_type A signed integer value converted from the source string.
+     * @return integer_type An integer value converted from the source string.
      */
-    signed_int_type GetSignedInt() const
+    integer_type GetInteger() const
     {
         FK_YAML_ASSERT(!m_value_buffer.empty());
 
@@ -370,24 +368,7 @@ public:
 
         FK_YAML_ASSERT(endptr == m_value_buffer.data() + m_value_buffer.size());
 
-        return static_cast<signed_int_type>(tmp_val);
-    }
-
-    /**
-     * @brief Convert from string to unsigned integer and get the converted value.
-     *
-     * @return unsigned_int_type An unsigned integer value converted from the source string.
-     */
-    unsigned_int_type GetUnsignedInt() const
-    {
-        FK_YAML_ASSERT(!m_value_buffer.empty());
-
-        char* endptr = nullptr;
-        const auto tmp_val = std::strtoull(m_value_buffer.data(), &endptr, 0);
-
-        FK_YAML_ASSERT(endptr == m_value_buffer.data() + m_value_buffer.size());
-
-        return static_cast<unsigned_int_type>(tmp_val);
+        return static_cast<integer_type>(tmp_val);
     }
 
     /**
@@ -591,7 +572,7 @@ private:
     }
 
     /**
-     * @brief Scan and determine a number type(signed/unsigned/float). This method is the entrypoint for all number
+     * @brief Scan and determine a number type(integer/float). This method is the entrypoint for all number
      * tokens.
      *
      * @return LexicalTokenType A lexical token type for a determined number type.
@@ -632,7 +613,7 @@ private:
     /**
      * @brief Scan a next character after the negative sign(-).
      *
-     * @return LexicalTokenType The lexical token type for either signed or float numbers.
+     * @return LexicalTokenType The lexical token type for either integer or float numbers.
      */
     LexicalTokenType ScanNegativeNumber()
     {
@@ -643,7 +624,7 @@ private:
         {
             m_value_buffer.push_back(next);
             const LexicalTokenType ret = ScanDecimalNumber();
-            return (ret == LexicalTokenType::FLOAT_NUMBER_VALUE) ? ret : LexicalTokenType::SIGNED_INT_VALUE;
+            return (ret == LexicalTokenType::FLOAT_NUMBER_VALUE) ? ret : LexicalTokenType::INTEGER_VALUE;
         }
 
         const std::string tmp_str = m_input_buffer.substr(m_position_info.total_read_char_counts, 4);
@@ -662,7 +643,7 @@ private:
     /**
      * @brief Scan a next character after '0' at the beginning of a token.
      *
-     * @return LexicalTokenType The lexical token type for one of number types(signed/unsigned/float).
+     * @return LexicalTokenType The lexical token type for one of number types(integer/float).
      */
     LexicalTokenType ScanNumberAfterZeroAtFirst()
     {
@@ -681,7 +662,7 @@ private:
             m_value_buffer.push_back(next);
             return ScanHexadecimalNumber();
         default:
-            return LexicalTokenType::UNSIGNED_INT_VALUE;
+            return LexicalTokenType::INTEGER_VALUE;
         }
     }
 
@@ -729,7 +710,7 @@ private:
     /**
      * @brief Scan a next character after a sign(+/-) after exponent(e/E).
      *
-     * @return LexicalTokenType The lexical token type for one of number types(signed/unsigned/float)
+     * @return LexicalTokenType The lexical token type for one of number types(integer/float)
      */
     LexicalTokenType ScanDecimalNumberAfterSign()
     {
@@ -748,7 +729,7 @@ private:
     /**
      * @brief Scan a next character for decimal numbers.
      *
-     * @return LexicalTokenType The lexical token type for one of number types(signed/unsigned/float)
+     * @return LexicalTokenType The lexical token type for one of number types(integer/float)
      */
     LexicalTokenType ScanDecimalNumber()
     {
@@ -777,14 +758,13 @@ private:
             return ScanDecimalNumberAfterExponent();
         }
 
-        return LexicalTokenType::UNSIGNED_INT_VALUE;
+        return LexicalTokenType::INTEGER_VALUE;
     }
 
     /**
      * @brief Scan a next character for octal numbers.
-     * @note All octal numbers are interpreted as unsigned integers.
      *
-     * @return LexicalTokenType The lexical token type for unsigned numbers.
+     * @return LexicalTokenType The lexical token type for integers.
      */
     LexicalTokenType ScanOctalNumber()
     {
@@ -794,14 +774,13 @@ private:
             m_value_buffer.push_back(next);
             ScanOctalNumber();
         }
-        return LexicalTokenType::UNSIGNED_INT_VALUE;
+        return LexicalTokenType::INTEGER_VALUE;
     }
 
     /**
      * @brief Scan a next character for hexadecimal numbers.
-     * @note All hexadecimal numbers are interpreted as unsigned integers.
      *
-     * @return LexicalTokenType The lexical token type for unsigned numbers.
+     * @return LexicalTokenType The lexical token type for integers.
      */
     LexicalTokenType ScanHexadecimalNumber()
     {
@@ -811,7 +790,7 @@ private:
             m_value_buffer.push_back(next);
             ScanHexadecimalNumber();
         }
-        return LexicalTokenType::UNSIGNED_INT_VALUE;
+        return LexicalTokenType::INTEGER_VALUE;
     }
 
     /**

--- a/include/fkYAML/Node.hpp
+++ b/include/fkYAML/Node.hpp
@@ -45,8 +45,7 @@ FK_YAML_NAMESPACE_BEGIN
 template <
     template <typename, typename...> class SequenceType = std::vector,
     template <typename, typename, typename...> class MappingType = OrderedMap, typename BooleanType = bool,
-    typename SignedIntegerType = std::int64_t, typename UnsignedIntegerType = std::uint64_t,
-    typename FloatNumberType = double, typename StringType = std::string>
+    typename IntegerType = std::int64_t, typename FloatNumberType = double, typename StringType = std::string>
 class BasicNode
 {
 public:
@@ -61,10 +60,8 @@ public:
     using mapping_type = MappingType<StringType, BasicNode>;
     /** A type for boolean BasicNode values. */
     using boolean_type = BooleanType;
-    /** A type for signed integer BasicNode values. */
-    using signed_int_type = SignedIntegerType;
-    /** A type for unsigned integer BasicNode values. */
-    using unsigned_int_type = UnsignedIntegerType;
+    /** A type for integer BasicNode values. */
+    using integer_type = IntegerType;
     /** A type for float number BasicNode values. */
     using float_number_type = FloatNumberType;
     /** A type for string BasicNode values. */
@@ -106,11 +103,8 @@ private:
             case NodeType::BOOLEAN:
                 boolean = static_cast<boolean_type>(false);
                 break;
-            case NodeType::SIGNED_INTEGER:
-                signed_int = static_cast<signed_int_type>(0);
-                break;
-            case NodeType::UNSIGNED_INTEGER:
-                unsigned_int = static_cast<unsigned_int_type>(0);
+            case NodeType::INTEGER:
+                integer = static_cast<integer_type>(0);
                 break;
             case NodeType::FLOAT_NUMBER:
                 float_val = static_cast<float_number_type>(0.0);
@@ -198,10 +192,8 @@ private:
         mapping_type* mapping;
         /** A value of boolean type. */
         boolean_type boolean;
-        /** A value of signed integer type. */
-        signed_int_type signed_int;
-        /** A value of unsigned integer type. */
-        unsigned_int_type unsigned_int;
+        /** A value of integer type. */
+        integer_type integer;
         /** A value of float number type. */
         float_number_type float_val;
         /** A pointer to the value of string type. */
@@ -307,11 +299,8 @@ public:
         case NodeType::BOOLEAN:
             m_node_value.boolean = rhs.m_node_value.boolean;
             break;
-        case NodeType::SIGNED_INTEGER:
-            m_node_value.signed_int = rhs.m_node_value.signed_int;
-            break;
-        case NodeType::UNSIGNED_INTEGER:
-            m_node_value.unsigned_int = rhs.m_node_value.unsigned_int;
+        case NodeType::INTEGER:
+            m_node_value.integer = rhs.m_node_value.integer;
             break;
         case NodeType::FLOAT_NUMBER:
             m_node_value.float_val = rhs.m_node_value.float_val;
@@ -362,13 +351,9 @@ public:
             m_node_value.boolean = rhs.m_node_value.boolean;
             rhs.m_node_value.boolean = static_cast<boolean_type>(false);
             break;
-        case NodeType::SIGNED_INTEGER:
-            m_node_value.signed_int = rhs.m_node_value.signed_int;
-            rhs.m_node_value.signed_int = static_cast<signed_int_type>(0);
-            break;
-        case NodeType::UNSIGNED_INTEGER:
-            m_node_value.unsigned_int = rhs.m_node_value.unsigned_int;
-            rhs.m_node_value.unsigned_int = static_cast<unsigned_int_type>(0);
+        case NodeType::INTEGER:
+            m_node_value.integer = rhs.m_node_value.integer;
+            rhs.m_node_value.integer = static_cast<integer_type>(0);
             break;
         case NodeType::FLOAT_NUMBER:
             m_node_value.float_val = rhs.m_node_value.float_val;
@@ -504,30 +489,16 @@ public:
     }
 
     /**
-     * @brief A factory method for signed integer scalar BasicNode objects.
+     * @brief A factory method for integer scalar BasicNode objects.
      *
-     * @param[in] signed_int A source of signed integer type.
-     * @return BasicNode A constructed BasicNode object of signed integer type.
+     * @param[in] integer A source of integer type.
+     * @return BasicNode A constructed BasicNode object of integer type.
      */
-    static BasicNode SignedIntegerScalar(const signed_int_type signed_int) noexcept
+    static BasicNode IntegerScalar(const integer_type integer) noexcept
     {
         BasicNode node;
-        node.m_node_type = NodeType::SIGNED_INTEGER;
-        node.m_node_value.signed_int = signed_int;
-        return node;
-    }
-
-    /**
-     * @brief A factory method for unsigned integer scalar BasicNode objects.
-     *
-     * @param[in] unsigned_int A source of unsigned integer type.
-     * @return BasicNode A constructed BasicNode object of unsigned integer type.
-     */
-    static BasicNode UnsignedIntegerScalar(const unsigned_int_type unsigned_int) noexcept
-    {
-        BasicNode node;
-        node.m_node_type = NodeType::UNSIGNED_INTEGER;
-        node.m_node_value.unsigned_int = unsigned_int;
+        node.m_node_type = NodeType::INTEGER;
+        node.m_node_value.integer = integer;
         return node;
     }
 
@@ -745,8 +716,7 @@ public:
      * @retval NodeType::MAPPINT          mapping type.
      * @retval NodeType::NULL_OBJECT      null type.
      * @retval NodeType::BOOLEAN          boolean type.
-     * @retval NodeType::SIGNED_INTEGER   signed integer type.
-     * @retval NodeType::UNSIGNED_INTEGER unsigned integer type.
+     * @retval NodeType::INTEGER          integer type.
      * @retval NodeType::FLOAT_NUMBER     float number type.
      * @retval NodeType::STRING           string type.
      */
@@ -804,27 +774,15 @@ public:
     }
 
     /**
-     * @brief Tests whether the current BasicNode value is of signed integer type.
+     * @brief Tests whether the current BasicNode value is of integer type.
      *
-     * @return bool A result of testing whetehre the current BasicNode value is of signed integer type.
-     * @retval true  The current BasicNode value is of signed integer type.
-     * @return false The current BasicNode value is not of signed integer type.
+     * @return bool A result of testing whetehre the current BasicNode value is of integer type.
+     * @retval true  The current BasicNode value is of integer type.
+     * @return false The current BasicNode value is not of integer type.
      */
-    bool IsSignedInteger() const noexcept
+    bool IsInteger() const noexcept
     {
-        return m_node_type == NodeType::SIGNED_INTEGER;
-    }
-
-    /**
-     * @brief Tests whether the current BasicNode value is of unsigned integer type.
-     *
-     * @return bool A result of testing whetehre the current BasicNode value is of unsigned integer type.
-     * @retval true  The current BasicNode value is of unsigned integer type.
-     * @return false The current BasicNode value is not of unsigned integer type.
-     */
-    bool IsUnsignedInteger() const noexcept
-    {
-        return m_node_type == NodeType::UNSIGNED_INTEGER;
+        return m_node_type == NodeType::INTEGER;
     }
 
     /**
@@ -1127,67 +1085,35 @@ public:
     }
 
     /**
-     * @brief Returns reference to signed integer BasicNode value from a non-const BasicNode object. Throws exception if
-     * the BasicNode value is not of signed integer type.
+     * @brief Returns reference to  integer BasicNode value from a non-const BasicNode object. Throws exception if
+     * the BasicNode value is not of  integer type.
      *
-     * @return signed_int_type& Reference to signed integer BasicNode value.
+     * @return integer_type& Reference to  integer BasicNode value.
      */
-    signed_int_type& ToSignedInteger()
+    integer_type& ToInteger()
     {
-        if (!IsSignedInteger())
+        if (!IsInteger())
         {
-            throw Exception("The target node is not of a signed integer type.");
+            throw Exception("The target node is not of integer type.");
         }
 
-        return m_node_value.signed_int;
+        return m_node_value.integer;
     }
 
     /**
-     * @brief Returns reference to signed integer BasicNode value from a const BasicNode object. Throws exception if the
-     * BasicNode value is not of signed integer type.
+     * @brief Returns reference to  integer BasicNode value from a const BasicNode object. Throws exception if the
+     * BasicNode value is not of  integer type.
      *
-     * @return const signed_int_type& Constant reference to signed integer BasicNode value.
+     * @return const integer_type& Constant reference to  integer BasicNode value.
      */
-    const signed_int_type& ToSignedInteger() const
+    const integer_type& ToInteger() const
     {
-        if (!IsSignedInteger())
+        if (!IsInteger())
         {
-            throw Exception("The target node is not of a signed integer type.");
+            throw Exception("The target node is not of integer type.");
         }
 
-        return m_node_value.signed_int;
-    }
-
-    /**
-     * @brief Returns reference to unsigned integer BasicNode value from a non-const BasicNode object. Throws exception
-     * if the BasicNode value is not of unsigned integer type.
-     *
-     * @return unsigned_int_type& Reference to unsigned integer BasicNode value.
-     */
-    unsigned_int_type& ToUnsignedInteger()
-    {
-        if (!IsUnsignedInteger())
-        {
-            throw Exception("The target node is not of an unsigned integer type.");
-        }
-
-        return m_node_value.unsigned_int;
-    }
-
-    /**
-     * @brief Returns reference to unsigned integer BasicNode value from a const BasicNode object. Throws exception if
-     * the BasicNode value is not of unsigned integer type.
-     *
-     * @return const unsigned_int_type& Constant reference to unsigned integer BasicNode value.
-     */
-    const unsigned_int_type& ToUnsignedInteger() const
-    {
-        if (!IsUnsignedInteger())
-        {
-            throw Exception("The target node is not of an unsigned integer type.");
-        }
-
-        return m_node_value.unsigned_int;
+        return m_node_value.integer;
     }
 
     /**
@@ -1436,11 +1362,8 @@ using NodeMappingType = typename Node::mapping_type;
 /** A default type for boolean Node values. */
 using NodeBooleanType = typename Node::boolean_type;
 
-/** A default type for signed integer Node values. */
-using NodeSignedIntType = typename Node::signed_int_type;
-
-/** A default type for unsigned integer Node values. */
-using NodeUnsignedIntType = typename Node::unsigned_int_type;
+/** A default type for integer Node values. */
+using NodeIntegerType = typename Node::integer_type;
 
 /** A default type for float number Node values. */
 using NodeFloatNumberType = typename Node::float_number_type;

--- a/include/fkYAML/NodeType.hpp
+++ b/include/fkYAML/NodeType.hpp
@@ -25,14 +25,13 @@ FK_YAML_NAMESPACE_BEGIN
  */
 enum class NodeType : std::uint32_t
 {
-    SEQUENCE,         //!< sequence value type
-    MAPPING,          //!< mapping value type
-    NULL_OBJECT,      //!< null value type
-    BOOLEAN,          //!< boolean value type
-    SIGNED_INTEGER,   //!< signed integer value type
-    UNSIGNED_INTEGER, //!< unsigned integer value type
-    FLOAT_NUMBER,     //!< float number value type
-    STRING,           //!< string value type
+    SEQUENCE,     //!< sequence value type
+    MAPPING,      //!< mapping value type
+    NULL_OBJECT,  //!< null value type
+    BOOLEAN,      //!< boolean value type
+    INTEGER,      //!< integer value type
+    FLOAT_NUMBER, //!< float number value type
+    STRING,       //!< string value type
 };
 
 FK_YAML_NAMESPACE_END

--- a/include/fkYAML/NodeTypeTraits.hpp
+++ b/include/fkYAML/NodeTypeTraits.hpp
@@ -22,8 +22,7 @@ FK_YAML_NAMESPACE_BEGIN
 // forward declaration for fkyaml::BasicNode<...>
 template <
     template <typename, typename...> class SequenceType, template <typename, typename, typename...> class MappingType,
-    typename BooleanType, typename SignedIntegerType, typename UnsignedIntegerType, typename FloatNumberType,
-    typename StringType>
+    typename BooleanType, typename IntegerType, typename FloatNumberType, typename StringType>
 class BasicNode;
 
 template <typename T>
@@ -33,10 +32,8 @@ struct IsBasicNode : std::false_type
 
 template <
     template <typename, typename...> class SequenceType, template <typename, typename, typename...> class MappingType,
-    typename BooleanType, typename SignedIntegerType, typename UnsignedIntegerType, typename FloatNumberType,
-    typename StringType>
-struct IsBasicNode<BasicNode<
-    SequenceType, MappingType, BooleanType, SignedIntegerType, UnsignedIntegerType, FloatNumberType, StringType>>
+    typename BooleanType, typename IntegerType, typename FloatNumberType, typename StringType>
+struct IsBasicNode<BasicNode<SequenceType, MappingType, BooleanType, IntegerType, FloatNumberType, StringType>>
     : std::true_type
 {
 };

--- a/include/fkYAML/Serializer.hpp
+++ b/include/fkYAML/Serializer.hpp
@@ -93,11 +93,8 @@ private:
                 str += "false";
             }
             break;
-        case NodeType::SIGNED_INTEGER:
-            str += std::to_string(node.ToSignedInteger());
-            break;
-        case NodeType::UNSIGNED_INTEGER:
-            str += std::to_string(node.ToUnsignedInteger());
+        case NodeType::INTEGER:
+            str += std::to_string(node.ToInteger());
             break;
         case NodeType::FLOAT_NUMBER: {
             typename BasicNodeType::float_number_type float_val = node.ToFloatNumber();

--- a/test/unit_test/DeserializerClassTest.cpp
+++ b/test/unit_test/DeserializerClassTest.cpp
@@ -152,15 +152,15 @@ TEST_CASE("DeserializerClassTest_DeserializeBlockSequenceTest", "[DeserializerCl
         fkyaml::Node& test_0_node = test_node[0];
         REQUIRE(test_0_node.HasAnchorName());
         REQUIRE(test_0_node.GetAnchorName().compare("anchor") == 0);
-        REQUIRE(test_0_node.IsSignedInteger());
-        REQUIRE_NOTHROW(test_0_node.ToSignedInteger());
-        REQUIRE(test_0_node.ToSignedInteger() == -123);
+        REQUIRE(test_0_node.IsInteger());
+        REQUIRE_NOTHROW(test_0_node.ToInteger());
+        REQUIRE(test_0_node.ToInteger() == -123);
 
         REQUIRE_NOTHROW(test_node[1]);
         fkyaml::Node& test_1_node = test_node[1];
-        REQUIRE(test_1_node.IsSignedInteger());
-        REQUIRE_NOTHROW(test_1_node.ToSignedInteger());
-        REQUIRE(test_1_node.ToSignedInteger() == test_0_node.ToSignedInteger());
+        REQUIRE(test_1_node.IsInteger());
+        REQUIRE_NOTHROW(test_1_node.ToInteger());
+        REQUIRE(test_1_node.ToInteger() == test_0_node.ToInteger());
     }
 
     SECTION("Input source No.5.")
@@ -181,15 +181,15 @@ TEST_CASE("DeserializerClassTest_DeserializeBlockSequenceTest", "[DeserializerCl
         fkyaml::Node& test_0_node = test_node[0];
         REQUIRE(test_0_node.HasAnchorName());
         REQUIRE(test_0_node.GetAnchorName().compare("anchor") == 0);
-        REQUIRE(test_0_node.IsUnsignedInteger());
-        REQUIRE_NOTHROW(test_0_node.ToUnsignedInteger());
-        REQUIRE(test_0_node.ToUnsignedInteger() == 567);
+        REQUIRE(test_0_node.IsInteger());
+        REQUIRE_NOTHROW(test_0_node.ToInteger());
+        REQUIRE(test_0_node.ToInteger() == 567);
 
         REQUIRE_NOTHROW(test_node[1]);
         fkyaml::Node& test_1_node = test_node[1];
-        REQUIRE(test_1_node.IsUnsignedInteger());
-        REQUIRE_NOTHROW(test_1_node.ToUnsignedInteger());
-        REQUIRE(test_1_node.ToUnsignedInteger() == test_0_node.ToUnsignedInteger());
+        REQUIRE(test_1_node.IsInteger());
+        REQUIRE_NOTHROW(test_1_node.ToInteger());
+        REQUIRE(test_1_node.ToInteger() == test_0_node.ToInteger());
     }
 
     SECTION("Input source No.6.")
@@ -352,15 +352,15 @@ TEST_CASE("DeserializerClassTest_DeserializeBlockMappingTest", "[DeserializerCla
         fkyaml::Node& foo_node = root["foo"];
         REQUIRE(foo_node.HasAnchorName());
         REQUIRE(foo_node.GetAnchorName().compare("anchor") == 0);
-        REQUIRE(foo_node.IsSignedInteger());
-        REQUIRE_NOTHROW(foo_node.ToSignedInteger());
-        REQUIRE(foo_node.ToSignedInteger() == -123);
+        REQUIRE(foo_node.IsInteger());
+        REQUIRE_NOTHROW(foo_node.ToInteger());
+        REQUIRE(foo_node.ToInteger() == -123);
 
         REQUIRE_NOTHROW(root["bar"]);
         fkyaml::Node& bar_node = root["bar"];
-        REQUIRE(bar_node.IsSignedInteger());
-        REQUIRE_NOTHROW(bar_node.ToSignedInteger());
-        REQUIRE(bar_node.ToSignedInteger() == foo_node.ToSignedInteger());
+        REQUIRE(bar_node.IsInteger());
+        REQUIRE_NOTHROW(bar_node.ToInteger());
+        REQUIRE(bar_node.ToInteger() == foo_node.ToInteger());
     }
 
     SECTION("Input source No.5.")
@@ -374,15 +374,15 @@ TEST_CASE("DeserializerClassTest_DeserializeBlockMappingTest", "[DeserializerCla
         fkyaml::Node& foo_node = root["foo"];
         REQUIRE(foo_node.HasAnchorName());
         REQUIRE(foo_node.GetAnchorName().compare("anchor") == 0);
-        REQUIRE(foo_node.IsUnsignedInteger());
-        REQUIRE_NOTHROW(foo_node.ToUnsignedInteger());
-        REQUIRE(foo_node.ToUnsignedInteger() == 567);
+        REQUIRE(foo_node.IsInteger());
+        REQUIRE_NOTHROW(foo_node.ToInteger());
+        REQUIRE(foo_node.ToInteger() == 567);
 
         REQUIRE_NOTHROW(root["bar"]);
         fkyaml::Node& bar_node = root["bar"];
-        REQUIRE(bar_node.IsUnsignedInteger());
-        REQUIRE_NOTHROW(bar_node.ToUnsignedInteger());
-        REQUIRE(bar_node.ToUnsignedInteger() == foo_node.ToUnsignedInteger());
+        REQUIRE(bar_node.IsInteger());
+        REQUIRE_NOTHROW(bar_node.ToInteger());
+        REQUIRE(bar_node.ToInteger() == foo_node.ToInteger());
     }
 
     SECTION("Input source No.6.")

--- a/test/unit_test/LexicalAnalyzerClassTest.cpp
+++ b/test/unit_test/LexicalAnalyzerClassTest.cpp
@@ -208,9 +208,9 @@ TEST_CASE("LexicalAnalyzerClassTest_ScanBooleanFalseTokenTest", "[LexicalAnalyze
     REQUIRE(lexer.GetBoolean() == false);
 }
 
-TEST_CASE("LexicalAnalyzerClassTest_ScanSignedDecimalIntegerTokenTest", "[LexicalAnalyzerClassTest]")
+TEST_CASE("LexicalAnalyzerClassTest_ScanIntegerTokenTest", "[LexicalAnalyzerClassTest]")
 {
-    using ValuePair = std::pair<std::string, fkyaml::NodeSignedIntType>;
+    using ValuePair = std::pair<std::string, fkyaml::NodeIntegerType>;
     auto value_pair = GENERATE(
         ValuePair(std::string("-1234"), -1234),
         ValuePair(std::string("-853255"), -853255),
@@ -221,33 +221,14 @@ TEST_CASE("LexicalAnalyzerClassTest_ScanSignedDecimalIntegerTokenTest", "[Lexica
     fkyaml::LexicalTokenType token;
 
     REQUIRE_NOTHROW(token = lexer.GetNextToken());
-    REQUIRE(token == fkyaml::LexicalTokenType::SIGNED_INT_VALUE);
-    REQUIRE_NOTHROW(lexer.GetSignedInt());
-    REQUIRE(lexer.GetSignedInt() == value_pair.second);
-}
-
-TEST_CASE("LexicalAnalyzerClassTest_ScanUnsignedDecimalIntegerTokenTest", "[LexicalAnalyzerClassTest]")
-{
-    using ValuePair = std::pair<std::string, fkyaml::NodeUnsignedIntType>;
-    auto value_pair = GENERATE(
-        ValuePair(std::string("1234"), 1234),
-        ValuePair(std::string("853255"), 853255),
-        ValuePair(std::string("1"), 1),
-        ValuePair(std::string("0"), 0));
-
-    fkyaml::LexicalAnalyzer<fkyaml::Node> lexer;
-    lexer.SetInputBuffer(value_pair.first.c_str());
-    fkyaml::LexicalTokenType token;
-
-    REQUIRE_NOTHROW(token = lexer.GetNextToken());
-    REQUIRE(token == fkyaml::LexicalTokenType::UNSIGNED_INT_VALUE);
-    REQUIRE_NOTHROW(lexer.GetUnsignedInt());
-    REQUIRE(lexer.GetUnsignedInt() == value_pair.second);
+    REQUIRE(token == fkyaml::LexicalTokenType::INTEGER_VALUE);
+    REQUIRE_NOTHROW(lexer.GetInteger());
+    REQUIRE(lexer.GetInteger() == value_pair.second);
 }
 
 TEST_CASE("LexicalAnalyzerClassTest_ScanOctalNumberTokenTest", "[LexicalAnalyzerClassTest]")
 {
-    using ValuePair = std::pair<std::string, fkyaml::NodeUnsignedIntType>;
+    using ValuePair = std::pair<std::string, fkyaml::NodeIntegerType>;
     auto value_pair = GENERATE(
         ValuePair(std::string("0o27"), 027),
         ValuePair(std::string("0o5"), 05),
@@ -258,14 +239,14 @@ TEST_CASE("LexicalAnalyzerClassTest_ScanOctalNumberTokenTest", "[LexicalAnalyzer
     fkyaml::LexicalTokenType token;
 
     REQUIRE_NOTHROW(token = lexer.GetNextToken());
-    REQUIRE(token == fkyaml::LexicalTokenType::UNSIGNED_INT_VALUE);
-    REQUIRE_NOTHROW(lexer.GetUnsignedInt());
-    REQUIRE(lexer.GetUnsignedInt() == value_pair.second);
+    REQUIRE(token == fkyaml::LexicalTokenType::INTEGER_VALUE);
+    REQUIRE_NOTHROW(lexer.GetInteger());
+    REQUIRE(lexer.GetInteger() == value_pair.second);
 }
 
 TEST_CASE("LexicalAnalyzerClassTest_ScanHexadecimalNumberTokenTest", "[LexicalAnalyzerClassTest]")
 {
-    using ValuePair = std::pair<std::string, fkyaml::NodeUnsignedIntType>;
+    using ValuePair = std::pair<std::string, fkyaml::NodeIntegerType>;
     auto value_pair = GENERATE(
         ValuePair(std::string("0xA04F"), 0xA04F),
         ValuePair(std::string("0xa7F3"), 0xa7F3),
@@ -276,9 +257,9 @@ TEST_CASE("LexicalAnalyzerClassTest_ScanHexadecimalNumberTokenTest", "[LexicalAn
     fkyaml::LexicalTokenType token;
 
     REQUIRE_NOTHROW(token = lexer.GetNextToken());
-    REQUIRE(token == fkyaml::LexicalTokenType::UNSIGNED_INT_VALUE);
-    REQUIRE_NOTHROW(lexer.GetUnsignedInt());
-    REQUIRE(lexer.GetUnsignedInt() == value_pair.second);
+    REQUIRE(token == fkyaml::LexicalTokenType::INTEGER_VALUE);
+    REQUIRE_NOTHROW(lexer.GetInteger());
+    REQUIRE(lexer.GetInteger() == value_pair.second);
 }
 
 TEST_CASE("LexicalAnalyzerClassTest_ScanFloatNumberTokenTest", "[LexicalAnalyzerClassTest]")
@@ -598,7 +579,7 @@ TEST_CASE("LexicalAnalyzerClassTest_ScanKeyBooleanValuePairTokenTest", "[Lexical
     REQUIRE(token == fkyaml::LexicalTokenType::END_OF_BUFFER);
 }
 
-TEST_CASE("LexicalAnalyzerClassTest_ScanKeySignedIntegerValuePairTokenTest", "[LexicalAnalyzerClassTest]")
+TEST_CASE("LexicalAnalyzerClassTest_ScanKeyIntegerValuePairTokenTest", "[LexicalAnalyzerClassTest]")
 {
     fkyaml::LexicalAnalyzer<fkyaml::Node> lexer;
     lexer.SetInputBuffer("test: -5784");
@@ -613,34 +594,9 @@ TEST_CASE("LexicalAnalyzerClassTest_ScanKeySignedIntegerValuePairTokenTest", "[L
     REQUIRE(token == fkyaml::LexicalTokenType::KEY_SEPARATOR);
 
     REQUIRE_NOTHROW(token = lexer.GetNextToken());
-    REQUIRE(token == fkyaml::LexicalTokenType::SIGNED_INT_VALUE);
-    REQUIRE_NOTHROW(lexer.GetSignedInt());
-    REQUIRE(lexer.GetSignedInt() == -5784);
-
-    REQUIRE_NOTHROW(token = lexer.GetNextToken());
-    REQUIRE(token == fkyaml::LexicalTokenType::END_OF_BUFFER);
-}
-
-TEST_CASE("LexicalAnalyzerClassTest_ScanKeyUnsignedIntegerValuePairTokenTest", "[LexicalAnalyzerClassTest]")
-{
-    auto buffer = GENERATE(std::string("test: 47239"), std::string("test: +47239"));
-
-    fkyaml::LexicalAnalyzer<fkyaml::Node> lexer;
-    lexer.SetInputBuffer(buffer.c_str());
-    fkyaml::LexicalTokenType token;
-
-    REQUIRE_NOTHROW(token = lexer.GetNextToken());
-    REQUIRE(token == fkyaml::LexicalTokenType::STRING_VALUE);
-    REQUIRE_NOTHROW(lexer.GetString());
-    REQUIRE(lexer.GetString().compare("test") == 0);
-
-    REQUIRE_NOTHROW(token = lexer.GetNextToken());
-    REQUIRE(token == fkyaml::LexicalTokenType::KEY_SEPARATOR);
-
-    REQUIRE_NOTHROW(token = lexer.GetNextToken());
-    REQUIRE(token == fkyaml::LexicalTokenType::UNSIGNED_INT_VALUE);
-    REQUIRE_NOTHROW(lexer.GetUnsignedInt());
-    REQUIRE(lexer.GetUnsignedInt() == 47239);
+    REQUIRE(token == fkyaml::LexicalTokenType::INTEGER_VALUE);
+    REQUIRE_NOTHROW(lexer.GetInteger());
+    REQUIRE(lexer.GetInteger() == -5784);
 
     REQUIRE_NOTHROW(token = lexer.GetNextToken());
     REQUIRE(token == fkyaml::LexicalTokenType::END_OF_BUFFER);

--- a/test/unit_test/NodeClassTest.cpp
+++ b/test/unit_test/NodeClassTest.cpp
@@ -48,18 +48,11 @@ TEST_CASE("NodeClassTest_BooleanTypeCtorTest", "[NodeClassTest]")
     REQUIRE(node.ToBoolean() == false);
 }
 
-TEST_CASE("NodeClassTest_SignedIntTypeCtorTest", "[NodeClassTest]")
+TEST_CASE("NodeClassTest_IntegerTypeCtorTest", "[NodeClassTest]")
 {
-    fkyaml::Node node(fkyaml::NodeType::SIGNED_INTEGER);
-    REQUIRE(node.IsSignedInteger());
-    REQUIRE(node.ToSignedInteger() == 0);
-}
-
-TEST_CASE("NodeClassTest_UnsignedIntTypeCtorTest", "[NodeClassTest]")
-{
-    fkyaml::Node node(fkyaml::NodeType::UNSIGNED_INTEGER);
-    REQUIRE(node.IsUnsignedInteger());
-    REQUIRE(node.ToUnsignedInteger() == 0);
+    fkyaml::Node node(fkyaml::NodeType::INTEGER);
+    REQUIRE(node.IsInteger());
+    REQUIRE(node.ToInteger() == 0);
 }
 
 TEST_CASE("NodeClassTest_FloatNumberTypeCtorTest", "[NodeClassTest]")
@@ -86,7 +79,7 @@ TEST_CASE("NodeClassTest_ThrowingSpecializationTypeCtorTest", "[NodeClassTest]")
         }
     };
 
-    using NodeType = fkyaml::BasicNode<std::vector, std::map, bool, int64_t, uint64_t, double, String>;
+    using NodeType = fkyaml::BasicNode<std::vector, std::map, bool, int64_t, double, String>;
     REQUIRE_THROWS_AS(NodeType::StringScalar(), fkyaml::Exception);
 }
 
@@ -113,15 +106,15 @@ TEST_CASE("NodeClassTest_SequenceCopyCtorTest", "[NodeClassTest]")
 TEST_CASE("NodeClassTest_MappingCopyCtorTest", "[NodeClassTest]")
 {
     fkyaml::Node copied = fkyaml::Node::Mapping(
-        {{"test0", fkyaml::Node::SignedIntegerScalar(123)}, {"test1", fkyaml::Node::FloatNumberScalar(3.14)}});
+        {{"test0", fkyaml::Node::IntegerScalar(123)}, {"test1", fkyaml::Node::FloatNumberScalar(3.14)}});
     fkyaml::Node node(copied);
     REQUIRE(node.IsMapping());
     REQUIRE_NOTHROW(node.Size());
     REQUIRE(node.Size() == 2);
     REQUIRE_NOTHROW(node["test0"]);
-    REQUIRE(node["test0"].IsSignedInteger());
-    REQUIRE_NOTHROW(node["test0"].ToSignedInteger());
-    REQUIRE(node["test0"].ToSignedInteger() == 123);
+    REQUIRE(node["test0"].IsInteger());
+    REQUIRE_NOTHROW(node["test0"].ToInteger());
+    REQUIRE(node["test0"].ToInteger() == 123);
     REQUIRE_NOTHROW(node["test1"]);
     REQUIRE(node["test1"].IsFloatNumber());
     REQUIRE_NOTHROW(node["test1"].ToFloatNumber());
@@ -144,22 +137,13 @@ TEST_CASE("NodeClassTest_BooleanCopyCtorTest", "[NodeClassTest]")
     REQUIRE(node.ToBoolean() == true);
 }
 
-TEST_CASE("NodeClassTest_SignedIntegerCopyCtorTest", "[NodeClassTest]")
+TEST_CASE("NodeClassTest_IntegerCopyCtorTest", "[NodeClassTest]")
 {
-    fkyaml::Node copied = fkyaml::Node::SignedIntegerScalar(123);
+    fkyaml::Node copied = fkyaml::Node::IntegerScalar(123);
     fkyaml::Node node(copied);
-    REQUIRE(node.IsSignedInteger());
-    REQUIRE_NOTHROW(node.ToSignedInteger());
-    REQUIRE(node.ToSignedInteger() == 123);
-}
-
-TEST_CASE("NodeClassTest_UnsignedIntegerCopyCtorTest", "[NodeClassTest]")
-{
-    fkyaml::Node copied = fkyaml::Node::UnsignedIntegerScalar(521);
-    fkyaml::Node node(copied);
-    REQUIRE(node.IsUnsignedInteger());
-    REQUIRE_NOTHROW(node.ToUnsignedInteger());
-    REQUIRE(node.ToUnsignedInteger() == 521);
+    REQUIRE(node.IsInteger());
+    REQUIRE_NOTHROW(node.ToInteger());
+    REQUIRE(node.ToInteger() == 123);
 }
 
 TEST_CASE("NodeClassTest_FloatNumberCopyCtorTest", "[NodeClassTest]")
@@ -216,15 +200,15 @@ TEST_CASE("NodeClassTest_SequenceMoveCtorTest", "[NodeClassTest]")
 TEST_CASE("NodeClassTest_MappingMoveCtorTest", "[NodeClassTest]")
 {
     fkyaml::Node moved = fkyaml::Node::Mapping(
-        {{"test0", fkyaml::Node::SignedIntegerScalar(123)}, {"test1", fkyaml::Node::FloatNumberScalar(3.14)}});
+        {{"test0", fkyaml::Node::IntegerScalar(123)}, {"test1", fkyaml::Node::FloatNumberScalar(3.14)}});
     fkyaml::Node node(std::move(moved));
     REQUIRE(node.IsMapping());
     REQUIRE_NOTHROW(node.Size());
     REQUIRE(node.Size() == 2);
     REQUIRE_NOTHROW(node["test0"]);
-    REQUIRE(node["test0"].IsSignedInteger());
-    REQUIRE_NOTHROW(node["test0"].ToSignedInteger());
-    REQUIRE(node["test0"].ToSignedInteger() == 123);
+    REQUIRE(node["test0"].IsInteger());
+    REQUIRE_NOTHROW(node["test0"].ToInteger());
+    REQUIRE(node["test0"].ToInteger() == 123);
     REQUIRE_NOTHROW(node["test1"]);
     REQUIRE(node["test1"].IsFloatNumber());
     REQUIRE_NOTHROW(node["test1"].ToFloatNumber());
@@ -247,22 +231,13 @@ TEST_CASE("NodeClassTest_BooleanMoveCtorTest", "[NodeClassTest]")
     REQUIRE(node.ToBoolean() == true);
 }
 
-TEST_CASE("NodeClassTest_SignedIntegerMoveCtorTest", "[NodeClassTest]")
+TEST_CASE("NodeClassTest_IntegerMoveCtorTest", "[NodeClassTest]")
 {
-    fkyaml::Node moved = fkyaml::Node::SignedIntegerScalar(123);
+    fkyaml::Node moved = fkyaml::Node::IntegerScalar(123);
     fkyaml::Node node(std::move(moved));
-    REQUIRE(node.IsSignedInteger());
-    REQUIRE_NOTHROW(node.ToSignedInteger());
-    REQUIRE(node.ToSignedInteger() == 123);
-}
-
-TEST_CASE("NodeClassTest_UnsignedIntegerMoveCtorTest", "[NodeClassTest]")
-{
-    fkyaml::Node moved = fkyaml::Node::UnsignedIntegerScalar(521);
-    fkyaml::Node node(std::move(moved));
-    REQUIRE(node.IsUnsignedInteger());
-    REQUIRE_NOTHROW(node.ToUnsignedInteger());
-    REQUIRE(node.ToUnsignedInteger() == 521);
+    REQUIRE(node.IsInteger());
+    REQUIRE_NOTHROW(node.ToInteger());
+    REQUIRE(node.ToInteger() == 123);
 }
 
 TEST_CASE("NodeClassTest_FloatNumberMoveCtorTest", "[NodeClassTest]")
@@ -378,26 +353,13 @@ TEST_CASE("NodeClassTest_BooleanNodeFactoryTest", "[NodeClassTest]")
     REQUIRE(node.ToBoolean() == boolean);
 }
 
-TEST_CASE("NodeClassTest_SignedIntegerNodeFactoryTest", "[NodeClassTest]")
+TEST_CASE("NodeClassTest_IntegerNodeFactoryTest", "[NodeClassTest]")
 {
-    auto signed_integer = GENERATE(
-        std::numeric_limits<fkyaml::NodeSignedIntType>::min(),
-        0,
-        std::numeric_limits<fkyaml::NodeSignedIntType>::max());
-    fkyaml::Node node = fkyaml::Node::SignedIntegerScalar(signed_integer);
-    REQUIRE(node.IsSignedInteger());
-    REQUIRE(node.ToSignedInteger() == signed_integer);
-}
-
-TEST_CASE("NodeClassTest_UnsignedIntegerNodeFactoryTest", "[NodeClassTest]")
-{
-    auto unsigned_integer = GENERATE(
-        std::numeric_limits<fkyaml::NodeUnsignedIntType>::min(),
-        1840,
-        std::numeric_limits<fkyaml::NodeUnsignedIntType>::max());
-    fkyaml::Node node = fkyaml::Node::UnsignedIntegerScalar(unsigned_integer);
-    REQUIRE(node.IsUnsignedInteger());
-    REQUIRE(node.ToUnsignedInteger() == unsigned_integer);
+    auto integer = GENERATE(
+        std::numeric_limits<fkyaml::NodeIntegerType>::min(), 0, std::numeric_limits<fkyaml::NodeIntegerType>::max());
+    fkyaml::Node node = fkyaml::Node::IntegerScalar(integer);
+    REQUIRE(node.IsInteger());
+    REQUIRE(node.ToInteger() == integer);
 }
 
 TEST_CASE("NodeClassTest_FloatNumberNodeFactoryTest", "[NodeClassTest]")
@@ -534,8 +496,7 @@ TEST_CASE("NodeClassTest_StringSubscriptOperatorTest", "[NodeClassTest]")
             fkyaml::Node::Sequence(),
             fkyaml::Node(),
             fkyaml::Node::BooleanScalar(false),
-            fkyaml::Node::SignedIntegerScalar(0),
-            fkyaml::Node::UnsignedIntegerScalar(0),
+            fkyaml::Node::IntegerScalar(0),
             fkyaml::Node::FloatNumberScalar(0.0),
             fkyaml::Node::StringScalar());
 
@@ -604,8 +565,7 @@ TEST_CASE("NodeClassTest_IntegerSubscriptOperatorTest", "[NodeClassTest]")
             fkyaml::Node::Mapping(),
             fkyaml::Node(),
             fkyaml::Node::BooleanScalar(false),
-            fkyaml::Node::SignedIntegerScalar(0),
-            fkyaml::Node::UnsignedIntegerScalar(0),
+            fkyaml::Node::IntegerScalar(0),
             fkyaml::Node::FloatNumberScalar(0.0),
             fkyaml::Node::StringScalar());
 
@@ -634,8 +594,7 @@ TEST_CASE("NodeClassTest_TypeGetterTest", "[NodeClassTest]")
         NodeTypePair(fkyaml::Node::Mapping(), fkyaml::NodeType::MAPPING),
         NodeTypePair(fkyaml::Node(), fkyaml::NodeType::NULL_OBJECT),
         NodeTypePair(fkyaml::Node::BooleanScalar(false), fkyaml::NodeType::BOOLEAN),
-        NodeTypePair(fkyaml::Node::SignedIntegerScalar(0), fkyaml::NodeType::SIGNED_INTEGER),
-        NodeTypePair(fkyaml::Node::UnsignedIntegerScalar(0), fkyaml::NodeType::UNSIGNED_INTEGER),
+        NodeTypePair(fkyaml::Node::IntegerScalar(0), fkyaml::NodeType::INTEGER),
         NodeTypePair(fkyaml::Node::FloatNumberScalar(0.0), fkyaml::NodeType::FLOAT_NUMBER),
         NodeTypePair(fkyaml::Node::StringScalar(), fkyaml::NodeType::STRING));
 
@@ -677,8 +636,7 @@ TEST_CASE("NodeClassTest_IsSequenceTest", "[NodeClassTest]")
             fkyaml::Node::Mapping(),
             fkyaml::Node(),
             fkyaml::Node::BooleanScalar(false),
-            fkyaml::Node::SignedIntegerScalar(0),
-            fkyaml::Node::UnsignedIntegerScalar(0),
+            fkyaml::Node::IntegerScalar(0),
             fkyaml::Node::FloatNumberScalar(0.0),
             fkyaml::Node::StringScalar());
 
@@ -721,8 +679,7 @@ TEST_CASE("NodeClassTest_IsMappingTest", "[NodeClassTest]")
             fkyaml::Node::Sequence(),
             fkyaml::Node(),
             fkyaml::Node::BooleanScalar(false),
-            fkyaml::Node::SignedIntegerScalar(0),
-            fkyaml::Node::UnsignedIntegerScalar(0),
+            fkyaml::Node::IntegerScalar(0),
             fkyaml::Node::FloatNumberScalar(0.0),
             fkyaml::Node::StringScalar());
 
@@ -765,8 +722,7 @@ TEST_CASE("NodeClassTest_IsNullTest", "[NodeClassTest]")
             fkyaml::Node::Sequence(),
             fkyaml::Node::Mapping(),
             fkyaml::Node::BooleanScalar(false),
-            fkyaml::Node::SignedIntegerScalar(0),
-            fkyaml::Node::UnsignedIntegerScalar(0),
+            fkyaml::Node::IntegerScalar(0),
             fkyaml::Node::FloatNumberScalar(0.0),
             fkyaml::Node::StringScalar());
 
@@ -809,8 +765,7 @@ TEST_CASE("NodeClassTest_IsBooleanTest", "[NodeClassTest]")
             fkyaml::Node::Sequence(),
             fkyaml::Node::Mapping(),
             fkyaml::Node(),
-            fkyaml::Node::SignedIntegerScalar(0),
-            fkyaml::Node::UnsignedIntegerScalar(0),
+            fkyaml::Node::IntegerScalar(0),
             fkyaml::Node::FloatNumberScalar(0.0),
             fkyaml::Node::StringScalar());
 
@@ -828,90 +783,45 @@ TEST_CASE("NodeClassTest_IsBooleanTest", "[NodeClassTest]")
     }
 }
 
-TEST_CASE("NodeClassTest_IsSignedIntegerTest", "[NodeClassTest]")
+TEST_CASE("NodeClassTest_IsIntegerTest", "[NodeClassTest]")
 {
-    SECTION("Test signed integer node type.")
+    SECTION("Test integer node type.")
     {
-        fkyaml::Node node = fkyaml::Node::SignedIntegerScalar(0);
+        fkyaml::Node node = fkyaml::Node::IntegerScalar(0);
 
-        SECTION("Test non-alias signed integer node type.")
+        SECTION("Test non-alias integer node type.")
         {
-            REQUIRE(node.IsSignedInteger());
+            REQUIRE(node.IsInteger());
         }
 
-        SECTION("Test alias signed integer node type.")
+        SECTION("Test alias integer node type.")
         {
             node.AddAnchorName("anchor_name");
             fkyaml::Node alias = fkyaml::Node::AliasOf(node);
-            REQUIRE(alias.IsSignedInteger());
+            REQUIRE(alias.IsInteger());
         }
     }
 
-    SECTION("Test non-signed-integer node types.")
+    SECTION("Test non-integer node types.")
     {
         auto node = GENERATE(
             fkyaml::Node::Sequence(),
             fkyaml::Node::Mapping(),
             fkyaml::Node(),
             fkyaml::Node::BooleanScalar(false),
-            fkyaml::Node::UnsignedIntegerScalar(0),
             fkyaml::Node::FloatNumberScalar(0.0),
             fkyaml::Node::StringScalar());
 
-        SECTION("Test non-alias non-signed-integer node types")
+        SECTION("Test non-alias non-integer node types")
         {
-            REQUIRE_FALSE(node.IsSignedInteger());
+            REQUIRE_FALSE(node.IsInteger());
         }
 
-        SECTION("Test alias non-signed-integer node types.")
+        SECTION("Test alias non-integer node types.")
         {
             node.AddAnchorName("anchor_name");
             fkyaml::Node alias = fkyaml::Node::AliasOf(node);
-            REQUIRE_FALSE(alias.IsSignedInteger());
-        }
-    }
-}
-
-TEST_CASE("NodeClassTest_IsUnsignedIntegerTest", "[NodeClassTest]")
-{
-    SECTION("Test unsigned integer node type.")
-    {
-        fkyaml::Node node = fkyaml::Node::UnsignedIntegerScalar(0);
-
-        SECTION("Test non-alias unsigned integer node type.")
-        {
-            REQUIRE(node.IsUnsignedInteger());
-        }
-
-        SECTION("Test alias unsigned integer node type.")
-        {
-            node.AddAnchorName("anchor_name");
-            fkyaml::Node alias = fkyaml::Node::AliasOf(node);
-            REQUIRE(alias.IsUnsignedInteger());
-        }
-    }
-
-    SECTION("Test non-unsigned-integer node types.")
-    {
-        auto node = GENERATE(
-            fkyaml::Node::Sequence(),
-            fkyaml::Node::Mapping(),
-            fkyaml::Node(),
-            fkyaml::Node::BooleanScalar(false),
-            fkyaml::Node::SignedIntegerScalar(0),
-            fkyaml::Node::FloatNumberScalar(0.0),
-            fkyaml::Node::StringScalar());
-
-        SECTION("Test non-alias non-unsigned-integer node types")
-        {
-            REQUIRE_FALSE(node.IsUnsignedInteger());
-        }
-
-        SECTION("Test alias non-unsigned-integer node types.")
-        {
-            node.AddAnchorName("anchor_name");
-            fkyaml::Node alias = fkyaml::Node::AliasOf(node);
-            REQUIRE_FALSE(alias.IsUnsignedInteger());
+            REQUIRE_FALSE(alias.IsInteger());
         }
     }
 }
@@ -942,8 +852,7 @@ TEST_CASE("NodeClassTest_IsFloatNumberTest", "[NodeClassTest]")
             fkyaml::Node::Mapping(),
             fkyaml::Node(),
             fkyaml::Node::BooleanScalar(false),
-            fkyaml::Node::SignedIntegerScalar(0),
-            fkyaml::Node::UnsignedIntegerScalar(0),
+            fkyaml::Node::IntegerScalar(0),
             fkyaml::Node::StringScalar());
 
         SECTION("Test non-alias non-float-number node types")
@@ -986,8 +895,7 @@ TEST_CASE("NodeClassTest_IsStringTest", "[NodeClassTest]")
             fkyaml::Node::Mapping(),
             fkyaml::Node(),
             fkyaml::Node::BooleanScalar(false),
-            fkyaml::Node::SignedIntegerScalar(0),
-            fkyaml::Node::UnsignedIntegerScalar(0),
+            fkyaml::Node::IntegerScalar(0),
             fkyaml::Node::FloatNumberScalar(0.0));
 
         SECTION("Test non-alias non-string node types")
@@ -1011,8 +919,7 @@ TEST_CASE("NodeClassTest_IsScalarTest", "[NodeClassTest]")
         auto node = GENERATE(
             fkyaml::Node(),
             fkyaml::Node::BooleanScalar(false),
-            fkyaml::Node::SignedIntegerScalar(0),
-            fkyaml::Node::UnsignedIntegerScalar(0),
+            fkyaml::Node::IntegerScalar(0),
             fkyaml::Node::FloatNumberScalar(0.0),
             fkyaml::Node::StringScalar());
 
@@ -1054,8 +961,7 @@ TEST_CASE("NodeClassTest_IsAliasTest", "[NodeClassTest]")
         fkyaml::Node::Mapping(),
         fkyaml::Node(),
         fkyaml::Node::BooleanScalar(false),
-        fkyaml::Node::SignedIntegerScalar(0),
-        fkyaml::Node::UnsignedIntegerScalar(0),
+        fkyaml::Node::IntegerScalar(0),
         fkyaml::Node::FloatNumberScalar(0.0),
         fkyaml::Node::StringScalar());
 
@@ -1121,8 +1027,7 @@ TEST_CASE("NodeClassTest_IsEmptyTest", "[NodeClassTest]")
         auto node = GENERATE(
             fkyaml::Node(),
             fkyaml::Node::BooleanScalar(false),
-            fkyaml::Node::SignedIntegerScalar(0),
-            fkyaml::Node::UnsignedIntegerScalar(0),
+            fkyaml::Node::IntegerScalar(0),
             fkyaml::Node::FloatNumberScalar(0.0));
 
         SECTION("Test non-const non-alias non-container node emptiness.")
@@ -1194,8 +1099,7 @@ TEST_CASE("NodeClassTest_ContainsTest", "[NodeClassTest]")
             fkyaml::Node::Sequence(),
             fkyaml::Node(),
             fkyaml::Node::BooleanScalar(false),
-            fkyaml::Node::SignedIntegerScalar(0),
-            fkyaml::Node::UnsignedIntegerScalar(0),
+            fkyaml::Node::IntegerScalar(0),
             fkyaml::Node::FloatNumberScalar(0.0),
             fkyaml::Node::StringScalar());
         std::string key = "test";
@@ -1274,8 +1178,7 @@ TEST_CASE("NodeClassTest_SizeGetterTest", "[NodeClassTest]")
         auto node = GENERATE(
             fkyaml::Node(),
             fkyaml::Node::BooleanScalar(false),
-            fkyaml::Node::SignedIntegerScalar(0),
-            fkyaml::Node::UnsignedIntegerScalar(0),
+            fkyaml::Node::IntegerScalar(0),
             fkyaml::Node::FloatNumberScalar(0.0));
 
         SECTION("Test non-const non-alias non-container node size.")
@@ -1457,8 +1360,7 @@ TEST_CASE("NodeClassTest_ToSequenceTest", "[NodeClassTest]")
             fkyaml::Node::Mapping(),
             fkyaml::Node(),
             fkyaml::Node::BooleanScalar(false),
-            fkyaml::Node::SignedIntegerScalar(0),
-            fkyaml::Node::UnsignedIntegerScalar(0),
+            fkyaml::Node::IntegerScalar(0),
             fkyaml::Node::FloatNumberScalar(0.0),
             fkyaml::Node::StringScalar());
 
@@ -1543,8 +1445,7 @@ TEST_CASE("NodeClassTest_ToMappingTest", "[NodeClassTest]")
             fkyaml::Node::Sequence(),
             fkyaml::Node(),
             fkyaml::Node::BooleanScalar(false),
-            fkyaml::Node::SignedIntegerScalar(0),
-            fkyaml::Node::UnsignedIntegerScalar(0),
+            fkyaml::Node::IntegerScalar(0),
             fkyaml::Node::FloatNumberScalar(0.0),
             fkyaml::Node::StringScalar());
 
@@ -1617,8 +1518,7 @@ TEST_CASE("NodeClassTest_ToBooleanTest", "[NodeClassTest]")
             fkyaml::Node::Sequence(),
             fkyaml::Node::Mapping(),
             fkyaml::Node(),
-            fkyaml::Node::SignedIntegerScalar(0),
-            fkyaml::Node::UnsignedIntegerScalar(0),
+            fkyaml::Node::IntegerScalar(0),
             fkyaml::Node::FloatNumberScalar(0.0),
             fkyaml::Node::StringScalar());
 
@@ -1649,40 +1549,40 @@ TEST_CASE("NodeClassTest_ToBooleanTest", "[NodeClassTest]")
     }
 }
 
-TEST_CASE("NodeClassTest_ToSignedIntegerTest", "[NodeClassTest]")
+TEST_CASE("NodeClassTest_ToIntegerTest", "[NodeClassTest]")
 {
     SECTION("Test nothrow expected nodes.")
     {
-        fkyaml::NodeSignedIntType signed_int = -123;
-        fkyaml::Node node = fkyaml::Node::SignedIntegerScalar(signed_int);
+        fkyaml::NodeIntegerType integer = -123;
+        fkyaml::Node node = fkyaml::Node::IntegerScalar(integer);
 
-        SECTION("Test non-alias signed integer node.")
+        SECTION("Test non-alias  integer node.")
         {
-            REQUIRE_NOTHROW(node.ToSignedInteger());
-            REQUIRE(node.ToSignedInteger() == signed_int);
+            REQUIRE_NOTHROW(node.ToInteger());
+            REQUIRE(node.ToInteger() == integer);
         }
 
-        SECTION("Test const non-alias signed integer node.")
+        SECTION("Test const non-alias  integer node.")
         {
             const fkyaml::Node const_node = node;
-            REQUIRE_NOTHROW(const_node.ToSignedInteger());
-            REQUIRE(const_node.ToSignedInteger() == signed_int);
+            REQUIRE_NOTHROW(const_node.ToInteger());
+            REQUIRE(const_node.ToInteger() == integer);
         }
 
-        SECTION("Test alias signed integer node.")
+        SECTION("Test alias  integer node.")
         {
             node.AddAnchorName("anchor_name");
             fkyaml::Node alias = fkyaml::Node::AliasOf(node);
-            REQUIRE_NOTHROW(alias.ToSignedInteger());
-            REQUIRE(alias.ToSignedInteger() == signed_int);
+            REQUIRE_NOTHROW(alias.ToInteger());
+            REQUIRE(alias.ToInteger() == integer);
         }
 
-        SECTION("Test const alias signed integer node.")
+        SECTION("Test const alias  integer node.")
         {
             node.AddAnchorName("anchor_name");
             const fkyaml::Node alias = fkyaml::Node::AliasOf(node);
-            REQUIRE_NOTHROW(alias.ToSignedInteger());
-            REQUIRE(alias.ToSignedInteger() == signed_int);
+            REQUIRE_NOTHROW(alias.ToInteger());
+            REQUIRE(alias.ToInteger() == integer);
         }
     }
 
@@ -1693,108 +1593,32 @@ TEST_CASE("NodeClassTest_ToSignedIntegerTest", "[NodeClassTest]")
             fkyaml::Node::Mapping(),
             fkyaml::Node(),
             fkyaml::Node::BooleanScalar(false),
-            fkyaml::Node::UnsignedIntegerScalar(0),
             fkyaml::Node::FloatNumberScalar(0.0),
             fkyaml::Node::StringScalar());
 
-        SECTION("Test non-alias non-signed-integer nodes.")
+        SECTION("Test non-alias non-integer nodes.")
         {
-            REQUIRE_THROWS_AS(node.ToSignedInteger(), fkyaml::Exception);
+            REQUIRE_THROWS_AS(node.ToInteger(), fkyaml::Exception);
         }
 
-        SECTION("Test const non-alias non-signed-integer nodes.")
+        SECTION("Test const non-alias non-integer nodes.")
         {
             const fkyaml::Node const_node = node;
-            REQUIRE_THROWS_AS(const_node.ToSignedInteger(), fkyaml::Exception);
+            REQUIRE_THROWS_AS(const_node.ToInteger(), fkyaml::Exception);
         }
 
-        SECTION("Test alias non-signed-integer nodes.")
+        SECTION("Test alias non-integer nodes.")
         {
             node.AddAnchorName("anchor_name");
             fkyaml::Node alias = fkyaml::Node::AliasOf(node);
-            REQUIRE_THROWS_AS(alias.ToSignedInteger(), fkyaml::Exception);
+            REQUIRE_THROWS_AS(alias.ToInteger(), fkyaml::Exception);
         }
 
-        SECTION("Test const alias non-signed-integer nodes.")
+        SECTION("Test const alias non-integer nodes.")
         {
             node.AddAnchorName("anchor_name");
             const fkyaml::Node alias = fkyaml::Node::AliasOf(node);
-            REQUIRE_THROWS_AS(alias.ToSignedInteger(), fkyaml::Exception);
-        }
-    }
-}
-
-TEST_CASE("NodeClassTest_ToUnsignedIntegerTest", "[NodeClassTest]")
-{
-    SECTION("Test nothrow expected nodes.")
-    {
-        fkyaml::NodeUnsignedIntType unsigned_int = 123;
-        fkyaml::Node node = fkyaml::Node::UnsignedIntegerScalar(unsigned_int);
-
-        SECTION("Test non-alias unsigned integer node.")
-        {
-            REQUIRE_NOTHROW(node.ToUnsignedInteger());
-            REQUIRE(node.ToUnsignedInteger() == unsigned_int);
-        }
-
-        SECTION("Test const non-alias unsigned integer node.")
-        {
-            const fkyaml::Node const_node = node;
-            REQUIRE_NOTHROW(const_node.ToUnsignedInteger());
-            REQUIRE(const_node.ToUnsignedInteger() == unsigned_int);
-        }
-
-        SECTION("Test alias unsigned integer node.")
-        {
-            node.AddAnchorName("anchor_name");
-            fkyaml::Node alias = fkyaml::Node::AliasOf(node);
-            REQUIRE_NOTHROW(alias.ToUnsignedInteger());
-            REQUIRE(alias.ToUnsignedInteger() == unsigned_int);
-        }
-
-        SECTION("Test const alias unsigned integer node.")
-        {
-            node.AddAnchorName("anchor_name");
-            const fkyaml::Node alias = fkyaml::Node::AliasOf(node);
-            REQUIRE_NOTHROW(alias.ToUnsignedInteger());
-            REQUIRE(alias.ToUnsignedInteger() == unsigned_int);
-        }
-    }
-
-    SECTION("Test nothrow unexpected nodes.")
-    {
-        auto node = GENERATE(
-            fkyaml::Node::Sequence(),
-            fkyaml::Node::Mapping(),
-            fkyaml::Node(),
-            fkyaml::Node::BooleanScalar(false),
-            fkyaml::Node::SignedIntegerScalar(0),
-            fkyaml::Node::FloatNumberScalar(0.0),
-            fkyaml::Node::StringScalar());
-
-        SECTION("Test non-alias non-unsigned-integer nodes.")
-        {
-            REQUIRE_THROWS_AS(node.ToUnsignedInteger(), fkyaml::Exception);
-        }
-
-        SECTION("Test const non-alias non-unsigned-integer nodes.")
-        {
-            const fkyaml::Node const_node = node;
-            REQUIRE_THROWS_AS(const_node.ToUnsignedInteger(), fkyaml::Exception);
-        }
-
-        SECTION("Test alias non-unsigned-integer nodes.")
-        {
-            node.AddAnchorName("anchor_name");
-            fkyaml::Node alias = fkyaml::Node::AliasOf(node);
-            REQUIRE_THROWS_AS(alias.ToUnsignedInteger(), fkyaml::Exception);
-        }
-
-        SECTION("Test const alias non-unsigned-integer nodes.")
-        {
-            node.AddAnchorName("anchor_name");
-            const fkyaml::Node alias = fkyaml::Node::AliasOf(node);
-            REQUIRE_THROWS_AS(alias.ToUnsignedInteger(), fkyaml::Exception);
+            REQUIRE_THROWS_AS(alias.ToInteger(), fkyaml::Exception);
         }
     }
 }
@@ -1843,8 +1667,7 @@ TEST_CASE("NodeClassTest_ToFloatNumberTest", "[NodeClassTest]")
             fkyaml::Node::Mapping(),
             fkyaml::Node(),
             fkyaml::Node::BooleanScalar(false),
-            fkyaml::Node::SignedIntegerScalar(0),
-            fkyaml::Node::UnsignedIntegerScalar(0),
+            fkyaml::Node::IntegerScalar(0),
             fkyaml::Node::StringScalar());
 
         SECTION("Test non-alias non-float-number nodes.")
@@ -1918,8 +1741,7 @@ TEST_CASE("NodeClassTest_ToStringTest", "[NodeClassTest]")
             fkyaml::Node::Mapping(),
             fkyaml::Node(),
             fkyaml::Node::BooleanScalar(false),
-            fkyaml::Node::SignedIntegerScalar(0),
-            fkyaml::Node::UnsignedIntegerScalar(0),
+            fkyaml::Node::IntegerScalar(0),
             fkyaml::Node::FloatNumberScalar(0.0));
 
         SECTION("Test non-alias non-string nodes.")
@@ -2001,8 +1823,7 @@ TEST_CASE("NodeClassTest_BeginTest", "[NodeClassTest]")
         auto node = GENERATE(
             fkyaml::Node(),
             fkyaml::Node::BooleanScalar(false),
-            fkyaml::Node::SignedIntegerScalar(0),
-            fkyaml::Node::UnsignedIntegerScalar(0),
+            fkyaml::Node::IntegerScalar(0),
             fkyaml::Node::FloatNumberScalar(0.0),
             fkyaml::Node::StringScalar());
 
@@ -2067,8 +1888,7 @@ TEST_CASE("NodeClassTest_EndTest", "[NodeClassTest]")
         auto node = GENERATE(
             fkyaml::Node(),
             fkyaml::Node::BooleanScalar(false),
-            fkyaml::Node::SignedIntegerScalar(0),
-            fkyaml::Node::UnsignedIntegerScalar(0),
+            fkyaml::Node::IntegerScalar(0),
             fkyaml::Node::FloatNumberScalar(0.0),
             fkyaml::Node::StringScalar());
 
@@ -2092,10 +1912,10 @@ TEST_CASE("NodeClassTest_EndTest", "[NodeClassTest]")
 TEST_CASE("NodeClassTest_SwapTest", "[NodeClassTest]")
 {
     fkyaml::Node lhs_node = fkyaml::Node::BooleanScalar(true);
-    fkyaml::Node rhs_node = fkyaml::Node::SignedIntegerScalar(123);
+    fkyaml::Node rhs_node = fkyaml::Node::IntegerScalar(123);
     lhs_node.Swap(rhs_node);
-    REQUIRE(lhs_node.IsSignedInteger());
-    REQUIRE(lhs_node.ToSignedInteger() == 123);
+    REQUIRE(lhs_node.IsInteger());
+    REQUIRE(lhs_node.ToInteger() == 123);
     REQUIRE(rhs_node.IsBoolean());
     REQUIRE(rhs_node.ToBoolean() == true);
 }
@@ -2103,10 +1923,10 @@ TEST_CASE("NodeClassTest_SwapTest", "[NodeClassTest]")
 TEST_CASE("NodeClassTest_StdSwapTest", "[NodeClassTest]")
 {
     fkyaml::Node lhs_node = fkyaml::Node::BooleanScalar(true);
-    fkyaml::Node rhs_node = fkyaml::Node::SignedIntegerScalar(123);
+    fkyaml::Node rhs_node = fkyaml::Node::IntegerScalar(123);
     std::swap(lhs_node, rhs_node);
-    REQUIRE(lhs_node.IsSignedInteger());
-    REQUIRE(lhs_node.ToSignedInteger() == 123);
+    REQUIRE(lhs_node.IsInteger());
+    REQUIRE(lhs_node.ToInteger() == 123);
     REQUIRE(rhs_node.IsBoolean());
     REQUIRE(rhs_node.ToBoolean() == true);
 }

--- a/test/unit_test/SerializerClassTest.cpp
+++ b/test/unit_test/SerializerClassTest.cpp
@@ -21,7 +21,7 @@ TEST_CASE("SerializerClassTest_SerializeSequenceNode", "[SerializerClassTest]")
             "- true\n- false\n"),
         NodeStrPair(
             fkyaml::Node::Sequence(
-                {fkyaml::Node::Mapping({{"foo", fkyaml::Node::SignedIntegerScalar(-1234)}, {"bar", fkyaml::Node()}})}),
+                {fkyaml::Node::Mapping({{"foo", fkyaml::Node::IntegerScalar(-1234)}, {"bar", fkyaml::Node()}})}),
             "-\n  foo: -1234\n  bar: null\n"));
     fkyaml::Serializer serializer;
     REQUIRE(serializer.Serialize(node_str_pair.first) == node_str_pair.second);
@@ -32,7 +32,7 @@ TEST_CASE("SerializerClassTest_SerializeMappingNode", "[SerializerClassTest]")
     using NodeStrPair = std::pair<fkyaml::Node, std::string>;
     auto node_str_pair = GENERATE(
         NodeStrPair(
-            fkyaml::Node::Mapping({{"foo", fkyaml::Node::SignedIntegerScalar(-1234)}, {"bar", fkyaml::Node()}}),
+            fkyaml::Node::Mapping({{"foo", fkyaml::Node::IntegerScalar(-1234)}, {"bar", fkyaml::Node()}}),
             "foo: -1234\nbar: null\n"),
         NodeStrPair(
             fkyaml::Node::Mapping(
@@ -60,22 +60,12 @@ TEST_CASE("SerializerClassTest_SerializeBooleanNode", "[SerializerClassTest]")
     REQUIRE(serializer.Serialize(node_str_pair.first) == node_str_pair.second);
 }
 
-TEST_CASE("SerializerClassTest_SerializeSignedIntegerNode", "[SerializerClassTest]")
+TEST_CASE("SerializerClassTest_SerializeIntegerNode", "[SerializerClassTest]")
 {
     using NodeStrPair = std::pair<fkyaml::Node, std::string>;
     auto node_str_pair = GENERATE(
-        NodeStrPair(fkyaml::Node::SignedIntegerScalar(-1234), "-1234"),
-        NodeStrPair(fkyaml::Node::SignedIntegerScalar(5678), "5678"));
-    fkyaml::Serializer serializer;
-    REQUIRE(serializer.Serialize(node_str_pair.first) == node_str_pair.second);
-}
-
-TEST_CASE("SerializeClassTest_SerializeUnsignedIntegerNode", "[SerializeClassTest]")
-{
-    using NodeStrPair = std::pair<fkyaml::Node, std::string>;
-    auto node_str_pair = GENERATE(
-        NodeStrPair(fkyaml::Node::UnsignedIntegerScalar(1234), "1234"),
-        NodeStrPair(fkyaml::Node::UnsignedIntegerScalar(5678), "5678"));
+        NodeStrPair(fkyaml::Node::IntegerScalar(-1234), "-1234"),
+        NodeStrPair(fkyaml::Node::IntegerScalar(5678), "5678"));
     fkyaml::Serializer serializer;
     REQUIRE(serializer.Serialize(node_str_pair.first) == node_str_pair.second);
 }


### PR DESCRIPTION
Integer scalar data type has been changed to int64_t only.  
Not int64_t & uint64_t separately anymore.  
This is for clarity of implementation as well as usage.  
The acceptable range of integer values is therefore the one which int64_t can have: 4 bytes of buffer each for signed/unsigned in a single integer value.  

The unit test app has also support the above change, and all the test cases have passed successfully.  