### PR TITLE
#113 Generate API documentation only for public members

### DIFF
--- a/docs/Doxyfile.in
+++ b/docs/Doxyfile.in
@@ -524,7 +524,7 @@ EXTRACT_ALL            = YES
 # be included in the documentation.
 # The default value is: NO.
 
-EXTRACT_PRIVATE        = YES
+EXTRACT_PRIVATE        = NO
 
 # If the EXTRACT_PRIV_VIRTUAL tag is set to YES, documented private virtual
 # methods of a class will be included in the documentation.

--- a/include/fkYAML/Deserializer.hpp
+++ b/include/fkYAML/Deserializer.hpp
@@ -263,6 +263,11 @@ public:
     }
 
 private:
+    /**
+     * @brief Add new key string to the current YAML node.
+     *
+     * @param key a key string to be added to the current YAML node.
+     */
     void AddNewKey(const string_type& key) noexcept
     {
         m_current_node->ToMapping().emplace(key, BasicNodeType());
@@ -331,14 +336,14 @@ private:
     }
 
 private:
-    lexer_type m_lexer {};
-    BasicNodeType* m_current_node = nullptr;
-    std::vector<BasicNodeType*> m_node_stack;
-    YamlVersionType m_yaml_version = YamlVersionType::VER_1_2;
-    uint32_t m_current_indent_width = 0;
-    bool m_needs_anchor_impl = false;
-    string_type m_anchor_name {};
-    std::unordered_map<std::string, BasicNodeType> m_anchor_table;
+    lexer_type m_lexer {};                                     /** A lexical analyzer object. */
+    BasicNodeType* m_current_node = nullptr;                   /** The currently focused YAML node. */
+    std::vector<BasicNodeType*> m_node_stack;                  /** The stack of YAML nodes. */
+    YamlVersionType m_yaml_version = YamlVersionType::VER_1_2; /** The YAML version specification type. */
+    uint32_t m_current_indent_width = 0;                       /** The current indentation width. */
+    bool m_needs_anchor_impl = false; /** A flag to determine the need for YAML anchor node implementation */
+    string_type m_anchor_name {};     /** The last YAML anchor name. */
+    std::unordered_map<std::string, BasicNodeType> m_anchor_table; /** The table of YAML anchor nodes. */
 };
 
 /**

--- a/include/fkYAML/Iterator.hpp
+++ b/include/fkYAML/Iterator.hpp
@@ -527,11 +527,21 @@ public:
     }
 
 public:
+    /**
+     * @brief Get the type of the internal iterator implementation.
+     *
+     * @return IteratorType The type of the internal iterator implementation.
+     */
     IteratorType Type() const noexcept
     {
         return m_inner_iterator_type;
     }
 
+    /**
+     * @brief Get the key string of the YAML mapping node for the current iterator.
+     *
+     * @return const std::string& The key string of the YAML mapping node for the current iterator.
+     */
     const std::string& Key() const
     {
         switch (m_inner_iterator_type)
@@ -545,6 +555,11 @@ public:
         }
     }
 
+    /**
+     * @brief Get the reference of the YAML node for the current iterator.
+     *
+     * @return reference A reference to the YAML node for the current iterator.
+     */
     reference Value() noexcept // NOLINT(bugprone-exception-escape)
     {
         return operator*();

--- a/include/fkYAML/Node.hpp
+++ b/include/fkYAML/Node.hpp
@@ -45,8 +45,7 @@ FK_YAML_NAMESPACE_BEGIN
  * @tparam SequenceType A type for sequence node value containers.
  * @tparam MappingType A type for mapping node value containers.
  * @tparam BooleanType A type for boolean node values.
- * @tparam SignedIntegerType A type for signed integer node values.
- * @tparam UnsignedIntegerType A type for unsigned integer node values.
+ * @tparam IntegerType A type for integer node values.
  * @tparam FloatNumberType A type for float number node values.
  * @tparam StringType A type for string node values.
  */

--- a/include/fkYAML/NodeTypeTraits.hpp
+++ b/include/fkYAML/NodeTypeTraits.hpp
@@ -33,11 +33,27 @@ template <
     typename BooleanType, typename IntegerType, typename FloatNumberType, typename StringType>
 class BasicNode;
 
+/**
+ * @struct IsBasicNode
+ * @brief A struct to check the template parameter class is a kind of BasicNode template class.
+ *
+ * @tparam T A class to be checked if it's a kind of BasicNode template class.
+ */
 template <typename T>
 struct IsBasicNode : std::false_type
 {
 };
 
+/**
+ * @brief A partial specialization of IsBasicNode for BasicNode template class.
+ *
+ * @tparam SequenceType A type for sequence node value containers.
+ * @tparam MappingType A type for mapping node value containers.
+ * @tparam BooleanType A type for boolean node values.
+ * @tparam IntegerType A type for integer node values.
+ * @tparam FloatNumberType A type for float number node values.
+ * @tparam StringType A type for string node values.
+ */
 template <
     template <typename, typename...> class SequenceType, template <typename, typename, typename...> class MappingType,
     typename BooleanType, typename IntegerType, typename FloatNumberType, typename StringType>

--- a/include/fkYAML/OrderedMap.hpp
+++ b/include/fkYAML/OrderedMap.hpp
@@ -35,10 +35,10 @@ FK_YAML_NAMESPACE_BEGIN
 /**
  * @brief A minimal map-like container which preserves insertion order.
  *
- * @tparam Key
- * @tparam Value
- * @tparam IgnoredCompare
- * @tparam Allocator
+ * @tparam Key A type for keys.
+ * @tparam Value A type for values.
+ * @tparam IgnoredCompare A placeholder for key comparison. This will be ignored.
+ * @tparam Allocator A class for allocators.
  */
 template <
     typename Key, typename Value, typename IgnoredCompare = std::less<Key>,
@@ -46,13 +46,21 @@ template <
 class OrderedMap : public std::vector<std::pair<const Key, Value>, Allocator>
 {
 public:
+    /** A type for keys. */
     using key_type = Key;
+    /** A type for values. */
     using mapped_type = Value;
+    /** A type for internal key-value containers */
     using Container = std::vector<std::pair<const Key, Value>, Allocator>;
+    /** A type for key-value pairs */
     using value_type = typename Container::value_type;
+    /** A type for non-const iterators */
     using iterator = typename Container::iterator;
+    /** A type for const iterators. */
     using const_iterator = typename Container::const_iterator;
+    /** A type for size parameters used in this class. */
     using size_type = typename Container::size_type;
+    /** A type for comparison between keys. */
     using key_compare = std::equal_to<Key>;
 
 public:
@@ -77,12 +85,25 @@ public:
     }
 
 public:
+    /**
+     * @brief A subscript operator with keys for this OrderedMap class.
+     *
+     * @param key A key to find values with.
+     * @return mapped_type& The found value or the initial value of the value object.
+     */
     mapped_type& operator[](const key_type& key) noexcept
     {
         return emplace(key, mapped_type()).first->second;
     }
 
 public:
+    /**
+     * @brief Emplace a new key-value pair if the new key does not exist.
+     *
+     * @param key A key to be emplaced to this OrderedMap object.
+     * @param value A value to be emplaced to this OrderedMap object.
+     * @return std::pair<iterator, bool> A result of emplacement of the new key-value pair.
+     */
     // NOLINTNEXTLINE(readability-identifier-naming)
     std::pair<iterator, bool> emplace(const key_type& key, const mapped_type& value) noexcept
     {
@@ -97,6 +118,12 @@ public:
         return {std::prev(this->end()), true};
     }
 
+    /**
+     * @brief Find a value associated to the given key. Throws an exception if the search fails.
+     *
+     * @param key A key to find a value with.
+     * @return mapped_type& The value associated to the given key.
+     */
     // NOLINTNEXTLINE(readability-identifier-naming)
     mapped_type& at(const key_type& key)
     {
@@ -110,6 +137,12 @@ public:
         throw Exception("key not found.");
     }
 
+    /**
+     * @brief Find a value associated to the given key. Throws an exception if the search fails.
+     *
+     * @param key A key to find a value with.
+     * @return const mapped_type& The value associated to the given key.
+     */
     // NOLINTNEXTLINE(readability-identifier-naming)
     const mapped_type& at(const key_type& key) const
     {
@@ -123,6 +156,12 @@ public:
         throw Exception("key not found.");
     }
 
+    /**
+     * @brief Find a value with the given key.
+     *
+     * @param key A key to find a value with.
+     * @return iterator The iterator for the found value, or the result of end().
+     */
     // NOLINTNEXTLINE(readability-identifier-naming)
     iterator find(const key_type& key) noexcept
     {
@@ -136,6 +175,12 @@ public:
         return this->end();
     }
 
+    /**
+     * @brief Find a value with the given key.
+     *
+     * @param key A key to find a value with.
+     * @return const_iterator The constant iterator for the found value, or the result of end().
+     */
     // NOLINTNEXTLINE(readability-identifier-naming)
     const_iterator find(const key_type& key) const noexcept
     {
@@ -150,7 +195,7 @@ public:
     }
 
 private:
-    key_compare m_compare;
+    key_compare m_compare; /** The object for comparing keys. */
 };
 
 FK_YAML_NAMESPACE_END

--- a/include/fkYAML/Serializer.hpp
+++ b/include/fkYAML/Serializer.hpp
@@ -29,6 +29,11 @@
 
 FK_YAML_NAMESPACE_BEGIN
 
+/**
+ * @brief A basic implementation of serialization feature for YAML nodes.
+ *
+ * @tparam BasicNodeType A BasicNode template class instantiation.
+ */
 template <typename BasicNodeType = Node>
 class BasicSerializer
 {
@@ -40,6 +45,12 @@ public:
      */
     BasicSerializer() = default;
 
+    /**
+     * @brief Serialize the given Node value.
+     *
+     * @param node A Node object to be serialized.
+     * @return std::string A serialization result of the given Node value.
+     */
     std::string Serialize(BasicNodeType& node)
     {
         std::string str {};
@@ -48,6 +59,13 @@ public:
     }
 
 private:
+    /**
+     * @brief Recursively serialize each Node object.
+     *
+     * @param node A Node object to be serialized.
+     * @param cur_indent The current indent width
+     * @param str A string to hold serialization result.
+     */
     void SerializeNode(BasicNodeType& node, const uint32_t cur_indent, std::string& str)
     {
         switch (node.Type())
@@ -137,11 +155,23 @@ private:
         }
     }
 
+    /**
+     * @brief Serialize mapping keys.
+     *
+     * @param key A key string to be serialized.
+     * @param str A string to hold serialization result.
+     */
     void SerializeKey(const std::string& key, std::string& str)
     {
         str += key + ":";
     }
 
+    /**
+     * @brief Insert indentation to the serialization result.
+     *
+     * @param cur_indent The current indent width to be inserted.
+     * @param str A string to hold serialization result.
+     */
     void InsertIndentation(const uint32_t cur_indent, std::string& str)
     {
         for (uint32_t i = 0; i < cur_indent; ++i)
@@ -151,6 +181,9 @@ private:
     }
 };
 
+/**
+ * @brief default YAML node serializer.
+ */
 using Serializer = BasicSerializer<>;
 
 FK_YAML_NAMESPACE_END


### PR DESCRIPTION
Currently, the API documentation of this project describes all the members of each class in the fkYAML library on GitHub Pages.  
The descriptions of private members could bring confusion to its readers, especially developers who just use the library, because of its too much concreteness.  
So, I would like to regulate the contents of the API documents to private members.  

See #113. 