### PR TITLE
Release fkYAML v0.0.0

### DIFF
--- a/.github/workflows/clang_format_check.yml
+++ b/.github/workflows/clang_format_check.yml
@@ -2,14 +2,16 @@ name: Clang_Format_Check
 
 on:
   push:
-    paths:
-      - '**.hpp'
-      - '**.cpp'
+    branches:
+      - develop
+      - main
+      - release/*
   pull_request:
-    branches: [ "main", "develop" ]
+  workflow_dispatch:
 
-env:
-  BUILD_TYPE: Release
+concurrency:
+  group: ${{github.workflow}}-${{github.ref || github.run_id}}
+  cancel-in-progress: true
 
 jobs:
   format-check:

--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -2,12 +2,14 @@ name: CodeQL
 
 on:
   push:
-    branches: [ "develop", "main" ]
+    branches:
+      - "develop"
+      - "main"
+      - "release/*"
   pull_request:
-    # The branches below must be a subset of the branches above
-    branches: [ "develop" ]
   schedule:
-    - cron: '30 9 * * *'
+    - cron: '00 0 * * 1'
+  workflow_dispatch:
 
 jobs:
   analyze:

--- a/.github/workflows/coverage.yml
+++ b/.github/workflows/coverage.yml
@@ -2,12 +2,12 @@ name: Coverage
 
 on:
   push:
-    paths:
-      - '**.hpp'
-      - '**.cpp'
+    branches:
+      - develop
+      - main
+      - release/*
   pull_request:
   workflow_dispatch:
-
 
 jobs:
   coverage:

--- a/.github/workflows/macos.yml
+++ b/.github/workflows/macos.yml
@@ -2,13 +2,16 @@ name: macOS
 
 on:
   push:
-    paths:
-      - '**.hpp'
-      - '**.cpp'
-      - '**.cmake'
-      - '**.yml'
+    branches:
+      - develop
+      - main
+      - release/*
   pull_request:
   workflow_dispatch:
+
+concurrency:
+  group: ${{github.workflow}}-${{github.ref || github.run_id}}
+  cancel-in-progress: true
 
 jobs:
   xcode_for_macos11:

--- a/.github/workflows/publish_docs.yml
+++ b/.github/workflows/publish_docs.yml
@@ -1,0 +1,52 @@
+name: PublishDocs
+
+on:
+  push:
+    branches:
+      - main
+  workflow_dispatch:
+
+permissions:
+  contents: read
+  pages: write
+  id-token: write
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+
+    steps:
+      - uses: actions/checkout@v3
+        with:
+          submodules: recursive
+
+      - name: Install graphviz and doxygen
+        run: |
+          sudo apt update
+          sudo apt install -y --no-install-recommends graphviz doxygen
+
+      - name: Configure CMake
+        run: cmake -B ${{github.workspace}}/build -S ${{github.workspace}} -DFK_YAML_RUN_DOXYGEN=ON
+
+      - name: Create API documents with Doxygen
+        run: cmake --build ${{github.workspace}}/build --target doxygen
+
+      - name: Setup Pages
+        uses: actions/configure-pages@v3
+
+      - name: Upload API documents
+        uses: actions/upload-pages-artifact@v2
+        with:
+          path: ${{github.workspace}}/build/doxygen/html
+
+  deploy:
+    needs: build
+    environment:
+      name: github-pages
+      url: ${{steps.deployment.outputs.page_url}}
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Deploy to GitHub Pages
+        id: deployment
+        uses: actions/deploy-pages@v2

--- a/.github/workflows/release_package.yml
+++ b/.github/workflows/release_package.yml
@@ -1,26 +1,23 @@
-name: CMake_Package_Release
+name: ReleasePackage
 
 on:
-  pull_request:
-    branches: [ "main" ]
-
-env:
-  BUILD_TYPE: Release
+  push:
+    branches: 
+      - main
+  workflow_dispatch:
 
 jobs:
-  build:
+  create_package:
     timeout-minutes: 10
     runs-on: ${{matrix.os}}
     strategy:
       matrix:
-        os: [ubuntu-latest, windows-latest, macos-latest]
+        os: [ubuntu-latest, windows-latest]
         include:
           - os: ubuntu-latest
-            artifact_name: fkYAML_linux_x64.tgz
+            artifact_name: fkYAML.tgz
           - os: windows-latest
-            artifact_name: fkYAML_windows_x64.zip
-          - os: macos-latest
-            artifact_name: fkYAML_mac_darwin.tgz
+            artifact_name: fkYAML.zip
 
     steps:
     - uses: actions/checkout@v3
@@ -28,11 +25,11 @@ jobs:
         submodules: recursive
 
     - name: Configure CMake
-      run: cmake -B ${{github.workspace}}/build -DCMAKE_BUILD_TYPE=${{env.BUILD_TYPE}} -DCMAKE_INSTALL_PREFIX="${{github.workspace}}/build/package"
+      run: cmake -B ${{github.workspace}}/build -DCMAKE_BUILD_TYPE=Release -DCMAKE_INSTALL_PREFIX="${{github.workspace}}/build/package"
 
     - name: Install
       run: |
-        cmake --build ${{github.workspace}}/build --config ${{env.BUILD_TYPE}} --target install
+        cmake --build ${{github.workspace}}/build --config Release --target install
         ls ${{github.workspace}}/build/package
 
     - name: Package

--- a/.github/workflows/ubuntu.yml
+++ b/.github/workflows/ubuntu.yml
@@ -2,13 +2,16 @@ name: Ubuntu
 
 on:
   push:
-    paths:
-      - '**.hpp'
-      - '**.cpp'
-      - '**.cmake'
-      - '**.yml'
+    branches:
+      - develop
+      - main
+      - release/*
   pull_request:
   workflow_dispatch:
+
+concurrency:
+  group: ${{github.workflow}}-${{github.ref || github.run_id}}
+  cancel-in-progress: true
 
 jobs:
   ubuntu-latest:

--- a/.github/workflows/windows.yml
+++ b/.github/workflows/windows.yml
@@ -2,13 +2,16 @@ name: Windows
 
 on:
   push:
-    paths:
-      - '**.hpp'
-      - '**.cpp'
-      - '**.cmake'
-      - '**.yml'
+    branches:
+      - develop
+      - main
+      - release/*
   pull_request:
   workflow_dispatch:
+
+concurrency:
+  group: ${{github.workflow}}-${{github.ref || github.run_id}}
+  cancel-in-progress: true
 
 jobs:
   msvc2019:

--- a/README.md
+++ b/README.md
@@ -3,7 +3,7 @@
 [![macOS](https://github.com/fktn-k/fkYAML/workflows/macOS/badge.svg)](https://github.com/fktn-k/fkYAML/actions?query=workflow%3AmacOS)
 [![Coverage Status](https://coveralls.io/repos/github/fktn-k/fkYAML/badge.svg?branch=develop)](https://coveralls.io/github/fktn-k/fkYAML?branch=develop)
 [![CodeQL](https://github.com/fktn-k/fkYAML/workflows/CodeQL/badge.svg)](https://github.com/fktn-k/fkYAML/actions?query=workflow%3ACodeQL)
-[![GitHub Releases](https://img.shields.io/github/release/fktn-k/fkYAML.svg)](https://github.com/fktn-k/fkYAML/releases)
+[![GitHub Releases](https://img.shields.io/github/release/fktn-k/fkYAML.svg)](https://github.com/fktn-k/fkYAML/releases/latest)
 [![GitHub license](https://img.shields.io/badge/license-MIT-blue.svg)](https://raw.githubusercontent.com/fktn-k/fkYAML/develop/LICENSE.txt)
 [![GitHub Issues](https://img.shields.io/github/issues/fktn-k/fkYAML.svg)](https://github.com/fktn-k/fkYAML/issues)
 

--- a/include/fkYAML/Assert.hpp
+++ b/include/fkYAML/Assert.hpp
@@ -1,6 +1,14 @@
 /**
+ *   __ _  __     __      __  __ _
+ *  / _| | \ \   / //\   |  \/  | |
+ * | |_| | _\ \_/ //  \  | \  / | |
+ * |  _| |/ /\   // /\ \ | |\/| | |
+ * | | |   <  | |/ ____ \| |  | | |____
+ * |_| |_|\_\ |_/_/    \_\_|  |_|______|
+ *
  * @file Assert.hpp
  * @brief Definition of assertion for fkYAML library implementation.
+ * @version 0.0.0
  *
  * Copyright (c) 2023 fktn
  * Distributed under the MIT License (https://opensource.org/licenses/MIT)

--- a/include/fkYAML/Deserializer.hpp
+++ b/include/fkYAML/Deserializer.hpp
@@ -1,6 +1,14 @@
 /**
+ *   __ _  __     __      __  __ _
+ *  / _| | \ \   / //\   |  \/  | |
+ * | |_| | _\ \_/ //  \  | \  / | |
+ * |  _| |/ /\   // /\ \ | |\/| | |
+ * | | |   <  | |/ ____ \| |  | | |____
+ * |_| |_|\_\ |_/_/    \_\_|  |_|______|
+ *
  * @file Deserializer.hpp
  * @brief Implementation of the deserializer for YAML documents.
+ * @version 0.0.0
  *
  * Copyright (c) 2023 fktn
  * Distributed under the MIT License (https://opensource.org/licenses/MIT)

--- a/include/fkYAML/Exception.hpp
+++ b/include/fkYAML/Exception.hpp
@@ -1,6 +1,14 @@
 /**
+ *   __ _  __     __      __  __ _
+ *  / _| | \ \   / //\   |  \/  | |
+ * | |_| | _\ \_/ //  \  | \  / | |
+ * |  _| |/ /\   // /\ \ | |\/| | |
+ * | | |   <  | |/ ____ \| |  | | |____
+ * |_| |_|\_\ |_/_/    \_\_|  |_|______|
+ *
  * @file Exception.hpp
  * @brief Implementation of custom exception classes.
+ * @version 0.0.0
  *
  * Copyright (c) 2023 fktn
  * Distributed under the MIT License (https://opensource.org/licenses/MIT)

--- a/include/fkYAML/Iterator.hpp
+++ b/include/fkYAML/Iterator.hpp
@@ -1,6 +1,14 @@
 /**
+ *   __ _  __     __      __  __ _
+ *  / _| | \ \   / //\   |  \/  | |
+ * | |_| | _\ \_/ //  \  | \  / | |
+ * |  _| |/ /\   // /\ \ | |\/| | |
+ * | | |   <  | |/ ____ \| |  | | |____
+ * |_| |_|\_\ |_/_/    \_\_|  |_|______|
+ *
  * @file Iterator.hpp
  * @brief Implementation of the YAML node iterator.
+ * @version 0.0.0
  *
  * Copyright (c) 2023 fktn
  * Distributed under the MIT License (https://opensource.org/licenses/MIT)

--- a/include/fkYAML/LexicalAnalyzer.hpp
+++ b/include/fkYAML/LexicalAnalyzer.hpp
@@ -1,6 +1,14 @@
 /**
+ *   __ _  __     __      __  __ _
+ *  / _| | \ \   / //\   |  \/  | |
+ * | |_| | _\ \_/ //  \  | \  / | |
+ * |  _| |/ /\   // /\ \ | |\/| | |
+ * | | |   <  | |/ ____ \| |  | | |____
+ * |_| |_|\_\ |_/_/    \_\_|  |_|______|
+ *
  * @file LexicalAnalyzer.hpp
  * @brief Implementation of the lexical analyzer for YAML documents.
+ * @version 0.0.0
  *
  * Copyright (c) 2023 fktn
  * Distributed under the MIT License (https://opensource.org/licenses/MIT)

--- a/include/fkYAML/Node.hpp
+++ b/include/fkYAML/Node.hpp
@@ -1,6 +1,14 @@
 /**
+ *   __ _  __     __      __  __ _
+ *  / _| | \ \   / //\   |  \/  | |
+ * | |_| | _\ \_/ //  \  | \  / | |
+ * |  _| |/ /\   // /\ \ | |\/| | |
+ * | | |   <  | |/ ____ \| |  | | |____
+ * |_| |_|\_\ |_/_/    \_\_|  |_|______|
+ *
  * @file Node.hpp
  * @brief Implementation of YAML node data structure.
+ * @version 0.0.0
  *
  * Copyright (c) 2023 fktn
  * Distributed under the MIT License (https://opensource.org/licenses/MIT)

--- a/include/fkYAML/NodeType.hpp
+++ b/include/fkYAML/NodeType.hpp
@@ -1,6 +1,14 @@
 /**
+ *   __ _  __     __      __  __ _
+ *  / _| | \ \   / //\   |  \/  | |
+ * | |_| | _\ \_/ //  \  | \  / | |
+ * |  _| |/ /\   // /\ \ | |\/| | |
+ * | | |   <  | |/ ____ \| |  | | |____
+ * |_| |_|\_\ |_/_/    \_\_|  |_|______|
+ *
  * @file NodeType.hpp
  * @brief Definitions of YAML node data types.
+ * @version 0.0.0
  *
  * Copyright (c) 2023 fktn
  * Distributed under the MIT License (https://opensource.org/licenses/MIT)

--- a/include/fkYAML/NodeTypeTraits.hpp
+++ b/include/fkYAML/NodeTypeTraits.hpp
@@ -1,6 +1,14 @@
 /**
+ *   __ _  __     __      __  __ _
+ *  / _| | \ \   / //\   |  \/  | |
+ * | |_| | _\ \_/ //  \  | \  / | |
+ * |  _| |/ /\   // /\ \ | |\/| | |
+ * | | |   <  | |/ ____ \| |  | | |____
+ * |_| |_|\_\ |_/_/    \_\_|  |_|______|
+ *
  * @file NodeTypeTraits.hpp
  * @brief Implementation of YAML node data type traits.
+ * @version 0.0.0
  *
  * Copyright (c) 2023 fktn
  * Distributed under the MIT License (https://opensource.org/licenses/MIT)

--- a/include/fkYAML/OrderedMap.hpp
+++ b/include/fkYAML/OrderedMap.hpp
@@ -1,6 +1,14 @@
 /**
+ *   __ _  __     __      __  __ _
+ *  / _| | \ \   / //\   |  \/  | |
+ * | |_| | _\ \_/ //  \  | \  / | |
+ * |  _| |/ /\   // /\ \ | |\/| | |
+ * | | |   <  | |/ ____ \| |  | | |____
+ * |_| |_|\_\ |_/_/    \_\_|  |_|______|
+ *
  * @file Deserializer.hpp
  * @brief Implementation of a minimal map-like container which preserves insertion order.
+ * @version 0.0.0
  *
  * Copyright (c) 2023 fktn
  * Distributed under the MIT License (https://opensource.org/licenses/MIT)

--- a/include/fkYAML/Serializer.hpp
+++ b/include/fkYAML/Serializer.hpp
@@ -1,6 +1,14 @@
 /**
+ *   __ _  __     __      __  __ _
+ *  / _| | \ \   / //\   |  \/  | |
+ * | |_| | _\ \_/ //  \  | \  / | |
+ * |  _| |/ /\   // /\ \ | |\/| | |
+ * | | |   <  | |/ ____ \| |  | | |____
+ * |_| |_|\_\ |_/_/    \_\_|  |_|______|
+ *
  * @file Deserializer.hpp
  * @brief Implementation of the serializer for YAML nodes.
+ * @version 0.0.0
  *
  * Copyright (c) 2023 fktn
  * Distributed under the MIT License (https://opensource.org/licenses/MIT)

--- a/include/fkYAML/VersioningMacros.hpp
+++ b/include/fkYAML/VersioningMacros.hpp
@@ -1,6 +1,14 @@
 /**
+ *   __ _  __     __      __  __ _
+ *  / _| | \ \   / //\   |  \/  | |
+ * | |_| | _\ \_/ //  \  | \  / | |
+ * |  _| |/ /\   // /\ \ | |\/| | |
+ * | | |   <  | |/ ____ \| |  | | |____
+ * |_| |_|\_\ |_/_/    \_\_|  |_|______|
+ *
  * @file VersioningMacros.hpp
  * @brief Definitions of macro for versioning fkYAML library.
+ * @version 0.0.0
  *
  * Copyright (c) 2023 fktn
  * Distributed under the MIT License (https://opensource.org/licenses/MIT)

--- a/include/fkYAML/YAMLVersionType.hpp
+++ b/include/fkYAML/YAMLVersionType.hpp
@@ -1,6 +1,14 @@
 /**
+ *   __ _  __     __      __  __ _
+ *  / _| | \ \   / //\   |  \/  | |
+ * | |_| | _\ \_/ //  \  | \  / | |
+ * |  _| |/ /\   // /\ \ | |\/| | |
+ * | | |   <  | |/ ____ \| |  | | |____
+ * |_| |_|\_\ |_/_/    \_\_|  |_|______|
+ *
  * @file YAMLVersionType.hpp
  * @brief Definitions of YAML version specification types.
+ * @version 0.0.0
  *
  * Copyright (c) 2023 fktn
  * Distributed under the MIT License (https://opensource.org/licenses/MIT)

--- a/test/cmake_add_subdirectory_test/project/main.cpp
+++ b/test/cmake_add_subdirectory_test/project/main.cpp
@@ -1,3 +1,19 @@
+/**
+ *   __ _  __     __      __  __ _
+ *  / _| | \ \   / //\   |  \/  | |
+ * | |_| | _\ \_/ //  \  | \  / | |
+ * |  _| |/ /\   // /\ \ | |\/| | |
+ * | | |   <  | |/ ____ \| |  | | |____
+ * |_| |_|\_\ |_/_/    \_\_|  |_|______|
+ *
+ * @file main.cpp
+ * @brief main source file for CMake add_subdirectory() test project.
+ * @version 0.0.0
+ *
+ * Copyright (c) 2023 fktn
+ * Distributed under the MIT License (https://opensource.org/licenses/MIT)
+ */
+
 #include <iostream>
 
 #include "fkYAML/Node.hpp"

--- a/test/cmake_fetch_content_test/project/main.cpp
+++ b/test/cmake_fetch_content_test/project/main.cpp
@@ -1,3 +1,19 @@
+/**
+ *   __ _  __     __      __  __ _
+ *  / _| | \ \   / //\   |  \/  | |
+ * | |_| | _\ \_/ //  \  | \  / | |
+ * |  _| |/ /\   // /\ \ | |\/| | |
+ * | | |   <  | |/ ____ \| |  | | |____
+ * |_| |_|\_\ |_/_/    \_\_|  |_|______|
+ *
+ * @file main.cpp
+ * @brief main source file for CMake FetchContet module test project.
+ * @version 0.0.0
+ *
+ * Copyright (c) 2023 fktn
+ * Distributed under the MIT License (https://opensource.org/licenses/MIT)
+ */
+
 #include <iostream>
 
 #include "fkYAML/Node.hpp"

--- a/test/cmake_find_package_test/project/main.cpp
+++ b/test/cmake_find_package_test/project/main.cpp
@@ -1,3 +1,19 @@
+/**
+ *   __ _  __     __      __  __ _
+ *  / _| | \ \   / //\   |  \/  | |
+ * | |_| | _\ \_/ //  \  | \  / | |
+ * |  _| |/ /\   // /\ \ | |\/| | |
+ * | | |   <  | |/ ____ \| |  | | |____
+ * |_| |_|\_\ |_/_/    \_\_|  |_|______|
+ *
+ * @file main.cpp
+ * @brief main source file for CMake find_package() test project.
+ * @version 0.0.0
+ *
+ * Copyright (c) 2023 fktn
+ * Distributed under the MIT License (https://opensource.org/licenses/MIT)
+ */
+
 #include <iostream>
 
 #include "fkYAML/Node.hpp"

--- a/test/cmake_target_include_directories_test/project/main.cpp
+++ b/test/cmake_target_include_directories_test/project/main.cpp
@@ -1,3 +1,19 @@
+/**
+ *   __ _  __     __      __  __ _
+ *  / _| | \ \   / //\   |  \/  | |
+ * | |_| | _\ \_/ //  \  | \  / | |
+ * |  _| |/ /\   // /\ \ | |\/| | |
+ * | | |   <  | |/ ____ \| |  | | |____
+ * |_| |_|\_\ |_/_/    \_\_|  |_|______|
+ *
+ * @file main.cpp
+ * @brief main source file for CMake target_include_directories() test project.
+ * @version 0.0.0
+ *
+ * Copyright (c) 2023 fktn
+ * Distributed under the MIT License (https://opensource.org/licenses/MIT)
+ */
+
 #include <iostream>
 
 #include "fkYAML/Node.hpp"

--- a/test/unit_test/DeserializerClassTest.cpp
+++ b/test/unit_test/DeserializerClassTest.cpp
@@ -6,7 +6,7 @@
  * | | |   <  | |/ ____ \| |  | | |____
  * |_| |_|\_\ |_/_/    \_\_|  |_|______|
  *
- * @file DeserializerClassTest.cpp 
+ * @file DeserializerClassTest.cpp
  * @brief Implementation of test functions for the Deserializer class.
  * @version 0.0.0
  *

--- a/test/unit_test/DeserializerClassTest.cpp
+++ b/test/unit_test/DeserializerClassTest.cpp
@@ -1,5 +1,14 @@
 /**
- * DeserializerClassTest.cpp - implementation of test functions for the Deserializer class
+ *   __ _  __     __      __  __ _
+ *  / _| | \ \   / //\   |  \/  | |
+ * | |_| | _\ \_/ //  \  | \  / | |
+ * |  _| |/ /\   // /\ \ | |\/| | |
+ * | | |   <  | |/ ____ \| |  | | |____
+ * |_| |_|\_\ |_/_/    \_\_|  |_|______|
+ *
+ * @file DeserializerClassTest.cpp 
+ * @brief Implementation of test functions for the Deserializer class.
+ * @version 0.0.0
  *
  * Copyright (c) 2023 fktn
  * Distributed under the MIT License (https://opensource.org/licenses/MIT)

--- a/test/unit_test/ExceptionClassTest.cpp
+++ b/test/unit_test/ExceptionClassTest.cpp
@@ -1,5 +1,14 @@
 /**
- * ExceptionClassTest.cpp - implementation of test functions for the Exception class
+ *   __ _  __     __      __  __ _
+ *  / _| | \ \   / //\   |  \/  | |
+ * | |_| | _\ \_/ //  \  | \  / | |
+ * |  _| |/ /\   // /\ \ | |\/| | |
+ * | | |   <  | |/ ____ \| |  | | |____
+ * |_| |_|\_\ |_/_/    \_\_|  |_|______|
+ *
+ * @file ExceptionClassTest.cpp
+ * @brief Implementation of test functions for the Exception class.
+ * @version 0.0.0
  *
  * Copyright (c) 2023 fktn
  * Distributed under the MIT License (https://opensource.org/licenses/MIT)

--- a/test/unit_test/IteratorClassTest.cpp
+++ b/test/unit_test/IteratorClassTest.cpp
@@ -1,5 +1,14 @@
 /**
- * IteratorClassTest.cpp - implementation of test functions for the Iterator class
+ *   __ _  __     __      __  __ _
+ *  / _| | \ \   / //\   |  \/  | |
+ * | |_| | _\ \_/ //  \  | \  / | |
+ * |  _| |/ /\   // /\ \ | |\/| | |
+ * | | |   <  | |/ ____ \| |  | | |____
+ * |_| |_|\_\ |_/_/    \_\_|  |_|______|
+ *
+ * @file IteratorClassTest.cpp
+ * @brief Implementation of test functions for the Iterator class.
+ * @version 0.0.0
  *
  * Copyright (c) 2023 fktn
  * Distributed under the MIT License (https://opensource.org/licenses/MIT)

--- a/test/unit_test/LexicalAnalyzerClassTest.cpp
+++ b/test/unit_test/LexicalAnalyzerClassTest.cpp
@@ -1,5 +1,14 @@
 /**
- * LexicalAnalyzerClassTest.cpp - implementation of test functions for the LexicalAnalyzer class
+ *   __ _  __     __      __  __ _
+ *  / _| | \ \   / //\   |  \/  | |
+ * | |_| | _\ \_/ //  \  | \  / | |
+ * |  _| |/ /\   // /\ \ | |\/| | |
+ * | | |   <  | |/ ____ \| |  | | |____
+ * |_| |_|\_\ |_/_/    \_\_|  |_|______|
+ *
+ * @file LexicalAnalyzerClassTest.cpp
+ * @brief Implementation of test functions for the LexicalAnalyzer class.
+ * @version 0.0.0
  *
  * Copyright (c) 2023 fktn
  * Distributed under the MIT License (https://opensource.org/licenses/MIT)

--- a/test/unit_test/NodeClassTest.cpp
+++ b/test/unit_test/NodeClassTest.cpp
@@ -1,5 +1,14 @@
 /**
- * NodeClassTest.cpp - implementation of test functions for the Node class
+ *   __ _  __     __      __  __ _
+ *  / _| | \ \   / //\   |  \/  | |
+ * | |_| | _\ \_/ //  \  | \  / | |
+ * |  _| |/ /\   // /\ \ | |\/| | |
+ * | | |   <  | |/ ____ \| |  | | |____
+ * |_| |_|\_\ |_/_/    \_\_|  |_|______|
+ *
+ * @file NodeClassTest.cpp
+ * @brief Implementation of test functions for the Node class.
+ * @version 0.0.0
  *
  * Copyright (c) 2023 fktn
  * Distributed under the MIT License (https://opensource.org/licenses/MIT)

--- a/test/unit_test/OrderedMapClassTest.cpp
+++ b/test/unit_test/OrderedMapClassTest.cpp
@@ -1,5 +1,14 @@
 /**
- * OrderedMapClassTest.cpp - implementation of test functions for the OrderedMap class
+ *   __ _  __     __      __  __ _
+ *  / _| | \ \   / //\   |  \/  | |
+ * | |_| | _\ \_/ //  \  | \  / | |
+ * |  _| |/ /\   // /\ \ | |\/| | |
+ * | | |   <  | |/ ____ \| |  | | |____
+ * |_| |_|\_\ |_/_/    \_\_|  |_|______|
+ *
+ * @file OrderedMapClassTest.cpp
+ * @brief Implementation of test functions for the OrderedMap class.
+ * @version 0.0.0
  *
  * Copyright (c) 2023 fktn
  * Distributed under the MIT License (https://opensource.org/licenses/MIT)

--- a/test/unit_test/SerializerClassTest.cpp
+++ b/test/unit_test/SerializerClassTest.cpp
@@ -1,5 +1,14 @@
 /**
- * SerializerClassTest.cpp - implementation of test functions for the Serializer class
+ *   __ _  __     __      __  __ _
+ *  / _| | \ \   / //\   |  \/  | |
+ * | |_| | _\ \_/ //  \  | \  / | |
+ * |  _| |/ /\   // /\ \ | |\/| | |
+ * | | |   <  | |/ ____ \| |  | | |____
+ * |_| |_|\_\ |_/_/    \_\_|  |_|______|
+ *
+ * @file SerializerClassTest.cpp
+ * @brief Implementation of test functions for the Serializer class.
+ * @version 0.0.0
  *
  * Copyright (c) 2023 fktn
  * Distributed under the MIT License (https://opensource.org/licenses/MIT)

--- a/test/unit_test/main.cpp
+++ b/test/unit_test/main.cpp
@@ -1,5 +1,14 @@
 /**
- * main.cpp - implementation of the entry point of the unit test application.
+ *   __ _  __     __      __  __ _
+ *  / _| | \ \   / //\   |  \/  | |
+ * | |_| | _\ \_/ //  \  | \  / | |
+ * |  _| |/ /\   // /\ \ | |\/| | |
+ * | | |   <  | |/ ____ \| |  | | |____
+ * |_| |_|\_\ |_/_/    \_\_|  |_|______|
+ *
+ * @file main.cpp
+ * @brief Implementation of the entry point of the unit test application.
+ * @version 0.0.0
  *
  * Copyright (c) 2023 fktn
  * Distributed under the MIT License (https://opensource.org/licenses/MIT)

--- a/tool/clang_tidy/ClangTidyHelper.cpp
+++ b/tool/clang_tidy/ClangTidyHelper.cpp
@@ -1,3 +1,19 @@
+/**
+ *   __ _  __     __      __  __ _
+ *  / _| | \ \   / //\   |  \/  | |
+ * | |_| | _\ \_/ //  \  | \  / | |
+ * |  _| |/ /\   // /\ \ | |\/| | |
+ * | | |   <  | |/ ____ \| |  | | |____
+ * |_| |_|\_\ |_/_/    \_\_|  |_|______|
+ *
+ * @file ClangTidyHelper.cpp
+ * @brief A helper source file to run Clang-Tidy tool for the fkYAML library.
+ * @version 0.0.0
+ *
+ * Copyright (c) 2023 fktn
+ * Distributed under the MIT License (https://opensource.org/licenses/MIT)
+ */
+
 #include "fkYAML/Assert.hpp"
 #include "fkYAML/Deserializer.hpp"
 #include "fkYAML/Exception.hpp"

--- a/tool/iwyu/IWYUHelper.cpp.in
+++ b/tool/iwyu/IWYUHelper.cpp.in
@@ -1,3 +1,19 @@
+/**
+ *   __ _  __     __      __  __ _
+ *  / _| | \ \   / //\   |  \/  | |
+ * | |_| | _\ \_/ //  \  | \  / | |
+ * |  _| |/ /\   // /\ \ | |\/| | |
+ * | | |   <  | |/ ____ \| |  | | |____
+ * |_| |_|\_\ |_/_/    \_\_|  |_|______|
+ *
+ * @file IWYUHelper_@REL_SRC_FILE_REPLACED@.cpp
+ * @brief A helper source file to run include-what-you-use tool for @REL_SRC_FILE@ file.
+ * @version 0.0.0
+ *
+ * Copyright (c) 2023 fktn
+ * Distributed under the MIT License (https://opensource.org/licenses/MIT)
+ */
+
 #include "fkYAML/@REL_SRC_FILE@" // IWYU pragma: keep
 
 // This is just a dummy main function for compilation.


### PR DESCRIPTION
The fkYAML library is released as v0.0.0.  
To prepare for v0.0.0 release, the following changes have been added:

- re-organization of GitHub Actions workflows
- addition of version info to file header descriptions
- renaming of release packages