### PR TITLE
#120 added target to use github-changelog-generator tool

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,3 +1,5 @@
+.PHONY: CHANGELOG.md update-version
+
 #################
 #   variables   #
 #################
@@ -124,7 +126,15 @@ reuse: update-reuse-templates
 		--license MIT --year 2023 --style c
 	pipx run reuse lint
 
-update-version: update-version-macros update-project-version reuse
+CHANGELOG.md:
+	github_changelog_generator --user fktn-k --project fkYAML \
+		--no-issues \
+		--simple-list \
+		--exclude-labels release \
+		--release-url https://github.com/fktn-k/fkYAML/releases/tag/%s \
+		--future-release v$(TARGET_VERSION_FULL)
+
+update-version: update-version-macros update-project-version reuse CHANGELOG.md
 	@echo "updated version to $(TARGET_VERSION_FULL)"
 
 ################


### PR DESCRIPTION
I have introduced the github-changelog-generator tool to the project to generate CHANGELOG.md automatically for future releases of the project.  
The routine command to use the tool has also been added to Makefile as part of update-version target.  

#120 