### PR TITLE
#83 Add compiler support on Windows & macOS

### DIFF
--- a/.github/workflows/macos.yml
+++ b/.github/workflows/macos.yml
@@ -16,7 +16,7 @@ jobs:
     runs-on: macos-11
     strategy:
       matrix:
-        xcode: [ '11.7', '12.4', '12.5.1', '13.0' ]
+        xcode: [ '11.7', '12.4', '12.5.1', '13.0', '13.1', '13.2.1' ]
     env:
       DEVELOPER_DIR: /Applications/Xcode_${{matrix.xcode}}.app/Contents/Developer
 
@@ -40,7 +40,7 @@ jobs:
     runs-on: macos-12
     strategy:
       matrix:
-        xcode: [ '13.1', '13.2.1', '13.3.1', '13.4.1' ]
+        xcode: [ '13.1', '13.2.1', '13.3.1', '13.4.1', '14.0.1', '14.1', '14.2' ]
     env:
       DEVELOPER_DIR: /Applications/Xcode_${{matrix.xcode}}.app/Contents/Developer
 

--- a/.github/workflows/macos.yml
+++ b/.github/workflows/macos.yml
@@ -11,12 +11,14 @@ on:
   workflow_dispatch:
 
 jobs:
-  build:
+  xcode_for_macos11:
     timeout-minutes: 10
-    runs-on: macos-latest
+    runs-on: macos-11
     strategy:
       matrix:
-        build_type: [ Debug, Release ]
+        xcode: [ '11.7', '12.4', '12.5.1', '13.0' ]
+    env:
+      DEVELOPER_DIR: /Applications/Xcode_${{matrix.xcode}}.app/Contents/Developer
 
     steps:
     - uses: actions/checkout@v3
@@ -24,11 +26,35 @@ jobs:
         submodules: recursive
 
     - name: Configure CMake
-      run: cmake -B ${{github.workspace}}/build_${{matrix.build_type}} -DCMAKE_BUILD_TYPE=${{matrix.build_type}} -DFK_YAML_BUILD_TEST=ON
+      run: cmake -B ${{github.workspace}}/build -DCMAKE_BUILD_TYPE=Debug -DFK_YAML_BUILD_TEST=ON
 
     - name: Build
-      run: cmake --build ${{github.workspace}}/build_${{matrix.build_type}} --config ${{matrix.build_type}}
+      run: cmake --build ${{github.workspace}}/build --config Debug
 
     - name: Test
-      working-directory: ${{github.workspace}}/build_${{matrix.build_type}}
-      run: ctest -C ${{matrix.build_type}} --output-on-failure
+      working-directory: ${{github.workspace}}/build
+      run: ctest -C Debug --output-on-failure
+
+  xcode_for_macos12:
+    timeout-minutes: 10
+    runs-on: macos-12
+    strategy:
+      matrix:
+        xcode: [ '13.1', '13.2.1', '13.3.1', '13.4.1' ]
+    env:
+      DEVELOPER_DIR: /Applications/Xcode_${{matrix.xcode}}.app/Contents/Developer
+
+    steps:
+    - uses: actions/checkout@v3
+      with:
+        submodules: recursive
+
+    - name: Configure CMake
+      run: cmake -B ${{github.workspace}}/build -DCMAKE_BUILD_TYPE=Debug -DFK_YAML_BUILD_TEST=ON
+
+    - name: Build
+      run: cmake --build ${{github.workspace}}/build --config Debug
+
+    - name: Test
+      working-directory: ${{github.workspace}}/build
+      run: ctest -C Debug --output-on-failure

--- a/.github/workflows/windows.yml
+++ b/.github/workflows/windows.yml
@@ -72,7 +72,7 @@ jobs:
       run: cmake -B ${{github.workspace}}/build -S ${{github.workspace}} -G "MinGW Makefiles" -DCMAKE_BUILD_TYPE=${{matrix.build_type}} -DFK_YAML_BUILD_TEST=ON
 
     - name: Build
-      run: cmake --build ${{github.workflow}}/build --config ${{matrix.build_type}}
+      run: cmake --build ${{github.workspace}}/build --config ${{matrix.build_type}}
 
     - name: Test
       working-directory: ${{github.workspace}}/build

--- a/.github/workflows/windows.yml
+++ b/.github/workflows/windows.yml
@@ -83,13 +83,11 @@ jobs:
         choco install mingw.8.1.0.nupkg ''
         $prefix = 'x86_64-w64-mingw32'
         $mingw = 'mingw64'
-        $mingw_install = Join-Path C: ProgramData chocolatey lib mingw tools install
+        $mingw_install = Join-Path C: 'Program Data' chocolatey lib mingw tools install
         $mingw_root = Join-Path $mingw_install $mingw
         $mingw_bin = Join-Path $mingw_root bin
         $mingw_lib = Join-Path $mingw_root $prefix lib
         echo $mingw_bin >> $env:GITHUB_PATH
-        Remove-Item (Join-Path $mingw_lib 'libpthread.dll.a')
-        Remove-Item (Join-Path $mingw_lib 'libwinpthread.dll.a')
     - name: Configure CMake
       run: cmake -B ${{github.workspace}}/build -S ${{github.workspace}} -G "MinGW Makefiles" -DCMAKE_BUILD_TYPE=${{matrix.build_type}} -DFK_YAML_BUILD_TEST=ON
 

--- a/.github/workflows/windows.yml
+++ b/.github/workflows/windows.yml
@@ -68,9 +68,19 @@ jobs:
       with:
         submodules: recursive
 
+    - name: Download MinGW 8.1.0
+      run: |
+        $headers = @{Authorization = 'Bearer ${{secrets.GITHUB_TOKEN}}'}
+        $uri = 'https://nuget.pkg.github.com/falbrechtskirchinger/download/mingw/8.1.0/mingw.8.1.0.nupkg'
+        Invoke-WebRequest -Uri $uri -Headers $headers -OutFile mingw.8.1.0.nupkg
+
+    - name: Uninstall existing MinGW
+      continue-on-error: true
+      run: choco uninstall mingw
+
     - name: Install MinGW 8.1.0
       run: |
-        choco install mingw.8.1.0.nupkg
+        choco install mingw.8.1.0.nupkg ''
         $prefix = 'x86_64-w64-mingw32'
         $mingw = 'mingw64'
         $mingw_install = Join-Path C: ProgramData chocolatey lib mingw tools install

--- a/.github/workflows/windows.yml
+++ b/.github/workflows/windows.yml
@@ -54,3 +54,38 @@ jobs:
     - name: Test
       working-directory: ${{github.workspace}}/build
       run: ctest -C ${{matrix.build_type}} --output-on-failure
+
+  mingw:
+    timeout-minutes: 10
+    runs-on: ${{matrix.os}}
+    strategy:
+      matrix:
+        os: [ windows-2019, windows-2022 ]
+        build_type: [ Debug, Release ]
+
+    steps:
+    - uses: actions/checkout@v3
+      with:
+        submodules: recursive
+
+    - name: Install MinGW 8.1.0
+      run: |
+        choco install mingw.8.1.0.nupkg
+        $prefix = 'x86_64-w64-mingw32'
+        $mingw = 'mingw64'
+        $mingw_install = Join-Path C: ProgramData chocolatey lib mingw tools install
+        $mingw_root = Join-Path $mingw_install $mingw
+        $mingw_bin = Join-Path $mingw_root bin
+        $mingw_lib = Join-Path $mingw_root $prefix lib
+        echo $mingw_bin >> $env:GITHUB_PATH
+        Remove-Item (Join-Path $mingw_lib 'libpthread.dll.a')
+        Remove-Item (Join-Path $mingw_lib 'libwinpthread.dll.a')
+    - name: Configure CMake
+      run: cmake -B ${{github.workspace}}/build -S ${{github.workspace}} -G "MinGW Makefiles" -DCMAKE_BUILD_TYPE=${{matrix.build_type}} -DFK_YAML_BUILD_TEST=ON
+
+    - name: Build
+      run: cmake --build ${{github.workflow}}/build --config ${{matrix.build_type}}
+
+    - name: Test
+      working-directory: ${{github.workspace}}/build
+      run: ctest -C ${{matrix.build_type}} --output-on-failure

--- a/.github/workflows/windows.yml
+++ b/.github/workflows/windows.yml
@@ -68,26 +68,6 @@ jobs:
       with:
         submodules: recursive
 
-    - name: Download MinGW 8.1.0
-      run: |
-        $headers = @{Authorization = 'Bearer ${{secrets.GITHUB_TOKEN}}'}
-        $uri = 'https://nuget.pkg.github.com/falbrechtskirchinger/download/mingw/8.1.0/mingw.8.1.0.nupkg'
-        Invoke-WebRequest -Uri $uri -Headers $headers -OutFile mingw.8.1.0.nupkg
-
-    - name: Uninstall existing MinGW
-      continue-on-error: true
-      run: choco uninstall mingw
-
-    - name: Install MinGW 8.1.0
-      run: |
-        choco install mingw.8.1.0.nupkg ''
-        $prefix = 'x86_64-w64-mingw32'
-        $mingw = 'mingw64'
-        $mingw_install = Join-Path C: 'Program Data' chocolatey lib mingw tools install
-        $mingw_root = Join-Path $mingw_install $mingw
-        $mingw_bin = Join-Path $mingw_root bin
-        $mingw_lib = Join-Path $mingw_root $prefix lib
-        echo $mingw_bin >> $env:GITHUB_PATH
     - name: Configure CMake
       run: cmake -B ${{github.workspace}}/build -S ${{github.workspace}} -G "MinGW Makefiles" -DCMAKE_BUILD_TYPE=${{matrix.build_type}} -DFK_YAML_BUILD_TEST=ON
 

--- a/README.md
+++ b/README.md
@@ -232,7 +232,7 @@ Currently, the following compilers are known to work and used in CI workflows:
 | GCC 11.4.0 | Ubuntu 22.04.3 LTS | GitHub Actions |
 | GCC 12.3.0 | Ubuntu 22.04.3 LTS | GitHub Actions |
 | MinGW-64 8.1.0 | Windows-10.0.17763 | GitHub Actions |
-| MinGW-64 8.1.0 | Windows-10.0.20348 | GitHub Actions |
+| MinGW-64 12.2.0 | Windows-10.0.20348 | GitHub Actions |
 | Visual Studio 16 2019 MSVC 19.29.30152.0 | Windows-10.0.17763 | GitHub Actions |
 | Visual Studio 17 2022 MSVC 19.35.32217.1 | Windows-10.0.20348 | GitHub Actions |
 

--- a/README.md
+++ b/README.md
@@ -231,6 +231,8 @@ Currently, the following compilers are known to work and used in CI workflows:
 | GCC 10.5.0 | Ubuntu 22.04.3 LTS | GitHub Actions |
 | GCC 11.4.0 | Ubuntu 22.04.3 LTS | GitHub Actions |
 | GCC 12.3.0 | Ubuntu 22.04.3 LTS | GitHub Actions |
+| MinGW-64 8.1.0 | Windows-10.0.17763 | GitHub Actions |
+| MinGW-64 8.1.0 | Windows-10.0.20348 | GitHub Actions |
 | Visual Studio 16 2019 MSVC 19.29.30152.0 | Windows-10.0.17763 | GitHub Actions |
 | Visual Studio 17 2022 MSVC 19.35.32217.1 | Windows-10.0.20348 | GitHub Actions |
 

--- a/README.md
+++ b/README.md
@@ -215,6 +215,12 @@ Currently, the following compilers are known to work and used in CI workflows:
 
 | Compiler | Operating System | CI provider |
 |----------|------------------|-------------|
+| AppleClang 11.0.3.11030032 | macOS 11.7.9 | GitHub Actions |
+| AppleClang 12.0.0.12000032 | macOS 11.7.9 | GitHub Actions |
+| AppleClang 12.0.5.12050022 | macOS 11.7.9 | GitHub Actions |
+| AppleClang 13.0.0.13000029 | macOS 11.7.9 | GitHub Actions |
+| AppleClang 13.0.0.13000029 | macOS 12.6.8 | GitHub Actions |
+| AppleClang 13.1.6.13160021 | macOS 12.6.8 | GitHub Actions |
 | AppleClang 14.0.0.14000029 | macOS 12.6.8 | GitHub Actions |
 | Clang 11.1.0 | Ubuntu 22.04.3 LTS | GitHub Actions |
 | Clang 12.0.1 | Ubuntu 22.04.3 LTS | GitHub Actions |


### PR DESCRIPTION
New compilers have been added to the supported compiler list.  
The fkYAML library is built and unit-tested with those compilers with successful results.  
Newly supported compilers are as follows:  

| Compiler | Operating System | CI provider |
|----------|------------------|-------------|
| AppleClang 11.0.3.11030032 | macOS 11.7.9 | GitHub Actions |
| AppleClang 12.0.0.12000032 | macOS 11.7.9 | GitHub Actions |
| AppleClang 12.0.5.12050022 | macOS 11.7.9 | GitHub Actions |
| AppleClang 13.0.0.13000029 | macOS 11.7.9 | GitHub Actions |
| AppleClang 13.0.0.13000029 | macOS 12.6.8 | GitHub Actions |
| AppleClang 13.1.6.13160021 | macOS 12.6.8 | GitHub Actions |
| MinGW-64 8.1.0 | Windows-10.0.17763 | GitHub Actions |
| MinGW-64 12.2.0 | Windows-10.0.20348 | GitHub Actions |