### PR TITLE
#109 Use official docker image for GCC during CI jobs

### DIFF
--- a/.github/workflows/ubuntu.yml
+++ b/.github/workflows/ubuntu.yml
@@ -105,29 +105,64 @@ jobs:
         run: |
           cmake --build ${{github.workspace}}/build --target ${{matrix.target}}
 
-  gcc-tests-with-self-hosted-runner:
-    runs-on: [self-hosted, linux, x64, gcc]
+  ci_test_gcc_cxx_versions:
+    runs-on: ubuntu-latest
+    container: gcc:latest
     strategy:
       matrix:
-        target:
-          - ci_test_compiler_g++-9
-          - ci_test_compiler_g++-10
-          - ci_test_compiler_g++-11
-          - ci_test_compiler_g++-12
-          - ci_test_g++_c++11
-          - ci_test_g++_c++14
-          - ci_test_g++_c++17
-          - ci_test_g++_c++20
-          - ci_test_g++_c++23
+        cxx_standard: [ "11", "14", "17", "20", "23" ]
+        build_type: [ Debug, Release ]
 
     steps:
       - uses: actions/checkout@v3
         with:
           submodules: recursive
 
-      - name: Configure CMake
-        run: cmake -B ${{github.workspace}}/build -DFK_YAML_CI=ON
+      - name: Get latest CMake
+        uses: lukka/get-cmake@latest
 
-      - name: Run builds & tests for the test target
+      - name: Install package for test
         run: |
-          cmake --build ${{github.workspace}}/build --target ${{matrix.target}}
+          cmake -B ${{github.workspace}}/build_for_package
+          cmake --build ${{github.workspace}}/build_for_package --target install
+          rm -rf ${{github.workspace}}/build_for_package
+
+      - name: Configure CMake and Ninja
+        run: cmake -B ${{github.workspace}}/build -DCMAKE_BUILD_TYPE=${{matrix.build_type}} -DFK_YAML_BUILD_ALL_TEST=ON -DFK_YAML_TEST_TARGET_CXX_STANDARD=${{matrix.cxx_standard}}
+
+      - name: Build
+        run: cmake --build ${{github.workspace}}/build --config ${{matrix.build_type}}
+
+      - name: Test
+        run: ctest -C ${{matrix.build_type}} --output-on-failure
+
+  ci_test_gcc_versions:
+    runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        compiler: [ "4.8", "5", "6", "7", "8", "9", "10", "11", "12", "13", latest ]
+        build_type: [ Debug, Release ]
+    container: gcc:${{matrix.compiler}}
+
+    steps:
+      - uses: actions/checkout@v3
+        with:
+          submodules: recursive
+
+      - name: Get latest CMake and Ninja
+        uses: lukka/get-cmake@latest
+
+      - name: Install package for test
+        run: |
+          cmake -B ${{github.workspace}}/build_for_package
+          cmake --build ${{github.workspace}}/build_for_package --target install
+          rm -rf ${{github.workspace}}/build_for_package
+
+      - name: Configure CMake
+        run: cmake -B ${{github.workspace}}/build -DCMAKE_BUILD_TYPE=${{matrix.build_type}} -DFK_YAML_BUILD_ALL_TEST=ON
+
+      - name: Build
+        run: cmake --build ${{github.workspace}}/build --config ${{matrix.build_type}}
+
+      - name: Test
+        run: ctest -C ${{matrix.build_type}} --output-on-failure

--- a/.github/workflows/ubuntu.yml
+++ b/.github/workflows/ubuntu.yml
@@ -140,7 +140,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        compiler: [ "4.8", "5", "6", "7", "8", "9", "10", "11", "12", "13", latest ]
+        compiler: [ "9", "10", "11", "12", "13", latest ]
         build_type: [ Debug, Release ]
     container: gcc:${{matrix.compiler}}
 

--- a/README.md
+++ b/README.md
@@ -234,6 +234,7 @@ Currently, the following compilers are known to work and used in CI workflows:
 | GCC 10.5.0 | Ubuntu 22.04.3 LTS | GitHub Actions |
 | GCC 11.4.0 | Ubuntu 22.04.3 LTS | GitHub Actions |
 | GCC 12.3.0 | Ubuntu 22.04.3 LTS | GitHub Actions |
+| GCC 13.2.0 | Ubuntu 22.04.3 LTS | GitHub Actions |
 | MinGW-64 8.1.0 | Windows-10.0.17763 | GitHub Actions |
 | MinGW-64 12.2.0 | Windows-10.0.20348 | GitHub Actions |
 | Visual Studio 16 2019 MSVC 19.29.30152.0 | Windows-10.0.17763 | GitHub Actions |

--- a/cmake/ci.cmake
+++ b/cmake/ci.cmake
@@ -5,11 +5,6 @@ execute_process(COMMAND ${CLANGXX_TOOL} --version OUTPUT_VARIABLE CLANGXX_TOOL_V
 string(REGEX MATCH "[0-9]+(\\.[0-9]+)+" CLANGXX_TOOL_VERSION "${CLANGXX_TOOL_VERSION}")
 message(STATUS "# clang++ # version: ${CLANGXX_TOOL_VERSION} path: ${CLANGXX_TOOL}")
 
-find_program(GXX_TOOL NAMES g++-12 g++-11 g++-10 g++-9 g++ REQUIRED)
-execute_process(COMMAND ${GXX_TOOL} --version OUTPUT_VARIABLE GXX_TOOL_VERSION ERROR_VARIABLE GXX_TOOL_VERSION)
-string(REGEX MATCH "[0-9]+(\\.[0-9]+)+" GXX_TOOL_VERSION "${GXX_TOOL_VERSION}")
-message(STATUS "# g++ # version: ${GXX_TOOL_VERSION} path: ${GXX_TOOL}")
-
 find_program(IWYU_TOOL NAMES include-what-you-use iwyu REQUIRED)
 execute_process(COMMAND ${IWYU_TOOL} --version OUTPUT_VARIABLE IWYU_TOOL_VERSION ERROR_VARIABLE IWYU_TOOL_VERSION)
 string(REGEX MATCH "[0-9]+(\\.[0-9]+)+" IWYU_TOOL_VERSION "${IWYU_TOOL_VERSION}")
@@ -20,11 +15,11 @@ execute_process(COMMAND ${NINJA_TOOL} --version OUTPUT_VARIABLE NINJA_TOOL_VERSI
 string(REGEX MATCH "[0-9]+(\\.[0-9]+)+" NINJA_TOOL_VERSION "${NINJA_TOOL_VERSION}")
 message(STATUS "# Ninja # version: ${NINJA_TOOL_VERSION} path: ${NINJA_TOOL}")
 
-#############################################################
-#  Execute unit tests with various versions of clang++/g++  #
-#############################################################
+#########################################################
+#  Execute unit tests with various versions of clang++  #
+#########################################################
 
-foreach(COMPILER clang++-11 clang++-12 clang++-13 clang++-14 clang++-15 g++-9 g++-10 g++-11 g++-12)
+foreach(COMPILER clang++-11 clang++-12 clang++-13 clang++-14 clang++-15)
   find_program(COMPILER_TOOL NAMES ${COMPILER})
   if(COMPILER_TOOL)
     add_custom_target(ci_test_compiler_${COMPILER}
@@ -38,9 +33,9 @@ foreach(COMPILER clang++-11 clang++-12 clang++-13 clang++-14 clang++-15 g++-9 g+
   unset(COMPILER_TOOL CACHE)
 endforeach()
 
-###################################################################
-#  Execute unit tests with clang++/g++ for various c++ standards  #
-###################################################################
+###############################################################
+#  Execute unit tests with clang++ for various c++ standards  #
+###############################################################
 
 foreach(TARGET_CXX_STANDARD 11 14 17 20 23)
   add_custom_target(ci_test_clang++_c++${TARGET_CXX_STANDARD}
@@ -50,15 +45,6 @@ foreach(TARGET_CXX_STANDARD 11 14 17 20 23)
     COMMAND ${CMAKE_COMMAND} --build ${PROJECT_BINARY_DIR}/build_clang++_c++${TARGET_CXX_STANDARD} --config Debug
     COMMAND cd ${PROJECT_BINARY_DIR}/build_clang++_c++${TARGET_CXX_STANDARD} && ${CMAKE_CTEST_COMMAND} -C Debug --output-on-failure
     COMMENT "Compile and test with clang++ for C++${TARGET_CXX_STANDARD}"
-  )
-
-  add_custom_target(ci_test_g++_c++${TARGET_CXX_STANDARD}
-    COMMAND CXX=${GXX_TOOL} ${CMAKE_COMMAND} -DCMAKE_BUILD_TYPE=Debug -GNinja -DFK_YAML_BUILD_ALL_TEST=ON
-      -DFK_YAML_TEST_TARGET_CXX_STANDARD=${TARGET_CXX_STANDARD}
-      -S${PROJECT_SOURCE_DIR} -B${PROJECT_BINARY_DIR}/build_g++_c++${TARGET_CXX_STANDARD}
-    COMMAND ${CMAKE_COMMAND} --build ${PROJECT_BINARY_DIR}/build_g++_c++${TARGET_CXX_STANDARD} --config Debug
-    COMMAND cd ${PROJECT_BINARY_DIR}/build_g++_c++${TARGET_CXX_STANDARD} && ${CMAKE_CTEST_COMMAND} -C Debug --output-on-failure
-    COMMENT "Compile and test with g++ for C++${CXX_STANDARD}"
   )
 endforeach()
 


### PR DESCRIPTION
Before this PR, GitHub Actions workflows use GCC compilers which have been pre-installed into the self-hosted runner.  
Since version management would be harder as development evolves, however, I've decided to change the management strategy to the one in which the workflows use the official docker images for GCC.  
Similar workflows which use Clang compilers still uses the ones pre-installed into the self-hosted runner, which will also be changed to using some docker images.  