### PR TITLE
#123 Change naming conventions to lower_snake_case

### DIFF
--- a/.clang-tidy
+++ b/.clang-tidy
@@ -27,11 +27,11 @@ CheckOptions:
   - { key: hicpp-special-member-functions.AllowSoleDefaultDtor, value: 1 }
   - { key: modernize-use-nullptr.NullMacros, value: 'NULL' }
 
-  - { key: readability-identifier-naming.ClassCase, value: CamelCase }
-  - { key: readability-identifier-naming.StructCase, value: CamelCase }
-  - { key: readability-identifier-naming.UnionCase, value: CamelCase }
-  - { key: readability-identifier-naming.EnumCase, value: CamelCase }
-  - { key: readability-identifier-naming.FunctionCase, value: CamelCase }
+  - { key: readability-identifier-naming.ClassCase, value: lower_case }
+  - { key: readability-identifier-naming.StructCase, value: lower_case }
+  - { key: readability-identifier-naming.UnionCase, value: lower_case }
+  - { key: readability-identifier-naming.EnumCase, value: lower_case }
+  - { key: readability-identifier-naming.FunctionCase, value: lower_case }
   - { key: readability-identifier-naming.ClassConstantCase, value: UPPER_CASE }
   - { key: readability-identifier-naming.ClassConstantPrefix, value: s_ }
   - { key: readability-identifier-naming.ClassMemberCase, value: lower_case }
@@ -44,7 +44,7 @@ CheckOptions:
   - { key: readability-identifier-naming.StaticConstantCase, value: UPPER_CASE }
   - { key: readability-identifier-naming.LocalConstantCase, value: lower_case }
   - { key: readability-identifier-naming.ConstantCase, value: UPPER_CASE }
-  - { key: readability-identifier-naming.FunctionCase, value: CamelCase }
+  - { key: readability-identifier-naming.FunctionCase, value: lower_case }
   - { key: readability-identifier-naming.TemplateParameter, value: CamelCase }
   - { key: readability-identifier-naming.Namespace, value: lower_case }
 ...

--- a/Makefile
+++ b/Makefile
@@ -151,7 +151,7 @@ lcov-coverage:
 	cmake --build build_coverage --config Debug --target generate_test_coverage
 
 # pre-requisites: genhtml lcov
-html-coverage: lcov_coverage
+html-coverage: lcov-coverage
 	genhtml build_coverage/coverage/fkYAML.info --output-directory build_coverage/html \
 	    --title "fkYAML: A C++ header-only YAML library" \
 	    --legend --demangle-cpp --show-details --branch-coverage

--- a/README.md
+++ b/README.md
@@ -107,7 +107,7 @@ Here are some examples to give you an idea how to use the fkYAML library.
 
 ### Deserialize YAML formatted strings
 
-The `Deserializer` class provides an API for deserializing a YAML string into `Node` objects.  
+The `Deserializer` class provides an API for deserializing a YAML string into `node` objects.  
 
 ```cpp
 #include <cassert>
@@ -116,25 +116,25 @@ The `Deserializer` class provides an API for deserializing a YAML string into `N
 
 // ...
 
-fkyaml::Deserializer deserializer;
-fkyaml::Node root = deserializer.Deserialize("foo: test\nbar: 3.14\nbuz: true");
+fkyaml::deserializer deserializer;
+fkyaml::node root = deserializer.deserialize("foo: test\nbar: 3.14\nbuz: true");
 
 // You can check that the `root` object has specific keys with the fkyaml::Node::Contains API.
 assert(root.Contains("foo"));
 assert(root.Contains("buz"));
 
 // You can check types of YAML node values associated to each key like the followings:
-assert(root["foo"].Type() == fkyaml::NodeType::STRING);
-assert(root["foo"].IsStringScalar());
-assert(root["bar"].Type() == fkyaml::NodeType::FLOAT_NUMBER);
-assert(root["bar"].IsFloatNumber());
-assert(root["buz"].Type() == fkyaml::NodeType::BOOLEAN);
-assert(root["buz"].IsBooleanScalar());
+assert(root["foo"].type() == fkyaml::node_t::STRING);
+assert(root["foo"].is_string_scalar());
+assert(root["bar"].type() == fkyaml::node_t::FLOAT_NUMBER);
+assert(root["bar"].is_float_number());
+assert(root["buz"].type() == fkyaml::node_t::BOOLEAN);
+assert(root["buz"].is_boolean_scalar());
 
 // You can get references to YAML node values like the followings:
-assert(root["foo"].ToString() == "test");
-assert(root["foo"].ToFloatNumber() == 3.14);
-assert(root["buz"].ToBoolean() == true);
+assert(root["foo"].to_string() == "test");
+assert(root["foo"].to_float_number() == 3.14);
+assert(root["buz"].to_boolean() == true);
 ```
 
 ### Serializing YAML node values
@@ -149,18 +149,18 @@ The `Serializer` class provides an API for serializing YAML node values into a s
 
 // ...
 
-fkyaml::Node root = fkyaml::Node::Mapping({
-    { "foo", fkyaml::Node::StringScalar("test") },
-    { "bar", fkyaml::Node::Sequence({
-        fkyaml::Node::FloatNumberScalar(3.14),
-        fkyaml::Node::FloatNumberScalar(std::nan(""))
+fkyaml::node root = fkyaml::node::Mapping({
+    { "foo", fkyaml::node::string_scalar("test") },
+    { "bar", fkyaml::node::sequence({
+        fkyaml::node::float_number_scalar(3.14),
+        fkyaml::node::float_number_scalar(std::nan(""))
     }) },
-    { "buz", fkyaml::Node::BooleanScalar(true) }
+    { "buz", fkyaml::node::boolean_scalar(true) }
 });
 
-fkyaml::Serializer serializer;
+fkyaml::serializer serializer;
 
-std::string str = serializer.Serialize(root);
+std::string str = serializer.serialize(root);
 // foo: test
 // bar:
 //   - 3.14
@@ -170,7 +170,7 @@ std::string str = serializer.Serialize(root);
 
 ### Build YAML nodes programatically
 
-The `Node` class provides APIs for building YAML nodes programatically.  
+The `node` class provides APIs for building YAML nodes programatically.  
 
 ```cpp
 #include "fkYAML/Node.hpp"
@@ -178,28 +178,28 @@ The `Node` class provides APIs for building YAML nodes programatically.
 // ...
 
 // Create an empty YAML node (mapping).
-fkyaml::Node root = fkyaml::Node::Mapping();
+fkyaml::node root = fkyaml::node::mapping();
 
 // Add a string scalar node.
-root["foo"] = fkyaml::Node::StringScalar("test");
+root["foo"] = fkyaml::node::string_scalar("test");
 
 // Add a sequence node containing floating number scalar nodes.
-root["bar"] = fkyaml::Node::Sequence({ 
-    fkyaml::Node::FloatNumberScalar(3.14),
-    fkyaml::Node::FloatNumberScalar(std::nan(""))
+root["bar"] = fkyaml::node::sequence({ 
+    fkyaml::node::float_number_scalar(3.14),
+    fkyaml::node::float_number_scalar(std::nan(""))
 });
 
 // Add a boolean node.
-root["buz"] = fkyaml::Node::BooleanScalar(true);
+root["buz"] = fkyaml::node::boolean_scalar(true);
 
 // Instead, you can build YAML nodes all at once.
-fkyaml::Node another_root = fkyaml::Node::Mapping({
-    { "foo", fkyaml::Node::StringScalar("test") },
-    { "bar", fkyaml::Node::Sequence({
-        fkyaml::Node::FloatNumberScalar(3.14),
-        fkyaml::Node::FloatNumberScalar(std::nan(""))
+fkyaml::node another_root = fkyaml::node::mapping({
+    { "foo", fkyaml::node::string_scalar("test") },
+    { "bar", fkyaml::node::sequence({
+        fkyaml::node::float_number_scalar(3.14),
+        fkyaml::node::float_number_scalar(std::nan(""))
     }) },
-    { "buz", fkyaml::Node::BooleanScalar(true) }
+    { "buz", fkyaml::node::boolean_scalar(true) }
 });
 ```
 

--- a/include/fkYAML/Deserializer.hpp
+++ b/include/fkYAML/Deserializer.hpp
@@ -108,25 +108,13 @@ public:
                 }
                 break;
             case lexical_token_t::VALUE_SEPARATOR:
-                if (!m_current_node->is_sequence() && !m_current_node->is_mapping())
-                {
-                    throw fkyaml::exception("A value separator must appear in a container node.");
-                }
                 break;
             case lexical_token_t::ANCHOR_PREFIX: {
-                if (m_current_node->is_mapping())
-                {
-                    throw fkyaml::exception("A mapping node cannot be an anchor.");
-                }
                 m_anchor_name = m_lexer.get_string();
                 m_needs_anchor_impl = true;
                 break;
             }
             case lexical_token_t::ALIAS_PREFIX: {
-                if (m_current_node->is_mapping())
-                {
-                    throw fkyaml::exception("Cannot apply alias to a mapping node.");
-                }
                 m_anchor_name = m_lexer.get_string();
                 if (m_anchor_table.find(m_anchor_name) == m_anchor_table.end())
                 {
@@ -165,18 +153,10 @@ public:
                 }
                 break;
             case lexical_token_t::SEQUENCE_FLOW_BEGIN:
-                if (m_current_node->is_mapping())
-                {
-                    throw fkyaml::exception("Cannot assign a sequence value as a key.");
-                }
                 *m_current_node = BasicNodeType::sequence();
                 set_yaml_version(*m_current_node);
                 break;
             case lexical_token_t::SEQUENCE_FLOW_END:
-                if (!m_current_node->is_sequence())
-                {
-                    throw fkyaml::exception("Invalid sequence flow ending found.");
-                }
                 m_current_node = m_node_stack.back();
                 m_node_stack.pop_back();
                 break;

--- a/include/fkYAML/Deserializer.hpp
+++ b/include/fkYAML/Deserializer.hpp
@@ -29,20 +29,20 @@
 FK_YAML_NAMESPACE_BEGIN
 
 /**
- * @class BasicDeserializer
+ * @class basic_deserializer
  * @brief A class which provides the feature of deserializing YAML documents.
  */
 
 /**
- * @class BasicDeserializer
+ * @class basic_deserializer
  * @brief A class which provides the feature of deserializing YAML documents.
  *
  * @tparam BasicNodeType A type of the container for deserialized YAML values.
  */
-template <typename BasicNodeType = Node>
-class BasicDeserializer
+template <typename BasicNodeType = node>
+class basic_deserializer
 {
-    static_assert(IsBasicNode<BasicNodeType>::value, "BasicDeserializer only accepts (const) BasicNode<...>");
+    static_assert(is_basic_node<BasicNodeType>::value, "basic_deserializer only accepts (const) basic_node<...>");
 
     /** A type for sequence node value containers. */
     using sequence_type = typename BasicNodeType::sequence_type;
@@ -57,13 +57,13 @@ class BasicDeserializer
     /** A type for string node values. */
     using string_type = typename BasicNodeType::string_type;
     /** A type for the lexical analyzer object used by this deserializer. */
-    using lexer_type = LexicalAnalyzer<BasicNodeType>;
+    using lexer_type = lexical_analyzer<BasicNodeType>;
 
 public:
     /**
-     * @brief Construct a new BasicDeserializer object.
+     * @brief Construct a new basic_deserializer object.
      */
-    BasicDeserializer() = default;
+    basic_deserializer() = default;
 
 public:
     /**
@@ -72,182 +72,182 @@ public:
      * @param source A YAML-formatted source string.
      * @return BasicNodeType A root YAML node deserialized from the source string.
      */
-    BasicNodeType Deserialize(const char* const source)
+    BasicNodeType deserialize(const char* const source)
     {
         if (!source)
         {
-            throw Exception("The given source for deserialization is nullptr.");
+            throw fkyaml::exception("The given source for deserialization is nullptr.");
         }
 
-        m_lexer.SetInputBuffer(source);
-        BasicNodeType root = BasicNodeType::Mapping();
+        m_lexer.set_input_buffer(source);
+        BasicNodeType root = BasicNodeType::mapping();
         m_current_node = &root;
 
-        LexicalTokenType type = m_lexer.GetNextToken();
-        while (type != LexicalTokenType::END_OF_BUFFER)
+        lexical_token_t type = m_lexer.get_next_token();
+        while (type != lexical_token_t::END_OF_BUFFER)
         {
             switch (type)
             {
-            case LexicalTokenType::KEY_SEPARATOR:
-                if (m_node_stack.empty() || !m_node_stack.back()->IsMapping())
+            case lexical_token_t::KEY_SEPARATOR:
+                if (m_node_stack.empty() || !m_node_stack.back()->is_mapping())
                 {
-                    throw Exception("A key separator found while a value token is expected.");
+                    throw fkyaml::exception("A key separator found while a value token is expected.");
                 }
-                if (m_current_node->IsSequence() && m_current_node->Size() == 1)
+                if (m_current_node->is_sequence() && m_current_node->size() == 1)
                 {
                     // make sequence node to mapping node.
-                    string_type tmp_str = m_current_node->operator[](0).ToString();
-                    m_current_node->operator[](0) = BasicNodeType::Mapping();
+                    string_type tmp_str = m_current_node->operator[](0).to_string();
+                    m_current_node->operator[](0) = BasicNodeType::mapping();
                     m_node_stack.emplace_back(m_current_node);
                     m_current_node = &(m_current_node->operator[](0));
-                    SetYamlVersion(*m_current_node);
-                    m_current_node->ToMapping().emplace(tmp_str, BasicNodeType());
+                    set_yaml_version(*m_current_node);
+                    m_current_node->to_mapping().emplace(tmp_str, BasicNodeType());
                     m_node_stack.emplace_back(m_current_node);
                     m_current_node = &(m_current_node->operator[](tmp_str));
-                    SetYamlVersion(*m_current_node);
+                    set_yaml_version(*m_current_node);
                 }
                 break;
-            case LexicalTokenType::VALUE_SEPARATOR:
-                if (!m_current_node->IsSequence() && !m_current_node->IsMapping())
+            case lexical_token_t::VALUE_SEPARATOR:
+                if (!m_current_node->is_sequence() && !m_current_node->is_mapping())
                 {
-                    throw Exception("A value separator must appear in a container node.");
+                    throw fkyaml::exception("A value separator must appear in a container node.");
                 }
                 break;
-            case LexicalTokenType::ANCHOR_PREFIX: {
-                if (m_current_node->IsMapping())
+            case lexical_token_t::ANCHOR_PREFIX: {
+                if (m_current_node->is_mapping())
                 {
-                    throw Exception("A mapping node cannot be an anchor.");
+                    throw fkyaml::exception("A mapping node cannot be an anchor.");
                 }
-                m_anchor_name = m_lexer.GetString();
+                m_anchor_name = m_lexer.get_string();
                 m_needs_anchor_impl = true;
                 break;
             }
-            case LexicalTokenType::ALIAS_PREFIX: {
-                if (m_current_node->IsMapping())
+            case lexical_token_t::ALIAS_PREFIX: {
+                if (m_current_node->is_mapping())
                 {
-                    throw Exception("Cannot apply alias to a mapping node.");
+                    throw fkyaml::exception("Cannot apply alias to a mapping node.");
                 }
-                m_anchor_name = m_lexer.GetString();
+                m_anchor_name = m_lexer.get_string();
                 if (m_anchor_table.find(m_anchor_name) == m_anchor_table.end())
                 {
-                    throw Exception("The given anchor name must appear prior to the alias node.");
+                    throw fkyaml::exception("The given anchor name must appear prior to the alias node.");
                 }
-                AssignNodeValue(BasicNodeType::AliasOf(m_anchor_table.at(m_anchor_name)));
+                assign_node_value(BasicNodeType::alias_of(m_anchor_table.at(m_anchor_name)));
                 break;
             }
-            case LexicalTokenType::COMMENT_PREFIX:
+            case lexical_token_t::COMMENT_PREFIX:
                 break;
-            case LexicalTokenType::YAML_VER_DIRECTIVE: {
+            case lexical_token_t::YAML_VER_DIRECTIVE: {
                 FK_YAML_ASSERT(m_current_node == &root);
-                UpdateYamlVersionFrom(m_lexer.GetYamlVersion());
-                SetYamlVersion(*m_current_node);
+                update_yaml_version_from(m_lexer.get_yaml_version());
+                set_yaml_version(*m_current_node);
                 break;
             }
-            case LexicalTokenType::TAG_DIRECTIVE:
+            case lexical_token_t::TAG_DIRECTIVE:
                 // TODO: implement tag directive deserialization.
-            case LexicalTokenType::INVALID_DIRECTIVE:
+            case lexical_token_t::INVALID_DIRECTIVE:
                 // TODO: should output a warning log. Currently just ignore this case.
                 break;
-            case LexicalTokenType::SEQUENCE_BLOCK_PREFIX:
-                if (m_current_node->IsMapping())
+            case lexical_token_t::SEQUENCE_BLOCK_PREFIX:
+                if (m_current_node->is_mapping())
                 {
-                    if (m_current_node->IsEmpty())
+                    if (m_current_node->empty())
                     {
-                        *m_current_node = BasicNodeType::Sequence();
+                        *m_current_node = BasicNodeType::sequence();
                         break;
                     }
 
                     // for the second or later mapping items in a sequence node.
-                    m_node_stack.back()->ToSequence().emplace_back(BasicNodeType::Mapping());
-                    m_current_node = &(m_node_stack.back()->ToSequence().back());
-                    SetYamlVersion(*m_current_node);
+                    m_node_stack.back()->to_sequence().emplace_back(BasicNodeType::mapping());
+                    m_current_node = &(m_node_stack.back()->to_sequence().back());
+                    set_yaml_version(*m_current_node);
                     break;
                 }
                 break;
-            case LexicalTokenType::SEQUENCE_FLOW_BEGIN:
-                if (m_current_node->IsMapping())
+            case lexical_token_t::SEQUENCE_FLOW_BEGIN:
+                if (m_current_node->is_mapping())
                 {
-                    throw Exception("Cannot assign a sequence value as a key.");
+                    throw fkyaml::exception("Cannot assign a sequence value as a key.");
                 }
-                *m_current_node = BasicNodeType::Sequence();
-                SetYamlVersion(*m_current_node);
+                *m_current_node = BasicNodeType::sequence();
+                set_yaml_version(*m_current_node);
                 break;
-            case LexicalTokenType::SEQUENCE_FLOW_END:
-                if (!m_current_node->IsSequence())
+            case lexical_token_t::SEQUENCE_FLOW_END:
+                if (!m_current_node->is_sequence())
                 {
-                    throw Exception("Invalid sequence flow ending found.");
-                }
-                m_current_node = m_node_stack.back();
-                m_node_stack.pop_back();
-                break;
-            case LexicalTokenType::MAPPING_BLOCK_PREFIX:
-                *m_current_node = BasicNodeType::Mapping();
-                SetYamlVersion(*m_current_node);
-                break;
-            case LexicalTokenType::MAPPING_FLOW_BEGIN:
-                if (m_current_node->IsMapping())
-                {
-                    throw Exception("Cannot assign a mapping value as a key.");
-                }
-                *m_current_node = BasicNodeType::Mapping();
-                SetYamlVersion(*m_current_node);
-                break;
-            case LexicalTokenType::MAPPING_FLOW_END:
-                if (!m_current_node->IsMapping())
-                {
-                    throw Exception("Invalid mapping flow ending found.");
+                    throw fkyaml::exception("Invalid sequence flow ending found.");
                 }
                 m_current_node = m_node_stack.back();
                 m_node_stack.pop_back();
                 break;
-            case LexicalTokenType::NULL_VALUE:
-                if (m_current_node->IsMapping())
+            case lexical_token_t::MAPPING_BLOCK_PREFIX:
+                *m_current_node = BasicNodeType::mapping();
+                set_yaml_version(*m_current_node);
+                break;
+            case lexical_token_t::MAPPING_FLOW_BEGIN:
+                if (m_current_node->is_mapping())
                 {
-                    AddNewKey(m_lexer.GetString());
+                    throw fkyaml::exception("Cannot assign a mapping value as a key.");
+                }
+                *m_current_node = BasicNodeType::mapping();
+                set_yaml_version(*m_current_node);
+                break;
+            case lexical_token_t::MAPPING_FLOW_END:
+                if (!m_current_node->is_mapping())
+                {
+                    throw fkyaml::exception("Invalid mapping flow ending found.");
+                }
+                m_current_node = m_node_stack.back();
+                m_node_stack.pop_back();
+                break;
+            case lexical_token_t::NULL_VALUE:
+                if (m_current_node->is_mapping())
+                {
+                    add_new_key(m_lexer.get_string());
                     break;
                 }
 
                 // Just make sure that the actual value is really a null value.
-                m_lexer.GetNull();
-                AssignNodeValue(BasicNodeType());
+                m_lexer.get_null();
+                assign_node_value(BasicNodeType());
                 break;
-            case LexicalTokenType::BOOLEAN_VALUE:
-                if (m_current_node->IsMapping())
+            case lexical_token_t::BOOLEAN_VALUE:
+                if (m_current_node->is_mapping())
                 {
-                    AddNewKey(m_lexer.GetString());
+                    add_new_key(m_lexer.get_string());
                     break;
                 }
-                AssignNodeValue(BasicNodeType::BooleanScalar(m_lexer.GetBoolean()));
+                assign_node_value(BasicNodeType::boolean_scalar(m_lexer.get_boolean()));
                 break;
-            case LexicalTokenType::INTEGER_VALUE:
-                if (m_current_node->IsMapping())
+            case lexical_token_t::INTEGER_VALUE:
+                if (m_current_node->is_mapping())
                 {
-                    AddNewKey(m_lexer.GetString());
+                    add_new_key(m_lexer.get_string());
                     break;
                 }
-                AssignNodeValue(BasicNodeType::IntegerScalar(m_lexer.GetInteger()));
+                assign_node_value(BasicNodeType::integer_scalar(m_lexer.get_integer()));
                 break;
-            case LexicalTokenType::FLOAT_NUMBER_VALUE:
-                if (m_current_node->IsMapping())
+            case lexical_token_t::FLOAT_NUMBER_VALUE:
+                if (m_current_node->is_mapping())
                 {
-                    AddNewKey(m_lexer.GetString());
+                    add_new_key(m_lexer.get_string());
                     break;
                 }
-                AssignNodeValue(BasicNodeType::FloatNumberScalar(m_lexer.GetFloatNumber()));
+                assign_node_value(BasicNodeType::float_number_scalar(m_lexer.get_float_number()));
                 break;
-            case LexicalTokenType::STRING_VALUE:
-                if (m_current_node->IsMapping())
+            case lexical_token_t::STRING_VALUE:
+                if (m_current_node->is_mapping())
                 {
-                    AddNewKey(m_lexer.GetString());
+                    add_new_key(m_lexer.get_string());
                     break;
                 }
-                AssignNodeValue(BasicNodeType::StringScalar(m_lexer.GetString()));
+                assign_node_value(BasicNodeType::string_scalar(m_lexer.get_string()));
                 break;
-            default:                                                 // LCOV_EXCL_LINE
-                throw Exception("Unsupported lexical token found."); // LCOV_EXCL_LINE
+            default:                                                         // LCOV_EXCL_LINE
+                throw fkyaml::exception("Unsupported lexical token found."); // LCOV_EXCL_LINE
             }
 
-            type = m_lexer.GetNextToken();
+            type = m_lexer.get_next_token();
         }
 
         m_current_node = nullptr;
@@ -264,11 +264,11 @@ private:
      *
      * @param key a key string to be added to the current YAML node.
      */
-    void AddNewKey(const string_type& key) noexcept
+    void add_new_key(const string_type& key) noexcept
     {
-        m_current_node->ToMapping().emplace(key, BasicNodeType());
+        m_current_node->to_mapping().emplace(key, BasicNodeType());
         m_node_stack.push_back(m_current_node);
-        m_current_node = &(m_current_node->ToMapping().at(key));
+        m_current_node = &(m_current_node->to_mapping().at(key));
     }
 
     /**
@@ -276,16 +276,16 @@ private:
      *
      * @param node_value A rvalue BasicNodeType object to be assigned to the current node.
      */
-    void AssignNodeValue(BasicNodeType&& node_value) noexcept
+    void assign_node_value(BasicNodeType&& node_value) noexcept
     {
-        if (m_current_node->IsSequence())
+        if (m_current_node->is_sequence())
         {
-            m_current_node->ToSequence().emplace_back(std::move(node_value));
-            SetYamlVersion(m_current_node->ToSequence().back());
+            m_current_node->to_sequence().emplace_back(std::move(node_value));
+            set_yaml_version(m_current_node->to_sequence().back());
             if (m_needs_anchor_impl)
             {
-                m_current_node->ToSequence().back().AddAnchorName(m_anchor_name);
-                m_anchor_table[m_anchor_name] = m_current_node->ToSequence().back();
+                m_current_node->to_sequence().back().add_anchor_name(m_anchor_name);
+                m_anchor_table[m_anchor_name] = m_current_node->to_sequence().back();
                 m_needs_anchor_impl = false;
                 m_anchor_name.clear();
             }
@@ -294,10 +294,10 @@ private:
 
         // a scalar node
         *m_current_node = std::move(node_value);
-        SetYamlVersion(*m_current_node);
+        set_yaml_version(*m_current_node);
         if (m_needs_anchor_impl)
         {
-            m_current_node->AddAnchorName(m_anchor_name);
+            m_current_node->add_anchor_name(m_anchor_name);
             m_anchor_table[m_anchor_name] = *m_current_node;
             m_needs_anchor_impl = false;
             m_anchor_name.clear();
@@ -307,13 +307,13 @@ private:
     }
 
     /**
-     * @brief Set the YamlVersionType object to the given node.
+     * @brief Set the yaml_version_t object to the given node.
      *
-     * @param node A BasicNodeType object to be set the YamlVersionType object.
+     * @param node A BasicNodeType object to be set the yaml_version_t object.
      */
-    void SetYamlVersion(BasicNodeType& node) noexcept
+    void set_yaml_version(BasicNodeType& node) noexcept
     {
-        node.SetVersion(m_yaml_version);
+        node.set_yaml_version(m_yaml_version);
     }
 
     /**
@@ -321,22 +321,22 @@ private:
      *
      * @param version_str A YAML version string.
      */
-    void UpdateYamlVersionFrom(const string_type& version_str) noexcept
+    void update_yaml_version_from(const string_type& version_str) noexcept
     {
         if (version_str == "1.1")
         {
-            m_yaml_version = YamlVersionType::VER_1_1;
+            m_yaml_version = yaml_version_t::VER_1_1;
             return;
         }
-        m_yaml_version = YamlVersionType::VER_1_2;
+        m_yaml_version = yaml_version_t::VER_1_2;
     }
 
 private:
-    lexer_type m_lexer {};                                     /** A lexical analyzer object. */
-    BasicNodeType* m_current_node = nullptr;                   /** The currently focused YAML node. */
-    std::vector<BasicNodeType*> m_node_stack;                  /** The stack of YAML nodes. */
-    YamlVersionType m_yaml_version = YamlVersionType::VER_1_2; /** The YAML version specification type. */
-    uint32_t m_current_indent_width = 0;                       /** The current indentation width. */
+    lexer_type m_lexer {};                                   /** A lexical analyzer object. */
+    BasicNodeType* m_current_node = nullptr;                 /** The currently focused YAML node. */
+    std::vector<BasicNodeType*> m_node_stack;                /** The stack of YAML nodes. */
+    yaml_version_t m_yaml_version = yaml_version_t::VER_1_2; /** The YAML version specification type. */
+    uint32_t m_current_indent_width = 0;                     /** The current indentation width. */
     bool m_needs_anchor_impl = false; /** A flag to determine the need for YAML anchor node implementation */
     string_type m_anchor_name {};     /** The last YAML anchor name. */
     std::unordered_map<std::string, BasicNodeType> m_anchor_table; /** The table of YAML anchor nodes. */
@@ -345,7 +345,7 @@ private:
 /**
  * @brief default YAML document deserializer.
  */
-using Deserializer = BasicDeserializer<>;
+using deserializer = basic_deserializer<>;
 
 FK_YAML_NAMESPACE_END
 

--- a/include/fkYAML/Exception.hpp
+++ b/include/fkYAML/Exception.hpp
@@ -25,23 +25,23 @@
 FK_YAML_NAMESPACE_BEGIN
 
 /**
- * @class Exception
+ * @class exception
  * @brief A base exception class used in fkYAML library.
  */
-class Exception : public std::exception
+class exception : public std::exception
 {
 public:
     /**
-     * @brief Construct a new Exception object without any error messages.
+     * @brief Construct a new exception object without any error messages.
      */
-    Exception() = default;
+    exception() = default;
 
     /**
-     * @brief Construct a new Exception object with an error message.
+     * @brief Construct a new exception object with an error message.
      *
      * @param msg An error description message.
      */
-    explicit Exception(const char* msg)
+    explicit exception(const char* msg)
     {
         if (msg)
         {

--- a/include/fkYAML/Iterator.hpp
+++ b/include/fkYAML/Iterator.hpp
@@ -27,29 +27,29 @@
 FK_YAML_NAMESPACE_BEGIN
 
 /**
- * @struct SequenceIteratorTag
+ * @struct sequence_iterator_tag
  * @brief A tag which tells Iterator will contain sequence value iterator.
  */
-struct SequenceIteratorTag
+struct sequence_iterator_tag
 {
 };
 
 /**
- * @struct MappingIteratorTag
+ * @struct mapping_iterator_tag
  * @brief A tag which tells Iterator will contain mapping value iterator.
  */
-struct MappingIteratorTag
+struct mapping_iterator_tag
 {
 };
 
 /**
- * @struct IteratorTraits
+ * @struct iterator_traits
  * @brief The template definitions of type informations used in @ref Iterator class
  *
  * @tparam ValueType The type of iterated elements.
  */
 template <typename ValueType>
-struct IteratorTraits
+struct iterator_traits
 {
     /** A type of iterated elements. */
     using value_type = ValueType;
@@ -64,12 +64,12 @@ struct IteratorTraits
 };
 
 /**
- * @brief A specialization of @ref IteratorTraits for constant value types.
+ * @brief A specialization of @ref iterator_traits for constant value types.
  *
  * @tparam ValueType The type of iterated elements.
  */
 template <typename ValueType>
-struct IteratorTraits<const ValueType>
+struct iterator_traits<const ValueType>
 {
     /** A type of iterated elements. */
     using value_type = ValueType;
@@ -84,27 +84,27 @@ struct IteratorTraits<const ValueType>
 };
 
 /**
- * @enum IteratorType
+ * @enum iterator_t
  * @brief Definitions of iterator types for iterators internally held.
  */
-enum class IteratorType
+enum class iterator_t
 {
     SEQUENCE, //!< sequence iterator type.
     MAPPING,  //!< mapping iterator type.
 };
 
 /**
- * @class Iterator
+ * @class iterator
  * @brief A class which holds iterators either of sequence or mapping type
  *
  * @tparam ValueType The type of iterated elements.
  */
 template <typename ValueType>
-class Iterator
+class iterator
 {
 public:
     /** A type for iterator traits of instantiated @Iterator template class. */
-    using ItrTraitsType = IteratorTraits<ValueType>;
+    using ItrTraitsType = iterator_traits<ValueType>;
 
     /** A type for iterator category tag. */
     using iterator_category = std::bidirectional_iterator_tag;
@@ -123,13 +123,13 @@ private:
     /** A type of non-const version of iterated elements. */
     using NonConstValueType = typename std::remove_const<ValueType>::type;
 
-    static_assert(IsBasicNode<NonConstValueType>::value, "Iterator only accepts (const) BasicNode<...>");
+    static_assert(is_basic_node<NonConstValueType>::value, "Iterator only accepts (const) BasicNode<...>");
 
     /**
-     * @struct IteratorHolder
+     * @struct iterator_holder
      * @brief The actual storage for iterators internally held in @ref Iterator.
      */
-    struct IteratorHolder
+    struct iterator_holder
     {
         /** A sequence iterator object. */
         typename NonConstValueType::sequence_type::iterator sequence_iterator {};
@@ -139,79 +139,79 @@ private:
 
 public:
     /**
-     * @brief Construct a new Iterator object with sequence iterator object.
+     * @brief Construct a new iterator object with sequence iterator object.
      *
      * @param[in] itr An sequence iterator object.
      */
-    Iterator(SequenceIteratorTag /* unused */, const typename ValueType::sequence_type::iterator& itr) noexcept
-        : m_inner_iterator_type(IteratorType::SEQUENCE)
+    iterator(sequence_iterator_tag /* unused */, const typename ValueType::sequence_type::iterator& itr) noexcept
+        : m_inner_iterator_type(iterator_t::SEQUENCE)
     {
         m_iterator_holder.sequence_iterator = itr;
     }
 
     /**
-     * @brief Construct a new Iterator object with mapping iterator object.
+     * @brief Construct a new iterator object with mapping iterator object.
      *
      * @param[in] itr An mapping iterator object.
      */
-    Iterator(MappingIteratorTag /* unused */, const typename ValueType::mapping_type::iterator& itr) noexcept
-        : m_inner_iterator_type(IteratorType::MAPPING)
+    iterator(mapping_iterator_tag /* unused */, const typename ValueType::mapping_type::iterator& itr) noexcept
+        : m_inner_iterator_type(iterator_t::MAPPING)
     {
         m_iterator_holder.mapping_iterator = itr;
     }
 
     /**
-     * @brief Copy constructor of the Iterator class.
+     * @brief Copy constructor of the iterator class.
      *
-     * @param other An Iterator object to be copied with.
+     * @param other An iterator object to be copied with.
      */
-    Iterator(const Iterator& other) noexcept // NOLINT(bugprone-exception-escape)
+    iterator(const iterator& other) noexcept // NOLINT(bugprone-exception-escape)
         : m_inner_iterator_type(other.m_inner_iterator_type)
     {
         switch (m_inner_iterator_type)
         {
-        case IteratorType::SEQUENCE:
+        case iterator_t::SEQUENCE:
             m_iterator_holder.sequence_iterator = other.m_iterator_holder.sequence_iterator;
             break;
-        case IteratorType::MAPPING:
+        case iterator_t::MAPPING:
             m_iterator_holder.mapping_iterator = other.m_iterator_holder.mapping_iterator;
             break;
-        default:                                                 // LCOV_EXCL_LINE
-            throw Exception("Unsupported inner iterator type."); // LCOV_EXCL_LINE
+        default:                                                         // LCOV_EXCL_LINE
+            throw fkyaml::exception("Unsupported inner iterator type."); // LCOV_EXCL_LINE
         }
     }
 
     /**
-     * @brief Move constructor of the Iterator class.
+     * @brief Move constructor of the iterator class.
      *
-     * @param other An Iterator object to be moved from.
+     * @param other An iterator object to be moved from.
      */
-    Iterator(Iterator&& other) noexcept // NOLINT(bugprone-exception-escape)
+    iterator(iterator&& other) noexcept // NOLINT(bugprone-exception-escape)
         : m_inner_iterator_type(other.m_inner_iterator_type)
     {
         switch (m_inner_iterator_type)
         {
-        case IteratorType::SEQUENCE:
+        case iterator_t::SEQUENCE:
             m_iterator_holder.sequence_iterator = std::move(other.m_iterator_holder.sequence_iterator);
             break;
-        case IteratorType::MAPPING:
+        case iterator_t::MAPPING:
             m_iterator_holder.mapping_iterator = std::move(other.m_iterator_holder.mapping_iterator);
             break;
-        default:                                                 // LCOV_EXCL_LINE
-            throw Exception("Unsupported inner iterator type."); // LCOV_EXCL_LINE
+        default:                                                         // LCOV_EXCL_LINE
+            throw fkyaml::exception("Unsupported inner iterator type."); // LCOV_EXCL_LINE
         }
     }
 
-    ~Iterator() = default;
+    ~iterator() = default;
 
 public:
     /**
-     * @brief A copy assignment operator of the Iterator class.
+     * @brief A copy assignment operator of the iterator class.
      *
-     * @param rhs An Iterator object to be copied with.
-     * @return Iterator& Reference to this Iterator object.
+     * @param rhs An iterator object to be copied with.
+     * @return iterator& Reference to this iterator object.
      */
-    Iterator& operator=(const Iterator& rhs) noexcept // NOLINT(cert-oop54-cpp,bugprone-exception-escape)
+    iterator& operator=(const iterator& rhs) noexcept // NOLINT(cert-oop54-cpp,bugprone-exception-escape)
     {
         if (&rhs == this)
         {
@@ -221,26 +221,26 @@ public:
         m_inner_iterator_type = rhs.m_inner_iterator_type;
         switch (m_inner_iterator_type)
         {
-        case IteratorType::SEQUENCE:
+        case iterator_t::SEQUENCE:
             m_iterator_holder.sequence_iterator = rhs.m_iterator_holder.sequence_iterator;
             break;
-        case IteratorType::MAPPING:
+        case iterator_t::MAPPING:
             m_iterator_holder.mapping_iterator = rhs.m_iterator_holder.mapping_iterator;
             break;
-        default:                                                 // LCOV_EXCL_LINE
-            throw Exception("Unsupported inner iterator type."); // LCOV_EXCL_LINE
+        default:                                                         // LCOV_EXCL_LINE
+            throw fkyaml::exception("Unsupported inner iterator type."); // LCOV_EXCL_LINE
         }
 
         return *this;
     }
 
     /**
-     * @brief A move assignment operator of the Iterator class.
+     * @brief A move assignment operator of the iterator class.
      *
-     * @param rhs An Iterator object to be moved from.
-     * @return Iterator& Reference to this Iterator object.
+     * @param rhs An iterator object to be moved from.
+     * @return iterator& Reference to this iterator object.
      */
-    Iterator& operator=(Iterator&& rhs) noexcept // NOLINT(bugprone-exception-escape)
+    iterator& operator=(iterator&& rhs) noexcept // NOLINT(bugprone-exception-escape)
     {
         if (&rhs == this)
         {
@@ -250,39 +250,39 @@ public:
         m_inner_iterator_type = rhs.m_inner_iterator_type;
         switch (m_inner_iterator_type)
         {
-        case IteratorType::SEQUENCE:
+        case iterator_t::SEQUENCE:
             m_iterator_holder.sequence_iterator = std::move(rhs.m_iterator_holder.sequence_iterator);
             break;
-        case IteratorType::MAPPING:
+        case iterator_t::MAPPING:
             m_iterator_holder.mapping_iterator = std::move(rhs.m_iterator_holder.mapping_iterator);
             break;
-        default:                                                 // LCOV_EXCL_LINE
-            throw Exception("Unsupported inner iterator type."); // LCOV_EXCL_LINE
+        default:                                                         // LCOV_EXCL_LINE
+            throw fkyaml::exception("Unsupported inner iterator type."); // LCOV_EXCL_LINE
         }
 
         return *this;
     }
 
     /**
-     * @brief An arrow operator of the Iterator class.
+     * @brief An arrow operator of the iterator class.
      *
-     * @return pointer A pointer to the Node object internally referenced by the actual iterator object.
+     * @return pointer A pointer to the BasicNodeType object internally referenced by the actual iterator object.
      */
     pointer operator->() noexcept // NOLINT(bugprone-exception-escape)
     {
         switch (m_inner_iterator_type)
         {
-        case IteratorType::SEQUENCE:
+        case iterator_t::SEQUENCE:
             return &(*(m_iterator_holder.sequence_iterator));
-        case IteratorType::MAPPING:
+        case iterator_t::MAPPING:
             return &(m_iterator_holder.mapping_iterator->second);
-        default:                                                 // LCOV_EXCL_LINE
-            throw Exception("Unsupported inner iterator type."); // LCOV_EXCL_LINE
+        default:                                                         // LCOV_EXCL_LINE
+            throw fkyaml::exception("Unsupported inner iterator type."); // LCOV_EXCL_LINE
         }
     }
 
     /**
-     * @brief A dereference operator of the Iterator class.
+     * @brief A dereference operator of the iterator class.
      *
      * @return reference Reference to the Node object internally referenced by the actual iterator object.
      */
@@ -290,12 +290,12 @@ public:
     {
         switch (m_inner_iterator_type)
         {
-        case IteratorType::SEQUENCE:
+        case iterator_t::SEQUENCE:
             return *(m_iterator_holder.sequence_iterator);
-        case IteratorType::MAPPING:
+        case iterator_t::MAPPING:
             return m_iterator_holder.mapping_iterator->second;
-        default:                                                 // LCOV_EXCL_LINE
-            throw Exception("Unsupported inner iterator type."); // LCOV_EXCL_LINE
+        default:                                                         // LCOV_EXCL_LINE
+            throw fkyaml::exception("Unsupported inner iterator type."); // LCOV_EXCL_LINE
         }
     }
 
@@ -305,29 +305,29 @@ public:
      * @param i The difference from this Iterator object with which it moves forward.
      * @return Iterator& Reference to this Iterator object.
      */
-    Iterator& operator+=(difference_type i) noexcept // NOLINT(bugprone-exception-escape)
+    iterator& operator+=(difference_type i) noexcept // NOLINT(bugprone-exception-escape)
     {
         switch (m_inner_iterator_type)
         {
-        case IteratorType::SEQUENCE:
+        case iterator_t::SEQUENCE:
             std::advance(m_iterator_holder.sequence_iterator, i);
             break;
-        case IteratorType::MAPPING:
+        case iterator_t::MAPPING:
             std::advance(m_iterator_holder.mapping_iterator, i);
             break;
-        default:                                                 // LCOV_EXCL_LINE
-            throw Exception("Unsupported inner iterator type."); // LCOV_EXCL_LINE
+        default:                                                         // LCOV_EXCL_LINE
+            throw fkyaml::exception("Unsupported inner iterator type."); // LCOV_EXCL_LINE
         }
         return *this;
     }
 
     /**
-     * @brief A plus operator of the Iterator class.
+     * @brief A plus operator of the iterator class.
      *
-     * @param i The difference from this Iterator object.
-     * @return Iterator An Iterator object which has been added @a i.
+     * @param i The difference from this iterator object.
+     * @return iterator An iterator object which has been added @a i.
      */
-    Iterator operator+(difference_type i) const noexcept
+    iterator operator+(difference_type i) const noexcept
     {
         auto result = *this;
         result += i;
@@ -335,32 +335,32 @@ public:
     }
 
     /**
-     * @brief An pre-increment operator of the Iterator class.
+     * @brief An pre-increment operator of the iterator class.
      *
-     * @return Iterator& Reference to this Iterator object.
+     * @return iterator& Reference to this iterator object.
      */
-    Iterator& operator++() noexcept // NOLINT(bugprone-exception-escape)
+    iterator& operator++() noexcept // NOLINT(bugprone-exception-escape)
     {
         switch (m_inner_iterator_type)
         {
-        case IteratorType::SEQUENCE:
+        case iterator_t::SEQUENCE:
             std::advance(m_iterator_holder.sequence_iterator, 1);
             break;
-        case IteratorType::MAPPING:
+        case iterator_t::MAPPING:
             std::advance(m_iterator_holder.mapping_iterator, 1);
             break;
-        default:                                                 // LCOV_EXCL_LINE
-            throw Exception("Unsupported inner iterator type."); // LCOV_EXCL_LINE
+        default:                                                         // LCOV_EXCL_LINE
+            throw fkyaml::exception("Unsupported inner iterator type."); // LCOV_EXCL_LINE
         }
         return *this;
     }
 
     /**
-     * @brief A post-increment opretor of the Iterator class.
+     * @brief A post-increment opretor of the iterator class.
      *
-     * @return Iterator An Iterator object which has been incremented.
+     * @return iterator An iterator object which has been incremented.
      */
-    Iterator operator++(int) & noexcept // NOLINT(cert-dcl21-cpp)
+    iterator operator++(int) & noexcept // NOLINT(cert-dcl21-cpp)
     {
         auto result = *this;
         ++(*this);
@@ -368,23 +368,23 @@ public:
     }
 
     /**
-     * @brief A compound assignment operator by difference of the Iterator class.
+     * @brief A compound assignment operator by difference of the iterator class.
      *
-     * @param i The difference from this Iterator object with which it moves backward.
-     * @return Iterator& Reference to this Iterator object.
+     * @param i The difference from this iterator object with which it moves backward.
+     * @return iterator& Reference to this iterator object.
      */
-    Iterator& operator-=(difference_type i) noexcept // NOLINT(bugprone-exception-escape)
+    iterator& operator-=(difference_type i) noexcept // NOLINT(bugprone-exception-escape)
     {
         return operator+=(-i);
     }
 
     /**
-     * @brief A minus operator of the Iterator class.
+     * @brief A minus operator of the iterator class.
      *
-     * @param i The difference from this Iterator object.
-     * @return Iterator An Iterator object from which has been subtracted @ i.
+     * @param i The difference from this iterator object.
+     * @return iterator An iterator object from which has been subtracted @ i.
      */
-    Iterator operator-(difference_type i) noexcept
+    iterator operator-(difference_type i) noexcept
     {
         auto result = *this;
         result -= i;
@@ -392,32 +392,32 @@ public:
     }
 
     /**
-     * @brief A pre-decrement operator of the Iterator class.
+     * @brief A pre-decrement operator of the iterator class.
      *
-     * @return Iterator& Reference to this Iterator object.
+     * @return iterator& Reference to this iterator object.
      */
-    Iterator& operator--() noexcept // NOLINT(bugprone-exception-escape)
+    iterator& operator--() noexcept // NOLINT(bugprone-exception-escape)
     {
         switch (m_inner_iterator_type)
         {
-        case IteratorType::SEQUENCE:
+        case iterator_t::SEQUENCE:
             std::advance(m_iterator_holder.sequence_iterator, -1);
             break;
-        case IteratorType::MAPPING:
+        case iterator_t::MAPPING:
             std::advance(m_iterator_holder.mapping_iterator, -1);
             break;
-        default:                                                 // LCOV_EXCL_LINE
-            throw Exception("Unsupported inner iterator type."); // LCOV_EXCL_LINE
+        default:                                                         // LCOV_EXCL_LINE
+            throw fkyaml::exception("Unsupported inner iterator type."); // LCOV_EXCL_LINE
         }
         return *this;
     }
 
     /**
-     * @brief A post-decrement operator of the Iterator class
+     * @brief A post-decrement operator of the iterator class
      *
-     * @return Iterator An Iterator object which has been decremented.
+     * @return iterator An iterator object which has been decremented.
      */
-    Iterator operator--(int) & noexcept // NOLINT(cert-dcl21-cpp)
+    iterator operator--(int) & noexcept // NOLINT(cert-dcl21-cpp)
     {
         auto result = *this;
         --(*this);
@@ -425,99 +425,99 @@ public:
     }
 
     /**
-     * @brief An equal-to operator of the Iterator class.
+     * @brief An equal-to operator of the iterator class.
      *
-     * @param rhs An Iterator object to be compared with this Iterator object.
-     * @return true  This Iterator object is equal to the other.
-     * @return false This Iterator object is not equal to the other.
+     * @param rhs An iterator object to be compared with this iterator object.
+     * @return true  This iterator object is equal to the other.
+     * @return false This iterator object is not equal to the other.
      */
-    bool operator==(const Iterator& rhs) const
+    bool operator==(const iterator& rhs) const
     {
         if (m_inner_iterator_type != rhs.m_inner_iterator_type)
         {
-            throw Exception("Cannot compare iterators of different container types.");
+            throw fkyaml::exception("Cannot compare iterators of different container types.");
         }
 
         switch (m_inner_iterator_type)
         {
-        case IteratorType::SEQUENCE:
+        case iterator_t::SEQUENCE:
             return (m_iterator_holder.sequence_iterator == rhs.m_iterator_holder.sequence_iterator);
-        case IteratorType::MAPPING:
+        case iterator_t::MAPPING:
             return (m_iterator_holder.mapping_iterator == rhs.m_iterator_holder.mapping_iterator);
-        default:                                                 // LCOV_EXCL_LINE
-            throw Exception("Unsupported inner iterator type."); // LCOV_EXCL_LINE
+        default:                                                         // LCOV_EXCL_LINE
+            throw fkyaml::exception("Unsupported inner iterator type."); // LCOV_EXCL_LINE
         }
     }
 
     /**
-     * @brief An not-equal-to operator of the Iterator class.
+     * @brief An not-equal-to operator of the iterator class.
      *
-     * @param rhs An Iterator object to be compared with this Iterator object.
-     * @return true  This Iterator object is not equal to the other.
-     * @return false This Iterator object is equal to the other.
+     * @param rhs An iterator object to be compared with this iterator object.
+     * @return true  This iterator object is not equal to the other.
+     * @return false This iterator object is equal to the other.
      */
-    bool operator!=(const Iterator& rhs) const
+    bool operator!=(const iterator& rhs) const
     {
         return !operator==(rhs);
     }
 
     /**
-     * @brief A less-than operator of the Iterator class.
+     * @brief A less-than operator of the iterator class.
      *
-     * @param rhs An Iterator object to be compared with this Iterator object.
-     * @return true  This Iterator object is less than the other.
-     * @return false This Iterator object is not less than the other.
+     * @param rhs An iterator object to be compared with this iterator object.
+     * @return true  This iterator object is less than the other.
+     * @return false This iterator object is not less than the other.
      */
-    bool operator<(const Iterator& rhs) const
+    bool operator<(const iterator& rhs) const
     {
         if (m_inner_iterator_type != rhs.m_inner_iterator_type)
         {
-            throw Exception("Cannot compare iterators of different container types.");
+            throw fkyaml::exception("Cannot compare iterators of different container types.");
         }
 
         switch (m_inner_iterator_type)
         {
-        case IteratorType::SEQUENCE:
+        case iterator_t::SEQUENCE:
             return (m_iterator_holder.sequence_iterator < rhs.m_iterator_holder.sequence_iterator);
-        case IteratorType::MAPPING:
-            throw Exception("Cannot compare order of iterators of the mapping container type");
-        default:                                                 // LCOV_EXCL_LINE
-            throw Exception("Unsupported inner iterator type."); // LCOV_EXCL_LINE
+        case iterator_t::MAPPING:
+            throw fkyaml::exception("Cannot compare order of iterators of the mapping container type");
+        default:                                                         // LCOV_EXCL_LINE
+            throw fkyaml::exception("Unsupported inner iterator type."); // LCOV_EXCL_LINE
         }
     }
 
     /**
-     * @brief A less-than-or-equal-to operator of the Iterator class.
+     * @brief A less-than-or-equal-to operator of the iterator class.
      *
-     * @param rhs An Iterator object to be compared with this Iterator object.
-     * @return true  This Iterator object is either less than or equal to the other.
-     * @return false This Iterator object is neither less than nor equal to the other.
+     * @param rhs An iterator object to be compared with this iterator object.
+     * @return true  This iterator object is either less than or equal to the other.
+     * @return false This iterator object is neither less than nor equal to the other.
      */
-    bool operator<=(const Iterator& rhs) const
+    bool operator<=(const iterator& rhs) const
     {
         return !rhs.operator<(*this);
     }
 
     /**
-     * @brief A greater-than operator of the Iterator class.
+     * @brief A greater-than operator of the iterator class.
      *
-     * @param rhs An Iterator object to be compared with this Iterator object.
-     * @return true  This Iterator object is greater than the other.
-     * @return false This Iterator object is not greater than the other.
+     * @param rhs An iterator object to be compared with this iterator object.
+     * @return true  This iterator object is greater than the other.
+     * @return false This iterator object is not greater than the other.
      */
-    bool operator>(const Iterator& rhs) const
+    bool operator>(const iterator& rhs) const
     {
         return !operator<=(rhs);
     }
 
     /**
-     * @brief A greater-than-or-equal-to operator of the Iterator class.
+     * @brief A greater-than-or-equal-to operator of the iterator class.
      *
-     * @param rhs An Iterator object to be compared with this Iterator object.
-     * @return true  This Iterator object is either greater than or equal to the other.
-     * @return false This Iterator object is neither greater than nor equal to the other.
+     * @param rhs An iterator object to be compared with this iterator object.
+     * @return true  This iterator object is either greater than or equal to the other.
+     * @return false This iterator object is neither greater than nor equal to the other.
      */
-    bool operator>=(const Iterator& rhs) const
+    bool operator>=(const iterator& rhs) const
     {
         return !operator<(rhs);
     }
@@ -526,9 +526,9 @@ public:
     /**
      * @brief Get the type of the internal iterator implementation.
      *
-     * @return IteratorType The type of the internal iterator implementation.
+     * @return iterator_t The type of the internal iterator implementation.
      */
-    IteratorType Type() const noexcept
+    iterator_t type() const noexcept
     {
         return m_inner_iterator_type;
     }
@@ -538,16 +538,16 @@ public:
      *
      * @return const std::string& The key string of the YAML mapping node for the current iterator.
      */
-    const std::string& Key() const
+    const std::string& key() const
     {
         switch (m_inner_iterator_type)
         {
-        case IteratorType::SEQUENCE:
-            throw Exception("Cannot retrieve key from non-mapping iterators.");
-        case IteratorType::MAPPING:
+        case iterator_t::SEQUENCE:
+            throw fkyaml::exception("Cannot retrieve key from non-mapping iterators.");
+        case iterator_t::MAPPING:
             return m_iterator_holder.mapping_iterator->first;
-        default:                                                 // LCOV_EXCL_LINE
-            throw Exception("Unsupported inner iterator type."); // LCOV_EXCL_LINE
+        default:                                                         // LCOV_EXCL_LINE
+            throw fkyaml::exception("Unsupported inner iterator type."); // LCOV_EXCL_LINE
         }
     }
 
@@ -556,16 +556,16 @@ public:
      *
      * @return reference A reference to the YAML node for the current iterator.
      */
-    reference Value() noexcept // NOLINT(bugprone-exception-escape)
+    reference value() noexcept // NOLINT(bugprone-exception-escape)
     {
         return operator*();
     }
 
 private:
     /** A type of the internally-held iterator. */
-    IteratorType m_inner_iterator_type;
+    iterator_t m_inner_iterator_type;
     /** A holder of actual iterators. */
-    mutable IteratorHolder m_iterator_holder;
+    mutable iterator_holder m_iterator_holder;
 };
 
 FK_YAML_NAMESPACE_END

--- a/include/fkYAML/NodeType.hpp
+++ b/include/fkYAML/NodeType.hpp
@@ -24,10 +24,10 @@
 FK_YAML_NAMESPACE_BEGIN
 
 /**
- * @enum NodeType
+ * @enum node_t
  * @brief Definition of node value types.
  */
-enum class NodeType : std::uint32_t
+enum class node_t : std::uint32_t
 {
     SEQUENCE,     //!< sequence value type
     MAPPING,      //!< mapping value type

--- a/include/fkYAML/OrderedMap.hpp
+++ b/include/fkYAML/OrderedMap.hpp
@@ -40,7 +40,7 @@ FK_YAML_NAMESPACE_BEGIN
 template <
     typename Key, typename Value, typename IgnoredCompare = std::less<Key>,
     typename Allocator = std::allocator<std::pair<const Key, Value>>>
-class OrderedMap : public std::vector<std::pair<const Key, Value>, Allocator>
+class ordered_map : public std::vector<std::pair<const Key, Value>, Allocator>
 {
 public:
     /** A type for keys. */
@@ -62,20 +62,20 @@ public:
 
 public:
     /**
-     * @brief Construct a new OrderedMap object.
+     * @brief Construct a new ordered_map object.
      */
-    OrderedMap() noexcept(noexcept(Container()))
+    ordered_map() noexcept(noexcept(Container()))
         : Container(),
           m_compare()
     {
     }
 
     /**
-     * @brief Construct a new OrderedMap object with an initializer list.
+     * @brief Construct a new ordered_map object with an initializer list.
      *
      * @param init An initializer list to construct the inner container object.
      */
-    OrderedMap(std::initializer_list<value_type> init)
+    ordered_map(std::initializer_list<value_type> init)
         : Container {init},
           m_compare()
     {
@@ -83,13 +83,14 @@ public:
 
 public:
     /**
-     * @brief A subscript operator for OrderedMap objects.
+     * @brief A subscript operator for ordered_map objects.
      *
      * @tparam KeyType A type for the input key.
      * @param key A key to the target value.
      * @return mapped_type& Reference to a mapped_type object associated with the given key.
      */
-    template <typename KeyType, fkyaml::enable_if_t<IsUsableAsKeyType<key_compare, key_type, KeyType>::value, int> = 0>
+    template <
+        typename KeyType, fkyaml::enable_if_t<is_usable_as_key_type<key_compare, key_type, KeyType>::value, int> = 0>
     mapped_type& operator[](KeyType&& key) noexcept
     {
         return emplace(std::forward<KeyType>(key), mapped_type()).first->second;
@@ -99,12 +100,12 @@ public:
     /**
      * @brief Emplace a new key-value pair if the new key does not exist.
      *
-     * @param key A key to be emplaced to this OrderedMap object.
-     * @param value A value to be emplaced to this OrderedMap object.
+     * @param key A key to be emplaced to this ordered_map object.
+     * @param value A value to be emplaced to this ordered_map object.
      * @return std::pair<iterator, bool> A result of emplacement of the new key-value pair.
      */
-    template <typename KeyType, fkyaml::enable_if_t<IsUsableAsKeyType<key_compare, key_type, KeyType>::value, int> = 0>
-    // NOLINTNEXTLINE(readability-identifier-naming)
+    template <
+        typename KeyType, fkyaml::enable_if_t<is_usable_as_key_type<key_compare, key_type, KeyType>::value, int> = 0>
     std::pair<iterator, bool> emplace(KeyType&& key, const mapped_type& value) noexcept
     {
         for (auto itr = this->begin(); itr != this->end(); ++itr)
@@ -125,8 +126,8 @@ public:
      * @param key A key to find a value with.
      * @return mapped_type& The value associated to the given key.
      */
-    template <typename KeyType, fkyaml::enable_if_t<IsUsableAsKeyType<key_compare, key_type, KeyType>::value, int> = 0>
-    // NOLINTNEXTLINE(readability-identifier-naming)
+    template <
+        typename KeyType, fkyaml::enable_if_t<is_usable_as_key_type<key_compare, key_type, KeyType>::value, int> = 0>
     mapped_type& at(KeyType&& key)
     {
         for (auto itr = this->begin(); itr != this->end(); ++itr)
@@ -136,7 +137,7 @@ public:
                 return itr->second;
             }
         }
-        throw Exception("key not found.");
+        throw fkyaml::exception("key not found.");
     }
 
     /**
@@ -146,8 +147,8 @@ public:
      * @param key A key to find a value with.
      * @return const mapped_type& The value associated to the given key.
      */
-    template <typename KeyType, fkyaml::enable_if_t<IsUsableAsKeyType<key_compare, key_type, KeyType>::value, int> = 0>
-    // NOLINTNEXTLINE(readability-identifier-naming)
+    template <
+        typename KeyType, fkyaml::enable_if_t<is_usable_as_key_type<key_compare, key_type, KeyType>::value, int> = 0>
     const mapped_type& at(KeyType&& key) const
     {
         for (auto itr = this->begin(); itr != this->end(); ++itr)
@@ -157,7 +158,7 @@ public:
                 return itr->second;
             }
         }
-        throw Exception("key not found.");
+        throw fkyaml::exception("key not found.");
     }
 
     /**
@@ -167,8 +168,8 @@ public:
      * @param key A key to find a value with.
      * @return iterator The iterator for the found value, or the result of end().
      */
-    template <typename KeyType, fkyaml::enable_if_t<IsUsableAsKeyType<key_compare, key_type, KeyType>::value, int> = 0>
-    // NOLINTNEXTLINE(readability-identifier-naming)
+    template <
+        typename KeyType, fkyaml::enable_if_t<is_usable_as_key_type<key_compare, key_type, KeyType>::value, int> = 0>
     iterator find(KeyType&& key) noexcept
     {
         for (auto itr = this->begin(); itr != this->end(); ++itr)
@@ -188,8 +189,8 @@ public:
      * @param key A key to find a value with.
      * @return const_iterator The constant iterator for the found value, or the result of end().
      */
-    template <typename KeyType, fkyaml::enable_if_t<IsUsableAsKeyType<key_compare, key_type, KeyType>::value, int> = 0>
-    // NOLINTNEXTLINE(readability-identifier-naming)
+    template <
+        typename KeyType, fkyaml::enable_if_t<is_usable_as_key_type<key_compare, key_type, KeyType>::value, int> = 0>
     const_iterator find(KeyType&& key) const noexcept
     {
         for (auto itr = this->begin(); itr != this->end(); ++itr)

--- a/include/fkYAML/Serializer.hpp
+++ b/include/fkYAML/Serializer.hpp
@@ -30,16 +30,16 @@ FK_YAML_NAMESPACE_BEGIN
  *
  * @tparam BasicNodeType A BasicNode template class instantiation.
  */
-template <typename BasicNodeType = Node>
-class BasicSerializer
+template <typename BasicNodeType = node>
+class basic_serializer
 {
-    static_assert(IsBasicNode<BasicNodeType>::value, "BasicSerializer only accepts (const) BasicNode<...>");
+    static_assert(is_basic_node<BasicNodeType>::value, "basic_serializer only accepts (const) BasicNode<...>");
 
 public:
     /**
-     * @brief Construct a new BasicSerializer object.
+     * @brief Construct a new basic_serializer object.
      */
-    BasicSerializer() = default;
+    basic_serializer() = default;
 
     /**
      * @brief Serialize the given Node value.
@@ -47,10 +47,10 @@ public:
      * @param node A Node object to be serialized.
      * @return std::string A serialization result of the given Node value.
      */
-    std::string Serialize(BasicNodeType& node)
+    std::string serialize(BasicNodeType& node)
     {
         std::string str {};
-        SerializeNode(node, 0, str);
+        serialize_node(node, 0, str);
         return str;
     }
 
@@ -62,51 +62,51 @@ private:
      * @param cur_indent The current indent width
      * @param str A string to hold serialization result.
      */
-    void SerializeNode(BasicNodeType& node, const uint32_t cur_indent, std::string& str)
+    void serialize_node(BasicNodeType& node, const uint32_t cur_indent, std::string& str)
     {
-        switch (node.Type())
+        switch (node.type())
         {
-        case NodeType::SEQUENCE:
+        case node_t::SEQUENCE:
             for (auto& seq_item : node)
             {
-                InsertIndentation(cur_indent, str);
+                insert_indentation(cur_indent, str);
                 str += "-";
-                if (seq_item.IsScalar())
+                if (seq_item.is_scalar())
                 {
                     str += " ";
-                    SerializeNode(seq_item, cur_indent, str);
+                    serialize_node(seq_item, cur_indent, str);
                     str += "\n";
                 }
                 else
                 {
                     str += "\n";
-                    SerializeNode(seq_item, cur_indent + 2, str);
+                    serialize_node(seq_item, cur_indent + 2, str);
                 }
             }
             break;
-        case NodeType::MAPPING:
-            for (auto itr = node.Begin(); itr != node.End(); ++itr)
+        case node_t::MAPPING:
+            for (auto itr = node.begin(); itr != node.end(); ++itr)
             {
-                InsertIndentation(cur_indent, str);
-                SerializeKey(itr.Key(), str);
-                if (itr->IsScalar())
+                insert_indentation(cur_indent, str);
+                serialize_key(itr.key(), str);
+                if (itr->is_scalar())
                 {
                     str += " ";
-                    SerializeNode(*itr, cur_indent, str);
+                    serialize_node(*itr, cur_indent, str);
                     str += "\n";
                 }
                 else
                 {
                     str += "\n";
-                    SerializeNode(*itr, cur_indent + 2, str);
+                    serialize_node(*itr, cur_indent + 2, str);
                 }
             }
             break;
-        case NodeType::NULL_OBJECT:
+        case node_t::NULL_OBJECT:
             str += "null";
             break;
-        case NodeType::BOOLEAN:
-            if (node.ToBoolean())
+        case node_t::BOOLEAN:
+            if (node.to_boolean())
             {
                 str += "true";
             }
@@ -115,11 +115,11 @@ private:
                 str += "false";
             }
             break;
-        case NodeType::INTEGER:
-            str += std::to_string(node.ToInteger());
+        case node_t::INTEGER:
+            str += std::to_string(node.to_integer());
             break;
-        case NodeType::FLOAT_NUMBER: {
-            typename BasicNodeType::float_number_type float_val = node.ToFloatNumber();
+        case node_t::FLOAT_NUMBER: {
+            typename BasicNodeType::float_number_type float_val = node.to_float_number();
             if (std::isnan(float_val))
             {
                 str += ".nan";
@@ -138,16 +138,16 @@ private:
             else
             {
                 std::stringstream ss;
-                ss << node.ToFloatNumber();
+                ss << node.to_float_number();
                 str += ss.str();
             }
             break;
         }
-        case NodeType::STRING:
-            str += node.ToString();
+        case node_t::STRING:
+            str += node.to_string();
             break;
         default:
-            throw Exception("Unsupported node type found.");
+            throw fkyaml::exception("Unsupported node type found.");
         }
     }
 
@@ -157,7 +157,7 @@ private:
      * @param key A key string to be serialized.
      * @param str A string to hold serialization result.
      */
-    void SerializeKey(const std::string& key, std::string& str)
+    void serialize_key(const std::string& key, std::string& str)
     {
         str += key + ":";
     }
@@ -168,7 +168,7 @@ private:
      * @param cur_indent The current indent width to be inserted.
      * @param str A string to hold serialization result.
      */
-    void InsertIndentation(const uint32_t cur_indent, std::string& str)
+    void insert_indentation(const uint32_t cur_indent, std::string& str)
     {
         for (uint32_t i = 0; i < cur_indent; ++i)
         {
@@ -180,7 +180,7 @@ private:
 /**
  * @brief default YAML node serializer.
  */
-using Serializer = BasicSerializer<>;
+using serializer = basic_serializer<>;
 
 FK_YAML_NAMESPACE_END
 

--- a/include/fkYAML/TypeTraits.hpp
+++ b/include/fkYAML/TypeTraits.hpp
@@ -23,25 +23,25 @@
  */
 FK_YAML_NAMESPACE_BEGIN
 
-// forward declaration for fkyaml::BasicNode<...>
+// forward declaration for fkyaml::basic_node<...>
 template <
     template <typename, typename...> class SequenceType, template <typename, typename, typename...> class MappingType,
     typename BooleanType, typename IntegerType, typename FloatNumberType, typename StringType>
-class BasicNode;
+class basic_node;
 
 /**
- * @struct IsBasicNode
- * @brief A struct to check the template parameter class is a kind of BasicNode template class.
+ * @struct is_basic_node
+ * @brief A struct to check the template parameter class is a kind of basic_node template class.
  *
- * @tparam T A class to be checked if it's a kind of BasicNode template class.
+ * @tparam T A class to be checked if it's a kind of basic_node template class.
  */
 template <typename T>
-struct IsBasicNode : std::false_type
+struct is_basic_node : std::false_type
 {
 };
 
 /**
- * @brief A partial specialization of IsBasicNode for BasicNode template class.
+ * @brief A partial specialization of is_basic_node for basic_node template class.
  *
  * @tparam SequenceType A type for sequence node value containers.
  * @tparam MappingType A type for mapping node value containers.
@@ -53,7 +53,7 @@ struct IsBasicNode : std::false_type
 template <
     template <typename, typename...> class SequenceType, template <typename, typename, typename...> class MappingType,
     typename BooleanType, typename IntegerType, typename FloatNumberType, typename StringType>
-struct IsBasicNode<BasicNode<SequenceType, MappingType, BooleanType, IntegerType, FloatNumberType, StringType>>
+struct is_basic_node<basic_node<SequenceType, MappingType, BooleanType, IntegerType, FloatNumberType, StringType>>
     : std::true_type
 {
 };
@@ -64,7 +64,7 @@ struct IsBasicNode<BasicNode<SequenceType, MappingType, BooleanType, IntegerType
  * @tparam Types Any types to be transformed to void type.
  */
 template <typename... Types>
-struct MakeVoid
+struct make_void
 {
     using type = void;
 };
@@ -76,7 +76,7 @@ struct MakeVoid
  * @tparam Types Any types to be transformed to void type.
  */
 template <typename... Types>
-using void_t = typename MakeVoid<Types...>::type;
+using void_t = typename make_void<Types...>::type;
 
 /**
  * @brief An alias template for std::enable_if::type with C++11.
@@ -97,19 +97,19 @@ using enable_if_t = typename std::enable_if<Condition, T>::type;
  * @tparam typename Placeholder for determining T and U are comparable types.
  */
 template <typename Comparator, typename T, typename U, typename = void>
-struct IsComparable : std::false_type
+struct is_comparable : std::false_type
 {
 };
 
 /**
- * @brief A partial specialization of IsComparable if T and U are comparable types.
+ * @brief A partial specialization of is_comparable if T and U are comparable types.
  *
  * @tparam Comparator An object type to compare T and U objects.
  * @tparam T A type for comparison.
  * @tparam U Ther other type for comparison.
  */
 template <typename Comparator, typename T, typename U>
-struct IsComparable<
+struct is_comparable<
     Comparator, T, U,
     void_t<
         decltype(std::declval<Comparator>()(std::declval<T>(), std::declval<U>())),
@@ -125,8 +125,8 @@ struct IsComparable<
  * @tparam KeyType A type to be used as key type.
  */
 template <typename Comparator, typename ObjectKeyType, typename KeyType>
-using IsUsableAsKeyType = typename std::conditional<
-    IsComparable<Comparator, ObjectKeyType, KeyType>::value, std::true_type, std::false_type>::type;
+using is_usable_as_key_type = typename std::conditional<
+    is_comparable<Comparator, ObjectKeyType, KeyType>::value, std::true_type, std::false_type>::type;
 
 FK_YAML_NAMESPACE_END
 

--- a/include/fkYAML/YAMLVersionType.hpp
+++ b/include/fkYAML/YAMLVersionType.hpp
@@ -24,10 +24,10 @@
 FK_YAML_NAMESPACE_BEGIN
 
 /**
- * @enum YamlVersionType
+ * @enum yaml_version_t
  * @brief Definition of YAML version types.
  */
-enum class YamlVersionType : std::uint32_t
+enum class yaml_version_t : std::uint32_t
 {
     VER_1_1, //!< YAML version 1.1
     VER_1_2, //!< YAML version 1.2

--- a/test/cmake_add_subdirectory_test/project/main.cpp
+++ b/test/cmake_add_subdirectory_test/project/main.cpp
@@ -13,10 +13,10 @@
 
 int main()
 {
-    fkyaml::Deserializer deserializer;
-    fkyaml::Node node = deserializer.Deserialize("test: true");
+    fkyaml::deserializer deserializer;
+    fkyaml::node node = deserializer.deserialize("test: true");
 
-    std::cout << "test: " << node["test"].ToString() << std::endl;
+    std::cout << "test: " << node["test"].to_string() << std::endl;
 
     return 0;
 }

--- a/test/cmake_fetch_content_test/project/CMakeLists.txt
+++ b/test/cmake_fetch_content_test/project/CMakeLists.txt
@@ -8,8 +8,7 @@ include(FetchContent)
 FetchContent_Declare(
   fkYAML
   GIT_REPOSITORY https://github.com/fktn-k/fkYAML.git
-  GIT_TAG v0.0.1
-  )
+  GIT_TAG v0.0.1)
 FetchContent_MakeAvailable(fkYAML)
 
 add_executable(CMakeFetchContentTest main.cpp)

--- a/test/cmake_fetch_content_test/project/main.cpp
+++ b/test/cmake_fetch_content_test/project/main.cpp
@@ -13,6 +13,7 @@
 
 int main()
 {
+    // NOTE: API signatures must remain old until v0.1.0 release.
     fkyaml::Deserializer deserializer;
     fkyaml::Node node = deserializer.Deserialize("test: true");
 

--- a/test/cmake_find_package_test/project/main.cpp
+++ b/test/cmake_find_package_test/project/main.cpp
@@ -13,10 +13,10 @@
 
 int main()
 {
-    fkyaml::Deserializer deserializer;
-    fkyaml::Node node = deserializer.Deserialize("test: true");
+    fkyaml::deserializer deserializer;
+    fkyaml::node node = deserializer.deserialize("test: true");
 
-    std::cout << "test: " << node["test"].ToString() << std::endl;
+    std::cout << "test: " << node["test"].to_string() << std::endl;
 
     return 0;
 }

--- a/test/cmake_target_include_directories_test/project/main.cpp
+++ b/test/cmake_target_include_directories_test/project/main.cpp
@@ -13,10 +13,10 @@
 
 int main()
 {
-    fkyaml::Deserializer deserializer;
-    fkyaml::Node node = deserializer.Deserialize("test: true");
+    fkyaml::deserializer deserializer;
+    fkyaml::node node = deserializer.deserialize("test: true");
 
-    std::cout << "test: " << node["test"].ToString() << std::endl;
+    std::cout << "test: " << node["test"].to_string() << std::endl;
 
     return 0;
 }

--- a/test/unit_test/DeserializerClassTest.cpp
+++ b/test/unit_test/DeserializerClassTest.cpp
@@ -12,636 +12,636 @@
 
 TEST_CASE("DeserializerClassTest_InputStringTest", "[DeserializerClassTest]")
 {
-    fkyaml::Deserializer deserializer;
+    fkyaml::deserializer deserializer;
 
-    REQUIRE_NOTHROW(deserializer.Deserialize("test: hoge"));
-    REQUIRE_THROWS_AS(deserializer.Deserialize(nullptr), fkyaml::Exception);
+    REQUIRE_NOTHROW(deserializer.deserialize("test: hoge"));
+    REQUIRE_THROWS_AS(deserializer.deserialize(nullptr), fkyaml::exception);
 }
 
 TEST_CASE("DeserializerClassTest_DeserializeKeySeparator", "[DeserializerClassTest]")
 {
-    fkyaml::Deserializer deserializer;
-    fkyaml::Node root;
+    fkyaml::deserializer deserializer;
+    fkyaml::node root;
 
     SECTION("normal key-value cases")
     {
         auto input_str = GENERATE(
             std::string("test: hoge"), std::string("test:\n  foo: bar"), std::string("test:\n  - foo\n  - bar"));
-        REQUIRE_NOTHROW(root = deserializer.Deserialize(input_str.c_str()));
-        REQUIRE(root.IsMapping());
-        REQUIRE(root.Size() == 1);
+        REQUIRE_NOTHROW(root = deserializer.deserialize(input_str.c_str()));
+        REQUIRE(root.is_mapping());
+        REQUIRE(root.size() == 1);
     }
 
     SECTION("error cases")
     {
         auto input_str = GENERATE(std::string(": foo"), std::string("- : foo"));
-        REQUIRE_THROWS_AS(root = deserializer.Deserialize(input_str.c_str()), fkyaml::Exception);
+        REQUIRE_THROWS_AS(root = deserializer.deserialize(input_str.c_str()), fkyaml::exception);
     }
 }
 
 TEST_CASE("DeserializerClassTest_DeserializeValueSeparator", "[DeserializerClassTest]")
 {
-    fkyaml::Deserializer deserializer;
-    fkyaml::Node root;
+    fkyaml::deserializer deserializer;
+    fkyaml::node root;
 
     auto input_str = GENERATE(std::string("test: [ foo, bar ]"), std::string("test: { foo: bar, buz: val }"));
-    REQUIRE_NOTHROW(root = deserializer.Deserialize(input_str.c_str()));
-    REQUIRE(root.IsMapping());
-    REQUIRE(root.Size() == 1);
+    REQUIRE_NOTHROW(root = deserializer.deserialize(input_str.c_str()));
+    REQUIRE(root.is_mapping());
+    REQUIRE(root.size() == 1);
 }
 
 TEST_CASE("DeserializerClassTest_DeserializeNullValue", "[DeserializerClassTes]")
 {
-    fkyaml::Deserializer deserializer;
-    fkyaml::Node root;
+    fkyaml::deserializer deserializer;
+    fkyaml::node root;
 
     auto input_str = GENERATE(std::string("test: null"), std::string("Null: test"));
-    REQUIRE_NOTHROW(root = deserializer.Deserialize(input_str.c_str()));
-    REQUIRE(root.IsMapping());
-    REQUIRE(root.Size() == 1);
+    REQUIRE_NOTHROW(root = deserializer.deserialize(input_str.c_str()));
+    REQUIRE(root.is_mapping());
+    REQUIRE(root.size() == 1);
 }
 
 TEST_CASE("DeserializerClassTest_DeserializeBooleanValue", "[DeserializerClassTest]")
 {
-    fkyaml::Deserializer deserializer;
-    fkyaml::Node root;
+    fkyaml::deserializer deserializer;
+    fkyaml::node root;
 
     auto input_str =
         GENERATE(std::string("test: true"), std::string("test: [ True, False ]"), std::string("True: TRUE"));
-    REQUIRE_NOTHROW(root = deserializer.Deserialize(input_str.c_str()));
-    REQUIRE(root.IsMapping());
-    REQUIRE(root.Size() == 1);
+    REQUIRE_NOTHROW(root = deserializer.deserialize(input_str.c_str()));
+    REQUIRE(root.is_mapping());
+    REQUIRE(root.size() == 1);
 }
 
 TEST_CASE("DeserializerClassTest_DeserializeNumericKey", "[DeserializerClassTest]")
 {
-    fkyaml::Deserializer deserializer;
-    fkyaml::Node root;
+    fkyaml::deserializer deserializer;
+    fkyaml::node root;
 
     using StringValuePair = std::pair<std::string, std::string>;
 
     auto str_val_pair = GENERATE(StringValuePair("123: foo", "123"), StringValuePair("3.14: foo", "3.14"));
-    REQUIRE_NOTHROW(root = deserializer.Deserialize(str_val_pair.first.c_str()));
-    REQUIRE(root.IsMapping());
-    REQUIRE(root.Size() == 1);
-    REQUIRE(root.Contains(str_val_pair.second));
-    REQUIRE(root[str_val_pair.second].ToString() == "foo");
+    REQUIRE_NOTHROW(root = deserializer.deserialize(str_val_pair.first.c_str()));
+    REQUIRE(root.is_mapping());
+    REQUIRE(root.size() == 1);
+    REQUIRE(root.contains(str_val_pair.second));
+    REQUIRE(root[str_val_pair.second].to_string() == "foo");
 }
 
 TEST_CASE("DeserializerClassTest_DeserializeBlockSequenceTest", "[DeserializerClassTest]")
 {
-    fkyaml::Deserializer deserializer;
-    fkyaml::Node root;
+    fkyaml::deserializer deserializer;
+    fkyaml::node root;
 
     SECTION("Input source No.1.")
     {
-        REQUIRE_NOTHROW(root = deserializer.Deserialize("test:\n  - foo\n  - bar"));
+        REQUIRE_NOTHROW(root = deserializer.deserialize("test:\n  - foo\n  - bar"));
 
-        REQUIRE(root.IsMapping());
-        REQUIRE_NOTHROW(root.Size());
-        REQUIRE(root.Size() == 1);
+        REQUIRE(root.is_mapping());
+        REQUIRE_NOTHROW(root.size());
+        REQUIRE(root.size() == 1);
 
         REQUIRE_NOTHROW(root["test"]);
-        fkyaml::Node& test_node = root["test"];
-        REQUIRE(test_node.IsSequence());
-        REQUIRE_NOTHROW(test_node.Size());
-        REQUIRE(test_node.Size() == 2);
+        fkyaml::node& test_node = root["test"];
+        REQUIRE(test_node.is_sequence());
+        REQUIRE_NOTHROW(test_node.size());
+        REQUIRE(test_node.size() == 2);
 
         REQUIRE_NOTHROW(test_node[0]);
-        fkyaml::Node& test_0_node = test_node[0];
-        REQUIRE(test_0_node.IsString());
-        REQUIRE_NOTHROW(test_0_node.Size());
-        REQUIRE(test_0_node.Size() == 3);
-        REQUIRE_NOTHROW(test_0_node.ToString());
-        REQUIRE(test_0_node.ToString().compare("foo") == 0);
+        fkyaml::node& test_0_node = test_node[0];
+        REQUIRE(test_0_node.is_string());
+        REQUIRE_NOTHROW(test_0_node.size());
+        REQUIRE(test_0_node.size() == 3);
+        REQUIRE_NOTHROW(test_0_node.to_string());
+        REQUIRE(test_0_node.to_string().compare("foo") == 0);
 
         REQUIRE_NOTHROW(test_node[1]);
-        fkyaml::Node& test_1_node = test_node[1];
-        REQUIRE(test_1_node.IsString());
-        REQUIRE_NOTHROW(test_1_node.Size());
-        REQUIRE(test_1_node.Size() == 3);
-        REQUIRE_NOTHROW(test_1_node.ToString());
-        REQUIRE(test_1_node.ToString().compare("bar") == 0);
+        fkyaml::node& test_1_node = test_node[1];
+        REQUIRE(test_1_node.is_string());
+        REQUIRE_NOTHROW(test_1_node.size());
+        REQUIRE(test_1_node.size() == 3);
+        REQUIRE_NOTHROW(test_1_node.to_string());
+        REQUIRE(test_1_node.to_string().compare("bar") == 0);
     }
 
     SECTION("Input source No.2.")
     {
         REQUIRE_NOTHROW(
-            root = deserializer.Deserialize("test:\n  - foo: true\n    bar: one\n  - foo: false\n    bar: two"));
+            root = deserializer.deserialize("test:\n  - foo: true\n    bar: one\n  - foo: false\n    bar: two"));
 
-        REQUIRE(root.IsMapping());
-        REQUIRE_NOTHROW(root.Size());
-        REQUIRE(root.Size() == 1);
+        REQUIRE(root.is_mapping());
+        REQUIRE_NOTHROW(root.size());
+        REQUIRE(root.size() == 1);
 
         REQUIRE_NOTHROW(root["test"]);
-        fkyaml::Node& test_node = root["test"];
-        REQUIRE(test_node.IsSequence());
-        REQUIRE_NOTHROW(test_node.Size());
-        REQUIRE(test_node.Size() == 2);
+        fkyaml::node& test_node = root["test"];
+        REQUIRE(test_node.is_sequence());
+        REQUIRE_NOTHROW(test_node.size());
+        REQUIRE(test_node.size() == 2);
 
         REQUIRE_NOTHROW(test_node[0]);
-        fkyaml::Node& test_0_node = test_node[0];
-        REQUIRE(test_0_node.IsMapping());
-        REQUIRE_NOTHROW(test_0_node.Size());
-        REQUIRE(test_0_node.Size() == 2);
+        fkyaml::node& test_0_node = test_node[0];
+        REQUIRE(test_0_node.is_mapping());
+        REQUIRE_NOTHROW(test_0_node.size());
+        REQUIRE(test_0_node.size() == 2);
 
         REQUIRE_NOTHROW(test_0_node["foo"]);
-        fkyaml::Node& test_0_foo_node = test_0_node["foo"];
-        REQUIRE(test_0_foo_node.IsBoolean());
-        REQUIRE_NOTHROW(test_0_foo_node.ToBoolean());
-        REQUIRE(test_0_foo_node.ToBoolean() == true);
+        fkyaml::node& test_0_foo_node = test_0_node["foo"];
+        REQUIRE(test_0_foo_node.is_boolean());
+        REQUIRE_NOTHROW(test_0_foo_node.to_boolean());
+        REQUIRE(test_0_foo_node.to_boolean() == true);
 
         REQUIRE_NOTHROW(test_0_node["bar"]);
-        fkyaml::Node& test_0_bar_node = test_0_node["bar"];
-        REQUIRE(test_0_bar_node.IsString());
-        REQUIRE_NOTHROW(test_0_bar_node.ToString());
-        REQUIRE(test_0_bar_node.ToString().compare("one") == 0);
+        fkyaml::node& test_0_bar_node = test_0_node["bar"];
+        REQUIRE(test_0_bar_node.is_string());
+        REQUIRE_NOTHROW(test_0_bar_node.to_string());
+        REQUIRE(test_0_bar_node.to_string().compare("one") == 0);
 
         REQUIRE_NOTHROW(test_node[1]);
-        fkyaml::Node& test_1_node = test_node[1];
-        REQUIRE(test_1_node.IsMapping());
-        REQUIRE_NOTHROW(test_1_node.Size());
-        REQUIRE(test_1_node.Size() == 2);
+        fkyaml::node& test_1_node = test_node[1];
+        REQUIRE(test_1_node.is_mapping());
+        REQUIRE_NOTHROW(test_1_node.size());
+        REQUIRE(test_1_node.size() == 2);
 
         REQUIRE_NOTHROW(test_1_node["foo"]);
-        fkyaml::Node& test_1_foo_node = test_1_node["foo"];
-        REQUIRE(test_1_foo_node.IsBoolean());
-        REQUIRE_NOTHROW(test_1_foo_node.ToBoolean());
-        REQUIRE(test_1_foo_node.ToBoolean() == false);
+        fkyaml::node& test_1_foo_node = test_1_node["foo"];
+        REQUIRE(test_1_foo_node.is_boolean());
+        REQUIRE_NOTHROW(test_1_foo_node.to_boolean());
+        REQUIRE(test_1_foo_node.to_boolean() == false);
 
         REQUIRE_NOTHROW(test_1_node["bar"]);
-        fkyaml::Node& test_1_bar_node = test_1_node["bar"];
-        REQUIRE(test_1_bar_node.IsString());
-        REQUIRE_NOTHROW(test_1_bar_node.ToString());
-        REQUIRE(test_1_bar_node.ToString().compare("two") == 0);
+        fkyaml::node& test_1_bar_node = test_1_node["bar"];
+        REQUIRE(test_1_bar_node.is_string());
+        REQUIRE_NOTHROW(test_1_bar_node.to_string());
+        REQUIRE(test_1_bar_node.to_string().compare("two") == 0);
     }
 
     SECTION("Input source No.3.")
     {
-        REQUIRE_NOTHROW(root = deserializer.Deserialize("test:\n  - &anchor true\n  - *anchor"));
+        REQUIRE_NOTHROW(root = deserializer.deserialize("test:\n  - &anchor true\n  - *anchor"));
 
-        REQUIRE(root.IsMapping());
-        REQUIRE_NOTHROW(root.Size());
-        REQUIRE(root.Size() == 1);
+        REQUIRE(root.is_mapping());
+        REQUIRE_NOTHROW(root.size());
+        REQUIRE(root.size() == 1);
 
         REQUIRE_NOTHROW(root["test"]);
-        fkyaml::Node& test_node = root["test"];
-        REQUIRE(test_node.IsSequence());
-        REQUIRE_NOTHROW(test_node.Size());
-        REQUIRE(test_node.Size() == 2);
+        fkyaml::node& test_node = root["test"];
+        REQUIRE(test_node.is_sequence());
+        REQUIRE_NOTHROW(test_node.size());
+        REQUIRE(test_node.size() == 2);
 
         REQUIRE_NOTHROW(test_node[0]);
-        fkyaml::Node& test_0_node = test_node[0];
-        REQUIRE(test_0_node.HasAnchorName());
-        REQUIRE(test_0_node.GetAnchorName().compare("anchor") == 0);
-        REQUIRE(test_0_node.IsBoolean());
-        REQUIRE_NOTHROW(test_0_node.ToBoolean());
-        REQUIRE(test_0_node.ToBoolean() == true);
+        fkyaml::node& test_0_node = test_node[0];
+        REQUIRE(test_0_node.has_anchor_name());
+        REQUIRE(test_0_node.get_anchor_name().compare("anchor") == 0);
+        REQUIRE(test_0_node.is_boolean());
+        REQUIRE_NOTHROW(test_0_node.to_boolean());
+        REQUIRE(test_0_node.to_boolean() == true);
 
         REQUIRE_NOTHROW(test_node[1]);
-        fkyaml::Node& test_1_node = test_node[1];
-        REQUIRE(test_1_node.IsBoolean());
-        REQUIRE_NOTHROW(test_1_node.ToBoolean());
-        REQUIRE(test_1_node.ToBoolean() == test_0_node.ToBoolean());
+        fkyaml::node& test_1_node = test_node[1];
+        REQUIRE(test_1_node.is_boolean());
+        REQUIRE_NOTHROW(test_1_node.to_boolean());
+        REQUIRE(test_1_node.to_boolean() == test_0_node.to_boolean());
     }
 
     SECTION("Input source No.4.")
     {
-        REQUIRE_NOTHROW(root = deserializer.Deserialize("test:\n  - &anchor -123\n  - *anchor"));
+        REQUIRE_NOTHROW(root = deserializer.deserialize("test:\n  - &anchor -123\n  - *anchor"));
 
-        REQUIRE(root.IsMapping());
-        REQUIRE_NOTHROW(root.Size());
-        REQUIRE(root.Size() == 1);
+        REQUIRE(root.is_mapping());
+        REQUIRE_NOTHROW(root.size());
+        REQUIRE(root.size() == 1);
 
         REQUIRE_NOTHROW(root["test"]);
-        fkyaml::Node& test_node = root["test"];
-        REQUIRE(test_node.IsSequence());
-        REQUIRE_NOTHROW(test_node.Size());
-        REQUIRE(test_node.Size() == 2);
+        fkyaml::node& test_node = root["test"];
+        REQUIRE(test_node.is_sequence());
+        REQUIRE_NOTHROW(test_node.size());
+        REQUIRE(test_node.size() == 2);
 
         REQUIRE_NOTHROW(test_node[0]);
-        fkyaml::Node& test_0_node = test_node[0];
-        REQUIRE(test_0_node.HasAnchorName());
-        REQUIRE(test_0_node.GetAnchorName().compare("anchor") == 0);
-        REQUIRE(test_0_node.IsInteger());
-        REQUIRE_NOTHROW(test_0_node.ToInteger());
-        REQUIRE(test_0_node.ToInteger() == -123);
+        fkyaml::node& test_0_node = test_node[0];
+        REQUIRE(test_0_node.has_anchor_name());
+        REQUIRE(test_0_node.get_anchor_name().compare("anchor") == 0);
+        REQUIRE(test_0_node.is_integer());
+        REQUIRE_NOTHROW(test_0_node.to_integer());
+        REQUIRE(test_0_node.to_integer() == -123);
 
         REQUIRE_NOTHROW(test_node[1]);
-        fkyaml::Node& test_1_node = test_node[1];
-        REQUIRE(test_1_node.IsInteger());
-        REQUIRE_NOTHROW(test_1_node.ToInteger());
-        REQUIRE(test_1_node.ToInteger() == test_0_node.ToInteger());
+        fkyaml::node& test_1_node = test_node[1];
+        REQUIRE(test_1_node.is_integer());
+        REQUIRE_NOTHROW(test_1_node.to_integer());
+        REQUIRE(test_1_node.to_integer() == test_0_node.to_integer());
     }
 
     SECTION("Input source No.5.")
     {
-        REQUIRE_NOTHROW(root = deserializer.Deserialize("test:\n  - &anchor 567\n  - *anchor"));
+        REQUIRE_NOTHROW(root = deserializer.deserialize("test:\n  - &anchor 567\n  - *anchor"));
 
-        REQUIRE(root.IsMapping());
-        REQUIRE_NOTHROW(root.Size());
-        REQUIRE(root.Size() == 1);
+        REQUIRE(root.is_mapping());
+        REQUIRE_NOTHROW(root.size());
+        REQUIRE(root.size() == 1);
 
         REQUIRE_NOTHROW(root["test"]);
-        fkyaml::Node& test_node = root["test"];
-        REQUIRE(test_node.IsSequence());
-        REQUIRE_NOTHROW(test_node.Size());
-        REQUIRE(test_node.Size() == 2);
+        fkyaml::node& test_node = root["test"];
+        REQUIRE(test_node.is_sequence());
+        REQUIRE_NOTHROW(test_node.size());
+        REQUIRE(test_node.size() == 2);
 
         REQUIRE_NOTHROW(test_node[0]);
-        fkyaml::Node& test_0_node = test_node[0];
-        REQUIRE(test_0_node.HasAnchorName());
-        REQUIRE(test_0_node.GetAnchorName().compare("anchor") == 0);
-        REQUIRE(test_0_node.IsInteger());
-        REQUIRE_NOTHROW(test_0_node.ToInteger());
-        REQUIRE(test_0_node.ToInteger() == 567);
+        fkyaml::node& test_0_node = test_node[0];
+        REQUIRE(test_0_node.has_anchor_name());
+        REQUIRE(test_0_node.get_anchor_name().compare("anchor") == 0);
+        REQUIRE(test_0_node.is_integer());
+        REQUIRE_NOTHROW(test_0_node.to_integer());
+        REQUIRE(test_0_node.to_integer() == 567);
 
         REQUIRE_NOTHROW(test_node[1]);
-        fkyaml::Node& test_1_node = test_node[1];
-        REQUIRE(test_1_node.IsInteger());
-        REQUIRE_NOTHROW(test_1_node.ToInteger());
-        REQUIRE(test_1_node.ToInteger() == test_0_node.ToInteger());
+        fkyaml::node& test_1_node = test_node[1];
+        REQUIRE(test_1_node.is_integer());
+        REQUIRE_NOTHROW(test_1_node.to_integer());
+        REQUIRE(test_1_node.to_integer() == test_0_node.to_integer());
     }
 
     SECTION("Input source No.6.")
     {
-        REQUIRE_NOTHROW(root = deserializer.Deserialize("test:\n  - &anchor 3.14\n  - *anchor"));
+        REQUIRE_NOTHROW(root = deserializer.deserialize("test:\n  - &anchor 3.14\n  - *anchor"));
 
-        REQUIRE(root.IsMapping());
-        REQUIRE_NOTHROW(root.Size());
-        REQUIRE(root.Size() == 1);
+        REQUIRE(root.is_mapping());
+        REQUIRE_NOTHROW(root.size());
+        REQUIRE(root.size() == 1);
 
         REQUIRE_NOTHROW(root["test"]);
-        fkyaml::Node& test_node = root["test"];
-        REQUIRE(test_node.IsSequence());
-        REQUIRE_NOTHROW(test_node.Size());
-        REQUIRE(test_node.Size() == 2);
+        fkyaml::node& test_node = root["test"];
+        REQUIRE(test_node.is_sequence());
+        REQUIRE_NOTHROW(test_node.size());
+        REQUIRE(test_node.size() == 2);
 
         REQUIRE_NOTHROW(test_node[0]);
-        fkyaml::Node& test_0_node = test_node[0];
-        REQUIRE(test_0_node.HasAnchorName());
-        REQUIRE(test_0_node.GetAnchorName().compare("anchor") == 0);
-        REQUIRE(test_0_node.IsFloatNumber());
-        REQUIRE_NOTHROW(test_0_node.ToFloatNumber());
-        REQUIRE(test_0_node.ToFloatNumber() == 3.14);
+        fkyaml::node& test_0_node = test_node[0];
+        REQUIRE(test_0_node.has_anchor_name());
+        REQUIRE(test_0_node.get_anchor_name().compare("anchor") == 0);
+        REQUIRE(test_0_node.is_float_number());
+        REQUIRE_NOTHROW(test_0_node.to_float_number());
+        REQUIRE(test_0_node.to_float_number() == 3.14);
 
         REQUIRE_NOTHROW(test_node[1]);
-        fkyaml::Node& test_1_node = test_node[1];
-        REQUIRE(test_1_node.IsFloatNumber());
-        REQUIRE_NOTHROW(test_1_node.ToFloatNumber());
-        REQUIRE(test_1_node.ToFloatNumber() == test_0_node.ToFloatNumber());
+        fkyaml::node& test_1_node = test_node[1];
+        REQUIRE(test_1_node.is_float_number());
+        REQUIRE_NOTHROW(test_1_node.to_float_number());
+        REQUIRE(test_1_node.to_float_number() == test_0_node.to_float_number());
     }
 
     SECTION("Input source No.7.")
     {
-        REQUIRE_NOTHROW(root = deserializer.Deserialize("test:\n  - &anchor foo\n  - *anchor"));
+        REQUIRE_NOTHROW(root = deserializer.deserialize("test:\n  - &anchor foo\n  - *anchor"));
 
-        REQUIRE(root.IsMapping());
-        REQUIRE_NOTHROW(root.Size());
-        REQUIRE(root.Size() == 1);
+        REQUIRE(root.is_mapping());
+        REQUIRE_NOTHROW(root.size());
+        REQUIRE(root.size() == 1);
 
         REQUIRE_NOTHROW(root["test"]);
-        fkyaml::Node& test_node = root["test"];
-        REQUIRE(test_node.IsSequence());
-        REQUIRE_NOTHROW(test_node.Size());
-        REQUIRE(test_node.Size() == 2);
+        fkyaml::node& test_node = root["test"];
+        REQUIRE(test_node.is_sequence());
+        REQUIRE_NOTHROW(test_node.size());
+        REQUIRE(test_node.size() == 2);
 
         REQUIRE_NOTHROW(test_node[0]);
-        fkyaml::Node& test_0_node = test_node[0];
-        REQUIRE(test_0_node.HasAnchorName());
-        REQUIRE(test_0_node.GetAnchorName().compare("anchor") == 0);
-        REQUIRE(test_0_node.IsString());
-        REQUIRE_NOTHROW(test_0_node.Size());
-        REQUIRE(test_0_node.Size() == 3);
-        REQUIRE_NOTHROW(test_0_node.ToString());
-        REQUIRE(test_0_node.ToString().compare("foo") == 0);
+        fkyaml::node& test_0_node = test_node[0];
+        REQUIRE(test_0_node.has_anchor_name());
+        REQUIRE(test_0_node.get_anchor_name().compare("anchor") == 0);
+        REQUIRE(test_0_node.is_string());
+        REQUIRE_NOTHROW(test_0_node.size());
+        REQUIRE(test_0_node.size() == 3);
+        REQUIRE_NOTHROW(test_0_node.to_string());
+        REQUIRE(test_0_node.to_string().compare("foo") == 0);
 
         REQUIRE_NOTHROW(test_node[1]);
-        fkyaml::Node& test_1_node = test_node[1];
-        REQUIRE(test_1_node.IsString());
-        REQUIRE_NOTHROW(test_1_node.Size());
-        REQUIRE(test_1_node.Size() == 3);
-        REQUIRE_NOTHROW(test_1_node.ToString());
-        REQUIRE(test_1_node.ToString().compare("foo") == 0);
+        fkyaml::node& test_1_node = test_node[1];
+        REQUIRE(test_1_node.is_string());
+        REQUIRE_NOTHROW(test_1_node.size());
+        REQUIRE(test_1_node.size() == 3);
+        REQUIRE_NOTHROW(test_1_node.to_string());
+        REQUIRE(test_1_node.to_string().compare("foo") == 0);
     }
 }
 
 TEST_CASE("DeserializerClassTest_DeserializeBlockMappingTest", "[DeserializerClassTest]")
 {
-    fkyaml::Deserializer deserializer;
-    fkyaml::Node root;
+    fkyaml::deserializer deserializer;
+    fkyaml::node root;
 
     SECTION("Input source No.1.")
     {
-        REQUIRE_NOTHROW(root = deserializer.Deserialize("foo: one\nbar: true\npi: 3.14"));
+        REQUIRE_NOTHROW(root = deserializer.deserialize("foo: one\nbar: true\npi: 3.14"));
 
-        REQUIRE(root.IsMapping());
-        REQUIRE(root.Size() == 3);
+        REQUIRE(root.is_mapping());
+        REQUIRE(root.size() == 3);
 
         REQUIRE_NOTHROW(root["foo"]);
-        fkyaml::Node& foo_node = root["foo"];
-        REQUIRE(foo_node.IsString());
-        REQUIRE_NOTHROW(foo_node.ToString());
-        REQUIRE(foo_node.ToString().compare("one") == 0);
+        fkyaml::node& foo_node = root["foo"];
+        REQUIRE(foo_node.is_string());
+        REQUIRE_NOTHROW(foo_node.to_string());
+        REQUIRE(foo_node.to_string().compare("one") == 0);
 
         REQUIRE_NOTHROW(root["bar"]);
-        fkyaml::Node& bar_node = root["bar"];
-        REQUIRE(bar_node.IsBoolean());
-        REQUIRE_NOTHROW(bar_node.ToBoolean());
-        REQUIRE(bar_node.ToBoolean() == true);
+        fkyaml::node& bar_node = root["bar"];
+        REQUIRE(bar_node.is_boolean());
+        REQUIRE_NOTHROW(bar_node.to_boolean());
+        REQUIRE(bar_node.to_boolean() == true);
 
         REQUIRE_NOTHROW(root["pi"]);
-        fkyaml::Node& pi_node = root["pi"];
-        REQUIRE(pi_node.IsFloatNumber());
-        REQUIRE_NOTHROW(pi_node.ToFloatNumber());
-        REQUIRE(pi_node.ToFloatNumber() == 3.14);
+        fkyaml::node& pi_node = root["pi"];
+        REQUIRE(pi_node.is_float_number());
+        REQUIRE_NOTHROW(pi_node.to_float_number());
+        REQUIRE(pi_node.to_float_number() == 3.14);
     }
 
     SECTION("Input source No.2.")
     {
-        REQUIRE_NOTHROW(root = deserializer.Deserialize("test:\n  bool: true\n  foo: bar\n  pi: 3.14"));
+        REQUIRE_NOTHROW(root = deserializer.deserialize("test:\n  bool: true\n  foo: bar\n  pi: 3.14"));
 
-        REQUIRE(root.IsMapping());
-        REQUIRE_NOTHROW(root.Size());
-        REQUIRE(root.Size() == 1);
+        REQUIRE(root.is_mapping());
+        REQUIRE_NOTHROW(root.size());
+        REQUIRE(root.size() == 1);
 
         REQUIRE_NOTHROW(root["test"]);
-        fkyaml::Node& test_node = root["test"];
-        REQUIRE(test_node.IsMapping());
-        REQUIRE_NOTHROW(test_node.Size());
-        REQUIRE(test_node.Size() == 3);
+        fkyaml::node& test_node = root["test"];
+        REQUIRE(test_node.is_mapping());
+        REQUIRE_NOTHROW(test_node.size());
+        REQUIRE(test_node.size() == 3);
 
         REQUIRE_NOTHROW(test_node["bool"]);
-        fkyaml::Node& test_bool_node = test_node["bool"];
-        REQUIRE(test_bool_node.IsBoolean());
-        REQUIRE_NOTHROW(test_bool_node.ToBoolean());
-        REQUIRE(test_bool_node.ToBoolean() == true);
+        fkyaml::node& test_bool_node = test_node["bool"];
+        REQUIRE(test_bool_node.is_boolean());
+        REQUIRE_NOTHROW(test_bool_node.to_boolean());
+        REQUIRE(test_bool_node.to_boolean() == true);
 
         REQUIRE_NOTHROW(test_node["foo"]);
-        fkyaml::Node& test_foo_node = test_node["foo"];
-        REQUIRE(test_foo_node.IsString());
-        REQUIRE_NOTHROW(test_foo_node.ToString());
-        REQUIRE(test_foo_node.ToString().compare("bar") == 0);
+        fkyaml::node& test_foo_node = test_node["foo"];
+        REQUIRE(test_foo_node.is_string());
+        REQUIRE_NOTHROW(test_foo_node.to_string());
+        REQUIRE(test_foo_node.to_string().compare("bar") == 0);
 
         REQUIRE_NOTHROW(test_node["pi"]);
-        fkyaml::Node& test_pi_node = test_node["pi"];
-        REQUIRE(test_pi_node.IsFloatNumber());
-        REQUIRE_NOTHROW(test_pi_node.ToFloatNumber());
-        REQUIRE(test_pi_node.ToFloatNumber() == 3.14);
+        fkyaml::node& test_pi_node = test_node["pi"];
+        REQUIRE(test_pi_node.is_float_number());
+        REQUIRE_NOTHROW(test_pi_node.to_float_number());
+        REQUIRE(test_pi_node.to_float_number() == 3.14);
     }
 
     SECTION("Input source No.3.")
     {
-        REQUIRE_NOTHROW(root = deserializer.Deserialize("foo: &anchor true\nbar: *anchor"));
+        REQUIRE_NOTHROW(root = deserializer.deserialize("foo: &anchor true\nbar: *anchor"));
 
-        REQUIRE(root.IsMapping());
-        REQUIRE(root.Size() == 2);
+        REQUIRE(root.is_mapping());
+        REQUIRE(root.size() == 2);
 
         REQUIRE_NOTHROW(root["foo"]);
-        fkyaml::Node& foo_node = root["foo"];
-        REQUIRE(foo_node.HasAnchorName());
-        REQUIRE(foo_node.GetAnchorName().compare("anchor") == 0);
-        REQUIRE(foo_node.IsBoolean());
-        REQUIRE_NOTHROW(foo_node.ToBoolean());
-        REQUIRE(foo_node.ToBoolean() == true);
+        fkyaml::node& foo_node = root["foo"];
+        REQUIRE(foo_node.has_anchor_name());
+        REQUIRE(foo_node.get_anchor_name().compare("anchor") == 0);
+        REQUIRE(foo_node.is_boolean());
+        REQUIRE_NOTHROW(foo_node.to_boolean());
+        REQUIRE(foo_node.to_boolean() == true);
 
         REQUIRE_NOTHROW(root["bar"]);
-        fkyaml::Node& bar_node = root["bar"];
-        REQUIRE(bar_node.IsBoolean());
-        REQUIRE_NOTHROW(bar_node.ToBoolean());
-        REQUIRE(bar_node.ToBoolean() == foo_node.ToBoolean());
+        fkyaml::node& bar_node = root["bar"];
+        REQUIRE(bar_node.is_boolean());
+        REQUIRE_NOTHROW(bar_node.to_boolean());
+        REQUIRE(bar_node.to_boolean() == foo_node.to_boolean());
     }
 
     SECTION("Input source No.4.")
     {
-        REQUIRE_NOTHROW(root = deserializer.Deserialize("foo: &anchor -123\nbar: *anchor"));
+        REQUIRE_NOTHROW(root = deserializer.deserialize("foo: &anchor -123\nbar: *anchor"));
 
-        REQUIRE(root.IsMapping());
-        REQUIRE(root.Size() == 2);
+        REQUIRE(root.is_mapping());
+        REQUIRE(root.size() == 2);
 
         REQUIRE_NOTHROW(root["foo"]);
-        fkyaml::Node& foo_node = root["foo"];
-        REQUIRE(foo_node.HasAnchorName());
-        REQUIRE(foo_node.GetAnchorName().compare("anchor") == 0);
-        REQUIRE(foo_node.IsInteger());
-        REQUIRE_NOTHROW(foo_node.ToInteger());
-        REQUIRE(foo_node.ToInteger() == -123);
+        fkyaml::node& foo_node = root["foo"];
+        REQUIRE(foo_node.has_anchor_name());
+        REQUIRE(foo_node.get_anchor_name().compare("anchor") == 0);
+        REQUIRE(foo_node.is_integer());
+        REQUIRE_NOTHROW(foo_node.to_integer());
+        REQUIRE(foo_node.to_integer() == -123);
 
         REQUIRE_NOTHROW(root["bar"]);
-        fkyaml::Node& bar_node = root["bar"];
-        REQUIRE(bar_node.IsInteger());
-        REQUIRE_NOTHROW(bar_node.ToInteger());
-        REQUIRE(bar_node.ToInteger() == foo_node.ToInteger());
+        fkyaml::node& bar_node = root["bar"];
+        REQUIRE(bar_node.is_integer());
+        REQUIRE_NOTHROW(bar_node.to_integer());
+        REQUIRE(bar_node.to_integer() == foo_node.to_integer());
     }
 
     SECTION("Input source No.5.")
     {
-        REQUIRE_NOTHROW(root = deserializer.Deserialize("foo: &anchor 567\nbar: *anchor"));
+        REQUIRE_NOTHROW(root = deserializer.deserialize("foo: &anchor 567\nbar: *anchor"));
 
-        REQUIRE(root.IsMapping());
-        REQUIRE(root.Size() == 2);
+        REQUIRE(root.is_mapping());
+        REQUIRE(root.size() == 2);
 
         REQUIRE_NOTHROW(root["foo"]);
-        fkyaml::Node& foo_node = root["foo"];
-        REQUIRE(foo_node.HasAnchorName());
-        REQUIRE(foo_node.GetAnchorName().compare("anchor") == 0);
-        REQUIRE(foo_node.IsInteger());
-        REQUIRE_NOTHROW(foo_node.ToInteger());
-        REQUIRE(foo_node.ToInteger() == 567);
+        fkyaml::node& foo_node = root["foo"];
+        REQUIRE(foo_node.has_anchor_name());
+        REQUIRE(foo_node.get_anchor_name().compare("anchor") == 0);
+        REQUIRE(foo_node.is_integer());
+        REQUIRE_NOTHROW(foo_node.to_integer());
+        REQUIRE(foo_node.to_integer() == 567);
 
         REQUIRE_NOTHROW(root["bar"]);
-        fkyaml::Node& bar_node = root["bar"];
-        REQUIRE(bar_node.IsInteger());
-        REQUIRE_NOTHROW(bar_node.ToInteger());
-        REQUIRE(bar_node.ToInteger() == foo_node.ToInteger());
+        fkyaml::node& bar_node = root["bar"];
+        REQUIRE(bar_node.is_integer());
+        REQUIRE_NOTHROW(bar_node.to_integer());
+        REQUIRE(bar_node.to_integer() == foo_node.to_integer());
     }
 
     SECTION("Input source No.6.")
     {
-        REQUIRE_NOTHROW(root = deserializer.Deserialize("foo: &anchor 3.14\nbar: *anchor"));
+        REQUIRE_NOTHROW(root = deserializer.deserialize("foo: &anchor 3.14\nbar: *anchor"));
 
-        REQUIRE(root.IsMapping());
-        REQUIRE(root.Size() == 2);
+        REQUIRE(root.is_mapping());
+        REQUIRE(root.size() == 2);
 
         REQUIRE_NOTHROW(root["foo"]);
-        fkyaml::Node& foo_node = root["foo"];
-        REQUIRE(foo_node.HasAnchorName());
-        REQUIRE(foo_node.GetAnchorName().compare("anchor") == 0);
-        REQUIRE(foo_node.IsFloatNumber());
-        REQUIRE_NOTHROW(foo_node.ToFloatNumber());
-        REQUIRE(foo_node.ToFloatNumber() == 3.14);
+        fkyaml::node& foo_node = root["foo"];
+        REQUIRE(foo_node.has_anchor_name());
+        REQUIRE(foo_node.get_anchor_name().compare("anchor") == 0);
+        REQUIRE(foo_node.is_float_number());
+        REQUIRE_NOTHROW(foo_node.to_float_number());
+        REQUIRE(foo_node.to_float_number() == 3.14);
 
         REQUIRE_NOTHROW(root["bar"]);
-        fkyaml::Node& bar_node = root["bar"];
-        REQUIRE(bar_node.IsFloatNumber());
-        REQUIRE_NOTHROW(bar_node.ToFloatNumber());
-        REQUIRE(bar_node.ToFloatNumber() == foo_node.ToFloatNumber());
+        fkyaml::node& bar_node = root["bar"];
+        REQUIRE(bar_node.is_float_number());
+        REQUIRE_NOTHROW(bar_node.to_float_number());
+        REQUIRE(bar_node.to_float_number() == foo_node.to_float_number());
     }
 
     SECTION("Input source No.7.")
     {
-        REQUIRE_NOTHROW(root = deserializer.Deserialize("foo: &anchor one\nbar: *anchor"));
+        REQUIRE_NOTHROW(root = deserializer.deserialize("foo: &anchor one\nbar: *anchor"));
 
-        REQUIRE(root.IsMapping());
-        REQUIRE(root.Size() == 2);
+        REQUIRE(root.is_mapping());
+        REQUIRE(root.size() == 2);
 
         REQUIRE_NOTHROW(root["foo"]);
-        fkyaml::Node& foo_node = root["foo"];
-        REQUIRE(foo_node.HasAnchorName());
-        REQUIRE(foo_node.GetAnchorName().compare("anchor") == 0);
-        REQUIRE(foo_node.IsString());
-        REQUIRE_NOTHROW(foo_node.ToString());
-        REQUIRE(foo_node.ToString().compare("one") == 0);
+        fkyaml::node& foo_node = root["foo"];
+        REQUIRE(foo_node.has_anchor_name());
+        REQUIRE(foo_node.get_anchor_name().compare("anchor") == 0);
+        REQUIRE(foo_node.is_string());
+        REQUIRE_NOTHROW(foo_node.to_string());
+        REQUIRE(foo_node.to_string().compare("one") == 0);
 
         REQUIRE_NOTHROW(root["bar"]);
-        fkyaml::Node& bar_node = root["bar"];
-        REQUIRE(bar_node.IsString());
-        REQUIRE_NOTHROW(bar_node.ToString());
-        REQUIRE(bar_node.ToString() == foo_node.ToString());
+        fkyaml::node& bar_node = root["bar"];
+        REQUIRE(bar_node.is_string());
+        REQUIRE_NOTHROW(bar_node.to_string());
+        REQUIRE(bar_node.to_string() == foo_node.to_string());
     }
 }
 
 TEST_CASE("DeserializerClassTest_DeserializeFlowSequenceTest", "[DeserializerClassTest]")
 {
-    fkyaml::Deserializer deserializer;
-    fkyaml::Node root;
+    fkyaml::deserializer deserializer;
+    fkyaml::node root;
 
     SECTION("Input source No.1.")
     {
-        REQUIRE_NOTHROW(root = deserializer.Deserialize("test: [ foo, bar ]"));
+        REQUIRE_NOTHROW(root = deserializer.deserialize("test: [ foo, bar ]"));
 
-        REQUIRE(root.IsMapping());
-        REQUIRE_NOTHROW(root.Size());
-        REQUIRE(root.Size() == 1);
+        REQUIRE(root.is_mapping());
+        REQUIRE_NOTHROW(root.size());
+        REQUIRE(root.size() == 1);
 
         REQUIRE_NOTHROW(root["test"]);
-        fkyaml::Node& test_node = root["test"];
-        REQUIRE(test_node.IsSequence());
-        REQUIRE_NOTHROW(test_node.Size());
-        REQUIRE(test_node.Size() == 2);
+        fkyaml::node& test_node = root["test"];
+        REQUIRE(test_node.is_sequence());
+        REQUIRE_NOTHROW(test_node.size());
+        REQUIRE(test_node.size() == 2);
 
         REQUIRE_NOTHROW(test_node[0]);
-        fkyaml::Node& test_0_node = test_node[0];
-        REQUIRE(test_0_node.IsString());
-        REQUIRE_NOTHROW(test_0_node.ToString());
-        REQUIRE(test_0_node.ToString().compare("foo") == 0);
+        fkyaml::node& test_0_node = test_node[0];
+        REQUIRE(test_0_node.is_string());
+        REQUIRE_NOTHROW(test_0_node.to_string());
+        REQUIRE(test_0_node.to_string().compare("foo") == 0);
 
         REQUIRE_NOTHROW(test_node[1]);
-        fkyaml::Node& test_1_node = test_node[1];
-        REQUIRE(test_1_node.IsString());
-        REQUIRE_NOTHROW(test_1_node.ToString());
-        REQUIRE(test_1_node.ToString().compare("bar") == 0);
+        fkyaml::node& test_1_node = test_node[1];
+        REQUIRE(test_1_node.is_string());
+        REQUIRE_NOTHROW(test_1_node.to_string());
+        REQUIRE(test_1_node.to_string().compare("bar") == 0);
     }
 }
 
 TEST_CASE("DeserializerClassTest_DeserializeFlowMappingTest", "[DeserializerClassTest]")
 {
-    fkyaml::Deserializer deserializer;
-    fkyaml::Node root;
+    fkyaml::deserializer deserializer;
+    fkyaml::node root;
 
     SECTION("Input source No.1.")
     {
-        REQUIRE_NOTHROW(root = deserializer.Deserialize("test: { bool: true, foo: bar, pi: 3.14 }"));
+        REQUIRE_NOTHROW(root = deserializer.deserialize("test: { bool: true, foo: bar, pi: 3.14 }"));
 
-        REQUIRE(root.IsMapping());
-        REQUIRE_NOTHROW(root.Size());
-        REQUIRE(root.Size() == 1);
+        REQUIRE(root.is_mapping());
+        REQUIRE_NOTHROW(root.size());
+        REQUIRE(root.size() == 1);
 
         REQUIRE_NOTHROW(root["test"]);
-        fkyaml::Node& test_node = root["test"];
-        REQUIRE(test_node.IsMapping());
-        REQUIRE_NOTHROW(test_node.Size());
-        REQUIRE(test_node.Size() == 3);
+        fkyaml::node& test_node = root["test"];
+        REQUIRE(test_node.is_mapping());
+        REQUIRE_NOTHROW(test_node.size());
+        REQUIRE(test_node.size() == 3);
 
         REQUIRE_NOTHROW(test_node["bool"]);
-        fkyaml::Node& test_bool_node = test_node["bool"];
-        REQUIRE(test_bool_node.IsBoolean());
-        REQUIRE_NOTHROW(test_bool_node.ToBoolean());
-        REQUIRE(test_bool_node.ToBoolean() == true);
+        fkyaml::node& test_bool_node = test_node["bool"];
+        REQUIRE(test_bool_node.is_boolean());
+        REQUIRE_NOTHROW(test_bool_node.to_boolean());
+        REQUIRE(test_bool_node.to_boolean() == true);
 
         REQUIRE_NOTHROW(test_node["foo"]);
-        fkyaml::Node& test_foo_node = test_node["foo"];
-        REQUIRE(test_foo_node.IsString());
-        REQUIRE_NOTHROW(test_foo_node.ToString());
-        REQUIRE(test_foo_node.ToString().compare("bar") == 0);
+        fkyaml::node& test_foo_node = test_node["foo"];
+        REQUIRE(test_foo_node.is_string());
+        REQUIRE_NOTHROW(test_foo_node.to_string());
+        REQUIRE(test_foo_node.to_string().compare("bar") == 0);
 
         REQUIRE_NOTHROW(test_node["pi"]);
-        fkyaml::Node& test_pi_node = test_node["pi"];
-        REQUIRE(test_pi_node.IsFloatNumber());
-        REQUIRE_NOTHROW(test_pi_node.ToFloatNumber());
-        REQUIRE(test_pi_node.ToFloatNumber() == 3.14);
+        fkyaml::node& test_pi_node = test_node["pi"];
+        REQUIRE(test_pi_node.is_float_number());
+        REQUIRE_NOTHROW(test_pi_node.to_float_number());
+        REQUIRE(test_pi_node.to_float_number() == 3.14);
     }
 }
 
 TEST_CASE("DeserializerClassTest_DeserializeInputWithCommentTest", "[DeserializerClassTest]")
 {
-    fkyaml::Deserializer deserializer;
-    fkyaml::Node root;
+    fkyaml::deserializer deserializer;
+    fkyaml::node root;
 
-    REQUIRE_NOTHROW(root = deserializer.Deserialize("foo: one # comment\nbar: true\npi: 3.14"));
+    REQUIRE_NOTHROW(root = deserializer.deserialize("foo: one # comment\nbar: true\npi: 3.14"));
 
-    REQUIRE(root.IsMapping());
-    REQUIRE(root.Size() == 3);
+    REQUIRE(root.is_mapping());
+    REQUIRE(root.size() == 3);
 
     REQUIRE_NOTHROW(root["foo"]);
-    fkyaml::Node& foo_node = root["foo"];
-    REQUIRE(foo_node.IsString());
-    REQUIRE_NOTHROW(foo_node.ToString());
-    REQUIRE(foo_node.ToString().compare("one") == 0);
+    fkyaml::node& foo_node = root["foo"];
+    REQUIRE(foo_node.is_string());
+    REQUIRE_NOTHROW(foo_node.to_string());
+    REQUIRE(foo_node.to_string().compare("one") == 0);
 
     REQUIRE_NOTHROW(root["bar"]);
-    fkyaml::Node& bar_node = root["bar"];
-    REQUIRE(bar_node.IsBoolean());
-    REQUIRE_NOTHROW(bar_node.ToBoolean());
-    REQUIRE(bar_node.ToBoolean() == true);
+    fkyaml::node& bar_node = root["bar"];
+    REQUIRE(bar_node.is_boolean());
+    REQUIRE_NOTHROW(bar_node.to_boolean());
+    REQUIRE(bar_node.to_boolean() == true);
 
     REQUIRE_NOTHROW(root["pi"]);
-    fkyaml::Node& pi_node = root["pi"];
-    REQUIRE(pi_node.IsFloatNumber());
-    REQUIRE_NOTHROW(pi_node.ToFloatNumber());
-    REQUIRE(pi_node.ToFloatNumber() == 3.14);
+    fkyaml::node& pi_node = root["pi"];
+    REQUIRE(pi_node.is_float_number());
+    REQUIRE_NOTHROW(pi_node.to_float_number());
+    REQUIRE(pi_node.to_float_number() == 3.14);
 }
 
 TEST_CASE("DeserializerClassTest_DeserializeYAMLVerDirectiveTest", "[DeserializerClassTest]")
 {
-    fkyaml::Deserializer deserializer;
-    fkyaml::Node root;
+    fkyaml::deserializer deserializer;
+    fkyaml::node root;
 
     SECTION("YAML 1.1")
     {
-        REQUIRE_NOTHROW(root = deserializer.Deserialize("%YAML 1.1\nfoo: one"));
+        REQUIRE_NOTHROW(root = deserializer.deserialize("%YAML 1.1\nfoo: one"));
 
-        REQUIRE(root.GetVersion() == fkyaml::YamlVersionType::VER_1_1);
-        REQUIRE(root.IsMapping());
-        REQUIRE(root.Size() == 1);
+        REQUIRE(root.get_yaml_version() == fkyaml::yaml_version_t::VER_1_1);
+        REQUIRE(root.is_mapping());
+        REQUIRE(root.size() == 1);
 
         REQUIRE_NOTHROW(root["foo"]);
-        fkyaml::Node& foo_node = root["foo"];
-        REQUIRE(root.GetVersion() == fkyaml::YamlVersionType::VER_1_1);
-        REQUIRE(foo_node.IsString());
-        REQUIRE_NOTHROW(foo_node.ToString());
-        REQUIRE(foo_node.ToString().compare("one") == 0);
+        fkyaml::node& foo_node = root["foo"];
+        REQUIRE(root.get_yaml_version() == fkyaml::yaml_version_t::VER_1_1);
+        REQUIRE(foo_node.is_string());
+        REQUIRE_NOTHROW(foo_node.to_string());
+        REQUIRE(foo_node.to_string().compare("one") == 0);
     }
 
     SECTION("YAML 1.2")
     {
-        REQUIRE_NOTHROW(root = deserializer.Deserialize("%YAML 1.2\nfoo: one"));
+        REQUIRE_NOTHROW(root = deserializer.deserialize("%YAML 1.2\nfoo: one"));
 
-        REQUIRE(root.GetVersion() == fkyaml::YamlVersionType::VER_1_2);
-        REQUIRE(root.IsMapping());
-        REQUIRE(root.Size() == 1);
+        REQUIRE(root.get_yaml_version() == fkyaml::yaml_version_t::VER_1_2);
+        REQUIRE(root.is_mapping());
+        REQUIRE(root.size() == 1);
 
         REQUIRE_NOTHROW(root["foo"]);
-        fkyaml::Node& foo_node = root["foo"];
-        REQUIRE(root.GetVersion() == fkyaml::YamlVersionType::VER_1_2);
-        REQUIRE(foo_node.IsString());
-        REQUIRE_NOTHROW(foo_node.ToString());
-        REQUIRE(foo_node.ToString().compare("one") == 0);
+        fkyaml::node& foo_node = root["foo"];
+        REQUIRE(root.get_yaml_version() == fkyaml::yaml_version_t::VER_1_2);
+        REQUIRE(foo_node.is_string());
+        REQUIRE_NOTHROW(foo_node.to_string());
+        REQUIRE(foo_node.to_string().compare("one") == 0);
     }
 }
 
 TEST_CASE("DeserializerClassTest_DeserializeNoMachingAnchorTest", "[DeserializerClassTest]")
 {
-    fkyaml::Deserializer deserializer;
-    REQUIRE_THROWS_AS(deserializer.Deserialize("foo: *anchor"), fkyaml::Exception);
+    fkyaml::deserializer deserializer;
+    REQUIRE_THROWS_AS(deserializer.deserialize("foo: *anchor"), fkyaml::exception);
 }

--- a/test/unit_test/DeserializerClassTest.cpp
+++ b/test/unit_test/DeserializerClassTest.cpp
@@ -80,9 +80,7 @@ TEST_CASE("DeserializerClassTest_DeserializeNumericKey", "[DeserializerClassTest
 
     using string_value_pair_t = std::pair<std::string, std::string>;
 
-    auto str_val_pair = GENERATE(
-        string_value_pair_t("123: foo", "123"),
-        string_value_pair_t("3.14: foo", "3.14"));
+    auto str_val_pair = GENERATE(string_value_pair_t("123: foo", "123"), string_value_pair_t("3.14: foo", "3.14"));
     REQUIRE_NOTHROW(root = deserializer.deserialize(str_val_pair.first.c_str()));
     REQUIRE(root.is_mapping());
     REQUIRE(root.size() == 1);

--- a/test/unit_test/DeserializerClassTest.cpp
+++ b/test/unit_test/DeserializerClassTest.cpp
@@ -78,9 +78,11 @@ TEST_CASE("DeserializerClassTest_DeserializeNumericKey", "[DeserializerClassTest
     fkyaml::deserializer deserializer;
     fkyaml::node root;
 
-    using StringValuePair = std::pair<std::string, std::string>;
+    using string_value_pair_t = std::pair<std::string, std::string>;
 
-    auto str_val_pair = GENERATE(StringValuePair("123: foo", "123"), StringValuePair("3.14: foo", "3.14"));
+    auto str_val_pair = GENERATE(
+        string_value_pair_t("123: foo", "123"),
+        string_value_pair_t("3.14: foo", "3.14"));
     REQUIRE_NOTHROW(root = deserializer.deserialize(str_val_pair.first.c_str()));
     REQUIRE(root.is_mapping());
     REQUIRE(root.size() == 1);

--- a/test/unit_test/ExceptionClassTest.cpp
+++ b/test/unit_test/ExceptionClassTest.cpp
@@ -14,7 +14,7 @@
 
 TEST_CASE("ExceptionClassTest_DefaultCtorTest", "[ExceptionClassTest]")
 {
-    fkyaml::Exception exception;
+    fkyaml::exception exception;
     REQUIRE(std::string(exception.what()).empty());
 }
 
@@ -23,14 +23,14 @@ TEST_CASE("ExceptionClassTest_CtorWithMessageTest", "[ExceptionClassTest]")
     SECTION("Test non-null message.")
     {
         const char* message = "test error message.";
-        fkyaml::Exception exception(message);
+        fkyaml::exception exception(message);
         REQUIRE(std::string(exception.what()).compare(message) == 0);
     }
 
     SECTION("Test null message.")
     {
         const char* message = nullptr;
-        fkyaml::Exception exception(message);
+        fkyaml::exception exception(message);
         REQUIRE(std::string(exception.what()).empty());
     }
 }

--- a/test/unit_test/IteratorClassTest.cpp
+++ b/test/unit_test/IteratorClassTest.cpp
@@ -13,126 +13,126 @@
 
 TEST_CASE("IteratorClassTest_SequenceCtorTest", "[IteratorClassTest]")
 {
-    fkyaml::Node sequence = fkyaml::Node::Sequence();
-    fkyaml::Iterator<fkyaml::Node> iterator(fkyaml::SequenceIteratorTag {}, sequence.ToSequence().begin());
-    REQUIRE(iterator.Type() == fkyaml::IteratorType::SEQUENCE);
+    fkyaml::node sequence = fkyaml::node::sequence();
+    fkyaml::iterator<fkyaml::node> iterator(fkyaml::sequence_iterator_tag {}, sequence.to_sequence().begin());
+    REQUIRE(iterator.type() == fkyaml::iterator_t::SEQUENCE);
 }
 
 TEST_CASE("IteratorClassTest_MappingCtorTest", "[IteratorClassTest]")
 {
-    fkyaml::Node mapping = fkyaml::Node::Mapping();
-    fkyaml::Iterator<fkyaml::Node> iterator(fkyaml::MappingIteratorTag {}, mapping.ToMapping().begin());
-    REQUIRE(iterator.Type() == fkyaml::IteratorType::MAPPING);
+    fkyaml::node mapping = fkyaml::node::mapping();
+    fkyaml::iterator<fkyaml::node> iterator(fkyaml::mapping_iterator_tag {}, mapping.to_mapping().begin());
+    REQUIRE(iterator.type() == fkyaml::iterator_t::MAPPING);
 }
 
 TEST_CASE("IteratorClassTest_SequenceCopyCtorTest", "[IteratorClassTest]")
 {
-    fkyaml::Node sequence = fkyaml::Node::Sequence({fkyaml::Node()});
-    fkyaml::Iterator<fkyaml::Node> copied(fkyaml::SequenceIteratorTag {}, sequence.ToSequence().begin());
-    fkyaml::Iterator<fkyaml::Node> iterator(copied);
-    REQUIRE(iterator.Type() == fkyaml::IteratorType::SEQUENCE);
-    REQUIRE(iterator->IsNull());
+    fkyaml::node sequence = fkyaml::node::sequence({fkyaml::node()});
+    fkyaml::iterator<fkyaml::node> copied(fkyaml::sequence_iterator_tag {}, sequence.to_sequence().begin());
+    fkyaml::iterator<fkyaml::node> iterator(copied);
+    REQUIRE(iterator.type() == fkyaml::iterator_t::SEQUENCE);
+    REQUIRE(iterator->is_null());
 }
 
 TEST_CASE("IteratorClassTest_MappingCopyCtorTest", "[IteratorClassTest]")
 {
-    fkyaml::Node mapping = fkyaml::Node::Mapping({{"test", fkyaml::Node()}});
-    fkyaml::Iterator<fkyaml::Node> copied(fkyaml::MappingIteratorTag {}, mapping.ToMapping().begin());
-    fkyaml::Iterator<fkyaml::Node> iterator(copied);
-    REQUIRE(iterator.Type() == fkyaml::IteratorType::MAPPING);
-    REQUIRE(iterator.Key().compare("test") == 0);
-    REQUIRE(iterator.Value().IsNull());
+    fkyaml::node mapping = fkyaml::node::mapping({{"test", fkyaml::node()}});
+    fkyaml::iterator<fkyaml::node> copied(fkyaml::mapping_iterator_tag {}, mapping.to_mapping().begin());
+    fkyaml::iterator<fkyaml::node> iterator(copied);
+    REQUIRE(iterator.type() == fkyaml::iterator_t::MAPPING);
+    REQUIRE(iterator.key().compare("test") == 0);
+    REQUIRE(iterator.value().is_null());
 }
 
 TEST_CASE("IteratorClassTest_SequenceMoveCtorTest", "[IteratorClassTest]")
 {
-    fkyaml::Node sequence = fkyaml::Node::Sequence({fkyaml::Node::StringScalar("test")});
-    fkyaml::Iterator<fkyaml::Node> moved(fkyaml::SequenceIteratorTag {}, sequence.ToSequence().begin());
-    fkyaml::Iterator<fkyaml::Node> iterator(std::move(moved));
-    REQUIRE(iterator.Type() == fkyaml::IteratorType::SEQUENCE);
-    REQUIRE(iterator->IsString());
-    REQUIRE(iterator->ToString().compare("test") == 0);
+    fkyaml::node sequence = fkyaml::node::sequence({fkyaml::node::string_scalar("test")});
+    fkyaml::iterator<fkyaml::node> moved(fkyaml::sequence_iterator_tag {}, sequence.to_sequence().begin());
+    fkyaml::iterator<fkyaml::node> iterator(std::move(moved));
+    REQUIRE(iterator.type() == fkyaml::iterator_t::SEQUENCE);
+    REQUIRE(iterator->is_string());
+    REQUIRE(iterator->to_string().compare("test") == 0);
 }
 
 TEST_CASE("IteratorClassTest_MappingMoveCtorTest", "[IteratorClassTest]")
 {
-    fkyaml::Node mapping = fkyaml::Node::Mapping({{"test", fkyaml::Node()}});
-    fkyaml::Iterator<fkyaml::Node> moved(fkyaml::MappingIteratorTag {}, mapping.ToMapping().begin());
-    fkyaml::Iterator<fkyaml::Node> iterator(std::move(moved));
-    REQUIRE(iterator.Type() == fkyaml::IteratorType::MAPPING);
-    REQUIRE(iterator.Key().compare("test") == 0);
-    REQUIRE(iterator.Value().IsNull());
+    fkyaml::node mapping = fkyaml::node::mapping({{"test", fkyaml::node()}});
+    fkyaml::iterator<fkyaml::node> moved(fkyaml::mapping_iterator_tag {}, mapping.to_mapping().begin());
+    fkyaml::iterator<fkyaml::node> iterator(std::move(moved));
+    REQUIRE(iterator.type() == fkyaml::iterator_t::MAPPING);
+    REQUIRE(iterator.key().compare("test") == 0);
+    REQUIRE(iterator.value().is_null());
 }
 
 TEST_CASE("IteratorClassTest_AssignmentOperatorTest", "[IteratorClassTest]")
 {
     SECTION("Test self assignment.")
     {
-        fkyaml::Node sequence = fkyaml::Node::Sequence({fkyaml::Node()});
-        fkyaml::Iterator<fkyaml::Node> iterator(fkyaml::SequenceIteratorTag {}, sequence.ToSequence().begin());
+        fkyaml::node sequence = fkyaml::node::sequence({fkyaml::node()});
+        fkyaml::iterator<fkyaml::node> iterator(fkyaml::sequence_iterator_tag {}, sequence.to_sequence().begin());
 
         SECTION("Test lvalue iterator.")
         {
             iterator = iterator;
-            REQUIRE(iterator.Type() == fkyaml::IteratorType::SEQUENCE);
-            REQUIRE(iterator->IsNull());
+            REQUIRE(iterator.type() == fkyaml::iterator_t::SEQUENCE);
+            REQUIRE(iterator->is_null());
         }
 
         SECTION("Test rvalue iterator.")
         {
             iterator = std::move(iterator);
-            REQUIRE(iterator.Type() == fkyaml::IteratorType::SEQUENCE);
-            REQUIRE(iterator->IsNull());
+            REQUIRE(iterator.type() == fkyaml::iterator_t::SEQUENCE);
+            REQUIRE(iterator->is_null());
         }
     }
 
     SECTION("Test sequence iterators.")
     {
-        fkyaml::Node copied_seq = fkyaml::Node::Sequence({fkyaml::Node::StringScalar("test")});
-        fkyaml::Iterator<fkyaml::Node> copied_itr(fkyaml::SequenceIteratorTag {}, copied_seq.ToSequence().begin());
-        fkyaml::Node sequence = fkyaml::Node::Sequence({fkyaml::Node::BooleanScalar(false)});
-        fkyaml::Iterator<fkyaml::Node> iterator(fkyaml::SequenceIteratorTag {}, sequence.ToSequence().begin());
+        fkyaml::node copied_seq = fkyaml::node::sequence({fkyaml::node::string_scalar("test")});
+        fkyaml::iterator<fkyaml::node> copied_itr(fkyaml::sequence_iterator_tag {}, copied_seq.to_sequence().begin());
+        fkyaml::node sequence = fkyaml::node::sequence({fkyaml::node::boolean_scalar(false)});
+        fkyaml::iterator<fkyaml::node> iterator(fkyaml::sequence_iterator_tag {}, sequence.to_sequence().begin());
 
         SECTION("Test lvalue iterator.")
         {
             iterator = copied_itr;
-            REQUIRE(iterator.Type() == fkyaml::IteratorType::SEQUENCE);
-            REQUIRE(iterator->IsString());
-            REQUIRE(iterator->ToString().compare("test") == 0);
+            REQUIRE(iterator.type() == fkyaml::iterator_t::SEQUENCE);
+            REQUIRE(iterator->is_string());
+            REQUIRE(iterator->to_string().compare("test") == 0);
         }
 
         SECTION("Test rvalue iterator.")
         {
             iterator = std::move(copied_itr);
-            REQUIRE(iterator.Type() == fkyaml::IteratorType::SEQUENCE);
-            REQUIRE(iterator->IsString());
-            REQUIRE(iterator->ToString().compare("test") == 0);
+            REQUIRE(iterator.type() == fkyaml::iterator_t::SEQUENCE);
+            REQUIRE(iterator->is_string());
+            REQUIRE(iterator->to_string().compare("test") == 0);
         }
     }
 
     SECTION("Test mapping iterators.")
     {
-        fkyaml::Node copied_map = fkyaml::Node::Mapping({{"key", fkyaml::Node::StringScalar("test")}});
-        fkyaml::Iterator<fkyaml::Node> copied_itr(fkyaml::MappingIteratorTag {}, copied_map.ToMapping().begin());
-        fkyaml::Node map = fkyaml::Node::Mapping({{"foo", fkyaml::Node::BooleanScalar(false)}});
-        fkyaml::Iterator<fkyaml::Node> iterator(fkyaml::MappingIteratorTag {}, map.ToMapping().begin());
+        fkyaml::node copied_map = fkyaml::node::mapping({{"key", fkyaml::node::string_scalar("test")}});
+        fkyaml::iterator<fkyaml::node> copied_itr(fkyaml::mapping_iterator_tag {}, copied_map.to_mapping().begin());
+        fkyaml::node map = fkyaml::node::mapping({{"foo", fkyaml::node::boolean_scalar(false)}});
+        fkyaml::iterator<fkyaml::node> iterator(fkyaml::mapping_iterator_tag {}, map.to_mapping().begin());
 
         SECTION("Test lvalue iterator.")
         {
             iterator = copied_itr;
-            REQUIRE(iterator.Type() == fkyaml::IteratorType::MAPPING);
-            REQUIRE(iterator.Key().compare("key") == 0);
-            REQUIRE(iterator.Value().IsString());
-            REQUIRE(iterator.Value().ToString().compare("test") == 0);
+            REQUIRE(iterator.type() == fkyaml::iterator_t::MAPPING);
+            REQUIRE(iterator.key().compare("key") == 0);
+            REQUIRE(iterator.value().is_string());
+            REQUIRE(iterator.value().to_string().compare("test") == 0);
         }
 
         SECTION("Test rvalue iterator.")
         {
             iterator = std::move(copied_itr);
-            REQUIRE(iterator.Type() == fkyaml::IteratorType::MAPPING);
-            REQUIRE(iterator.Key().compare("key") == 0);
-            REQUIRE(iterator.Value().IsString());
-            REQUIRE(iterator.Value().ToString().compare("test") == 0);
+            REQUIRE(iterator.type() == fkyaml::iterator_t::MAPPING);
+            REQUIRE(iterator.key().compare("key") == 0);
+            REQUIRE(iterator.value().is_string());
+            REQUIRE(iterator.value().to_string().compare("test") == 0);
         }
     }
 }
@@ -141,16 +141,16 @@ TEST_CASE("IteratorClassTest_ArrowOperatorTest", "[IteratorClassTest]")
 {
     SECTION("Test sequence iterator.")
     {
-        fkyaml::Node seq = fkyaml::Node::Sequence({fkyaml::Node::StringScalar("test")});
-        fkyaml::Iterator<fkyaml::Node> iterator(fkyaml::SequenceIteratorTag {}, seq.ToSequence().begin());
-        REQUIRE(iterator.operator->() == &(seq.ToSequence().operator[](0)));
+        fkyaml::node seq = fkyaml::node::sequence({fkyaml::node::string_scalar("test")});
+        fkyaml::iterator<fkyaml::node> iterator(fkyaml::sequence_iterator_tag {}, seq.to_sequence().begin());
+        REQUIRE(iterator.operator->() == &(seq.to_sequence().operator[](0)));
     }
 
     SECTION("Test mapping iterator.")
     {
-        fkyaml::Node map = fkyaml::Node::Mapping({{"key", fkyaml::Node::StringScalar("test")}});
-        fkyaml::Iterator<fkyaml::Node> iterator(fkyaml::MappingIteratorTag {}, map.ToMapping().begin());
-        REQUIRE(iterator.operator->() == &(map.ToMapping().operator[]("key")));
+        fkyaml::node map = fkyaml::node::mapping({{"key", fkyaml::node::string_scalar("test")}});
+        fkyaml::iterator<fkyaml::node> iterator(fkyaml::mapping_iterator_tag {}, map.to_mapping().begin());
+        REQUIRE(iterator.operator->() == &(map.to_mapping().operator[]("key")));
     }
 }
 
@@ -158,16 +158,16 @@ TEST_CASE("IteratorClassTest_DereferenceOperatorTest", "[IteratorClassTest]")
 {
     SECTION("Test sequence iterator.")
     {
-        fkyaml::Node seq = fkyaml::Node::Sequence({fkyaml::Node::StringScalar("test")});
-        fkyaml::Iterator<fkyaml::Node> iterator(fkyaml::SequenceIteratorTag {}, seq.ToSequence().begin());
-        REQUIRE(&(iterator.operator*()) == &(seq.ToSequence().operator[](0)));
+        fkyaml::node seq = fkyaml::node::sequence({fkyaml::node::string_scalar("test")});
+        fkyaml::iterator<fkyaml::node> iterator(fkyaml::sequence_iterator_tag {}, seq.to_sequence().begin());
+        REQUIRE(&(iterator.operator*()) == &(seq.to_sequence().operator[](0)));
     }
 
     SECTION("Test mapping iterator.")
     {
-        fkyaml::Node map = fkyaml::Node::Mapping({{"key", fkyaml::Node::StringScalar("test")}});
-        fkyaml::Iterator<fkyaml::Node> iterator(fkyaml::MappingIteratorTag {}, map.ToMapping().begin());
-        REQUIRE(&(iterator.operator*()) == &(map.ToMapping().operator[]("key")));
+        fkyaml::node map = fkyaml::node::mapping({{"key", fkyaml::node::string_scalar("test")}});
+        fkyaml::iterator<fkyaml::node> iterator(fkyaml::mapping_iterator_tag {}, map.to_mapping().begin());
+        REQUIRE(&(iterator.operator*()) == &(map.to_mapping().operator[]("key")));
     }
 }
 
@@ -175,23 +175,23 @@ TEST_CASE("IteratorClassTest_CompoundAssignmentOperatorBySumTest", "[IteratorCla
 {
     SECTION("Test sequence iterator.")
     {
-        fkyaml::Node sequence =
-            fkyaml::Node::Sequence({fkyaml::Node::BooleanScalar(false), fkyaml::Node::BooleanScalar(true)});
-        fkyaml::Iterator<fkyaml::Node> iterator(fkyaml::SequenceIteratorTag {}, sequence.ToSequence().begin());
+        fkyaml::node sequence =
+            fkyaml::node::sequence({fkyaml::node::boolean_scalar(false), fkyaml::node::boolean_scalar(true)});
+        fkyaml::iterator<fkyaml::node> iterator(fkyaml::sequence_iterator_tag {}, sequence.to_sequence().begin());
         iterator += 1;
-        REQUIRE(iterator->IsBoolean());
-        REQUIRE(iterator->ToBoolean() == true);
+        REQUIRE(iterator->is_boolean());
+        REQUIRE(iterator->to_boolean() == true);
     }
 
     SECTION("Test mapping iterator.")
     {
-        fkyaml::Node mapping = fkyaml::Node::Mapping(
-            {{"test0", fkyaml::Node::BooleanScalar(false)}, {"test1", fkyaml::Node::BooleanScalar(true)}});
-        fkyaml::Iterator<fkyaml::Node> iterator(fkyaml::MappingIteratorTag {}, mapping.ToMapping().begin());
+        fkyaml::node mapping = fkyaml::node::mapping(
+            {{"test0", fkyaml::node::boolean_scalar(false)}, {"test1", fkyaml::node::boolean_scalar(true)}});
+        fkyaml::iterator<fkyaml::node> iterator(fkyaml::mapping_iterator_tag {}, mapping.to_mapping().begin());
         iterator += 1;
-        REQUIRE(iterator.Key().compare("test1") == 0);
-        REQUIRE(iterator.Value().IsBoolean());
-        REQUIRE(iterator.Value().ToBoolean() == true);
+        REQUIRE(iterator.key().compare("test1") == 0);
+        REQUIRE(iterator.value().is_boolean());
+        REQUIRE(iterator.value().to_boolean() == true);
     }
 }
 
@@ -199,23 +199,23 @@ TEST_CASE("IteratorClassTest_PlusOperatorTest", "[IteratorClassTest]")
 {
     SECTION("Test sequence iterator.")
     {
-        fkyaml::Node sequence =
-            fkyaml::Node::Sequence({fkyaml::Node::BooleanScalar(false), fkyaml::Node::BooleanScalar(true)});
-        fkyaml::Iterator<fkyaml::Node> iterator(fkyaml::SequenceIteratorTag {}, sequence.ToSequence().begin());
-        fkyaml::Iterator<fkyaml::Node> after_plus_itr = iterator + 1;
-        REQUIRE(after_plus_itr->IsBoolean());
-        REQUIRE(after_plus_itr->ToBoolean() == true);
+        fkyaml::node sequence =
+            fkyaml::node::sequence({fkyaml::node::boolean_scalar(false), fkyaml::node::boolean_scalar(true)});
+        fkyaml::iterator<fkyaml::node> iterator(fkyaml::sequence_iterator_tag {}, sequence.to_sequence().begin());
+        fkyaml::iterator<fkyaml::node> after_plus_itr = iterator + 1;
+        REQUIRE(after_plus_itr->is_boolean());
+        REQUIRE(after_plus_itr->to_boolean() == true);
     }
 
     SECTION("Test mapping iterator.")
     {
-        fkyaml::Node mapping = fkyaml::Node::Mapping(
-            {{"test0", fkyaml::Node::BooleanScalar(false)}, {"test1", fkyaml::Node::BooleanScalar(true)}});
-        fkyaml::Iterator<fkyaml::Node> iterator(fkyaml::MappingIteratorTag {}, mapping.ToMapping().begin());
-        fkyaml::Iterator<fkyaml::Node> after_plus_itr = iterator + 1;
-        REQUIRE(after_plus_itr.Key().compare("test1") == 0);
-        REQUIRE(after_plus_itr.Value().IsBoolean());
-        REQUIRE(after_plus_itr.Value().ToBoolean() == true);
+        fkyaml::node mapping = fkyaml::node::mapping(
+            {{"test0", fkyaml::node::boolean_scalar(false)}, {"test1", fkyaml::node::boolean_scalar(true)}});
+        fkyaml::iterator<fkyaml::node> iterator(fkyaml::mapping_iterator_tag {}, mapping.to_mapping().begin());
+        fkyaml::iterator<fkyaml::node> after_plus_itr = iterator + 1;
+        REQUIRE(after_plus_itr.key().compare("test1") == 0);
+        REQUIRE(after_plus_itr.value().is_boolean());
+        REQUIRE(after_plus_itr.value().to_boolean() == true);
     }
 }
 
@@ -223,23 +223,23 @@ TEST_CASE("IteratorClassTest_PreIncrementOperatorTest", "[IteratorClassTest]")
 {
     SECTION("Test sequence iterator.")
     {
-        fkyaml::Node sequence =
-            fkyaml::Node::Sequence({fkyaml::Node::BooleanScalar(false), fkyaml::Node::BooleanScalar(true)});
-        fkyaml::Iterator<fkyaml::Node> iterator(fkyaml::SequenceIteratorTag {}, sequence.ToSequence().begin());
+        fkyaml::node sequence =
+            fkyaml::node::sequence({fkyaml::node::boolean_scalar(false), fkyaml::node::boolean_scalar(true)});
+        fkyaml::iterator<fkyaml::node> iterator(fkyaml::sequence_iterator_tag {}, sequence.to_sequence().begin());
         ++iterator;
-        REQUIRE(iterator->IsBoolean());
-        REQUIRE(iterator->ToBoolean() == true);
+        REQUIRE(iterator->is_boolean());
+        REQUIRE(iterator->to_boolean() == true);
     }
 
     SECTION("Test mapping iterator.")
     {
-        fkyaml::Node mapping = fkyaml::Node::Mapping(
-            {{"test0", fkyaml::Node::BooleanScalar(false)}, {"test1", fkyaml::Node::BooleanScalar(true)}});
-        fkyaml::Iterator<fkyaml::Node> iterator(fkyaml::MappingIteratorTag {}, mapping.ToMapping().begin());
+        fkyaml::node mapping = fkyaml::node::mapping(
+            {{"test0", fkyaml::node::boolean_scalar(false)}, {"test1", fkyaml::node::boolean_scalar(true)}});
+        fkyaml::iterator<fkyaml::node> iterator(fkyaml::mapping_iterator_tag {}, mapping.to_mapping().begin());
         ++iterator;
-        REQUIRE(iterator.Key().compare("test1") == 0);
-        REQUIRE(iterator.Value().IsBoolean());
-        REQUIRE(iterator.Value().ToBoolean() == true);
+        REQUIRE(iterator.key().compare("test1") == 0);
+        REQUIRE(iterator.value().is_boolean());
+        REQUIRE(iterator.value().to_boolean() == true);
     }
 }
 
@@ -247,23 +247,23 @@ TEST_CASE("IteratorClassTest_PostIncrementOperatorTest", "[IteratorClassTest]")
 {
     SECTION("Test sequence iterator.")
     {
-        fkyaml::Node sequence =
-            fkyaml::Node::Sequence({fkyaml::Node::BooleanScalar(false), fkyaml::Node::BooleanScalar(true)});
-        fkyaml::Iterator<fkyaml::Node> iterator(fkyaml::SequenceIteratorTag {}, sequence.ToSequence().begin());
+        fkyaml::node sequence =
+            fkyaml::node::sequence({fkyaml::node::boolean_scalar(false), fkyaml::node::boolean_scalar(true)});
+        fkyaml::iterator<fkyaml::node> iterator(fkyaml::sequence_iterator_tag {}, sequence.to_sequence().begin());
         iterator++;
-        REQUIRE(iterator->IsBoolean());
-        REQUIRE(iterator->ToBoolean() == true);
+        REQUIRE(iterator->is_boolean());
+        REQUIRE(iterator->to_boolean() == true);
     }
 
     SECTION("Test mapping iterator.")
     {
-        fkyaml::Node mapping = fkyaml::Node::Mapping(
-            {{"test0", fkyaml::Node::BooleanScalar(false)}, {"test1", fkyaml::Node::BooleanScalar(true)}});
-        fkyaml::Iterator<fkyaml::Node> iterator(fkyaml::MappingIteratorTag {}, mapping.ToMapping().begin());
+        fkyaml::node mapping = fkyaml::node::mapping(
+            {{"test0", fkyaml::node::boolean_scalar(false)}, {"test1", fkyaml::node::boolean_scalar(true)}});
+        fkyaml::iterator<fkyaml::node> iterator(fkyaml::mapping_iterator_tag {}, mapping.to_mapping().begin());
         iterator++;
-        REQUIRE(iterator.Key().compare("test1") == 0);
-        REQUIRE(iterator.Value().IsBoolean());
-        REQUIRE(iterator.Value().ToBoolean() == true);
+        REQUIRE(iterator.key().compare("test1") == 0);
+        REQUIRE(iterator.value().is_boolean());
+        REQUIRE(iterator.value().to_boolean() == true);
     }
 }
 
@@ -273,23 +273,23 @@ TEST_CASE("IteratorClassTest_CompoundAssignmentOperatorByDifferenceTest", "[Iter
 {
     SECTION("Test sequence iterator.")
     {
-        fkyaml::Node sequence =
-            fkyaml::Node::Sequence({fkyaml::Node::BooleanScalar(false), fkyaml::Node::BooleanScalar(true)});
-        fkyaml::Iterator<fkyaml::Node> iterator(fkyaml::SequenceIteratorTag {}, sequence.ToSequence().end());
+        fkyaml::node sequence =
+            fkyaml::node::sequence({fkyaml::node::boolean_scalar(false), fkyaml::node::boolean_scalar(true)});
+        fkyaml::iterator<fkyaml::node> iterator(fkyaml::sequence_iterator_tag {}, sequence.to_sequence().end());
         iterator -= 1;
-        REQUIRE(iterator->IsBoolean());
-        REQUIRE(iterator->ToBoolean() == true);
+        REQUIRE(iterator->is_boolean());
+        REQUIRE(iterator->to_boolean() == true);
     }
 
     SECTION("Test mapping iterator.")
     {
-        fkyaml::Node mapping = fkyaml::Node::Mapping(
-            {{"test0", fkyaml::Node::BooleanScalar(false)}, {"test1", fkyaml::Node::BooleanScalar(true)}});
-        fkyaml::Iterator<fkyaml::Node> iterator(fkyaml::MappingIteratorTag {}, mapping.ToMapping().end());
+        fkyaml::node mapping = fkyaml::node::mapping(
+            {{"test0", fkyaml::node::boolean_scalar(false)}, {"test1", fkyaml::node::boolean_scalar(true)}});
+        fkyaml::iterator<fkyaml::node> iterator(fkyaml::mapping_iterator_tag {}, mapping.to_mapping().end());
         iterator -= 1;
-        REQUIRE(iterator.Key().compare("test1") == 0);
-        REQUIRE(iterator.Value().IsBoolean());
-        REQUIRE(iterator.Value().ToBoolean() == true);
+        REQUIRE(iterator.key().compare("test1") == 0);
+        REQUIRE(iterator.value().is_boolean());
+        REQUIRE(iterator.value().to_boolean() == true);
     }
 }
 
@@ -297,23 +297,23 @@ TEST_CASE("IteratorClassTest_MinusOperatorTest", "[IteratorClassTest]")
 {
     SECTION("Test sequence iterator.")
     {
-        fkyaml::Node sequence =
-            fkyaml::Node::Sequence({fkyaml::Node::BooleanScalar(false), fkyaml::Node::BooleanScalar(true)});
-        fkyaml::Iterator<fkyaml::Node> iterator(fkyaml::SequenceIteratorTag {}, sequence.ToSequence().end());
-        fkyaml::Iterator<fkyaml::Node> after_minus_itr = iterator - 1;
-        REQUIRE(after_minus_itr->IsBoolean());
-        REQUIRE(after_minus_itr->ToBoolean() == true);
+        fkyaml::node sequence =
+            fkyaml::node::sequence({fkyaml::node::boolean_scalar(false), fkyaml::node::boolean_scalar(true)});
+        fkyaml::iterator<fkyaml::node> iterator(fkyaml::sequence_iterator_tag {}, sequence.to_sequence().end());
+        fkyaml::iterator<fkyaml::node> after_minus_itr = iterator - 1;
+        REQUIRE(after_minus_itr->is_boolean());
+        REQUIRE(after_minus_itr->to_boolean() == true);
     }
 
     SECTION("Test mapping iterator.")
     {
-        fkyaml::Node mapping = fkyaml::Node::Mapping(
-            {{"test0", fkyaml::Node::BooleanScalar(false)}, {"test1", fkyaml::Node::BooleanScalar(true)}});
-        fkyaml::Iterator<fkyaml::Node> iterator(fkyaml::MappingIteratorTag {}, mapping.ToMapping().end());
-        fkyaml::Iterator<fkyaml::Node> after_minus_itr = iterator - 1;
-        REQUIRE(after_minus_itr.Key().compare("test1") == 0);
-        REQUIRE(after_minus_itr.Value().IsBoolean());
-        REQUIRE(after_minus_itr.Value().ToBoolean() == true);
+        fkyaml::node mapping = fkyaml::node::mapping(
+            {{"test0", fkyaml::node::boolean_scalar(false)}, {"test1", fkyaml::node::boolean_scalar(true)}});
+        fkyaml::iterator<fkyaml::node> iterator(fkyaml::mapping_iterator_tag {}, mapping.to_mapping().end());
+        fkyaml::iterator<fkyaml::node> after_minus_itr = iterator - 1;
+        REQUIRE(after_minus_itr.key().compare("test1") == 0);
+        REQUIRE(after_minus_itr.value().is_boolean());
+        REQUIRE(after_minus_itr.value().to_boolean() == true);
     }
 }
 
@@ -321,23 +321,23 @@ TEST_CASE("IteratorClassTest_PreDecrementOperatorTest", "[IteratorClassTest]")
 {
     SECTION("Test sequence iterator.")
     {
-        fkyaml::Node sequence =
-            fkyaml::Node::Sequence({fkyaml::Node::BooleanScalar(false), fkyaml::Node::BooleanScalar(true)});
-        fkyaml::Iterator<fkyaml::Node> iterator(fkyaml::SequenceIteratorTag {}, sequence.ToSequence().end());
+        fkyaml::node sequence =
+            fkyaml::node::sequence({fkyaml::node::boolean_scalar(false), fkyaml::node::boolean_scalar(true)});
+        fkyaml::iterator<fkyaml::node> iterator(fkyaml::sequence_iterator_tag {}, sequence.to_sequence().end());
         --iterator;
-        REQUIRE(iterator->IsBoolean());
-        REQUIRE(iterator->ToBoolean() == true);
+        REQUIRE(iterator->is_boolean());
+        REQUIRE(iterator->to_boolean() == true);
     }
 
     SECTION("Test mapping iterator.")
     {
-        fkyaml::Node mapping = fkyaml::Node::Mapping(
-            {{"test0", fkyaml::Node::BooleanScalar(false)}, {"test1", fkyaml::Node::BooleanScalar(true)}});
-        fkyaml::Iterator<fkyaml::Node> iterator(fkyaml::MappingIteratorTag {}, mapping.ToMapping().end());
+        fkyaml::node mapping = fkyaml::node::mapping(
+            {{"test0", fkyaml::node::boolean_scalar(false)}, {"test1", fkyaml::node::boolean_scalar(true)}});
+        fkyaml::iterator<fkyaml::node> iterator(fkyaml::mapping_iterator_tag {}, mapping.to_mapping().end());
         --iterator;
-        REQUIRE(iterator.Key().compare("test1") == 0);
-        REQUIRE(iterator.Value().IsBoolean());
-        REQUIRE(iterator.Value().ToBoolean() == true);
+        REQUIRE(iterator.key().compare("test1") == 0);
+        REQUIRE(iterator.value().is_boolean());
+        REQUIRE(iterator.value().to_boolean() == true);
     }
 }
 
@@ -345,23 +345,23 @@ TEST_CASE("IteratorClassTest_PostDecrementOperatorTest", "[IteratorClassTest]")
 {
     SECTION("Test sequence iterator.")
     {
-        fkyaml::Node sequence =
-            fkyaml::Node::Sequence({fkyaml::Node::BooleanScalar(false), fkyaml::Node::BooleanScalar(true)});
-        fkyaml::Iterator<fkyaml::Node> iterator(fkyaml::SequenceIteratorTag {}, sequence.ToSequence().end());
+        fkyaml::node sequence =
+            fkyaml::node::sequence({fkyaml::node::boolean_scalar(false), fkyaml::node::boolean_scalar(true)});
+        fkyaml::iterator<fkyaml::node> iterator(fkyaml::sequence_iterator_tag {}, sequence.to_sequence().end());
         iterator--;
-        REQUIRE(iterator->IsBoolean());
-        REQUIRE(iterator->ToBoolean() == true);
+        REQUIRE(iterator->is_boolean());
+        REQUIRE(iterator->to_boolean() == true);
     }
 
     SECTION("Test mapping iterator.")
     {
-        fkyaml::Node mapping = fkyaml::Node::Mapping(
-            {{"test0", fkyaml::Node::BooleanScalar(false)}, {"test1", fkyaml::Node::BooleanScalar(true)}});
-        fkyaml::Iterator<fkyaml::Node> iterator(fkyaml::MappingIteratorTag {}, mapping.ToMapping().end());
+        fkyaml::node mapping = fkyaml::node::mapping(
+            {{"test0", fkyaml::node::boolean_scalar(false)}, {"test1", fkyaml::node::boolean_scalar(true)}});
+        fkyaml::iterator<fkyaml::node> iterator(fkyaml::mapping_iterator_tag {}, mapping.to_mapping().end());
         iterator--;
-        REQUIRE(iterator.Key().compare("test1") == 0);
-        REQUIRE(iterator.Value().IsBoolean());
-        REQUIRE(iterator.Value().ToBoolean() == true);
+        REQUIRE(iterator.key().compare("test1") == 0);
+        REQUIRE(iterator.value().is_boolean());
+        REQUIRE(iterator.value().to_boolean() == true);
     }
 }
 
@@ -369,31 +369,31 @@ TEST_CASE("IteratorClassTest_EqualToOperatorTest", "[IteratorClassTest]")
 {
     SECTION("Test sequence iterator.")
     {
-        fkyaml::Node sequence =
-            fkyaml::Node::Sequence({fkyaml::Node::BooleanScalar(false), fkyaml::Node::BooleanScalar(true)});
-        fkyaml::Iterator<fkyaml::Node> lhs(fkyaml::SequenceIteratorTag {}, sequence.ToSequence().begin());
-        fkyaml::Iterator<fkyaml::Node> rhs(fkyaml::SequenceIteratorTag {}, sequence.ToSequence().begin());
+        fkyaml::node sequence =
+            fkyaml::node::sequence({fkyaml::node::boolean_scalar(false), fkyaml::node::boolean_scalar(true)});
+        fkyaml::iterator<fkyaml::node> lhs(fkyaml::sequence_iterator_tag {}, sequence.to_sequence().begin());
+        fkyaml::iterator<fkyaml::node> rhs(fkyaml::sequence_iterator_tag {}, sequence.to_sequence().begin());
         REQUIRE(lhs == rhs);
     }
 
     SECTION("Test mapping iterator.")
     {
-        fkyaml::Node mapping = fkyaml::Node::Mapping(
-            {{"test0", fkyaml::Node::BooleanScalar(false)}, {"test1", fkyaml::Node::BooleanScalar(true)}});
-        fkyaml::Iterator<fkyaml::Node> lhs(fkyaml::MappingIteratorTag {}, mapping.ToMapping().begin());
-        fkyaml::Iterator<fkyaml::Node> rhs(fkyaml::MappingIteratorTag {}, mapping.ToMapping().begin());
+        fkyaml::node mapping = fkyaml::node::mapping(
+            {{"test0", fkyaml::node::boolean_scalar(false)}, {"test1", fkyaml::node::boolean_scalar(true)}});
+        fkyaml::iterator<fkyaml::node> lhs(fkyaml::mapping_iterator_tag {}, mapping.to_mapping().begin());
+        fkyaml::iterator<fkyaml::node> rhs(fkyaml::mapping_iterator_tag {}, mapping.to_mapping().begin());
         REQUIRE(lhs == rhs);
     }
 
     SECTION("Test equality check between different type iterators.")
     {
-        fkyaml::Node sequence =
-            fkyaml::Node::Sequence({fkyaml::Node::BooleanScalar(false), fkyaml::Node::BooleanScalar(true)});
-        fkyaml::Iterator<fkyaml::Node> lhs(fkyaml::SequenceIteratorTag {}, sequence.ToSequence().begin());
-        fkyaml::Node mapping = fkyaml::Node::Mapping(
-            {{"test0", fkyaml::Node::BooleanScalar(false)}, {"test1", fkyaml::Node::BooleanScalar(true)}});
-        fkyaml::Iterator<fkyaml::Node> rhs(fkyaml::MappingIteratorTag {}, mapping.ToMapping().begin());
-        REQUIRE_THROWS_AS(lhs == rhs, fkyaml::Exception);
+        fkyaml::node sequence =
+            fkyaml::node::sequence({fkyaml::node::boolean_scalar(false), fkyaml::node::boolean_scalar(true)});
+        fkyaml::iterator<fkyaml::node> lhs(fkyaml::sequence_iterator_tag {}, sequence.to_sequence().begin());
+        fkyaml::node mapping = fkyaml::node::mapping(
+            {{"test0", fkyaml::node::boolean_scalar(false)}, {"test1", fkyaml::node::boolean_scalar(true)}});
+        fkyaml::iterator<fkyaml::node> rhs(fkyaml::mapping_iterator_tag {}, mapping.to_mapping().begin());
+        REQUIRE_THROWS_AS(lhs == rhs, fkyaml::exception);
     }
 }
 
@@ -401,33 +401,33 @@ TEST_CASE("IteratorClassTest_NotEqualToOperatorTest", "[IteratorClassTest]")
 {
     SECTION("Test sequence iterator.")
     {
-        fkyaml::Node sequence =
-            fkyaml::Node::Sequence({fkyaml::Node::BooleanScalar(false), fkyaml::Node::BooleanScalar(true)});
-        fkyaml::Iterator<fkyaml::Node> lhs(fkyaml::SequenceIteratorTag {}, sequence.ToSequence().begin());
-        fkyaml::Iterator<fkyaml::Node> rhs(fkyaml::SequenceIteratorTag {}, sequence.ToSequence().begin());
+        fkyaml::node sequence =
+            fkyaml::node::sequence({fkyaml::node::boolean_scalar(false), fkyaml::node::boolean_scalar(true)});
+        fkyaml::iterator<fkyaml::node> lhs(fkyaml::sequence_iterator_tag {}, sequence.to_sequence().begin());
+        fkyaml::iterator<fkyaml::node> rhs(fkyaml::sequence_iterator_tag {}, sequence.to_sequence().begin());
         ++rhs;
         REQUIRE(lhs != rhs);
     }
 
     SECTION("Test mapping iterator.")
     {
-        fkyaml::Node mapping = fkyaml::Node::Mapping(
-            {{"test0", fkyaml::Node::BooleanScalar(false)}, {"test1", fkyaml::Node::BooleanScalar(true)}});
-        fkyaml::Iterator<fkyaml::Node> lhs(fkyaml::MappingIteratorTag {}, mapping.ToMapping().begin());
-        fkyaml::Iterator<fkyaml::Node> rhs(fkyaml::MappingIteratorTag {}, mapping.ToMapping().begin());
+        fkyaml::node mapping = fkyaml::node::mapping(
+            {{"test0", fkyaml::node::boolean_scalar(false)}, {"test1", fkyaml::node::boolean_scalar(true)}});
+        fkyaml::iterator<fkyaml::node> lhs(fkyaml::mapping_iterator_tag {}, mapping.to_mapping().begin());
+        fkyaml::iterator<fkyaml::node> rhs(fkyaml::mapping_iterator_tag {}, mapping.to_mapping().begin());
         ++rhs;
         REQUIRE(lhs != rhs);
     }
 
     SECTION("Test equality check between different type iterators.")
     {
-        fkyaml::Node sequence =
-            fkyaml::Node::Sequence({fkyaml::Node::BooleanScalar(false), fkyaml::Node::BooleanScalar(true)});
-        fkyaml::Iterator<fkyaml::Node> lhs(fkyaml::SequenceIteratorTag {}, sequence.ToSequence().begin());
-        fkyaml::Node mapping = fkyaml::Node::Mapping(
-            {{"test0", fkyaml::Node::BooleanScalar(false)}, {"test1", fkyaml::Node::BooleanScalar(true)}});
-        fkyaml::Iterator<fkyaml::Node> rhs(fkyaml::MappingIteratorTag {}, mapping.ToMapping().begin());
-        REQUIRE_THROWS_AS(lhs == rhs, fkyaml::Exception);
+        fkyaml::node sequence =
+            fkyaml::node::sequence({fkyaml::node::boolean_scalar(false), fkyaml::node::boolean_scalar(true)});
+        fkyaml::iterator<fkyaml::node> lhs(fkyaml::sequence_iterator_tag {}, sequence.to_sequence().begin());
+        fkyaml::node mapping = fkyaml::node::mapping(
+            {{"test0", fkyaml::node::boolean_scalar(false)}, {"test1", fkyaml::node::boolean_scalar(true)}});
+        fkyaml::iterator<fkyaml::node> rhs(fkyaml::mapping_iterator_tag {}, mapping.to_mapping().begin());
+        REQUIRE_THROWS_AS(lhs == rhs, fkyaml::exception);
     }
 }
 
@@ -435,10 +435,10 @@ TEST_CASE("IteratorClassTest_LessThanOperatorTest", "[IteratorClassTest]")
 {
     SECTION("Test sequence iterator.")
     {
-        fkyaml::Node sequence =
-            fkyaml::Node::Sequence({fkyaml::Node::BooleanScalar(false), fkyaml::Node::BooleanScalar(true)});
-        fkyaml::Iterator<fkyaml::Node> lhs(fkyaml::SequenceIteratorTag {}, sequence.ToSequence().begin());
-        fkyaml::Iterator<fkyaml::Node> rhs(fkyaml::SequenceIteratorTag {}, sequence.ToSequence().begin());
+        fkyaml::node sequence =
+            fkyaml::node::sequence({fkyaml::node::boolean_scalar(false), fkyaml::node::boolean_scalar(true)});
+        fkyaml::iterator<fkyaml::node> lhs(fkyaml::sequence_iterator_tag {}, sequence.to_sequence().begin());
+        fkyaml::iterator<fkyaml::node> rhs(fkyaml::sequence_iterator_tag {}, sequence.to_sequence().begin());
         REQUIRE_FALSE(lhs < rhs);
         ++rhs;
         REQUIRE(lhs < rhs);
@@ -446,22 +446,22 @@ TEST_CASE("IteratorClassTest_LessThanOperatorTest", "[IteratorClassTest]")
 
     SECTION("Test mapping iterator.")
     {
-        fkyaml::Node mapping = fkyaml::Node::Mapping(
-            {{"test0", fkyaml::Node::BooleanScalar(false)}, {"test1", fkyaml::Node::BooleanScalar(true)}});
-        fkyaml::Iterator<fkyaml::Node> lhs(fkyaml::MappingIteratorTag {}, mapping.ToMapping().begin());
-        fkyaml::Iterator<fkyaml::Node> rhs(fkyaml::MappingIteratorTag {}, mapping.ToMapping().begin());
-        REQUIRE_THROWS_AS(lhs < rhs, fkyaml::Exception);
+        fkyaml::node mapping = fkyaml::node::mapping(
+            {{"test0", fkyaml::node::boolean_scalar(false)}, {"test1", fkyaml::node::boolean_scalar(true)}});
+        fkyaml::iterator<fkyaml::node> lhs(fkyaml::mapping_iterator_tag {}, mapping.to_mapping().begin());
+        fkyaml::iterator<fkyaml::node> rhs(fkyaml::mapping_iterator_tag {}, mapping.to_mapping().begin());
+        REQUIRE_THROWS_AS(lhs < rhs, fkyaml::exception);
     }
 
     SECTION("Test less-than check between different type iterators.")
     {
-        fkyaml::Node sequence =
-            fkyaml::Node::Sequence({fkyaml::Node::BooleanScalar(false), fkyaml::Node::BooleanScalar(true)});
-        fkyaml::Iterator<fkyaml::Node> lhs(fkyaml::SequenceIteratorTag {}, sequence.ToSequence().begin());
-        fkyaml::Node mapping = fkyaml::Node::Mapping(
-            {{"test0", fkyaml::Node::BooleanScalar(false)}, {"test1", fkyaml::Node::BooleanScalar(true)}});
-        fkyaml::Iterator<fkyaml::Node> rhs(fkyaml::MappingIteratorTag {}, mapping.ToMapping().begin());
-        REQUIRE_THROWS_AS(lhs < rhs, fkyaml::Exception);
+        fkyaml::node sequence =
+            fkyaml::node::sequence({fkyaml::node::boolean_scalar(false), fkyaml::node::boolean_scalar(true)});
+        fkyaml::iterator<fkyaml::node> lhs(fkyaml::sequence_iterator_tag {}, sequence.to_sequence().begin());
+        fkyaml::node mapping = fkyaml::node::mapping(
+            {{"test0", fkyaml::node::boolean_scalar(false)}, {"test1", fkyaml::node::boolean_scalar(true)}});
+        fkyaml::iterator<fkyaml::node> rhs(fkyaml::mapping_iterator_tag {}, mapping.to_mapping().begin());
+        REQUIRE_THROWS_AS(lhs < rhs, fkyaml::exception);
     }
 }
 
@@ -469,10 +469,10 @@ TEST_CASE("IteratorClassTest_LessThanOrEqualToOperatorTest", "[IteratorClassTest
 {
     SECTION("Test sequence iterator.")
     {
-        fkyaml::Node sequence =
-            fkyaml::Node::Sequence({fkyaml::Node::BooleanScalar(false), fkyaml::Node::BooleanScalar(true)});
-        fkyaml::Iterator<fkyaml::Node> lhs(fkyaml::SequenceIteratorTag {}, sequence.ToSequence().begin());
-        fkyaml::Iterator<fkyaml::Node> rhs(fkyaml::SequenceIteratorTag {}, sequence.ToSequence().begin());
+        fkyaml::node sequence =
+            fkyaml::node::sequence({fkyaml::node::boolean_scalar(false), fkyaml::node::boolean_scalar(true)});
+        fkyaml::iterator<fkyaml::node> lhs(fkyaml::sequence_iterator_tag {}, sequence.to_sequence().begin());
+        fkyaml::iterator<fkyaml::node> rhs(fkyaml::sequence_iterator_tag {}, sequence.to_sequence().begin());
         ++lhs;
         REQUIRE_FALSE(lhs <= rhs);
         --lhs;
@@ -483,22 +483,22 @@ TEST_CASE("IteratorClassTest_LessThanOrEqualToOperatorTest", "[IteratorClassTest
 
     SECTION("Test mapping iterator.")
     {
-        fkyaml::Node mapping = fkyaml::Node::Mapping(
-            {{"test0", fkyaml::Node::BooleanScalar(false)}, {"test1", fkyaml::Node::BooleanScalar(true)}});
-        fkyaml::Iterator<fkyaml::Node> lhs(fkyaml::MappingIteratorTag {}, mapping.ToMapping().begin());
-        fkyaml::Iterator<fkyaml::Node> rhs(fkyaml::MappingIteratorTag {}, mapping.ToMapping().begin());
-        REQUIRE_THROWS_AS(lhs <= rhs, fkyaml::Exception);
+        fkyaml::node mapping = fkyaml::node::mapping(
+            {{"test0", fkyaml::node::boolean_scalar(false)}, {"test1", fkyaml::node::boolean_scalar(true)}});
+        fkyaml::iterator<fkyaml::node> lhs(fkyaml::mapping_iterator_tag {}, mapping.to_mapping().begin());
+        fkyaml::iterator<fkyaml::node> rhs(fkyaml::mapping_iterator_tag {}, mapping.to_mapping().begin());
+        REQUIRE_THROWS_AS(lhs <= rhs, fkyaml::exception);
     }
 
     SECTION("Test less-than-or-equal-to check between different type iterators.")
     {
-        fkyaml::Node sequence =
-            fkyaml::Node::Sequence({fkyaml::Node::BooleanScalar(false), fkyaml::Node::BooleanScalar(true)});
-        fkyaml::Iterator<fkyaml::Node> lhs(fkyaml::SequenceIteratorTag {}, sequence.ToSequence().begin());
-        fkyaml::Node mapping = fkyaml::Node::Mapping(
-            {{"test0", fkyaml::Node::BooleanScalar(false)}, {"test1", fkyaml::Node::BooleanScalar(true)}});
-        fkyaml::Iterator<fkyaml::Node> rhs(fkyaml::MappingIteratorTag {}, mapping.ToMapping().begin());
-        REQUIRE_THROWS_AS(lhs <= rhs, fkyaml::Exception);
+        fkyaml::node sequence =
+            fkyaml::node::sequence({fkyaml::node::boolean_scalar(false), fkyaml::node::boolean_scalar(true)});
+        fkyaml::iterator<fkyaml::node> lhs(fkyaml::sequence_iterator_tag {}, sequence.to_sequence().begin());
+        fkyaml::node mapping = fkyaml::node::mapping(
+            {{"test0", fkyaml::node::boolean_scalar(false)}, {"test1", fkyaml::node::boolean_scalar(true)}});
+        fkyaml::iterator<fkyaml::node> rhs(fkyaml::mapping_iterator_tag {}, mapping.to_mapping().begin());
+        REQUIRE_THROWS_AS(lhs <= rhs, fkyaml::exception);
     }
 }
 
@@ -506,10 +506,10 @@ TEST_CASE("IteratorClassTest_GreaterThanOperatorTest", "[IteratorClassTest]")
 {
     SECTION("Test sequence iterator.")
     {
-        fkyaml::Node sequence =
-            fkyaml::Node::Sequence({fkyaml::Node::BooleanScalar(false), fkyaml::Node::BooleanScalar(true)});
-        fkyaml::Iterator<fkyaml::Node> lhs(fkyaml::SequenceIteratorTag {}, sequence.ToSequence().begin());
-        fkyaml::Iterator<fkyaml::Node> rhs(fkyaml::SequenceIteratorTag {}, sequence.ToSequence().begin());
+        fkyaml::node sequence =
+            fkyaml::node::sequence({fkyaml::node::boolean_scalar(false), fkyaml::node::boolean_scalar(true)});
+        fkyaml::iterator<fkyaml::node> lhs(fkyaml::sequence_iterator_tag {}, sequence.to_sequence().begin());
+        fkyaml::iterator<fkyaml::node> rhs(fkyaml::sequence_iterator_tag {}, sequence.to_sequence().begin());
         REQUIRE_FALSE(lhs > rhs);
         ++lhs;
         REQUIRE(lhs > rhs);
@@ -517,22 +517,22 @@ TEST_CASE("IteratorClassTest_GreaterThanOperatorTest", "[IteratorClassTest]")
 
     SECTION("Test mapping iterator.")
     {
-        fkyaml::Node mapping = fkyaml::Node::Mapping(
-            {{"test0", fkyaml::Node::BooleanScalar(false)}, {"test1", fkyaml::Node::BooleanScalar(true)}});
-        fkyaml::Iterator<fkyaml::Node> lhs(fkyaml::MappingIteratorTag {}, mapping.ToMapping().begin());
-        fkyaml::Iterator<fkyaml::Node> rhs(fkyaml::MappingIteratorTag {}, mapping.ToMapping().begin());
-        REQUIRE_THROWS_AS(lhs > rhs, fkyaml::Exception);
+        fkyaml::node mapping = fkyaml::node::mapping(
+            {{"test0", fkyaml::node::boolean_scalar(false)}, {"test1", fkyaml::node::boolean_scalar(true)}});
+        fkyaml::iterator<fkyaml::node> lhs(fkyaml::mapping_iterator_tag {}, mapping.to_mapping().begin());
+        fkyaml::iterator<fkyaml::node> rhs(fkyaml::mapping_iterator_tag {}, mapping.to_mapping().begin());
+        REQUIRE_THROWS_AS(lhs > rhs, fkyaml::exception);
     }
 
     SECTION("Test greater-than check between different type iterators.")
     {
-        fkyaml::Node sequence =
-            fkyaml::Node::Sequence({fkyaml::Node::BooleanScalar(false), fkyaml::Node::BooleanScalar(true)});
-        fkyaml::Iterator<fkyaml::Node> lhs(fkyaml::SequenceIteratorTag {}, sequence.ToSequence().begin());
-        fkyaml::Node mapping = fkyaml::Node::Mapping(
-            {{"test0", fkyaml::Node::BooleanScalar(false)}, {"test1", fkyaml::Node::BooleanScalar(true)}});
-        fkyaml::Iterator<fkyaml::Node> rhs(fkyaml::MappingIteratorTag {}, mapping.ToMapping().begin());
-        REQUIRE_THROWS_AS(lhs > rhs, fkyaml::Exception);
+        fkyaml::node sequence =
+            fkyaml::node::sequence({fkyaml::node::boolean_scalar(false), fkyaml::node::boolean_scalar(true)});
+        fkyaml::iterator<fkyaml::node> lhs(fkyaml::sequence_iterator_tag {}, sequence.to_sequence().begin());
+        fkyaml::node mapping = fkyaml::node::mapping(
+            {{"test0", fkyaml::node::boolean_scalar(false)}, {"test1", fkyaml::node::boolean_scalar(true)}});
+        fkyaml::iterator<fkyaml::node> rhs(fkyaml::mapping_iterator_tag {}, mapping.to_mapping().begin());
+        REQUIRE_THROWS_AS(lhs > rhs, fkyaml::exception);
     }
 }
 
@@ -540,10 +540,10 @@ TEST_CASE("IteratorClassTest_GreaterThanOrEqualToOperatorTest", "[IteratorClassT
 {
     SECTION("Test sequence iterator.")
     {
-        fkyaml::Node sequence =
-            fkyaml::Node::Sequence({fkyaml::Node::BooleanScalar(false), fkyaml::Node::BooleanScalar(true)});
-        fkyaml::Iterator<fkyaml::Node> lhs(fkyaml::SequenceIteratorTag {}, sequence.ToSequence().begin());
-        fkyaml::Iterator<fkyaml::Node> rhs(fkyaml::SequenceIteratorTag {}, sequence.ToSequence().begin());
+        fkyaml::node sequence =
+            fkyaml::node::sequence({fkyaml::node::boolean_scalar(false), fkyaml::node::boolean_scalar(true)});
+        fkyaml::iterator<fkyaml::node> lhs(fkyaml::sequence_iterator_tag {}, sequence.to_sequence().begin());
+        fkyaml::iterator<fkyaml::node> rhs(fkyaml::sequence_iterator_tag {}, sequence.to_sequence().begin());
         ++rhs;
         REQUIRE_FALSE(lhs >= rhs);
         --rhs;
@@ -554,22 +554,22 @@ TEST_CASE("IteratorClassTest_GreaterThanOrEqualToOperatorTest", "[IteratorClassT
 
     SECTION("Test mapping iterator.")
     {
-        fkyaml::Node mapping = fkyaml::Node::Mapping(
-            {{"test0", fkyaml::Node::BooleanScalar(false)}, {"test1", fkyaml::Node::BooleanScalar(true)}});
-        fkyaml::Iterator<fkyaml::Node> lhs(fkyaml::MappingIteratorTag {}, mapping.ToMapping().begin());
-        fkyaml::Iterator<fkyaml::Node> rhs(fkyaml::MappingIteratorTag {}, mapping.ToMapping().begin());
-        REQUIRE_THROWS_AS(lhs >= rhs, fkyaml::Exception);
+        fkyaml::node mapping = fkyaml::node::mapping(
+            {{"test0", fkyaml::node::boolean_scalar(false)}, {"test1", fkyaml::node::boolean_scalar(true)}});
+        fkyaml::iterator<fkyaml::node> lhs(fkyaml::mapping_iterator_tag {}, mapping.to_mapping().begin());
+        fkyaml::iterator<fkyaml::node> rhs(fkyaml::mapping_iterator_tag {}, mapping.to_mapping().begin());
+        REQUIRE_THROWS_AS(lhs >= rhs, fkyaml::exception);
     }
 
     SECTION("Test greater-than-or-equal-to check between different type iterators.")
     {
-        fkyaml::Node sequence =
-            fkyaml::Node::Sequence({fkyaml::Node::BooleanScalar(false), fkyaml::Node::BooleanScalar(true)});
-        fkyaml::Iterator<fkyaml::Node> lhs(fkyaml::SequenceIteratorTag {}, sequence.ToSequence().begin());
-        fkyaml::Node mapping = fkyaml::Node::Mapping(
-            {{"test0", fkyaml::Node::BooleanScalar(false)}, {"test1", fkyaml::Node::BooleanScalar(true)}});
-        fkyaml::Iterator<fkyaml::Node> rhs(fkyaml::MappingIteratorTag {}, mapping.ToMapping().begin());
-        REQUIRE_THROWS_AS(lhs >= rhs, fkyaml::Exception);
+        fkyaml::node sequence =
+            fkyaml::node::sequence({fkyaml::node::boolean_scalar(false), fkyaml::node::boolean_scalar(true)});
+        fkyaml::iterator<fkyaml::node> lhs(fkyaml::sequence_iterator_tag {}, sequence.to_sequence().begin());
+        fkyaml::node mapping = fkyaml::node::mapping(
+            {{"test0", fkyaml::node::boolean_scalar(false)}, {"test1", fkyaml::node::boolean_scalar(true)}});
+        fkyaml::iterator<fkyaml::node> rhs(fkyaml::mapping_iterator_tag {}, mapping.to_mapping().begin());
+        REQUIRE_THROWS_AS(lhs >= rhs, fkyaml::exception);
     }
 }
 
@@ -577,18 +577,18 @@ TEST_CASE("IteratorClassTest_TypeGetterTest", "[IteratorClassTest]")
 {
     SECTION("Test sequence iterator.")
     {
-        fkyaml::Node sequence =
-            fkyaml::Node::Sequence({fkyaml::Node::BooleanScalar(false), fkyaml::Node::BooleanScalar(true)});
-        fkyaml::Iterator<fkyaml::Node> iterator(fkyaml::SequenceIteratorTag {}, sequence.ToSequence().begin());
-        REQUIRE(iterator.Type() == fkyaml::IteratorType::SEQUENCE);
+        fkyaml::node sequence =
+            fkyaml::node::sequence({fkyaml::node::boolean_scalar(false), fkyaml::node::boolean_scalar(true)});
+        fkyaml::iterator<fkyaml::node> iterator(fkyaml::sequence_iterator_tag {}, sequence.to_sequence().begin());
+        REQUIRE(iterator.type() == fkyaml::iterator_t::SEQUENCE);
     }
 
     SECTION("Test mapping iterator.")
     {
-        fkyaml::Node mapping = fkyaml::Node::Mapping(
-            {{"test0", fkyaml::Node::BooleanScalar(false)}, {"test1", fkyaml::Node::BooleanScalar(true)}});
-        fkyaml::Iterator<fkyaml::Node> iterator(fkyaml::MappingIteratorTag {}, mapping.ToMapping().begin());
-        REQUIRE(iterator.Type() == fkyaml::IteratorType::MAPPING);
+        fkyaml::node mapping = fkyaml::node::mapping(
+            {{"test0", fkyaml::node::boolean_scalar(false)}, {"test1", fkyaml::node::boolean_scalar(true)}});
+        fkyaml::iterator<fkyaml::node> iterator(fkyaml::mapping_iterator_tag {}, mapping.to_mapping().begin());
+        REQUIRE(iterator.type() == fkyaml::iterator_t::MAPPING);
     }
 }
 
@@ -596,19 +596,19 @@ TEST_CASE("IteratorClassTest_KeyGetterTest", "[IteratorClassTest]")
 {
     SECTION("Test sequence iterator.")
     {
-        fkyaml::Node sequence =
-            fkyaml::Node::Sequence({fkyaml::Node::BooleanScalar(false), fkyaml::Node::BooleanScalar(true)});
-        fkyaml::Iterator<fkyaml::Node> iterator(fkyaml::SequenceIteratorTag {}, sequence.ToSequence().begin());
-        REQUIRE_THROWS_AS(iterator.Key(), fkyaml::Exception);
+        fkyaml::node sequence =
+            fkyaml::node::sequence({fkyaml::node::boolean_scalar(false), fkyaml::node::boolean_scalar(true)});
+        fkyaml::iterator<fkyaml::node> iterator(fkyaml::sequence_iterator_tag {}, sequence.to_sequence().begin());
+        REQUIRE_THROWS_AS(iterator.key(), fkyaml::exception);
     }
 
     SECTION("Test mapping iterator.")
     {
-        fkyaml::Node mapping = fkyaml::Node::Mapping(
-            {{"test0", fkyaml::Node::BooleanScalar(false)}, {"test1", fkyaml::Node::BooleanScalar(true)}});
-        fkyaml::Iterator<fkyaml::Node> iterator(fkyaml::MappingIteratorTag {}, mapping.ToMapping().begin());
-        REQUIRE_NOTHROW(iterator.Key());
-        REQUIRE(iterator.Key().compare("test0") == 0);
+        fkyaml::node mapping = fkyaml::node::mapping(
+            {{"test0", fkyaml::node::boolean_scalar(false)}, {"test1", fkyaml::node::boolean_scalar(true)}});
+        fkyaml::iterator<fkyaml::node> iterator(fkyaml::mapping_iterator_tag {}, mapping.to_mapping().begin());
+        REQUIRE_NOTHROW(iterator.key());
+        REQUIRE(iterator.key().compare("test0") == 0);
     }
 }
 
@@ -616,19 +616,19 @@ TEST_CASE("IteratorClassTest_ValueGetterTest", "[IteratorClassTest]")
 {
     SECTION("Test sequence iterator.")
     {
-        fkyaml::Node sequence =
-            fkyaml::Node::Sequence({fkyaml::Node::BooleanScalar(false), fkyaml::Node::BooleanScalar(true)});
-        fkyaml::Iterator<fkyaml::Node> iterator(fkyaml::SequenceIteratorTag {}, sequence.ToSequence().begin());
-        REQUIRE(iterator.Value().IsBoolean());
-        REQUIRE(iterator.Value().ToBoolean() == false);
+        fkyaml::node sequence =
+            fkyaml::node::sequence({fkyaml::node::boolean_scalar(false), fkyaml::node::boolean_scalar(true)});
+        fkyaml::iterator<fkyaml::node> iterator(fkyaml::sequence_iterator_tag {}, sequence.to_sequence().begin());
+        REQUIRE(iterator.value().is_boolean());
+        REQUIRE(iterator.value().to_boolean() == false);
     }
 
     SECTION("Test mapping iterator.")
     {
-        fkyaml::Node mapping = fkyaml::Node::Mapping(
-            {{"test0", fkyaml::Node::BooleanScalar(false)}, {"test1", fkyaml::Node::BooleanScalar(true)}});
-        fkyaml::Iterator<fkyaml::Node> iterator(fkyaml::MappingIteratorTag {}, mapping.ToMapping().begin());
-        REQUIRE(iterator.Value().IsBoolean());
-        REQUIRE(iterator.Value().ToBoolean() == false);
+        fkyaml::node mapping = fkyaml::node::mapping(
+            {{"test0", fkyaml::node::boolean_scalar(false)}, {"test1", fkyaml::node::boolean_scalar(true)}});
+        fkyaml::iterator<fkyaml::node> iterator(fkyaml::mapping_iterator_tag {}, mapping.to_mapping().begin());
+        REQUIRE(iterator.value().is_boolean());
+        REQUIRE(iterator.value().to_boolean() == false);
     }
 }

--- a/test/unit_test/LexicalAnalyzerClassTest.cpp
+++ b/test/unit_test/LexicalAnalyzerClassTest.cpp
@@ -11,47 +11,47 @@
 #include "fkYAML/LexicalAnalyzer.hpp"
 #include "fkYAML/Node.hpp"
 
-TEST_CASE("LexicalAnalyzerClassTest_SetInputBufferTest", "[LexicalAnalyzerClassTest]")
+TEST_CASE("LexicalAnalyzerClassTest_set_input_bufferTest", "[LexicalAnalyzerClassTest]")
 {
-    fkyaml::LexicalAnalyzer<fkyaml::Node> lexer;
+    fkyaml::lexical_analyzer<fkyaml::node> lexer;
 
     SECTION("Test non-null non-empty input buffer.")
     {
-        REQUIRE_NOTHROW(lexer.SetInputBuffer("test"));
+        REQUIRE_NOTHROW(lexer.set_input_buffer("test"));
     }
 
     SECTION("Test non-null empty input buffer.")
     {
-        REQUIRE_THROWS_AS(lexer.SetInputBuffer(""), fkyaml::Exception);
+        REQUIRE_THROWS_AS(lexer.set_input_buffer(""), fkyaml::exception);
     }
 
     SECTION("Test null input buffer.")
     {
-        REQUIRE_THROWS_AS(lexer.SetInputBuffer(nullptr), fkyaml::Exception);
+        REQUIRE_THROWS_AS(lexer.set_input_buffer(nullptr), fkyaml::exception);
     }
 }
 
 TEST_CASE("LexicalAnalyzerClassTest_ScanYamlVersionDirectiveTest", "[LexicalAnalyzerClassTest]")
 {
-    fkyaml::LexicalAnalyzer<fkyaml::Node> lexer;
-    fkyaml::LexicalTokenType token;
+    fkyaml::lexical_analyzer<fkyaml::node> lexer;
+    fkyaml::lexical_token_t token;
 
     SECTION("Test nothrow expected tokens.")
     {
-        using ValuePair = std::pair<std::string, std::string>;
+        using value_pair_t = std::pair<std::string, std::string>;
         auto value_pair = GENERATE(
-            ValuePair(std::string("%YAML 1.1\r"), std::string("1.1")),
-            ValuePair(std::string("%YAML 1.2\n"), std::string("1.2")),
-            ValuePair(std::string("%YAML 1.2 "), std::string("1.2")));
+            value_pair_t(std::string("%YAML 1.1\r"), std::string("1.1")),
+            value_pair_t(std::string("%YAML 1.2\n"), std::string("1.2")),
+            value_pair_t(std::string("%YAML 1.2 "), std::string("1.2")));
 
-        lexer.SetInputBuffer(value_pair.first.c_str());
+        lexer.set_input_buffer(value_pair.first.c_str());
 
-        REQUIRE_NOTHROW(token = lexer.GetNextToken());
-        REQUIRE(token == fkyaml::LexicalTokenType::YAML_VER_DIRECTIVE);
-        REQUIRE(lexer.GetYamlVersion() == value_pair.second);
+        REQUIRE_NOTHROW(token = lexer.get_next_token());
+        REQUIRE(token == fkyaml::lexical_token_t::YAML_VER_DIRECTIVE);
+        REQUIRE(lexer.get_yaml_version() == value_pair.second);
 
-        REQUIRE_NOTHROW(token = lexer.GetNextToken());
-        REQUIRE(token == fkyaml::LexicalTokenType::END_OF_BUFFER);
+        REQUIRE_NOTHROW(token = lexer.get_next_token());
+        REQUIRE(token == fkyaml::lexical_token_t::END_OF_BUFFER);
     }
 
     SECTION("Test nothrow expected tokens with invalid content.")
@@ -62,12 +62,12 @@ TEST_CASE("LexicalAnalyzerClassTest_ScanYamlVersionDirectiveTest", "[LexicalAnal
             std::string("%YANR 1.2 \r\n"),
             std::string("%YANL 1.2    \n"));
 
-        lexer.SetInputBuffer(buffer.c_str());
-        REQUIRE_NOTHROW(token = lexer.GetNextToken());
-        REQUIRE(token == fkyaml::LexicalTokenType::INVALID_DIRECTIVE);
+        lexer.set_input_buffer(buffer.c_str());
+        REQUIRE_NOTHROW(token = lexer.get_next_token());
+        REQUIRE(token == fkyaml::lexical_token_t::INVALID_DIRECTIVE);
 
-        REQUIRE_NOTHROW(token = lexer.GetNextToken());
-        REQUIRE(token == fkyaml::LexicalTokenType::END_OF_BUFFER);
+        REQUIRE_NOTHROW(token = lexer.get_next_token());
+        REQUIRE(token == fkyaml::lexical_token_t::END_OF_BUFFER);
     }
 
     SECTION("Test nothrow unexpected tokens.")
@@ -82,8 +82,8 @@ TEST_CASE("LexicalAnalyzerClassTest_ScanYamlVersionDirectiveTest", "[LexicalAnal
             std::string("%YAML1.2 "),
             std::string("%YAML AbC"));
 
-        lexer.SetInputBuffer(buffer.c_str());
-        REQUIRE_THROWS_AS(lexer.GetNextToken(), fkyaml::Exception);
+        lexer.set_input_buffer(buffer.c_str());
+        REQUIRE_THROWS_AS(lexer.get_next_token(), fkyaml::exception);
     }
 }
 
@@ -92,196 +92,196 @@ TEST_CASE("LexicalAnalyzerClassTest_ScanReservedDirectiveTest", "[LexicalAnalyze
     auto buffer =
         GENERATE(std::string("%TEST"), std::string("%1984\n"), std::string("%TEST4LIB\r"), std::string("%%ERROR\r\n"));
 
-    fkyaml::LexicalAnalyzer<fkyaml::Node> lexer;
-    fkyaml::LexicalTokenType token;
-    lexer.SetInputBuffer(buffer.c_str());
-    REQUIRE_NOTHROW(token = lexer.GetNextToken());
-    REQUIRE(token == fkyaml::LexicalTokenType::INVALID_DIRECTIVE);
+    fkyaml::lexical_analyzer<fkyaml::node> lexer;
+    fkyaml::lexical_token_t token;
+    lexer.set_input_buffer(buffer.c_str());
+    REQUIRE_NOTHROW(token = lexer.get_next_token());
+    REQUIRE(token == fkyaml::lexical_token_t::INVALID_DIRECTIVE);
 
-    REQUIRE_NOTHROW(token = lexer.GetNextToken());
-    REQUIRE(token == fkyaml::LexicalTokenType::END_OF_BUFFER);
+    REQUIRE_NOTHROW(token = lexer.get_next_token());
+    REQUIRE(token == fkyaml::lexical_token_t::END_OF_BUFFER);
 }
 
 TEST_CASE("LexicalAnalyzerClassTest_ScanBeforeInputBufferSetTest", "[LexicalAnalyzerClassTest]")
 {
-    fkyaml::LexicalAnalyzer<fkyaml::Node> lexer;
-    REQUIRE_THROWS_AS(lexer.GetNextToken(), fkyaml::Exception);
+    fkyaml::lexical_analyzer<fkyaml::node> lexer;
+    REQUIRE_THROWS_AS(lexer.get_next_token(), fkyaml::exception);
 }
 
 TEST_CASE("LexicalAnalyzerClassTest_ScanColonTest", "[LexicalAnalyzerClassTest]")
 {
-    fkyaml::LexicalAnalyzer<fkyaml::Node> lexer;
-    fkyaml::LexicalTokenType token;
+    fkyaml::lexical_analyzer<fkyaml::node> lexer;
+    fkyaml::lexical_token_t token;
 
     SECTION("Test colon with half-width space.")
     {
-        lexer.SetInputBuffer(": ");
-        REQUIRE_NOTHROW(token = lexer.GetNextToken());
-        REQUIRE(token == fkyaml::LexicalTokenType::KEY_SEPARATOR);
+        lexer.set_input_buffer(": ");
+        REQUIRE_NOTHROW(token = lexer.get_next_token());
+        REQUIRE(token == fkyaml::lexical_token_t::KEY_SEPARATOR);
     }
 
     SECTION("Test colon with CR newline code.")
     {
-        lexer.SetInputBuffer(":\r");
-        REQUIRE_NOTHROW(token = lexer.GetNextToken());
-        REQUIRE(token == fkyaml::LexicalTokenType::MAPPING_BLOCK_PREFIX);
+        lexer.set_input_buffer(":\r");
+        REQUIRE_NOTHROW(token = lexer.get_next_token());
+        REQUIRE(token == fkyaml::lexical_token_t::MAPPING_BLOCK_PREFIX);
     }
 
     SECTION("Test colon with CRLF newline code.")
     {
-        lexer.SetInputBuffer(":\r\n");
-        REQUIRE_NOTHROW(token = lexer.GetNextToken());
-        REQUIRE(token == fkyaml::LexicalTokenType::MAPPING_BLOCK_PREFIX);
+        lexer.set_input_buffer(":\r\n");
+        REQUIRE_NOTHROW(token = lexer.get_next_token());
+        REQUIRE(token == fkyaml::lexical_token_t::MAPPING_BLOCK_PREFIX);
     }
 
     SECTION("Test colon with LF newline code.")
     {
-        lexer.SetInputBuffer(":\n");
-        REQUIRE_NOTHROW(token = lexer.GetNextToken());
-        REQUIRE(token == fkyaml::LexicalTokenType::MAPPING_BLOCK_PREFIX);
+        lexer.set_input_buffer(":\n");
+        REQUIRE_NOTHROW(token = lexer.get_next_token());
+        REQUIRE(token == fkyaml::lexical_token_t::MAPPING_BLOCK_PREFIX);
     }
 
     SECTION("Test colon with non-newline-code character.")
     {
-        lexer.SetInputBuffer(":test");
-        REQUIRE_THROWS_AS(token = lexer.GetNextToken(), fkyaml::Exception);
+        lexer.set_input_buffer(":test");
+        REQUIRE_THROWS_AS(token = lexer.get_next_token(), fkyaml::exception);
     }
 }
 
 TEST_CASE("LexicalAnalyzerClassTest_ScanNullTokenTest", "[LexicalAnalyzerClassTest]")
 {
-    fkyaml::LexicalAnalyzer<fkyaml::Node> lexer;
-    fkyaml::LexicalTokenType token;
+    fkyaml::lexical_analyzer<fkyaml::node> lexer;
+    fkyaml::lexical_token_t token;
 
     SECTION("Test nothrow expected tokens.")
     {
         auto buffer = GENERATE(std::string("null"), std::string("Null"), std::string("NULL"), std::string("~"));
-        lexer.SetInputBuffer(buffer.c_str());
+        lexer.set_input_buffer(buffer.c_str());
 
-        REQUIRE_NOTHROW(token = lexer.GetNextToken());
-        REQUIRE(token == fkyaml::LexicalTokenType::NULL_VALUE);
-        REQUIRE_NOTHROW(lexer.GetNull());
-        REQUIRE(lexer.GetNull() == nullptr);
+        REQUIRE_NOTHROW(token = lexer.get_next_token());
+        REQUIRE(token == fkyaml::lexical_token_t::NULL_VALUE);
+        REQUIRE_NOTHROW(lexer.get_null());
+        REQUIRE(lexer.get_null() == nullptr);
     }
 
     SECTION("Test nothrow unexpected tokens.")
     {
-        lexer.SetInputBuffer("test");
-        REQUIRE_NOTHROW(lexer.GetNextToken());
-        REQUIRE_THROWS_AS(lexer.GetNull(), fkyaml::Exception);
+        lexer.set_input_buffer("test");
+        REQUIRE_NOTHROW(lexer.get_next_token());
+        REQUIRE_THROWS_AS(lexer.get_null(), fkyaml::exception);
     }
 }
 
 TEST_CASE("LexicalAnalyzerClassTest_ScanBooleanTrueTokenTest", "[LexicalAnalyzerClassTest]")
 {
-    fkyaml::LexicalAnalyzer<fkyaml::Node> lexer;
-    fkyaml::LexicalTokenType token;
+    fkyaml::lexical_analyzer<fkyaml::node> lexer;
+    fkyaml::lexical_token_t token;
 
     SECTION("Test nothrow expected tokens.")
     {
         auto buffer = GENERATE(std::string("true"), std::string("True"), std::string("TRUE"));
-        lexer.SetInputBuffer(buffer.c_str());
+        lexer.set_input_buffer(buffer.c_str());
 
-        REQUIRE_NOTHROW(token = lexer.GetNextToken());
-        REQUIRE(token == fkyaml::LexicalTokenType::BOOLEAN_VALUE);
-        REQUIRE_NOTHROW(lexer.GetBoolean());
-        REQUIRE(lexer.GetBoolean() == true);
+        REQUIRE_NOTHROW(token = lexer.get_next_token());
+        REQUIRE(token == fkyaml::lexical_token_t::BOOLEAN_VALUE);
+        REQUIRE_NOTHROW(lexer.get_boolean());
+        REQUIRE(lexer.get_boolean() == true);
     }
 
     SECTION("Test nothrow unexpected tokens.")
     {
-        lexer.SetInputBuffer("test");
-        REQUIRE_NOTHROW(lexer.GetNextToken());
-        REQUIRE_THROWS_AS(lexer.GetBoolean(), fkyaml::Exception);
+        lexer.set_input_buffer("test");
+        REQUIRE_NOTHROW(lexer.get_next_token());
+        REQUIRE_THROWS_AS(lexer.get_boolean(), fkyaml::exception);
     }
 }
 
 TEST_CASE("LexicalAnalyzerClassTest_ScanBooleanFalseTokenTest", "[LexicalAnalyzerClassTest]")
 {
     auto buffer = GENERATE(std::string("false"), std::string("False"), std::string("FALSE"));
-    fkyaml::LexicalAnalyzer<fkyaml::Node> lexer;
-    lexer.SetInputBuffer(buffer.c_str());
-    fkyaml::LexicalTokenType token;
+    fkyaml::lexical_analyzer<fkyaml::node> lexer;
+    lexer.set_input_buffer(buffer.c_str());
+    fkyaml::lexical_token_t token;
 
-    REQUIRE_NOTHROW(token = lexer.GetNextToken());
-    REQUIRE(token == fkyaml::LexicalTokenType::BOOLEAN_VALUE);
-    REQUIRE_NOTHROW(lexer.GetBoolean());
-    REQUIRE(lexer.GetBoolean() == false);
+    REQUIRE_NOTHROW(token = lexer.get_next_token());
+    REQUIRE(token == fkyaml::lexical_token_t::BOOLEAN_VALUE);
+    REQUIRE_NOTHROW(lexer.get_boolean());
+    REQUIRE(lexer.get_boolean() == false);
 }
 
 TEST_CASE("LexicalAnalyzerClassTest_ScanIntegerTokenTest", "[LexicalAnalyzerClassTest]")
 {
-    using ValuePair = std::pair<std::string, fkyaml::NodeIntegerType>;
+    using value_pair_t = std::pair<std::string, fkyaml::node_integer_type>;
     auto value_pair = GENERATE(
-        ValuePair(std::string("-1234"), -1234),
-        ValuePair(std::string("-853255"), -853255),
-        ValuePair(std::string("-1"), -1));
+        value_pair_t(std::string("-1234"), -1234),
+        value_pair_t(std::string("-853255"), -853255),
+        value_pair_t(std::string("-1"), -1));
 
-    fkyaml::LexicalAnalyzer<fkyaml::Node> lexer;
-    lexer.SetInputBuffer(value_pair.first.c_str());
-    fkyaml::LexicalTokenType token;
+    fkyaml::lexical_analyzer<fkyaml::node> lexer;
+    lexer.set_input_buffer(value_pair.first.c_str());
+    fkyaml::lexical_token_t token;
 
-    REQUIRE_NOTHROW(token = lexer.GetNextToken());
-    REQUIRE(token == fkyaml::LexicalTokenType::INTEGER_VALUE);
-    REQUIRE_NOTHROW(lexer.GetInteger());
-    REQUIRE(lexer.GetInteger() == value_pair.second);
+    REQUIRE_NOTHROW(token = lexer.get_next_token());
+    REQUIRE(token == fkyaml::lexical_token_t::INTEGER_VALUE);
+    REQUIRE_NOTHROW(lexer.get_integer());
+    REQUIRE(lexer.get_integer() == value_pair.second);
 }
 
 TEST_CASE("LexicalAnalyzerClassTest_ScanOctalNumberTokenTest", "[LexicalAnalyzerClassTest]")
 {
-    using ValuePair = std::pair<std::string, fkyaml::NodeIntegerType>;
+    using value_pair_t = std::pair<std::string, fkyaml::node_integer_type>;
     auto value_pair = GENERATE(
-        ValuePair(std::string("0o27"), 027),
-        ValuePair(std::string("0o5"), 05),
-        ValuePair(std::string("0o77772"), 077772));
+        value_pair_t(std::string("0o27"), 027),
+        value_pair_t(std::string("0o5"), 05),
+        value_pair_t(std::string("0o77772"), 077772));
 
-    fkyaml::LexicalAnalyzer<fkyaml::Node> lexer;
-    lexer.SetInputBuffer(value_pair.first.c_str());
-    fkyaml::LexicalTokenType token;
+    fkyaml::lexical_analyzer<fkyaml::node> lexer;
+    lexer.set_input_buffer(value_pair.first.c_str());
+    fkyaml::lexical_token_t token;
 
-    REQUIRE_NOTHROW(token = lexer.GetNextToken());
-    REQUIRE(token == fkyaml::LexicalTokenType::INTEGER_VALUE);
-    REQUIRE_NOTHROW(lexer.GetInteger());
-    REQUIRE(lexer.GetInteger() == value_pair.second);
+    REQUIRE_NOTHROW(token = lexer.get_next_token());
+    REQUIRE(token == fkyaml::lexical_token_t::INTEGER_VALUE);
+    REQUIRE_NOTHROW(lexer.get_integer());
+    REQUIRE(lexer.get_integer() == value_pair.second);
 }
 
 TEST_CASE("LexicalAnalyzerClassTest_ScanHexadecimalNumberTokenTest", "[LexicalAnalyzerClassTest]")
 {
-    using ValuePair = std::pair<std::string, fkyaml::NodeIntegerType>;
+    using value_pair_t = std::pair<std::string, fkyaml::node_integer_type>;
     auto value_pair = GENERATE(
-        ValuePair(std::string("0xA04F"), 0xA04F),
-        ValuePair(std::string("0xa7F3"), 0xa7F3),
-        ValuePair(std::string("0xFf29Bc"), 0xFf29Bc));
+        value_pair_t(std::string("0xA04F"), 0xA04F),
+        value_pair_t(std::string("0xa7F3"), 0xa7F3),
+        value_pair_t(std::string("0xFf29Bc"), 0xFf29Bc));
 
-    fkyaml::LexicalAnalyzer<fkyaml::Node> lexer;
-    lexer.SetInputBuffer(value_pair.first.c_str());
-    fkyaml::LexicalTokenType token;
+    fkyaml::lexical_analyzer<fkyaml::node> lexer;
+    lexer.set_input_buffer(value_pair.first.c_str());
+    fkyaml::lexical_token_t token;
 
-    REQUIRE_NOTHROW(token = lexer.GetNextToken());
-    REQUIRE(token == fkyaml::LexicalTokenType::INTEGER_VALUE);
-    REQUIRE_NOTHROW(lexer.GetInteger());
-    REQUIRE(lexer.GetInteger() == value_pair.second);
+    REQUIRE_NOTHROW(token = lexer.get_next_token());
+    REQUIRE(token == fkyaml::lexical_token_t::INTEGER_VALUE);
+    REQUIRE_NOTHROW(lexer.get_integer());
+    REQUIRE(lexer.get_integer() == value_pair.second);
 }
 
 TEST_CASE("LexicalAnalyzerClassTest_ScanFloatNumberTokenTest", "[LexicalAnalyzerClassTest]")
 {
-    using ValuePair = std::pair<std::string, fkyaml::NodeFloatNumberType>;
+    using value_pair_t = std::pair<std::string, fkyaml::node_float_number_type>;
     auto value_pair = GENERATE(
-        ValuePair(std::string("-1.234"), -1.234),
-        ValuePair(std::string("567.8"), 567.8),
-        ValuePair(std::string("0.24"), 0.24),
-        ValuePair(std::string("9.8e-3"), 9.8e-3),
-        ValuePair(std::string("3.95e3"), 3.95e3),
-        ValuePair(std::string("1.863e+3"), 1.863e+3));
+        value_pair_t(std::string("-1.234"), -1.234),
+        value_pair_t(std::string("567.8"), 567.8),
+        value_pair_t(std::string("0.24"), 0.24),
+        value_pair_t(std::string("9.8e-3"), 9.8e-3),
+        value_pair_t(std::string("3.95e3"), 3.95e3),
+        value_pair_t(std::string("1.863e+3"), 1.863e+3));
 
-    fkyaml::LexicalAnalyzer<fkyaml::Node> lexer;
-    lexer.SetInputBuffer(value_pair.first.c_str());
-    fkyaml::LexicalTokenType token;
+    fkyaml::lexical_analyzer<fkyaml::node> lexer;
+    lexer.set_input_buffer(value_pair.first.c_str());
+    fkyaml::lexical_token_t token;
 
-    REQUIRE_NOTHROW(token = lexer.GetNextToken());
-    REQUIRE(token == fkyaml::LexicalTokenType::FLOAT_NUMBER_VALUE);
-    REQUIRE_NOTHROW(lexer.GetFloatNumber());
-    REQUIRE(lexer.GetFloatNumber() == value_pair.second);
+    REQUIRE_NOTHROW(token = lexer.get_next_token());
+    REQUIRE(token == fkyaml::lexical_token_t::FLOAT_NUMBER_VALUE);
+    REQUIRE_NOTHROW(lexer.get_float_number());
+    REQUIRE(lexer.get_float_number() == value_pair.second);
 }
 
 TEST_CASE("LexicalAnalyzerClassTest_ScanInfinityTokenTest", "[LexicalAnalyzerClassTest]")
@@ -293,94 +293,94 @@ TEST_CASE("LexicalAnalyzerClassTest_ScanInfinityTokenTest", "[LexicalAnalyzerCla
         std::string("-.inf"),
         std::string("-.Inf"),
         std::string("-.INF"));
-    fkyaml::LexicalAnalyzer<fkyaml::Node> lexer;
-    lexer.SetInputBuffer(buffer.c_str());
+    fkyaml::lexical_analyzer<fkyaml::node> lexer;
+    lexer.set_input_buffer(buffer.c_str());
 
     SECTION("Test nothrow expected buffers.")
     {
-        REQUIRE_NOTHROW(lexer.GetNextToken());
+        REQUIRE_NOTHROW(lexer.get_next_token());
     }
 
     SECTION("Test result of positive infinity literal tokens.")
     {
-        REQUIRE(lexer.GetNextToken() == fkyaml::LexicalTokenType::FLOAT_NUMBER_VALUE);
-        REQUIRE_NOTHROW(lexer.GetFloatNumber());
-        REQUIRE(std::isinf(lexer.GetFloatNumber()) == true);
+        REQUIRE(lexer.get_next_token() == fkyaml::lexical_token_t::FLOAT_NUMBER_VALUE);
+        REQUIRE_NOTHROW(lexer.get_float_number());
+        REQUIRE(std::isinf(lexer.get_float_number()) == true);
     }
 }
 
 TEST_CASE("LexicalAnalyzerClassTest_ScanNaNTokenTest", "[LexicalAnalyzerClassTest]")
 {
     auto buffer = GENERATE(std::string(".nan"), std::string(".NaN"), std::string(".NAN"));
-    fkyaml::LexicalAnalyzer<fkyaml::Node> lexer;
-    lexer.SetInputBuffer(buffer.c_str());
+    fkyaml::lexical_analyzer<fkyaml::node> lexer;
+    lexer.set_input_buffer(buffer.c_str());
 
     SECTION("Test nothrow expected buffers.")
     {
-        REQUIRE_NOTHROW(lexer.GetNextToken());
+        REQUIRE_NOTHROW(lexer.get_next_token());
     }
 
     SECTION("Test result of scanning NaN literal tokens.")
     {
-        REQUIRE(lexer.GetNextToken() == fkyaml::LexicalTokenType::FLOAT_NUMBER_VALUE);
-        REQUIRE_NOTHROW(lexer.GetFloatNumber());
-        REQUIRE(std::isnan(lexer.GetFloatNumber()) == true);
+        REQUIRE(lexer.get_next_token() == fkyaml::lexical_token_t::FLOAT_NUMBER_VALUE);
+        REQUIRE_NOTHROW(lexer.get_float_number());
+        REQUIRE(std::isnan(lexer.get_float_number()) == true);
     }
 }
 
 TEST_CASE("LexicalAnalyzerClassTest_ScanInvalidNumberTokenTest", "[LexicalAnalyzerClassTest]")
 {
     auto buffer = GENERATE(std::string("-.test"), std::string("1.0.0"));
-    fkyaml::LexicalAnalyzer<fkyaml::Node> lexer;
-    lexer.SetInputBuffer(buffer.c_str());
-    REQUIRE_THROWS_AS(lexer.GetNextToken(), fkyaml::Exception);
+    fkyaml::lexical_analyzer<fkyaml::node> lexer;
+    lexer.set_input_buffer(buffer.c_str());
+    REQUIRE_THROWS_AS(lexer.get_next_token(), fkyaml::exception);
 }
 
 TEST_CASE("LexicalAnalyzerClassTest_ScanStringTokenTest", "[LexicalAnalyzerClassTest]")
 {
-    using ValuePair = std::pair<std::string, fkyaml::NodeStringType>;
+    using value_pair_t = std::pair<std::string, fkyaml::node_string_type>;
     auto value_pair = GENERATE(
-        ValuePair(std::string("\"\""), fkyaml::NodeStringType("")),
-        ValuePair(std::string("\'\'"), fkyaml::NodeStringType("")),
-        ValuePair(std::string("test"), fkyaml::NodeStringType("test")),
-        ValuePair(std::string("nop"), fkyaml::NodeStringType("nop")),
-        ValuePair(std::string(".NET"), fkyaml::NodeStringType(".NET")),
-        ValuePair(std::string("foo:bar"), fkyaml::NodeStringType("foo:bar")),
-        ValuePair(std::string("\"foo bar\""), fkyaml::NodeStringType("foo bar")),
-        ValuePair(std::string("\"foo:bar\""), fkyaml::NodeStringType("foo:bar")),
-        ValuePair(std::string("\"foo,bar\""), fkyaml::NodeStringType("foo,bar")),
-        ValuePair(std::string("\"foo]bar\""), fkyaml::NodeStringType("foo]bar")),
-        ValuePair(std::string("\"foo}bar\""), fkyaml::NodeStringType("foo}bar")),
-        ValuePair(std::string("\"foo\\abar\""), fkyaml::NodeStringType("foo\abar")),
-        ValuePair(std::string("\"foo\\bbar\""), fkyaml::NodeStringType("foo\bbar")),
-        ValuePair(std::string("\"foo\\tbar\""), fkyaml::NodeStringType("foo\tbar")),
-        ValuePair(std::string("\"foo\tbar\""), fkyaml::NodeStringType("foo\tbar")),
-        ValuePair(std::string("\"foo\\nbar\""), fkyaml::NodeStringType("foo\nbar")),
-        ValuePair(std::string("\"foo\\vbar\""), fkyaml::NodeStringType("foo\vbar")),
-        ValuePair(std::string("\"foo\\fbar\""), fkyaml::NodeStringType("foo\fbar")),
-        ValuePair(std::string("\"foo\\rbar\""), fkyaml::NodeStringType("foo\rbar")),
-        ValuePair(std::string("\"foo\\ebar\""), fkyaml::NodeStringType("foo\u001Bbar")),
-        ValuePair(std::string("\"foo\\ bar\""), fkyaml::NodeStringType("foo bar")),
-        ValuePair(std::string("\"foo\\\"bar\""), fkyaml::NodeStringType("foo\"bar")),
-        ValuePair(std::string("\"foo\\/bar\""), fkyaml::NodeStringType("foo/bar")),
-        ValuePair(std::string("\"foo\\\\bar\""), fkyaml::NodeStringType("foo\\bar")),
-        ValuePair(std::string("\"\\x30\\x2B\\x6d\""), fkyaml::NodeStringType("0+m")),
-        ValuePair(std::string("\'foo bar\'"), fkyaml::NodeStringType("foo bar")),
-        ValuePair(std::string("\'foo\'\'bar\'"), fkyaml::NodeStringType("foo\'bar")),
-        ValuePair(std::string("\'foo,bar\'"), fkyaml::NodeStringType("foo,bar")),
-        ValuePair(std::string("\'foo]bar\'"), fkyaml::NodeStringType("foo]bar")),
-        ValuePair(std::string("\'foo}bar\'"), fkyaml::NodeStringType("foo}bar")),
-        ValuePair(std::string("\'foo\"bar\'"), fkyaml::NodeStringType("foo\"bar")),
-        ValuePair(std::string("\'foo:bar\'"), fkyaml::NodeStringType("foo:bar")));
+        value_pair_t(std::string("\"\""), fkyaml::node_string_type("")),
+        value_pair_t(std::string("\'\'"), fkyaml::node_string_type("")),
+        value_pair_t(std::string("test"), fkyaml::node_string_type("test")),
+        value_pair_t(std::string("nop"), fkyaml::node_string_type("nop")),
+        value_pair_t(std::string(".NET"), fkyaml::node_string_type(".NET")),
+        value_pair_t(std::string("foo:bar"), fkyaml::node_string_type("foo:bar")),
+        value_pair_t(std::string("\"foo bar\""), fkyaml::node_string_type("foo bar")),
+        value_pair_t(std::string("\"foo:bar\""), fkyaml::node_string_type("foo:bar")),
+        value_pair_t(std::string("\"foo,bar\""), fkyaml::node_string_type("foo,bar")),
+        value_pair_t(std::string("\"foo]bar\""), fkyaml::node_string_type("foo]bar")),
+        value_pair_t(std::string("\"foo}bar\""), fkyaml::node_string_type("foo}bar")),
+        value_pair_t(std::string("\"foo\\abar\""), fkyaml::node_string_type("foo\abar")),
+        value_pair_t(std::string("\"foo\\bbar\""), fkyaml::node_string_type("foo\bbar")),
+        value_pair_t(std::string("\"foo\\tbar\""), fkyaml::node_string_type("foo\tbar")),
+        value_pair_t(std::string("\"foo\tbar\""), fkyaml::node_string_type("foo\tbar")),
+        value_pair_t(std::string("\"foo\\nbar\""), fkyaml::node_string_type("foo\nbar")),
+        value_pair_t(std::string("\"foo\\vbar\""), fkyaml::node_string_type("foo\vbar")),
+        value_pair_t(std::string("\"foo\\fbar\""), fkyaml::node_string_type("foo\fbar")),
+        value_pair_t(std::string("\"foo\\rbar\""), fkyaml::node_string_type("foo\rbar")),
+        value_pair_t(std::string("\"foo\\ebar\""), fkyaml::node_string_type("foo\u001Bbar")),
+        value_pair_t(std::string("\"foo\\ bar\""), fkyaml::node_string_type("foo bar")),
+        value_pair_t(std::string("\"foo\\\"bar\""), fkyaml::node_string_type("foo\"bar")),
+        value_pair_t(std::string("\"foo\\/bar\""), fkyaml::node_string_type("foo/bar")),
+        value_pair_t(std::string("\"foo\\\\bar\""), fkyaml::node_string_type("foo\\bar")),
+        value_pair_t(std::string("\"\\x30\\x2B\\x6d\""), fkyaml::node_string_type("0+m")),
+        value_pair_t(std::string("\'foo bar\'"), fkyaml::node_string_type("foo bar")),
+        value_pair_t(std::string("\'foo\'\'bar\'"), fkyaml::node_string_type("foo\'bar")),
+        value_pair_t(std::string("\'foo,bar\'"), fkyaml::node_string_type("foo,bar")),
+        value_pair_t(std::string("\'foo]bar\'"), fkyaml::node_string_type("foo]bar")),
+        value_pair_t(std::string("\'foo}bar\'"), fkyaml::node_string_type("foo}bar")),
+        value_pair_t(std::string("\'foo\"bar\'"), fkyaml::node_string_type("foo\"bar")),
+        value_pair_t(std::string("\'foo:bar\'"), fkyaml::node_string_type("foo:bar")));
 
-    fkyaml::LexicalAnalyzer<fkyaml::Node> lexer;
-    lexer.SetInputBuffer(value_pair.first.c_str());
-    fkyaml::LexicalTokenType token;
+    fkyaml::lexical_analyzer<fkyaml::node> lexer;
+    lexer.set_input_buffer(value_pair.first.c_str());
+    fkyaml::lexical_token_t token;
 
-    REQUIRE_NOTHROW(token = lexer.GetNextToken());
-    REQUIRE(token == fkyaml::LexicalTokenType::STRING_VALUE);
-    REQUIRE_NOTHROW(lexer.GetString());
-    REQUIRE(lexer.GetString() == value_pair.second);
+    REQUIRE_NOTHROW(token = lexer.get_next_token());
+    REQUIRE(token == fkyaml::lexical_token_t::STRING_VALUE);
+    REQUIRE_NOTHROW(lexer.get_string());
+    REQUIRE(lexer.get_string() == value_pair.second);
 }
 
 TEST_CASE("LexicalAnalyzerClassTest_ScanInvalidStringTokenTest", "[LexicalAnalyzerClassTest]")
@@ -397,9 +397,9 @@ TEST_CASE("LexicalAnalyzerClassTest_ScanInvalidStringTokenTest", "[LexicalAnalyz
         std::string("\"\\N\""),
         std::string("\u0080"));
 
-    fkyaml::LexicalAnalyzer<fkyaml::Node> lexer;
-    lexer.SetInputBuffer(buffer.c_str());
-    REQUIRE_THROWS_AS(lexer.GetNextToken(), fkyaml::Exception);
+    fkyaml::lexical_analyzer<fkyaml::node> lexer;
+    lexer.set_input_buffer(buffer.c_str());
+    REQUIRE_THROWS_AS(lexer.get_next_token(), fkyaml::exception);
 }
 
 TEST_CASE("LexicalAnalyzerClassTest_ScanUnescapedControlCharacter", "[LexicalAnalyzerClassTest]")
@@ -436,101 +436,101 @@ TEST_CASE("LexicalAnalyzerClassTest_ScanUnescapedControlCharacter", "[LexicalAna
     std::string buffer("test");
     buffer.push_back(unescaped_char);
 
-    fkyaml::LexicalAnalyzer<fkyaml::Node> lexer;
-    lexer.SetInputBuffer(buffer.c_str());
-    REQUIRE_THROWS_AS(lexer.GetNextToken(), fkyaml::Exception);
+    fkyaml::lexical_analyzer<fkyaml::node> lexer;
+    lexer.set_input_buffer(buffer.c_str());
+    REQUIRE_THROWS_AS(lexer.get_next_token(), fkyaml::exception);
 }
 
 TEST_CASE("LexicalAnalyzerClassTest_ScanAnchorTokenTest", "[LexicalAnalyzerClassTest]")
 {
-    fkyaml::LexicalAnalyzer<fkyaml::Node> lexer;
-    fkyaml::LexicalTokenType token;
+    fkyaml::lexical_analyzer<fkyaml::node> lexer;
+    fkyaml::lexical_token_t token;
 
     SECTION("Test nothorw expected tokens with an anchor.")
     {
-        lexer.SetInputBuffer("test: &anchor foo");
+        lexer.set_input_buffer("test: &anchor foo");
 
-        REQUIRE_NOTHROW(token = lexer.GetNextToken());
-        REQUIRE(token == fkyaml::LexicalTokenType::STRING_VALUE);
-        REQUIRE_NOTHROW(lexer.GetString());
-        REQUIRE(lexer.GetString().compare("test") == 0);
+        REQUIRE_NOTHROW(token = lexer.get_next_token());
+        REQUIRE(token == fkyaml::lexical_token_t::STRING_VALUE);
+        REQUIRE_NOTHROW(lexer.get_string());
+        REQUIRE(lexer.get_string().compare("test") == 0);
 
-        REQUIRE_NOTHROW(token = lexer.GetNextToken());
-        REQUIRE(token == fkyaml::LexicalTokenType::KEY_SEPARATOR);
+        REQUIRE_NOTHROW(token = lexer.get_next_token());
+        REQUIRE(token == fkyaml::lexical_token_t::KEY_SEPARATOR);
 
-        REQUIRE_NOTHROW(token = lexer.GetNextToken());
-        REQUIRE(token == fkyaml::LexicalTokenType::ANCHOR_PREFIX);
-        REQUIRE_NOTHROW(lexer.GetString());
-        REQUIRE(lexer.GetString().compare("anchor") == 0);
+        REQUIRE_NOTHROW(token = lexer.get_next_token());
+        REQUIRE(token == fkyaml::lexical_token_t::ANCHOR_PREFIX);
+        REQUIRE_NOTHROW(lexer.get_string());
+        REQUIRE(lexer.get_string().compare("anchor") == 0);
 
-        REQUIRE_NOTHROW(token = lexer.GetNextToken());
-        REQUIRE(token == fkyaml::LexicalTokenType::STRING_VALUE);
-        REQUIRE_NOTHROW(lexer.GetString());
-        REQUIRE(lexer.GetString().compare("foo") == 0);
+        REQUIRE_NOTHROW(token = lexer.get_next_token());
+        REQUIRE(token == fkyaml::lexical_token_t::STRING_VALUE);
+        REQUIRE_NOTHROW(lexer.get_string());
+        REQUIRE(lexer.get_string().compare("foo") == 0);
 
-        REQUIRE_NOTHROW(token = lexer.GetNextToken());
-        REQUIRE(token == fkyaml::LexicalTokenType::END_OF_BUFFER);
+        REQUIRE_NOTHROW(token = lexer.get_next_token());
+        REQUIRE(token == fkyaml::lexical_token_t::END_OF_BUFFER);
     }
 
     SECTION("Test nothrow unexpected tokens with an anchor.")
     {
         auto buffer =
             GENERATE(std::string("test: &anchor"), std::string("test: &anchor\r\n"), std::string("test: &anchor\n"));
-        lexer.SetInputBuffer(buffer.c_str());
+        lexer.set_input_buffer(buffer.c_str());
 
-        REQUIRE_NOTHROW(token = lexer.GetNextToken());
-        REQUIRE(token == fkyaml::LexicalTokenType::STRING_VALUE);
-        REQUIRE_NOTHROW(lexer.GetString());
-        REQUIRE(lexer.GetString().compare("test") == 0);
+        REQUIRE_NOTHROW(token = lexer.get_next_token());
+        REQUIRE(token == fkyaml::lexical_token_t::STRING_VALUE);
+        REQUIRE_NOTHROW(lexer.get_string());
+        REQUIRE(lexer.get_string().compare("test") == 0);
 
-        REQUIRE_NOTHROW(token = lexer.GetNextToken());
-        REQUIRE(token == fkyaml::LexicalTokenType::KEY_SEPARATOR);
+        REQUIRE_NOTHROW(token = lexer.get_next_token());
+        REQUIRE(token == fkyaml::lexical_token_t::KEY_SEPARATOR);
 
-        REQUIRE_THROWS_AS(token = lexer.GetNextToken(), fkyaml::Exception);
+        REQUIRE_THROWS_AS(token = lexer.get_next_token(), fkyaml::exception);
     }
 }
 
 TEST_CASE("LexicalAnalyzerClassTest_ScanAliasTokenTest", "[LexicalAnalyzerClassTest]")
 {
-    fkyaml::LexicalAnalyzer<fkyaml::Node> lexer;
-    fkyaml::LexicalTokenType token;
+    fkyaml::lexical_analyzer<fkyaml::node> lexer;
+    fkyaml::lexical_token_t token;
 
     SECTION("Test nothrow expected tokens with an alias.")
     {
-        lexer.SetInputBuffer("test: *anchor");
+        lexer.set_input_buffer("test: *anchor");
 
-        REQUIRE_NOTHROW(token = lexer.GetNextToken());
-        REQUIRE(token == fkyaml::LexicalTokenType::STRING_VALUE);
-        REQUIRE_NOTHROW(lexer.GetString());
-        REQUIRE(lexer.GetString().compare("test") == 0);
+        REQUIRE_NOTHROW(token = lexer.get_next_token());
+        REQUIRE(token == fkyaml::lexical_token_t::STRING_VALUE);
+        REQUIRE_NOTHROW(lexer.get_string());
+        REQUIRE(lexer.get_string().compare("test") == 0);
 
-        REQUIRE_NOTHROW(token = lexer.GetNextToken());
-        REQUIRE(token == fkyaml::LexicalTokenType::KEY_SEPARATOR);
+        REQUIRE_NOTHROW(token = lexer.get_next_token());
+        REQUIRE(token == fkyaml::lexical_token_t::KEY_SEPARATOR);
 
-        REQUIRE_NOTHROW(token = lexer.GetNextToken());
-        REQUIRE(token == fkyaml::LexicalTokenType::ALIAS_PREFIX);
-        REQUIRE_NOTHROW(lexer.GetString());
-        REQUIRE(lexer.GetString().compare("anchor") == 0);
+        REQUIRE_NOTHROW(token = lexer.get_next_token());
+        REQUIRE(token == fkyaml::lexical_token_t::ALIAS_PREFIX);
+        REQUIRE_NOTHROW(lexer.get_string());
+        REQUIRE(lexer.get_string().compare("anchor") == 0);
 
-        REQUIRE_NOTHROW(token = lexer.GetNextToken());
-        REQUIRE(token == fkyaml::LexicalTokenType::END_OF_BUFFER);
+        REQUIRE_NOTHROW(token = lexer.get_next_token());
+        REQUIRE(token == fkyaml::lexical_token_t::END_OF_BUFFER);
     }
 
     SECTION("Test nothrow unexpected tokens with an anchor.")
     {
         auto buffer = GENERATE(
             std::string("test: *"), std::string("test: *\r\n"), std::string("test: *\n"), std::string("test: * "));
-        lexer.SetInputBuffer(buffer.c_str());
+        lexer.set_input_buffer(buffer.c_str());
 
-        REQUIRE_NOTHROW(token = lexer.GetNextToken());
-        REQUIRE(token == fkyaml::LexicalTokenType::STRING_VALUE);
-        REQUIRE_NOTHROW(lexer.GetString());
-        REQUIRE(lexer.GetString().compare("test") == 0);
+        REQUIRE_NOTHROW(token = lexer.get_next_token());
+        REQUIRE(token == fkyaml::lexical_token_t::STRING_VALUE);
+        REQUIRE_NOTHROW(lexer.get_string());
+        REQUIRE(lexer.get_string().compare("test") == 0);
 
-        REQUIRE_NOTHROW(token = lexer.GetNextToken());
-        REQUIRE(token == fkyaml::LexicalTokenType::KEY_SEPARATOR);
+        REQUIRE_NOTHROW(token = lexer.get_next_token());
+        REQUIRE(token == fkyaml::lexical_token_t::KEY_SEPARATOR);
 
-        REQUIRE_THROWS_AS(token = lexer.GetNextToken(), fkyaml::Exception);
+        REQUIRE_THROWS_AS(token = lexer.get_next_token(), fkyaml::exception);
     }
 }
 
@@ -538,398 +538,398 @@ TEST_CASE("LexicalAnalyzerClassTest_ScanCommentTokenTest", "[LexicalAnalyzerClas
 {
     auto buffer = GENERATE(
         std::string("# comment\r"), std::string("# comment\r\n"), std::string("# comment\n"), std::string("# comment"));
-    fkyaml::LexicalAnalyzer<fkyaml::Node> lexer;
-    lexer.SetInputBuffer(buffer.c_str());
-    fkyaml::LexicalTokenType token;
+    fkyaml::lexical_analyzer<fkyaml::node> lexer;
+    lexer.set_input_buffer(buffer.c_str());
+    fkyaml::lexical_token_t token;
 
-    REQUIRE_NOTHROW(token = lexer.GetNextToken());
-    REQUIRE(token == fkyaml::LexicalTokenType::COMMENT_PREFIX);
+    REQUIRE_NOTHROW(token = lexer.get_next_token());
+    REQUIRE(token == fkyaml::lexical_token_t::COMMENT_PREFIX);
 
-    REQUIRE_NOTHROW(token = lexer.GetNextToken());
-    REQUIRE(token == fkyaml::LexicalTokenType::END_OF_BUFFER);
+    REQUIRE_NOTHROW(token = lexer.get_next_token());
+    REQUIRE(token == fkyaml::lexical_token_t::END_OF_BUFFER);
 }
 
 TEST_CASE("LexicalAnalyzerClassTest_ScanReservedIndicatorTokenTest", "[LexicalAnalyzerClassTest]")
 {
     auto buffer = GENERATE(std::string("@invalid"), std::string("`invalid"));
-    fkyaml::LexicalAnalyzer<fkyaml::Node> lexer;
-    lexer.SetInputBuffer(buffer.c_str());
-    REQUIRE_THROWS_AS(lexer.GetNextToken(), fkyaml::Exception);
+    fkyaml::lexical_analyzer<fkyaml::node> lexer;
+    lexer.set_input_buffer(buffer.c_str());
+    REQUIRE_THROWS_AS(lexer.get_next_token(), fkyaml::exception);
 }
 
-TEST_CASE("LexicalAnalyzerClassTest_ScanKeyBooleanValuePairTokenTest", "[LexicalAnalyzerClassTest]")
+TEST_CASE("LexicalAnalyzerClassTest_ScanKeyBooleanvalue_pair_tTokenTest", "[LexicalAnalyzerClassTest]")
 {
-    fkyaml::LexicalAnalyzer<fkyaml::Node> lexer;
-    lexer.SetInputBuffer("test: true");
-    fkyaml::LexicalTokenType token;
+    fkyaml::lexical_analyzer<fkyaml::node> lexer;
+    lexer.set_input_buffer("test: true");
+    fkyaml::lexical_token_t token;
 
-    REQUIRE_NOTHROW(token = lexer.GetNextToken());
-    REQUIRE(token == fkyaml::LexicalTokenType::STRING_VALUE);
-    REQUIRE_NOTHROW(lexer.GetString());
-    REQUIRE(lexer.GetString().compare("test") == 0);
+    REQUIRE_NOTHROW(token = lexer.get_next_token());
+    REQUIRE(token == fkyaml::lexical_token_t::STRING_VALUE);
+    REQUIRE_NOTHROW(lexer.get_string());
+    REQUIRE(lexer.get_string().compare("test") == 0);
 
-    REQUIRE_NOTHROW(token = lexer.GetNextToken());
-    REQUIRE(token == fkyaml::LexicalTokenType::KEY_SEPARATOR);
+    REQUIRE_NOTHROW(token = lexer.get_next_token());
+    REQUIRE(token == fkyaml::lexical_token_t::KEY_SEPARATOR);
 
-    REQUIRE_NOTHROW(token = lexer.GetNextToken());
-    REQUIRE(token == fkyaml::LexicalTokenType::BOOLEAN_VALUE);
-    REQUIRE_NOTHROW(lexer.GetBoolean());
-    REQUIRE(lexer.GetBoolean() == true);
+    REQUIRE_NOTHROW(token = lexer.get_next_token());
+    REQUIRE(token == fkyaml::lexical_token_t::BOOLEAN_VALUE);
+    REQUIRE_NOTHROW(lexer.get_boolean());
+    REQUIRE(lexer.get_boolean() == true);
 
-    REQUIRE_NOTHROW(token = lexer.GetNextToken());
-    REQUIRE(token == fkyaml::LexicalTokenType::END_OF_BUFFER);
+    REQUIRE_NOTHROW(token = lexer.get_next_token());
+    REQUIRE(token == fkyaml::lexical_token_t::END_OF_BUFFER);
 }
 
-TEST_CASE("LexicalAnalyzerClassTest_ScanKeyIntegerValuePairTokenTest", "[LexicalAnalyzerClassTest]")
+TEST_CASE("LexicalAnalyzerClassTest_ScanKeyIntegervalue_pair_tTokenTest", "[LexicalAnalyzerClassTest]")
 {
-    fkyaml::LexicalAnalyzer<fkyaml::Node> lexer;
-    lexer.SetInputBuffer("test: -5784");
-    fkyaml::LexicalTokenType token;
+    fkyaml::lexical_analyzer<fkyaml::node> lexer;
+    lexer.set_input_buffer("test: -5784");
+    fkyaml::lexical_token_t token;
 
-    REQUIRE_NOTHROW(token = lexer.GetNextToken());
-    REQUIRE(token == fkyaml::LexicalTokenType::STRING_VALUE);
-    REQUIRE_NOTHROW(lexer.GetString());
-    REQUIRE(lexer.GetString().compare("test") == 0);
+    REQUIRE_NOTHROW(token = lexer.get_next_token());
+    REQUIRE(token == fkyaml::lexical_token_t::STRING_VALUE);
+    REQUIRE_NOTHROW(lexer.get_string());
+    REQUIRE(lexer.get_string().compare("test") == 0);
 
-    REQUIRE_NOTHROW(token = lexer.GetNextToken());
-    REQUIRE(token == fkyaml::LexicalTokenType::KEY_SEPARATOR);
+    REQUIRE_NOTHROW(token = lexer.get_next_token());
+    REQUIRE(token == fkyaml::lexical_token_t::KEY_SEPARATOR);
 
-    REQUIRE_NOTHROW(token = lexer.GetNextToken());
-    REQUIRE(token == fkyaml::LexicalTokenType::INTEGER_VALUE);
-    REQUIRE_NOTHROW(lexer.GetInteger());
-    REQUIRE(lexer.GetInteger() == -5784);
+    REQUIRE_NOTHROW(token = lexer.get_next_token());
+    REQUIRE(token == fkyaml::lexical_token_t::INTEGER_VALUE);
+    REQUIRE_NOTHROW(lexer.get_integer());
+    REQUIRE(lexer.get_integer() == -5784);
 
-    REQUIRE_NOTHROW(token = lexer.GetNextToken());
-    REQUIRE(token == fkyaml::LexicalTokenType::END_OF_BUFFER);
+    REQUIRE_NOTHROW(token = lexer.get_next_token());
+    REQUIRE(token == fkyaml::lexical_token_t::END_OF_BUFFER);
 }
 
-TEST_CASE("LexicalAnalyzerClassTest_ScanKeyFloatNumberValuePairTokenTest", "[LexicalAnalyzerClassTest]")
+TEST_CASE("LexicalAnalyzerClassTest_ScanKeyFloatNumbervalue_pair_tTokenTest", "[LexicalAnalyzerClassTest]")
 {
-    fkyaml::LexicalAnalyzer<fkyaml::Node> lexer;
-    lexer.SetInputBuffer("test: -5.58e-3");
-    fkyaml::LexicalTokenType token;
+    fkyaml::lexical_analyzer<fkyaml::node> lexer;
+    lexer.set_input_buffer("test: -5.58e-3");
+    fkyaml::lexical_token_t token;
 
-    REQUIRE_NOTHROW(token = lexer.GetNextToken());
-    REQUIRE(token == fkyaml::LexicalTokenType::STRING_VALUE);
-    REQUIRE_NOTHROW(lexer.GetString());
-    REQUIRE(lexer.GetString().compare("test") == 0);
+    REQUIRE_NOTHROW(token = lexer.get_next_token());
+    REQUIRE(token == fkyaml::lexical_token_t::STRING_VALUE);
+    REQUIRE_NOTHROW(lexer.get_string());
+    REQUIRE(lexer.get_string().compare("test") == 0);
 
-    REQUIRE_NOTHROW(token = lexer.GetNextToken());
-    REQUIRE(token == fkyaml::LexicalTokenType::KEY_SEPARATOR);
+    REQUIRE_NOTHROW(token = lexer.get_next_token());
+    REQUIRE(token == fkyaml::lexical_token_t::KEY_SEPARATOR);
 
-    REQUIRE_NOTHROW(token = lexer.GetNextToken());
-    REQUIRE(token == fkyaml::LexicalTokenType::FLOAT_NUMBER_VALUE);
-    REQUIRE_NOTHROW(lexer.GetFloatNumber());
-    REQUIRE(lexer.GetFloatNumber() == -5.58e-3);
+    REQUIRE_NOTHROW(token = lexer.get_next_token());
+    REQUIRE(token == fkyaml::lexical_token_t::FLOAT_NUMBER_VALUE);
+    REQUIRE_NOTHROW(lexer.get_float_number());
+    REQUIRE(lexer.get_float_number() == -5.58e-3);
 
-    REQUIRE_NOTHROW(token = lexer.GetNextToken());
-    REQUIRE(token == fkyaml::LexicalTokenType::END_OF_BUFFER);
+    REQUIRE_NOTHROW(token = lexer.get_next_token());
+    REQUIRE(token == fkyaml::lexical_token_t::END_OF_BUFFER);
 }
 
-TEST_CASE("LexicalAnalyzerClassTest_ScanKeyStringValuePairTokenTest", "[LexicalAnalyzerClassTest]")
+TEST_CASE("LexicalAnalyzerClassTest_ScanKeyStringvalue_pair_tTokenTest", "[LexicalAnalyzerClassTest]")
 {
-    fkyaml::LexicalAnalyzer<fkyaml::Node> lexer;
-    lexer.SetInputBuffer("test: \"some value\"");
-    fkyaml::LexicalTokenType token;
+    fkyaml::lexical_analyzer<fkyaml::node> lexer;
+    lexer.set_input_buffer("test: \"some value\"");
+    fkyaml::lexical_token_t token;
 
-    REQUIRE_NOTHROW(token = lexer.GetNextToken());
-    REQUIRE(token == fkyaml::LexicalTokenType::STRING_VALUE);
-    REQUIRE_NOTHROW(lexer.GetString());
-    REQUIRE(lexer.GetString().compare("test") == 0);
+    REQUIRE_NOTHROW(token = lexer.get_next_token());
+    REQUIRE(token == fkyaml::lexical_token_t::STRING_VALUE);
+    REQUIRE_NOTHROW(lexer.get_string());
+    REQUIRE(lexer.get_string().compare("test") == 0);
 
-    REQUIRE_NOTHROW(token = lexer.GetNextToken());
-    REQUIRE(token == fkyaml::LexicalTokenType::KEY_SEPARATOR);
+    REQUIRE_NOTHROW(token = lexer.get_next_token());
+    REQUIRE(token == fkyaml::lexical_token_t::KEY_SEPARATOR);
 
-    REQUIRE_NOTHROW(token = lexer.GetNextToken());
-    REQUIRE(token == fkyaml::LexicalTokenType::STRING_VALUE);
-    REQUIRE_NOTHROW(lexer.GetString());
-    REQUIRE(lexer.GetString().compare("some value") == 0);
+    REQUIRE_NOTHROW(token = lexer.get_next_token());
+    REQUIRE(token == fkyaml::lexical_token_t::STRING_VALUE);
+    REQUIRE_NOTHROW(lexer.get_string());
+    REQUIRE(lexer.get_string().compare("some value") == 0);
 
-    REQUIRE_NOTHROW(token = lexer.GetNextToken());
-    REQUIRE(token == fkyaml::LexicalTokenType::END_OF_BUFFER);
+    REQUIRE_NOTHROW(token = lexer.get_next_token());
+    REQUIRE(token == fkyaml::lexical_token_t::END_OF_BUFFER);
 }
 
 TEST_CASE("LexicalAnalyzerClassTest_ScanFlowSequenceTokenTest", "[LexicalAnalyzerClassTest]")
 {
-    fkyaml::LexicalAnalyzer<fkyaml::Node> lexer;
-    fkyaml::LexicalTokenType token;
+    fkyaml::lexical_analyzer<fkyaml::node> lexer;
+    fkyaml::lexical_token_t token;
 
     SECTION("Input source No.1.")
     {
-        lexer.SetInputBuffer("test: [ foo, bar ]");
+        lexer.set_input_buffer("test: [ foo, bar ]");
 
-        REQUIRE_NOTHROW(token = lexer.GetNextToken());
-        REQUIRE(token == fkyaml::LexicalTokenType::STRING_VALUE);
-        REQUIRE_NOTHROW(lexer.GetString());
-        REQUIRE(lexer.GetString().compare("test") == 0);
+        REQUIRE_NOTHROW(token = lexer.get_next_token());
+        REQUIRE(token == fkyaml::lexical_token_t::STRING_VALUE);
+        REQUIRE_NOTHROW(lexer.get_string());
+        REQUIRE(lexer.get_string().compare("test") == 0);
 
-        REQUIRE_NOTHROW(token = lexer.GetNextToken());
-        REQUIRE(token == fkyaml::LexicalTokenType::KEY_SEPARATOR);
+        REQUIRE_NOTHROW(token = lexer.get_next_token());
+        REQUIRE(token == fkyaml::lexical_token_t::KEY_SEPARATOR);
 
-        REQUIRE_NOTHROW(token = lexer.GetNextToken());
-        REQUIRE(token == fkyaml::LexicalTokenType::SEQUENCE_FLOW_BEGIN);
+        REQUIRE_NOTHROW(token = lexer.get_next_token());
+        REQUIRE(token == fkyaml::lexical_token_t::SEQUENCE_FLOW_BEGIN);
 
-        REQUIRE_NOTHROW(token = lexer.GetNextToken());
-        REQUIRE(token == fkyaml::LexicalTokenType::STRING_VALUE);
-        REQUIRE_NOTHROW(lexer.GetString());
-        REQUIRE(lexer.GetString().compare("foo") == 0);
+        REQUIRE_NOTHROW(token = lexer.get_next_token());
+        REQUIRE(token == fkyaml::lexical_token_t::STRING_VALUE);
+        REQUIRE_NOTHROW(lexer.get_string());
+        REQUIRE(lexer.get_string().compare("foo") == 0);
 
-        REQUIRE_NOTHROW(token = lexer.GetNextToken());
-        REQUIRE(token == fkyaml::LexicalTokenType::VALUE_SEPARATOR);
+        REQUIRE_NOTHROW(token = lexer.get_next_token());
+        REQUIRE(token == fkyaml::lexical_token_t::VALUE_SEPARATOR);
 
-        REQUIRE_NOTHROW(token = lexer.GetNextToken());
-        REQUIRE(token == fkyaml::LexicalTokenType::STRING_VALUE);
-        REQUIRE_NOTHROW(lexer.GetString());
-        REQUIRE(lexer.GetString().compare("bar") == 0);
+        REQUIRE_NOTHROW(token = lexer.get_next_token());
+        REQUIRE(token == fkyaml::lexical_token_t::STRING_VALUE);
+        REQUIRE_NOTHROW(lexer.get_string());
+        REQUIRE(lexer.get_string().compare("bar") == 0);
 
-        REQUIRE_NOTHROW(token = lexer.GetNextToken());
-        REQUIRE(token == fkyaml::LexicalTokenType::SEQUENCE_FLOW_END);
+        REQUIRE_NOTHROW(token = lexer.get_next_token());
+        REQUIRE(token == fkyaml::lexical_token_t::SEQUENCE_FLOW_END);
 
-        REQUIRE_NOTHROW(token = lexer.GetNextToken());
-        REQUIRE(token == fkyaml::LexicalTokenType::END_OF_BUFFER);
+        REQUIRE_NOTHROW(token = lexer.get_next_token());
+        REQUIRE(token == fkyaml::lexical_token_t::END_OF_BUFFER);
     }
 
     SECTION("Input source No.2.")
     {
-        lexer.SetInputBuffer("test: [ { foo: one, bar: false }, { foo: two, bar: true } ]");
+        lexer.set_input_buffer("test: [ { foo: one, bar: false }, { foo: two, bar: true } ]");
 
-        REQUIRE_NOTHROW(token = lexer.GetNextToken());
-        REQUIRE(token == fkyaml::LexicalTokenType::STRING_VALUE);
-        REQUIRE_NOTHROW(lexer.GetString());
-        REQUIRE(lexer.GetString().compare("test") == 0);
+        REQUIRE_NOTHROW(token = lexer.get_next_token());
+        REQUIRE(token == fkyaml::lexical_token_t::STRING_VALUE);
+        REQUIRE_NOTHROW(lexer.get_string());
+        REQUIRE(lexer.get_string().compare("test") == 0);
 
-        REQUIRE_NOTHROW(token = lexer.GetNextToken());
-        REQUIRE(token == fkyaml::LexicalTokenType::KEY_SEPARATOR);
+        REQUIRE_NOTHROW(token = lexer.get_next_token());
+        REQUIRE(token == fkyaml::lexical_token_t::KEY_SEPARATOR);
 
-        REQUIRE_NOTHROW(token = lexer.GetNextToken());
-        REQUIRE(token == fkyaml::LexicalTokenType::SEQUENCE_FLOW_BEGIN);
+        REQUIRE_NOTHROW(token = lexer.get_next_token());
+        REQUIRE(token == fkyaml::lexical_token_t::SEQUENCE_FLOW_BEGIN);
 
-        REQUIRE_NOTHROW(token = lexer.GetNextToken());
-        REQUIRE(token == fkyaml::LexicalTokenType::MAPPING_FLOW_BEGIN);
+        REQUIRE_NOTHROW(token = lexer.get_next_token());
+        REQUIRE(token == fkyaml::lexical_token_t::MAPPING_FLOW_BEGIN);
 
-        REQUIRE_NOTHROW(token = lexer.GetNextToken());
-        REQUIRE(token == fkyaml::LexicalTokenType::STRING_VALUE);
-        REQUIRE_NOTHROW(lexer.GetString());
-        REQUIRE(lexer.GetString().compare("foo") == 0);
+        REQUIRE_NOTHROW(token = lexer.get_next_token());
+        REQUIRE(token == fkyaml::lexical_token_t::STRING_VALUE);
+        REQUIRE_NOTHROW(lexer.get_string());
+        REQUIRE(lexer.get_string().compare("foo") == 0);
 
-        REQUIRE_NOTHROW(token = lexer.GetNextToken());
-        REQUIRE(token == fkyaml::LexicalTokenType::KEY_SEPARATOR);
+        REQUIRE_NOTHROW(token = lexer.get_next_token());
+        REQUIRE(token == fkyaml::lexical_token_t::KEY_SEPARATOR);
 
-        REQUIRE_NOTHROW(token = lexer.GetNextToken());
-        REQUIRE(token == fkyaml::LexicalTokenType::STRING_VALUE);
-        REQUIRE_NOTHROW(lexer.GetString());
-        REQUIRE(lexer.GetString().compare("one") == 0);
+        REQUIRE_NOTHROW(token = lexer.get_next_token());
+        REQUIRE(token == fkyaml::lexical_token_t::STRING_VALUE);
+        REQUIRE_NOTHROW(lexer.get_string());
+        REQUIRE(lexer.get_string().compare("one") == 0);
 
-        REQUIRE_NOTHROW(token = lexer.GetNextToken());
-        REQUIRE(token == fkyaml::LexicalTokenType::VALUE_SEPARATOR);
+        REQUIRE_NOTHROW(token = lexer.get_next_token());
+        REQUIRE(token == fkyaml::lexical_token_t::VALUE_SEPARATOR);
 
-        REQUIRE_NOTHROW(token = lexer.GetNextToken());
-        REQUIRE(token == fkyaml::LexicalTokenType::STRING_VALUE);
-        REQUIRE_NOTHROW(lexer.GetString());
-        REQUIRE(lexer.GetString().compare("bar") == 0);
+        REQUIRE_NOTHROW(token = lexer.get_next_token());
+        REQUIRE(token == fkyaml::lexical_token_t::STRING_VALUE);
+        REQUIRE_NOTHROW(lexer.get_string());
+        REQUIRE(lexer.get_string().compare("bar") == 0);
 
-        REQUIRE_NOTHROW(token = lexer.GetNextToken());
-        REQUIRE(token == fkyaml::LexicalTokenType::KEY_SEPARATOR);
+        REQUIRE_NOTHROW(token = lexer.get_next_token());
+        REQUIRE(token == fkyaml::lexical_token_t::KEY_SEPARATOR);
 
-        REQUIRE_NOTHROW(token = lexer.GetNextToken());
-        REQUIRE(token == fkyaml::LexicalTokenType::BOOLEAN_VALUE);
-        REQUIRE_NOTHROW(lexer.GetBoolean());
-        REQUIRE(lexer.GetBoolean() == false);
+        REQUIRE_NOTHROW(token = lexer.get_next_token());
+        REQUIRE(token == fkyaml::lexical_token_t::BOOLEAN_VALUE);
+        REQUIRE_NOTHROW(lexer.get_boolean());
+        REQUIRE(lexer.get_boolean() == false);
 
-        REQUIRE_NOTHROW(token = lexer.GetNextToken());
-        REQUIRE(token == fkyaml::LexicalTokenType::MAPPING_FLOW_END);
+        REQUIRE_NOTHROW(token = lexer.get_next_token());
+        REQUIRE(token == fkyaml::lexical_token_t::MAPPING_FLOW_END);
 
-        REQUIRE_NOTHROW(token = lexer.GetNextToken());
-        REQUIRE(token == fkyaml::LexicalTokenType::VALUE_SEPARATOR);
+        REQUIRE_NOTHROW(token = lexer.get_next_token());
+        REQUIRE(token == fkyaml::lexical_token_t::VALUE_SEPARATOR);
 
-        REQUIRE_NOTHROW(token = lexer.GetNextToken());
-        REQUIRE(token == fkyaml::LexicalTokenType::MAPPING_FLOW_BEGIN);
+        REQUIRE_NOTHROW(token = lexer.get_next_token());
+        REQUIRE(token == fkyaml::lexical_token_t::MAPPING_FLOW_BEGIN);
 
-        REQUIRE_NOTHROW(token = lexer.GetNextToken());
-        REQUIRE(token == fkyaml::LexicalTokenType::STRING_VALUE);
-        REQUIRE_NOTHROW(lexer.GetString());
-        REQUIRE(lexer.GetString().compare("foo") == 0);
+        REQUIRE_NOTHROW(token = lexer.get_next_token());
+        REQUIRE(token == fkyaml::lexical_token_t::STRING_VALUE);
+        REQUIRE_NOTHROW(lexer.get_string());
+        REQUIRE(lexer.get_string().compare("foo") == 0);
 
-        REQUIRE_NOTHROW(token = lexer.GetNextToken());
-        REQUIRE(token == fkyaml::LexicalTokenType::KEY_SEPARATOR);
+        REQUIRE_NOTHROW(token = lexer.get_next_token());
+        REQUIRE(token == fkyaml::lexical_token_t::KEY_SEPARATOR);
 
-        REQUIRE_NOTHROW(token = lexer.GetNextToken());
-        REQUIRE(token == fkyaml::LexicalTokenType::STRING_VALUE);
-        REQUIRE_NOTHROW(lexer.GetString());
-        REQUIRE(lexer.GetString().compare("two") == 0);
+        REQUIRE_NOTHROW(token = lexer.get_next_token());
+        REQUIRE(token == fkyaml::lexical_token_t::STRING_VALUE);
+        REQUIRE_NOTHROW(lexer.get_string());
+        REQUIRE(lexer.get_string().compare("two") == 0);
 
-        REQUIRE_NOTHROW(token = lexer.GetNextToken());
-        REQUIRE(token == fkyaml::LexicalTokenType::VALUE_SEPARATOR);
+        REQUIRE_NOTHROW(token = lexer.get_next_token());
+        REQUIRE(token == fkyaml::lexical_token_t::VALUE_SEPARATOR);
 
-        REQUIRE_NOTHROW(token = lexer.GetNextToken());
-        REQUIRE(token == fkyaml::LexicalTokenType::STRING_VALUE);
-        REQUIRE_NOTHROW(lexer.GetString());
-        REQUIRE(lexer.GetString().compare("bar") == 0);
+        REQUIRE_NOTHROW(token = lexer.get_next_token());
+        REQUIRE(token == fkyaml::lexical_token_t::STRING_VALUE);
+        REQUIRE_NOTHROW(lexer.get_string());
+        REQUIRE(lexer.get_string().compare("bar") == 0);
 
-        REQUIRE_NOTHROW(token = lexer.GetNextToken());
-        REQUIRE(token == fkyaml::LexicalTokenType::KEY_SEPARATOR);
+        REQUIRE_NOTHROW(token = lexer.get_next_token());
+        REQUIRE(token == fkyaml::lexical_token_t::KEY_SEPARATOR);
 
-        REQUIRE_NOTHROW(token = lexer.GetNextToken());
-        REQUIRE(token == fkyaml::LexicalTokenType::BOOLEAN_VALUE);
-        REQUIRE_NOTHROW(lexer.GetBoolean());
-        REQUIRE(lexer.GetBoolean() == true);
+        REQUIRE_NOTHROW(token = lexer.get_next_token());
+        REQUIRE(token == fkyaml::lexical_token_t::BOOLEAN_VALUE);
+        REQUIRE_NOTHROW(lexer.get_boolean());
+        REQUIRE(lexer.get_boolean() == true);
 
-        REQUIRE_NOTHROW(token = lexer.GetNextToken());
-        REQUIRE(token == fkyaml::LexicalTokenType::MAPPING_FLOW_END);
+        REQUIRE_NOTHROW(token = lexer.get_next_token());
+        REQUIRE(token == fkyaml::lexical_token_t::MAPPING_FLOW_END);
 
-        REQUIRE_NOTHROW(token = lexer.GetNextToken());
-        REQUIRE(token == fkyaml::LexicalTokenType::SEQUENCE_FLOW_END);
+        REQUIRE_NOTHROW(token = lexer.get_next_token());
+        REQUIRE(token == fkyaml::lexical_token_t::SEQUENCE_FLOW_END);
 
-        REQUIRE_NOTHROW(token = lexer.GetNextToken());
-        REQUIRE(token == fkyaml::LexicalTokenType::END_OF_BUFFER);
+        REQUIRE_NOTHROW(token = lexer.get_next_token());
+        REQUIRE(token == fkyaml::lexical_token_t::END_OF_BUFFER);
     }
 }
 
 TEST_CASE("LexicalAnalyzerClassTest_ScanFlowMappingTokenTest", "[LexicalAnalyzerClassTest]")
 {
-    fkyaml::LexicalAnalyzer<fkyaml::Node> lexer;
-    fkyaml::LexicalTokenType token;
+    fkyaml::lexical_analyzer<fkyaml::node> lexer;
+    fkyaml::lexical_token_t token;
 
     SECTION("Input source No.1.")
     {
-        lexer.SetInputBuffer("test: { bool: true, foo: bar, pi: 3.14 }");
+        lexer.set_input_buffer("test: { bool: true, foo: bar, pi: 3.14 }");
 
-        REQUIRE_NOTHROW(token = lexer.GetNextToken());
-        REQUIRE(token == fkyaml::LexicalTokenType::STRING_VALUE);
-        REQUIRE_NOTHROW(lexer.GetString());
-        REQUIRE(lexer.GetString().compare("test") == 0);
+        REQUIRE_NOTHROW(token = lexer.get_next_token());
+        REQUIRE(token == fkyaml::lexical_token_t::STRING_VALUE);
+        REQUIRE_NOTHROW(lexer.get_string());
+        REQUIRE(lexer.get_string().compare("test") == 0);
 
-        REQUIRE_NOTHROW(token = lexer.GetNextToken());
-        REQUIRE(token == fkyaml::LexicalTokenType::KEY_SEPARATOR);
+        REQUIRE_NOTHROW(token = lexer.get_next_token());
+        REQUIRE(token == fkyaml::lexical_token_t::KEY_SEPARATOR);
 
-        REQUIRE_NOTHROW(token = lexer.GetNextToken());
-        REQUIRE(token == fkyaml::LexicalTokenType::MAPPING_FLOW_BEGIN);
+        REQUIRE_NOTHROW(token = lexer.get_next_token());
+        REQUIRE(token == fkyaml::lexical_token_t::MAPPING_FLOW_BEGIN);
 
-        REQUIRE_NOTHROW(token = lexer.GetNextToken());
-        REQUIRE(token == fkyaml::LexicalTokenType::STRING_VALUE);
-        REQUIRE_NOTHROW(lexer.GetString());
-        REQUIRE(lexer.GetString().compare("bool") == 0);
+        REQUIRE_NOTHROW(token = lexer.get_next_token());
+        REQUIRE(token == fkyaml::lexical_token_t::STRING_VALUE);
+        REQUIRE_NOTHROW(lexer.get_string());
+        REQUIRE(lexer.get_string().compare("bool") == 0);
 
-        REQUIRE_NOTHROW(token = lexer.GetNextToken());
-        REQUIRE(token == fkyaml::LexicalTokenType::KEY_SEPARATOR);
+        REQUIRE_NOTHROW(token = lexer.get_next_token());
+        REQUIRE(token == fkyaml::lexical_token_t::KEY_SEPARATOR);
 
-        REQUIRE_NOTHROW(token = lexer.GetNextToken());
-        REQUIRE(token == fkyaml::LexicalTokenType::BOOLEAN_VALUE);
-        REQUIRE_NOTHROW(lexer.GetBoolean());
-        REQUIRE(lexer.GetBoolean() == true);
+        REQUIRE_NOTHROW(token = lexer.get_next_token());
+        REQUIRE(token == fkyaml::lexical_token_t::BOOLEAN_VALUE);
+        REQUIRE_NOTHROW(lexer.get_boolean());
+        REQUIRE(lexer.get_boolean() == true);
 
-        REQUIRE_NOTHROW(token = lexer.GetNextToken());
-        REQUIRE(token == fkyaml::LexicalTokenType::VALUE_SEPARATOR);
+        REQUIRE_NOTHROW(token = lexer.get_next_token());
+        REQUIRE(token == fkyaml::lexical_token_t::VALUE_SEPARATOR);
 
-        REQUIRE_NOTHROW(token = lexer.GetNextToken());
-        REQUIRE(token == fkyaml::LexicalTokenType::STRING_VALUE);
-        REQUIRE_NOTHROW(lexer.GetString());
-        REQUIRE(lexer.GetString().compare("foo") == 0);
+        REQUIRE_NOTHROW(token = lexer.get_next_token());
+        REQUIRE(token == fkyaml::lexical_token_t::STRING_VALUE);
+        REQUIRE_NOTHROW(lexer.get_string());
+        REQUIRE(lexer.get_string().compare("foo") == 0);
 
-        REQUIRE_NOTHROW(token = lexer.GetNextToken());
-        REQUIRE(token == fkyaml::LexicalTokenType::KEY_SEPARATOR);
+        REQUIRE_NOTHROW(token = lexer.get_next_token());
+        REQUIRE(token == fkyaml::lexical_token_t::KEY_SEPARATOR);
 
-        REQUIRE_NOTHROW(token = lexer.GetNextToken());
-        REQUIRE(token == fkyaml::LexicalTokenType::STRING_VALUE);
-        REQUIRE_NOTHROW(lexer.GetString());
-        REQUIRE(lexer.GetString().compare("bar") == 0);
+        REQUIRE_NOTHROW(token = lexer.get_next_token());
+        REQUIRE(token == fkyaml::lexical_token_t::STRING_VALUE);
+        REQUIRE_NOTHROW(lexer.get_string());
+        REQUIRE(lexer.get_string().compare("bar") == 0);
 
-        REQUIRE_NOTHROW(token = lexer.GetNextToken());
-        REQUIRE(token == fkyaml::LexicalTokenType::VALUE_SEPARATOR);
+        REQUIRE_NOTHROW(token = lexer.get_next_token());
+        REQUIRE(token == fkyaml::lexical_token_t::VALUE_SEPARATOR);
 
-        REQUIRE_NOTHROW(token = lexer.GetNextToken());
-        REQUIRE(token == fkyaml::LexicalTokenType::STRING_VALUE);
-        REQUIRE_NOTHROW(lexer.GetString());
-        REQUIRE(lexer.GetString().compare("pi") == 0);
+        REQUIRE_NOTHROW(token = lexer.get_next_token());
+        REQUIRE(token == fkyaml::lexical_token_t::STRING_VALUE);
+        REQUIRE_NOTHROW(lexer.get_string());
+        REQUIRE(lexer.get_string().compare("pi") == 0);
 
-        REQUIRE_NOTHROW(token = lexer.GetNextToken());
-        REQUIRE(token == fkyaml::LexicalTokenType::KEY_SEPARATOR);
+        REQUIRE_NOTHROW(token = lexer.get_next_token());
+        REQUIRE(token == fkyaml::lexical_token_t::KEY_SEPARATOR);
 
-        REQUIRE_NOTHROW(token = lexer.GetNextToken());
-        REQUIRE(token == fkyaml::LexicalTokenType::FLOAT_NUMBER_VALUE);
-        REQUIRE_NOTHROW(lexer.GetFloatNumber());
-        REQUIRE(lexer.GetFloatNumber() == 3.14);
+        REQUIRE_NOTHROW(token = lexer.get_next_token());
+        REQUIRE(token == fkyaml::lexical_token_t::FLOAT_NUMBER_VALUE);
+        REQUIRE_NOTHROW(lexer.get_float_number());
+        REQUIRE(lexer.get_float_number() == 3.14);
 
-        REQUIRE_NOTHROW(token = lexer.GetNextToken());
-        REQUIRE(token == fkyaml::LexicalTokenType::MAPPING_FLOW_END);
+        REQUIRE_NOTHROW(token = lexer.get_next_token());
+        REQUIRE(token == fkyaml::lexical_token_t::MAPPING_FLOW_END);
 
-        REQUIRE_NOTHROW(token = lexer.GetNextToken());
-        REQUIRE(token == fkyaml::LexicalTokenType::END_OF_BUFFER);
+        REQUIRE_NOTHROW(token = lexer.get_next_token());
+        REQUIRE(token == fkyaml::lexical_token_t::END_OF_BUFFER);
     }
 
     SECTION("Input source No.2.")
     {
-        lexer.SetInputBuffer("test: {foo: bar}");
+        lexer.set_input_buffer("test: {foo: bar}");
 
-        REQUIRE_NOTHROW(token = lexer.GetNextToken());
-        REQUIRE(token == fkyaml::LexicalTokenType::STRING_VALUE);
-        REQUIRE_NOTHROW(lexer.GetString());
-        REQUIRE(lexer.GetString().compare("test") == 0);
+        REQUIRE_NOTHROW(token = lexer.get_next_token());
+        REQUIRE(token == fkyaml::lexical_token_t::STRING_VALUE);
+        REQUIRE_NOTHROW(lexer.get_string());
+        REQUIRE(lexer.get_string().compare("test") == 0);
 
-        REQUIRE_NOTHROW(token = lexer.GetNextToken());
-        REQUIRE(token == fkyaml::LexicalTokenType::KEY_SEPARATOR);
+        REQUIRE_NOTHROW(token = lexer.get_next_token());
+        REQUIRE(token == fkyaml::lexical_token_t::KEY_SEPARATOR);
 
-        REQUIRE_NOTHROW(token = lexer.GetNextToken());
-        REQUIRE(token == fkyaml::LexicalTokenType::MAPPING_FLOW_BEGIN);
+        REQUIRE_NOTHROW(token = lexer.get_next_token());
+        REQUIRE(token == fkyaml::lexical_token_t::MAPPING_FLOW_BEGIN);
 
-        REQUIRE_NOTHROW(token = lexer.GetNextToken());
-        REQUIRE(token == fkyaml::LexicalTokenType::STRING_VALUE);
-        REQUIRE_NOTHROW(lexer.GetString());
-        REQUIRE(lexer.GetString().compare("foo") == 0);
+        REQUIRE_NOTHROW(token = lexer.get_next_token());
+        REQUIRE(token == fkyaml::lexical_token_t::STRING_VALUE);
+        REQUIRE_NOTHROW(lexer.get_string());
+        REQUIRE(lexer.get_string().compare("foo") == 0);
 
-        REQUIRE_NOTHROW(token = lexer.GetNextToken());
-        REQUIRE(token == fkyaml::LexicalTokenType::KEY_SEPARATOR);
+        REQUIRE_NOTHROW(token = lexer.get_next_token());
+        REQUIRE(token == fkyaml::lexical_token_t::KEY_SEPARATOR);
 
-        REQUIRE_NOTHROW(token = lexer.GetNextToken());
-        REQUIRE(token == fkyaml::LexicalTokenType::STRING_VALUE);
-        REQUIRE_NOTHROW(lexer.GetString());
-        REQUIRE(lexer.GetString().compare("bar") == 0);
+        REQUIRE_NOTHROW(token = lexer.get_next_token());
+        REQUIRE(token == fkyaml::lexical_token_t::STRING_VALUE);
+        REQUIRE_NOTHROW(lexer.get_string());
+        REQUIRE(lexer.get_string().compare("bar") == 0);
 
-        REQUIRE_NOTHROW(token = lexer.GetNextToken());
-        REQUIRE(token == fkyaml::LexicalTokenType::MAPPING_FLOW_END);
+        REQUIRE_NOTHROW(token = lexer.get_next_token());
+        REQUIRE(token == fkyaml::lexical_token_t::MAPPING_FLOW_END);
 
-        REQUIRE_NOTHROW(token = lexer.GetNextToken());
-        REQUIRE(token == fkyaml::LexicalTokenType::END_OF_BUFFER);
+        REQUIRE_NOTHROW(token = lexer.get_next_token());
+        REQUIRE(token == fkyaml::lexical_token_t::END_OF_BUFFER);
     }
 }
 
 TEST_CASE("LexicalAnalyzerClassTest_ScanBlockSequenceTokenTest", "[LexicalAnalyzerClassTest]")
 {
-    fkyaml::LexicalAnalyzer<fkyaml::Node> lexer;
-    fkyaml::LexicalTokenType token;
+    fkyaml::lexical_analyzer<fkyaml::node> lexer;
+    fkyaml::lexical_token_t token;
 
     SECTION("Input source No.1.")
     {
         auto buffer = GENERATE(std::string("test:\n  - foo\n  - bar"), std::string("test:\r\n  - foo\r\n  - bar"));
 
-        lexer.SetInputBuffer(buffer.c_str());
+        lexer.set_input_buffer(buffer.c_str());
 
-        REQUIRE_NOTHROW(token = lexer.GetNextToken());
-        REQUIRE(token == fkyaml::LexicalTokenType::STRING_VALUE);
-        REQUIRE_NOTHROW(lexer.GetString());
-        REQUIRE(lexer.GetString().compare("test") == 0);
+        REQUIRE_NOTHROW(token = lexer.get_next_token());
+        REQUIRE(token == fkyaml::lexical_token_t::STRING_VALUE);
+        REQUIRE_NOTHROW(lexer.get_string());
+        REQUIRE(lexer.get_string().compare("test") == 0);
 
-        REQUIRE_NOTHROW(token = lexer.GetNextToken());
-        REQUIRE(token == fkyaml::LexicalTokenType::MAPPING_BLOCK_PREFIX);
+        REQUIRE_NOTHROW(token = lexer.get_next_token());
+        REQUIRE(token == fkyaml::lexical_token_t::MAPPING_BLOCK_PREFIX);
 
-        REQUIRE_NOTHROW(token = lexer.GetNextToken());
-        REQUIRE(token == fkyaml::LexicalTokenType::SEQUENCE_BLOCK_PREFIX);
+        REQUIRE_NOTHROW(token = lexer.get_next_token());
+        REQUIRE(token == fkyaml::lexical_token_t::SEQUENCE_BLOCK_PREFIX);
 
-        REQUIRE_NOTHROW(token = lexer.GetNextToken());
-        REQUIRE(token == fkyaml::LexicalTokenType::STRING_VALUE);
-        REQUIRE_NOTHROW(lexer.GetString());
-        REQUIRE(lexer.GetString().compare("foo") == 0);
+        REQUIRE_NOTHROW(token = lexer.get_next_token());
+        REQUIRE(token == fkyaml::lexical_token_t::STRING_VALUE);
+        REQUIRE_NOTHROW(lexer.get_string());
+        REQUIRE(lexer.get_string().compare("foo") == 0);
 
-        REQUIRE_NOTHROW(token = lexer.GetNextToken());
-        REQUIRE(token == fkyaml::LexicalTokenType::SEQUENCE_BLOCK_PREFIX);
+        REQUIRE_NOTHROW(token = lexer.get_next_token());
+        REQUIRE(token == fkyaml::lexical_token_t::SEQUENCE_BLOCK_PREFIX);
 
-        REQUIRE_NOTHROW(token = lexer.GetNextToken());
-        REQUIRE(token == fkyaml::LexicalTokenType::STRING_VALUE);
-        REQUIRE_NOTHROW(lexer.GetString());
-        REQUIRE(lexer.GetString().compare("bar") == 0);
+        REQUIRE_NOTHROW(token = lexer.get_next_token());
+        REQUIRE(token == fkyaml::lexical_token_t::STRING_VALUE);
+        REQUIRE_NOTHROW(lexer.get_string());
+        REQUIRE(lexer.get_string().compare("bar") == 0);
 
-        REQUIRE_NOTHROW(token = lexer.GetNextToken());
-        REQUIRE(token == fkyaml::LexicalTokenType::END_OF_BUFFER);
+        REQUIRE_NOTHROW(token = lexer.get_next_token());
+        REQUIRE(token == fkyaml::lexical_token_t::END_OF_BUFFER);
     }
 
     SECTION("Input source No.2.")
@@ -938,136 +938,136 @@ TEST_CASE("LexicalAnalyzerClassTest_ScanBlockSequenceTokenTest", "[LexicalAnalyz
             std::string("test:\r\n  - foo: one\r\n    bar: false\r\n  - foo: two\r\n    bar: true"),
             std::string("test:\n  - foo: one\n    bar: false\n  - foo: two\n    bar: true"));
 
-        lexer.SetInputBuffer(buffer.c_str());
+        lexer.set_input_buffer(buffer.c_str());
 
-        REQUIRE_NOTHROW(token = lexer.GetNextToken());
-        REQUIRE(token == fkyaml::LexicalTokenType::STRING_VALUE);
-        REQUIRE_NOTHROW(lexer.GetString());
-        REQUIRE(lexer.GetString().compare("test") == 0);
+        REQUIRE_NOTHROW(token = lexer.get_next_token());
+        REQUIRE(token == fkyaml::lexical_token_t::STRING_VALUE);
+        REQUIRE_NOTHROW(lexer.get_string());
+        REQUIRE(lexer.get_string().compare("test") == 0);
 
-        REQUIRE_NOTHROW(token = lexer.GetNextToken());
-        REQUIRE(token == fkyaml::LexicalTokenType::MAPPING_BLOCK_PREFIX);
+        REQUIRE_NOTHROW(token = lexer.get_next_token());
+        REQUIRE(token == fkyaml::lexical_token_t::MAPPING_BLOCK_PREFIX);
 
-        REQUIRE_NOTHROW(token = lexer.GetNextToken());
-        REQUIRE(token == fkyaml::LexicalTokenType::SEQUENCE_BLOCK_PREFIX);
+        REQUIRE_NOTHROW(token = lexer.get_next_token());
+        REQUIRE(token == fkyaml::lexical_token_t::SEQUENCE_BLOCK_PREFIX);
 
-        REQUIRE_NOTHROW(token = lexer.GetNextToken());
-        REQUIRE(token == fkyaml::LexicalTokenType::STRING_VALUE);
-        REQUIRE_NOTHROW(lexer.GetString());
-        REQUIRE(lexer.GetString().compare("foo") == 0);
+        REQUIRE_NOTHROW(token = lexer.get_next_token());
+        REQUIRE(token == fkyaml::lexical_token_t::STRING_VALUE);
+        REQUIRE_NOTHROW(lexer.get_string());
+        REQUIRE(lexer.get_string().compare("foo") == 0);
 
-        REQUIRE_NOTHROW(token = lexer.GetNextToken());
-        REQUIRE(token == fkyaml::LexicalTokenType::KEY_SEPARATOR);
+        REQUIRE_NOTHROW(token = lexer.get_next_token());
+        REQUIRE(token == fkyaml::lexical_token_t::KEY_SEPARATOR);
 
-        REQUIRE_NOTHROW(token = lexer.GetNextToken());
-        REQUIRE(token == fkyaml::LexicalTokenType::STRING_VALUE);
-        REQUIRE_NOTHROW(lexer.GetString());
-        REQUIRE(lexer.GetString().compare("one") == 0);
+        REQUIRE_NOTHROW(token = lexer.get_next_token());
+        REQUIRE(token == fkyaml::lexical_token_t::STRING_VALUE);
+        REQUIRE_NOTHROW(lexer.get_string());
+        REQUIRE(lexer.get_string().compare("one") == 0);
 
-        REQUIRE_NOTHROW(token = lexer.GetNextToken());
-        REQUIRE(token == fkyaml::LexicalTokenType::STRING_VALUE);
-        REQUIRE_NOTHROW(lexer.GetString());
-        REQUIRE(lexer.GetString().compare("bar") == 0);
+        REQUIRE_NOTHROW(token = lexer.get_next_token());
+        REQUIRE(token == fkyaml::lexical_token_t::STRING_VALUE);
+        REQUIRE_NOTHROW(lexer.get_string());
+        REQUIRE(lexer.get_string().compare("bar") == 0);
 
-        REQUIRE_NOTHROW(token = lexer.GetNextToken());
-        REQUIRE(token == fkyaml::LexicalTokenType::KEY_SEPARATOR);
+        REQUIRE_NOTHROW(token = lexer.get_next_token());
+        REQUIRE(token == fkyaml::lexical_token_t::KEY_SEPARATOR);
 
-        REQUIRE_NOTHROW(token = lexer.GetNextToken());
-        REQUIRE(token == fkyaml::LexicalTokenType::BOOLEAN_VALUE);
-        REQUIRE_NOTHROW(lexer.GetBoolean());
-        REQUIRE(lexer.GetBoolean() == false);
+        REQUIRE_NOTHROW(token = lexer.get_next_token());
+        REQUIRE(token == fkyaml::lexical_token_t::BOOLEAN_VALUE);
+        REQUIRE_NOTHROW(lexer.get_boolean());
+        REQUIRE(lexer.get_boolean() == false);
 
-        REQUIRE_NOTHROW(token = lexer.GetNextToken());
-        REQUIRE(token == fkyaml::LexicalTokenType::SEQUENCE_BLOCK_PREFIX);
+        REQUIRE_NOTHROW(token = lexer.get_next_token());
+        REQUIRE(token == fkyaml::lexical_token_t::SEQUENCE_BLOCK_PREFIX);
 
-        REQUIRE_NOTHROW(token = lexer.GetNextToken());
-        REQUIRE(token == fkyaml::LexicalTokenType::STRING_VALUE);
-        REQUIRE_NOTHROW(lexer.GetString());
-        REQUIRE(lexer.GetString().compare("foo") == 0);
+        REQUIRE_NOTHROW(token = lexer.get_next_token());
+        REQUIRE(token == fkyaml::lexical_token_t::STRING_VALUE);
+        REQUIRE_NOTHROW(lexer.get_string());
+        REQUIRE(lexer.get_string().compare("foo") == 0);
 
-        REQUIRE_NOTHROW(token = lexer.GetNextToken());
-        REQUIRE(token == fkyaml::LexicalTokenType::KEY_SEPARATOR);
+        REQUIRE_NOTHROW(token = lexer.get_next_token());
+        REQUIRE(token == fkyaml::lexical_token_t::KEY_SEPARATOR);
 
-        REQUIRE_NOTHROW(token = lexer.GetNextToken());
-        REQUIRE(token == fkyaml::LexicalTokenType::STRING_VALUE);
-        REQUIRE_NOTHROW(lexer.GetString());
-        REQUIRE(lexer.GetString().compare("two") == 0);
+        REQUIRE_NOTHROW(token = lexer.get_next_token());
+        REQUIRE(token == fkyaml::lexical_token_t::STRING_VALUE);
+        REQUIRE_NOTHROW(lexer.get_string());
+        REQUIRE(lexer.get_string().compare("two") == 0);
 
-        REQUIRE_NOTHROW(token = lexer.GetNextToken());
-        REQUIRE(token == fkyaml::LexicalTokenType::STRING_VALUE);
-        REQUIRE_NOTHROW(lexer.GetString());
-        REQUIRE(lexer.GetString().compare("bar") == 0);
+        REQUIRE_NOTHROW(token = lexer.get_next_token());
+        REQUIRE(token == fkyaml::lexical_token_t::STRING_VALUE);
+        REQUIRE_NOTHROW(lexer.get_string());
+        REQUIRE(lexer.get_string().compare("bar") == 0);
 
-        REQUIRE_NOTHROW(token = lexer.GetNextToken());
-        REQUIRE(token == fkyaml::LexicalTokenType::KEY_SEPARATOR);
+        REQUIRE_NOTHROW(token = lexer.get_next_token());
+        REQUIRE(token == fkyaml::lexical_token_t::KEY_SEPARATOR);
 
-        REQUIRE_NOTHROW(token = lexer.GetNextToken());
-        REQUIRE(token == fkyaml::LexicalTokenType::BOOLEAN_VALUE);
-        REQUIRE_NOTHROW(lexer.GetBoolean());
-        REQUIRE(lexer.GetBoolean() == true);
+        REQUIRE_NOTHROW(token = lexer.get_next_token());
+        REQUIRE(token == fkyaml::lexical_token_t::BOOLEAN_VALUE);
+        REQUIRE_NOTHROW(lexer.get_boolean());
+        REQUIRE(lexer.get_boolean() == true);
 
-        REQUIRE_NOTHROW(token = lexer.GetNextToken());
-        REQUIRE(token == fkyaml::LexicalTokenType::END_OF_BUFFER);
+        REQUIRE_NOTHROW(token = lexer.get_next_token());
+        REQUIRE(token == fkyaml::lexical_token_t::END_OF_BUFFER);
     }
 }
 
 TEST_CASE("LexicalAnalyzerClassTest_ScanBlockMappingTokenTest", "[LexicalAnalyzerClassTest]")
 {
-    fkyaml::LexicalAnalyzer<fkyaml::Node> lexer;
-    fkyaml::LexicalTokenType token;
+    fkyaml::lexical_analyzer<fkyaml::node> lexer;
+    fkyaml::lexical_token_t token;
 
     SECTION("Input source No.1.")
     {
-        lexer.SetInputBuffer("test:\n  bool: true\n  foo: bar\n  pi: 3.14");
+        lexer.set_input_buffer("test:\n  bool: true\n  foo: bar\n  pi: 3.14");
 
-        REQUIRE_NOTHROW(token = lexer.GetNextToken());
-        REQUIRE(token == fkyaml::LexicalTokenType::STRING_VALUE);
-        REQUIRE_NOTHROW(lexer.GetString());
-        REQUIRE(lexer.GetString().compare("test") == 0);
+        REQUIRE_NOTHROW(token = lexer.get_next_token());
+        REQUIRE(token == fkyaml::lexical_token_t::STRING_VALUE);
+        REQUIRE_NOTHROW(lexer.get_string());
+        REQUIRE(lexer.get_string().compare("test") == 0);
 
-        REQUIRE_NOTHROW(token = lexer.GetNextToken());
-        REQUIRE(token == fkyaml::LexicalTokenType::MAPPING_BLOCK_PREFIX);
+        REQUIRE_NOTHROW(token = lexer.get_next_token());
+        REQUIRE(token == fkyaml::lexical_token_t::MAPPING_BLOCK_PREFIX);
 
-        REQUIRE_NOTHROW(token = lexer.GetNextToken());
-        REQUIRE(token == fkyaml::LexicalTokenType::STRING_VALUE);
-        REQUIRE_NOTHROW(lexer.GetString());
-        REQUIRE(lexer.GetString().compare("bool") == 0);
+        REQUIRE_NOTHROW(token = lexer.get_next_token());
+        REQUIRE(token == fkyaml::lexical_token_t::STRING_VALUE);
+        REQUIRE_NOTHROW(lexer.get_string());
+        REQUIRE(lexer.get_string().compare("bool") == 0);
 
-        REQUIRE_NOTHROW(token = lexer.GetNextToken());
-        REQUIRE(token == fkyaml::LexicalTokenType::KEY_SEPARATOR);
+        REQUIRE_NOTHROW(token = lexer.get_next_token());
+        REQUIRE(token == fkyaml::lexical_token_t::KEY_SEPARATOR);
 
-        REQUIRE_NOTHROW(token = lexer.GetNextToken());
-        REQUIRE(token == fkyaml::LexicalTokenType::BOOLEAN_VALUE);
-        REQUIRE_NOTHROW(lexer.GetBoolean());
-        REQUIRE(lexer.GetBoolean() == true);
+        REQUIRE_NOTHROW(token = lexer.get_next_token());
+        REQUIRE(token == fkyaml::lexical_token_t::BOOLEAN_VALUE);
+        REQUIRE_NOTHROW(lexer.get_boolean());
+        REQUIRE(lexer.get_boolean() == true);
 
-        REQUIRE_NOTHROW(token = lexer.GetNextToken());
-        REQUIRE(token == fkyaml::LexicalTokenType::STRING_VALUE);
-        REQUIRE_NOTHROW(lexer.GetString());
-        REQUIRE(lexer.GetString().compare("foo") == 0);
+        REQUIRE_NOTHROW(token = lexer.get_next_token());
+        REQUIRE(token == fkyaml::lexical_token_t::STRING_VALUE);
+        REQUIRE_NOTHROW(lexer.get_string());
+        REQUIRE(lexer.get_string().compare("foo") == 0);
 
-        REQUIRE_NOTHROW(token = lexer.GetNextToken());
-        REQUIRE(token == fkyaml::LexicalTokenType::KEY_SEPARATOR);
+        REQUIRE_NOTHROW(token = lexer.get_next_token());
+        REQUIRE(token == fkyaml::lexical_token_t::KEY_SEPARATOR);
 
-        REQUIRE_NOTHROW(token = lexer.GetNextToken());
-        REQUIRE(token == fkyaml::LexicalTokenType::STRING_VALUE);
-        REQUIRE_NOTHROW(lexer.GetString());
-        REQUIRE(lexer.GetString().compare("bar") == 0);
+        REQUIRE_NOTHROW(token = lexer.get_next_token());
+        REQUIRE(token == fkyaml::lexical_token_t::STRING_VALUE);
+        REQUIRE_NOTHROW(lexer.get_string());
+        REQUIRE(lexer.get_string().compare("bar") == 0);
 
-        REQUIRE_NOTHROW(token = lexer.GetNextToken());
-        REQUIRE(token == fkyaml::LexicalTokenType::STRING_VALUE);
-        REQUIRE_NOTHROW(lexer.GetString());
-        REQUIRE(lexer.GetString().compare("pi") == 0);
+        REQUIRE_NOTHROW(token = lexer.get_next_token());
+        REQUIRE(token == fkyaml::lexical_token_t::STRING_VALUE);
+        REQUIRE_NOTHROW(lexer.get_string());
+        REQUIRE(lexer.get_string().compare("pi") == 0);
 
-        REQUIRE_NOTHROW(token = lexer.GetNextToken());
-        REQUIRE(token == fkyaml::LexicalTokenType::KEY_SEPARATOR);
+        REQUIRE_NOTHROW(token = lexer.get_next_token());
+        REQUIRE(token == fkyaml::lexical_token_t::KEY_SEPARATOR);
 
-        REQUIRE_NOTHROW(token = lexer.GetNextToken());
-        REQUIRE(token == fkyaml::LexicalTokenType::FLOAT_NUMBER_VALUE);
-        REQUIRE_NOTHROW(lexer.GetFloatNumber());
-        REQUIRE(lexer.GetFloatNumber() == 3.14);
+        REQUIRE_NOTHROW(token = lexer.get_next_token());
+        REQUIRE(token == fkyaml::lexical_token_t::FLOAT_NUMBER_VALUE);
+        REQUIRE_NOTHROW(lexer.get_float_number());
+        REQUIRE(lexer.get_float_number() == 3.14);
 
-        REQUIRE_NOTHROW(token = lexer.GetNextToken());
-        REQUIRE(token == fkyaml::LexicalTokenType::END_OF_BUFFER);
+        REQUIRE_NOTHROW(token = lexer.get_next_token());
+        REQUIRE(token == fkyaml::lexical_token_t::END_OF_BUFFER);
     }
 }

--- a/test/unit_test/NodeClassTest.cpp
+++ b/test/unit_test/NodeClassTest.cpp
@@ -18,56 +18,56 @@
 
 TEST_CASE("NodeClassTest_DefaultCtorTest", "[NodeClassTest]")
 {
-    fkyaml::Node node;
-    REQUIRE(node.IsNull());
+    fkyaml::node node;
+    REQUIRE(node.is_null());
 }
 
 TEST_CASE("NodeClassTest_SequenceTypeCtorTest", "[NodeClassTest]")
 {
-    fkyaml::Node node(fkyaml::NodeType::SEQUENCE);
-    REQUIRE(node.IsSequence());
-    REQUIRE(node.Size() == 0);
+    fkyaml::node node(fkyaml::node_t::SEQUENCE);
+    REQUIRE(node.is_sequence());
+    REQUIRE(node.size() == 0);
 }
 
 TEST_CASE("NodeClassTest_MappingTypeCtorTest", "[NodeClassTest]")
 {
-    fkyaml::Node node(fkyaml::NodeType::MAPPING);
-    REQUIRE(node.IsMapping());
-    REQUIRE(node.Size() == 0);
+    fkyaml::node node(fkyaml::node_t::MAPPING);
+    REQUIRE(node.is_mapping());
+    REQUIRE(node.size() == 0);
 }
 
 TEST_CASE("NodeClassTest_NullTypeCtorTest", "[NodeClassTest]")
 {
-    fkyaml::Node node(fkyaml::NodeType::NULL_OBJECT);
-    REQUIRE(node.IsNull());
+    fkyaml::node node(fkyaml::node_t::NULL_OBJECT);
+    REQUIRE(node.is_null());
 }
 
 TEST_CASE("NodeClassTest_BooleanTypeCtorTest", "[NodeClassTest]")
 {
-    fkyaml::Node node(fkyaml::NodeType::BOOLEAN);
-    REQUIRE(node.IsBoolean());
-    REQUIRE(node.ToBoolean() == false);
+    fkyaml::node node(fkyaml::node_t::BOOLEAN);
+    REQUIRE(node.is_boolean());
+    REQUIRE(node.to_boolean() == false);
 }
 
 TEST_CASE("NodeClassTest_IntegerTypeCtorTest", "[NodeClassTest]")
 {
-    fkyaml::Node node(fkyaml::NodeType::INTEGER);
-    REQUIRE(node.IsInteger());
-    REQUIRE(node.ToInteger() == 0);
+    fkyaml::node node(fkyaml::node_t::INTEGER);
+    REQUIRE(node.is_integer());
+    REQUIRE(node.to_integer() == 0);
 }
 
 TEST_CASE("NodeClassTest_FloatNumberTypeCtorTest", "[NodeClassTest]")
 {
-    fkyaml::Node node(fkyaml::NodeType::FLOAT_NUMBER);
-    REQUIRE(node.IsFloatNumber());
-    REQUIRE(node.ToFloatNumber() == 0.0);
+    fkyaml::node node(fkyaml::node_t::FLOAT_NUMBER);
+    REQUIRE(node.is_float_number());
+    REQUIRE(node.to_float_number() == 0.0);
 }
 
 TEST_CASE("NodeClassTest_StringTypeCtorTest", "[NodeClassTest]")
 {
-    fkyaml::Node node(fkyaml::NodeType::STRING);
-    REQUIRE(node.IsString());
-    REQUIRE(node.Size() == 0);
+    fkyaml::node node(fkyaml::node_t::STRING);
+    REQUIRE(node.is_string());
+    REQUIRE(node.size() == 0);
 }
 
 TEST_CASE("NodeClassTest_ThrowingSpecializationTypeCtorTest", "[NodeClassTest]")
@@ -76,200 +76,200 @@ TEST_CASE("NodeClassTest_ThrowingSpecializationTypeCtorTest", "[NodeClassTest]")
     {
         String()
         {
-            throw fkyaml::Exception();
+            throw fkyaml::exception();
         }
     };
 
-    using NodeType = fkyaml::BasicNode<std::vector, std::map, bool, int64_t, double, String>;
-    REQUIRE_THROWS_AS(NodeType::StringScalar(), fkyaml::Exception);
+    using NodeType = fkyaml::basic_node<std::vector, std::map, bool, int64_t, double, String>;
+    REQUIRE_THROWS_AS(NodeType::string_scalar(), fkyaml::exception);
 }
 
 TEST_CASE("NodeClassTest_SequenceCopyCtorTest", "[NodeClassTest]")
 {
-    fkyaml::Node copied =
-        fkyaml::Node::Sequence({fkyaml::Node::BooleanScalar(true), fkyaml::Node::StringScalar("test")});
-    fkyaml::Node node(copied);
-    REQUIRE(node.IsSequence());
-    REQUIRE_NOTHROW(node.Size());
-    REQUIRE(node.Size() == 2);
+    fkyaml::node copied =
+        fkyaml::node::sequence({fkyaml::node::boolean_scalar(true), fkyaml::node::string_scalar("test")});
+    fkyaml::node node(copied);
+    REQUIRE(node.is_sequence());
+    REQUIRE_NOTHROW(node.size());
+    REQUIRE(node.size() == 2);
     REQUIRE_NOTHROW(node[0]);
-    REQUIRE(node[0].IsBoolean());
-    REQUIRE_NOTHROW(node[0].ToBoolean());
-    REQUIRE(node[0].ToBoolean() == true);
+    REQUIRE(node[0].is_boolean());
+    REQUIRE_NOTHROW(node[0].to_boolean());
+    REQUIRE(node[0].to_boolean() == true);
     REQUIRE_NOTHROW(node[1]);
-    REQUIRE(node[1].IsString());
-    REQUIRE_NOTHROW(node[1].ToString());
-    REQUIRE_NOTHROW(node[1].ToString().size());
-    REQUIRE(node[1].ToString().size() == 4);
-    REQUIRE(node[1].ToString().compare("test") == 0);
+    REQUIRE(node[1].is_string());
+    REQUIRE_NOTHROW(node[1].to_string());
+    REQUIRE_NOTHROW(node[1].to_string().size());
+    REQUIRE(node[1].to_string().size() == 4);
+    REQUIRE(node[1].to_string().compare("test") == 0);
 }
 
 TEST_CASE("NodeClassTest_MappingCopyCtorTest", "[NodeClassTest]")
 {
-    fkyaml::Node copied = fkyaml::Node::Mapping(
-        {{"test0", fkyaml::Node::IntegerScalar(123)}, {"test1", fkyaml::Node::FloatNumberScalar(3.14)}});
-    fkyaml::Node node(copied);
-    REQUIRE(node.IsMapping());
-    REQUIRE_NOTHROW(node.Size());
-    REQUIRE(node.Size() == 2);
+    fkyaml::node copied = fkyaml::node::mapping(
+        {{"test0", fkyaml::node::integer_scalar(123)}, {"test1", fkyaml::node::float_number_scalar(3.14)}});
+    fkyaml::node node(copied);
+    REQUIRE(node.is_mapping());
+    REQUIRE_NOTHROW(node.size());
+    REQUIRE(node.size() == 2);
     REQUIRE_NOTHROW(node["test0"]);
-    REQUIRE(node["test0"].IsInteger());
-    REQUIRE_NOTHROW(node["test0"].ToInteger());
-    REQUIRE(node["test0"].ToInteger() == 123);
+    REQUIRE(node["test0"].is_integer());
+    REQUIRE_NOTHROW(node["test0"].to_integer());
+    REQUIRE(node["test0"].to_integer() == 123);
     REQUIRE_NOTHROW(node["test1"]);
-    REQUIRE(node["test1"].IsFloatNumber());
-    REQUIRE_NOTHROW(node["test1"].ToFloatNumber());
-    REQUIRE(node["test1"].ToFloatNumber() == 3.14);
+    REQUIRE(node["test1"].is_float_number());
+    REQUIRE_NOTHROW(node["test1"].to_float_number());
+    REQUIRE(node["test1"].to_float_number() == 3.14);
 }
 
 TEST_CASE("NodeClassTest_NullCopyCtorTest", "[NodeClassTest]")
 {
-    fkyaml::Node copied;
-    fkyaml::Node node(copied);
-    REQUIRE(node.IsNull());
+    fkyaml::node copied;
+    fkyaml::node node(copied);
+    REQUIRE(node.is_null());
 }
 
 TEST_CASE("NodeClassTest_BooleanCopyCtorTest", "[NodeClassTest]")
 {
-    fkyaml::Node copied = fkyaml::Node::BooleanScalar(true);
-    fkyaml::Node node(copied);
-    REQUIRE(node.IsBoolean());
-    REQUIRE_NOTHROW(node.ToBoolean());
-    REQUIRE(node.ToBoolean() == true);
+    fkyaml::node copied = fkyaml::node::boolean_scalar(true);
+    fkyaml::node node(copied);
+    REQUIRE(node.is_boolean());
+    REQUIRE_NOTHROW(node.to_boolean());
+    REQUIRE(node.to_boolean() == true);
 }
 
 TEST_CASE("NodeClassTest_IntegerCopyCtorTest", "[NodeClassTest]")
 {
-    fkyaml::Node copied = fkyaml::Node::IntegerScalar(123);
-    fkyaml::Node node(copied);
-    REQUIRE(node.IsInteger());
-    REQUIRE_NOTHROW(node.ToInteger());
-    REQUIRE(node.ToInteger() == 123);
+    fkyaml::node copied = fkyaml::node::integer_scalar(123);
+    fkyaml::node node(copied);
+    REQUIRE(node.is_integer());
+    REQUIRE_NOTHROW(node.to_integer());
+    REQUIRE(node.to_integer() == 123);
 }
 
 TEST_CASE("NodeClassTest_FloatNumberCopyCtorTest", "[NodeClassTest]")
 {
-    fkyaml::Node copied = fkyaml::Node::FloatNumberScalar(3.14);
-    fkyaml::Node node(copied);
-    REQUIRE(node.IsFloatNumber());
-    REQUIRE_NOTHROW(node.ToFloatNumber());
-    REQUIRE(node.ToFloatNumber() == 3.14);
+    fkyaml::node copied = fkyaml::node::float_number_scalar(3.14);
+    fkyaml::node node(copied);
+    REQUIRE(node.is_float_number());
+    REQUIRE_NOTHROW(node.to_float_number());
+    REQUIRE(node.to_float_number() == 3.14);
 }
 
 TEST_CASE("NodeClassTest_StringCopyCtorTest", "[NodeClassTest]")
 {
-    fkyaml::Node copied = fkyaml::Node::StringScalar("test");
-    fkyaml::Node node(copied);
-    REQUIRE(node.IsString());
-    REQUIRE_NOTHROW(node.Size());
-    REQUIRE(node.Size() == 4);
-    REQUIRE_NOTHROW(node.ToString());
-    REQUIRE(node.ToString().compare("test") == 0);
+    fkyaml::node copied = fkyaml::node::string_scalar("test");
+    fkyaml::node node(copied);
+    REQUIRE(node.is_string());
+    REQUIRE_NOTHROW(node.size());
+    REQUIRE(node.size() == 4);
+    REQUIRE_NOTHROW(node.to_string());
+    REQUIRE(node.to_string().compare("test") == 0);
 }
 
 TEST_CASE("NodeClassTest_AliasCopyCtorTest", "[NodeClassTest]")
 {
-    fkyaml::Node tmp = fkyaml::Node::BooleanScalar(true);
-    tmp.AddAnchorName("anchor_name");
-    fkyaml::Node tmp_alias = fkyaml::Node::AliasOf(tmp);
-    fkyaml::Node alias(tmp_alias);
-    REQUIRE(alias.IsBoolean());
-    REQUIRE_NOTHROW(alias.ToBoolean());
-    REQUIRE(alias.ToBoolean() == true);
+    fkyaml::node tmp = fkyaml::node::boolean_scalar(true);
+    tmp.add_anchor_name("anchor_name");
+    fkyaml::node tmp_alias = fkyaml::node::alias_of(tmp);
+    fkyaml::node alias(tmp_alias);
+    REQUIRE(alias.is_boolean());
+    REQUIRE_NOTHROW(alias.to_boolean());
+    REQUIRE(alias.to_boolean() == true);
 }
 
 TEST_CASE("NodeClassTest_SequenceMoveCtorTest", "[NodeClassTest]")
 {
-    fkyaml::Node moved =
-        fkyaml::Node::Sequence({fkyaml::Node::BooleanScalar(true), fkyaml::Node::StringScalar("test")});
-    fkyaml::Node node(std::move(moved));
-    REQUIRE(node.IsSequence());
-    REQUIRE_NOTHROW(node.Size());
-    REQUIRE(node.Size() == 2);
+    fkyaml::node moved =
+        fkyaml::node::sequence({fkyaml::node::boolean_scalar(true), fkyaml::node::string_scalar("test")});
+    fkyaml::node node(std::move(moved));
+    REQUIRE(node.is_sequence());
+    REQUIRE_NOTHROW(node.size());
+    REQUIRE(node.size() == 2);
     REQUIRE_NOTHROW(node[0]);
-    REQUIRE(node[0].IsBoolean());
-    REQUIRE_NOTHROW(node[0].ToBoolean());
-    REQUIRE(node[0].ToBoolean() == true);
+    REQUIRE(node[0].is_boolean());
+    REQUIRE_NOTHROW(node[0].to_boolean());
+    REQUIRE(node[0].to_boolean() == true);
     REQUIRE_NOTHROW(node[1]);
-    REQUIRE(node[1].IsString());
-    REQUIRE_NOTHROW(node[1].ToString());
-    REQUIRE_NOTHROW(node[1].ToString().size());
-    REQUIRE(node[1].ToString().size() == 4);
-    REQUIRE(node[1].ToString().compare("test") == 0);
+    REQUIRE(node[1].is_string());
+    REQUIRE_NOTHROW(node[1].to_string());
+    REQUIRE_NOTHROW(node[1].to_string().size());
+    REQUIRE(node[1].to_string().size() == 4);
+    REQUIRE(node[1].to_string().compare("test") == 0);
 }
 
 TEST_CASE("NodeClassTest_MappingMoveCtorTest", "[NodeClassTest]")
 {
-    fkyaml::Node moved = fkyaml::Node::Mapping(
-        {{"test0", fkyaml::Node::IntegerScalar(123)}, {"test1", fkyaml::Node::FloatNumberScalar(3.14)}});
-    fkyaml::Node node(std::move(moved));
-    REQUIRE(node.IsMapping());
-    REQUIRE_NOTHROW(node.Size());
-    REQUIRE(node.Size() == 2);
+    fkyaml::node moved = fkyaml::node::mapping(
+        {{"test0", fkyaml::node::integer_scalar(123)}, {"test1", fkyaml::node::float_number_scalar(3.14)}});
+    fkyaml::node node(std::move(moved));
+    REQUIRE(node.is_mapping());
+    REQUIRE_NOTHROW(node.size());
+    REQUIRE(node.size() == 2);
     REQUIRE_NOTHROW(node["test0"]);
-    REQUIRE(node["test0"].IsInteger());
-    REQUIRE_NOTHROW(node["test0"].ToInteger());
-    REQUIRE(node["test0"].ToInteger() == 123);
+    REQUIRE(node["test0"].is_integer());
+    REQUIRE_NOTHROW(node["test0"].to_integer());
+    REQUIRE(node["test0"].to_integer() == 123);
     REQUIRE_NOTHROW(node["test1"]);
-    REQUIRE(node["test1"].IsFloatNumber());
-    REQUIRE_NOTHROW(node["test1"].ToFloatNumber());
-    REQUIRE(node["test1"].ToFloatNumber() == 3.14);
+    REQUIRE(node["test1"].is_float_number());
+    REQUIRE_NOTHROW(node["test1"].to_float_number());
+    REQUIRE(node["test1"].to_float_number() == 3.14);
 }
 
 TEST_CASE("NodeClassTest_NullMoveCtorTest", "[NodeClassTest]")
 {
-    fkyaml::Node moved;
-    fkyaml::Node node(std::move(moved));
-    REQUIRE(node.IsNull());
+    fkyaml::node moved;
+    fkyaml::node node(std::move(moved));
+    REQUIRE(node.is_null());
 }
 
 TEST_CASE("NodeClassTest_BooleanMoveCtorTest", "[NodeClassTest]")
 {
-    fkyaml::Node moved = fkyaml::Node::BooleanScalar(true);
-    fkyaml::Node node(std::move(moved));
-    REQUIRE(node.IsBoolean());
-    REQUIRE_NOTHROW(node.ToBoolean());
-    REQUIRE(node.ToBoolean() == true);
+    fkyaml::node moved = fkyaml::node::boolean_scalar(true);
+    fkyaml::node node(std::move(moved));
+    REQUIRE(node.is_boolean());
+    REQUIRE_NOTHROW(node.to_boolean());
+    REQUIRE(node.to_boolean() == true);
 }
 
 TEST_CASE("NodeClassTest_IntegerMoveCtorTest", "[NodeClassTest]")
 {
-    fkyaml::Node moved = fkyaml::Node::IntegerScalar(123);
-    fkyaml::Node node(std::move(moved));
-    REQUIRE(node.IsInteger());
-    REQUIRE_NOTHROW(node.ToInteger());
-    REQUIRE(node.ToInteger() == 123);
+    fkyaml::node moved = fkyaml::node::integer_scalar(123);
+    fkyaml::node node(std::move(moved));
+    REQUIRE(node.is_integer());
+    REQUIRE_NOTHROW(node.to_integer());
+    REQUIRE(node.to_integer() == 123);
 }
 
 TEST_CASE("NodeClassTest_FloatNumberMoveCtorTest", "[NodeClassTest]")
 {
-    fkyaml::Node moved = fkyaml::Node::FloatNumberScalar(3.14);
-    fkyaml::Node node(std::move(moved));
-    REQUIRE(node.IsFloatNumber());
-    REQUIRE_NOTHROW(node.ToFloatNumber());
-    REQUIRE(node.ToFloatNumber() == 3.14);
+    fkyaml::node moved = fkyaml::node::float_number_scalar(3.14);
+    fkyaml::node node(std::move(moved));
+    REQUIRE(node.is_float_number());
+    REQUIRE_NOTHROW(node.to_float_number());
+    REQUIRE(node.to_float_number() == 3.14);
 }
 
 TEST_CASE("NodeClassTest_StringMoveCtorTest", "[NodeClassTest]")
 {
-    fkyaml::Node moved = fkyaml::Node::StringScalar("test");
-    fkyaml::Node node(std::move(moved));
-    REQUIRE(node.IsString());
-    REQUIRE_NOTHROW(node.Size());
-    REQUIRE(node.Size() == 4);
-    REQUIRE_NOTHROW(node.ToString());
-    REQUIRE(node.ToString().compare("test") == 0);
+    fkyaml::node moved = fkyaml::node::string_scalar("test");
+    fkyaml::node node(std::move(moved));
+    REQUIRE(node.is_string());
+    REQUIRE_NOTHROW(node.size());
+    REQUIRE(node.size() == 4);
+    REQUIRE_NOTHROW(node.to_string());
+    REQUIRE(node.to_string().compare("test") == 0);
 }
 
 TEST_CASE("NodeClassTest_AliasMoveCtorTest", "[NodeClassTest]")
 {
-    fkyaml::Node tmp = fkyaml::Node::BooleanScalar(true);
-    tmp.AddAnchorName("anchor_name");
-    fkyaml::Node tmp_alias = fkyaml::Node::AliasOf(tmp);
-    fkyaml::Node alias(std::move(tmp_alias));
-    REQUIRE(alias.IsBoolean());
-    REQUIRE_NOTHROW(alias.ToBoolean());
-    REQUIRE(alias.ToBoolean() == true);
+    fkyaml::node tmp = fkyaml::node::boolean_scalar(true);
+    tmp.add_anchor_name("anchor_name");
+    fkyaml::node tmp_alias = fkyaml::node::alias_of(tmp);
+    fkyaml::node alias(std::move(tmp_alias));
+    REQUIRE(alias.is_boolean());
+    REQUIRE_NOTHROW(alias.to_boolean());
+    REQUIRE(alias.to_boolean() == true);
 }
 
 //
@@ -280,34 +280,34 @@ TEST_CASE("NodeClassTest_SequenceNodeFactoryTest", "[NodeClassTest]")
 {
     SECTION("Test empty sequence node factory method.")
     {
-        fkyaml::Node node = fkyaml::Node::Sequence();
-        REQUIRE(node.IsSequence());
-        REQUIRE(node.Size() == 0);
+        fkyaml::node node = fkyaml::node::sequence();
+        REQUIRE(node.is_sequence());
+        REQUIRE(node.size() == 0);
     }
 
     SECTION("Test non-empty sequence node factory methods.")
     {
-        fkyaml::NodeSequenceType seq(3);
+        fkyaml::node_sequence_type seq(3);
 
         SECTION("Test lvalue sequence node factory method.")
         {
-            fkyaml::Node node = fkyaml::Node::Sequence(seq);
-            REQUIRE(node.IsSequence());
-            REQUIRE(node.Size() == 3);
+            fkyaml::node node = fkyaml::node::sequence(seq);
+            REQUIRE(node.is_sequence());
+            REQUIRE(node.size() == 3);
             for (int i = 0; i < 3; ++i)
             {
-                REQUIRE(node[i].IsNull());
+                REQUIRE(node[i].is_null());
             }
         }
 
         SECTION("Test lvalue sequence node factory method.")
         {
-            fkyaml::Node node = fkyaml::Node::Sequence(std::move(seq));
-            REQUIRE(node.IsSequence());
-            REQUIRE(node.Size() == 3);
+            fkyaml::node node = fkyaml::node::sequence(std::move(seq));
+            REQUIRE(node.is_sequence());
+            REQUIRE(node.size() == 3);
             for (int i = 0; i < 3; ++i)
             {
-                REQUIRE(node[i].IsNull());
+                REQUIRE(node[i].is_null());
             }
         }
     }
@@ -317,31 +317,31 @@ TEST_CASE("NodeClassTest_MappingNodeFactoryTest", "[NodeClassTest]")
 {
     SECTION("Test empty mapping node factory method.")
     {
-        fkyaml::Node node = fkyaml::Node::Mapping();
-        REQUIRE(node.IsMapping());
-        REQUIRE(node.Size() == 0);
+        fkyaml::node node = fkyaml::node::mapping();
+        REQUIRE(node.is_mapping());
+        REQUIRE(node.size() == 0);
     }
 
     SECTION("Test non-empty mapping node factory methods.")
     {
-        fkyaml::NodeMappingType map {{std::string("test"), fkyaml::Node::BooleanScalar(true)}};
+        fkyaml::node_mapping_type map {{std::string("test"), fkyaml::node::boolean_scalar(true)}};
 
         SECTION("Test lvalue mapping node factory method.")
         {
-            fkyaml::Node node = fkyaml::Node::Mapping(map);
-            REQUIRE(node.IsMapping());
-            REQUIRE(node.Size() == 1);
-            REQUIRE(node["test"].IsBoolean());
-            REQUIRE(node["test"].ToBoolean() == true);
+            fkyaml::node node = fkyaml::node::mapping(map);
+            REQUIRE(node.is_mapping());
+            REQUIRE(node.size() == 1);
+            REQUIRE(node["test"].is_boolean());
+            REQUIRE(node["test"].to_boolean() == true);
         }
 
         SECTION("Test rvalue mapping node factory method.")
         {
-            fkyaml::Node node = fkyaml::Node::Mapping(std::move(map));
-            REQUIRE(node.IsMapping());
-            REQUIRE(node.Size() == 1);
-            REQUIRE(node["test"].IsBoolean());
-            REQUIRE(node["test"].ToBoolean() == true);
+            fkyaml::node node = fkyaml::node::mapping(std::move(map));
+            REQUIRE(node.is_mapping());
+            REQUIRE(node.size() == 1);
+            REQUIRE(node["test"].is_boolean());
+            REQUIRE(node["test"].to_boolean() == true);
         }
     }
 }
@@ -349,80 +349,82 @@ TEST_CASE("NodeClassTest_MappingNodeFactoryTest", "[NodeClassTest]")
 TEST_CASE("NodeClassTest_BooleanNodeFactoryTest", "[NodeClassTest]")
 {
     auto boolean = GENERATE(true, false);
-    fkyaml::Node node = fkyaml::Node::BooleanScalar(boolean);
-    REQUIRE(node.IsBoolean());
-    REQUIRE(node.ToBoolean() == boolean);
+    fkyaml::node node = fkyaml::node::boolean_scalar(boolean);
+    REQUIRE(node.is_boolean());
+    REQUIRE(node.to_boolean() == boolean);
 }
 
 TEST_CASE("NodeClassTest_IntegerNodeFactoryTest", "[NodeClassTest]")
 {
     auto integer = GENERATE(
-        std::numeric_limits<fkyaml::NodeIntegerType>::min(), 0, std::numeric_limits<fkyaml::NodeIntegerType>::max());
-    fkyaml::Node node = fkyaml::Node::IntegerScalar(integer);
-    REQUIRE(node.IsInteger());
-    REQUIRE(node.ToInteger() == integer);
+        std::numeric_limits<fkyaml::node_integer_type>::min(),
+        0,
+        std::numeric_limits<fkyaml::node_integer_type>::max());
+    fkyaml::node node = fkyaml::node::integer_scalar(integer);
+    REQUIRE(node.is_integer());
+    REQUIRE(node.to_integer() == integer);
 }
 
 TEST_CASE("NodeClassTest_FloatNumberNodeFactoryTest", "[NodeClassTest]")
 {
     auto float_val = GENERATE(
-        std::numeric_limits<fkyaml::NodeFloatNumberType>::min(),
+        std::numeric_limits<fkyaml::node_float_number_type>::min(),
         3.141592,
-        std::numeric_limits<fkyaml::NodeFloatNumberType>::max());
-    fkyaml::Node node = fkyaml::Node::FloatNumberScalar(float_val);
-    REQUIRE(node.IsFloatNumber());
-    REQUIRE(node.ToFloatNumber() == float_val);
+        std::numeric_limits<fkyaml::node_float_number_type>::max());
+    fkyaml::node node = fkyaml::node::float_number_scalar(float_val);
+    REQUIRE(node.is_float_number());
+    REQUIRE(node.to_float_number() == float_val);
 }
 
 TEST_CASE("NodeClassTest_StringNodeFactoryTest", "[NodeClassTest]")
 {
     SECTION("Test empty string node factory method.")
     {
-        fkyaml::Node node = fkyaml::Node::StringScalar();
-        REQUIRE(node.IsString());
-        REQUIRE(node.Size() == 0);
+        fkyaml::node node = fkyaml::node::string_scalar();
+        REQUIRE(node.is_string());
+        REQUIRE(node.size() == 0);
     }
 
     SECTION("Test lvalue string node factory method.")
     {
-        fkyaml::NodeStringType str("test");
-        fkyaml::Node node = fkyaml::Node::StringScalar(str);
-        REQUIRE(node.IsString());
-        REQUIRE(node.Size() == str.size());
-        REQUIRE(node.ToString() == str);
+        fkyaml::node_string_type str("test");
+        fkyaml::node node = fkyaml::node::string_scalar(str);
+        REQUIRE(node.is_string());
+        REQUIRE(node.size() == str.size());
+        REQUIRE(node.to_string() == str);
     }
 
     SECTION("Test rvalue string node factory method.")
     {
-        fkyaml::Node node = fkyaml::Node::StringScalar("test");
-        REQUIRE(node.IsString());
-        REQUIRE(node.Size() == 4);
-        REQUIRE(node.ToString().compare("test") == 0);
+        fkyaml::node node = fkyaml::node::string_scalar("test");
+        REQUIRE(node.is_string());
+        REQUIRE(node.size() == 4);
+        REQUIRE(node.to_string().compare("test") == 0);
     }
 }
 
 TEST_CASE("NodeClassTest_AliasNodeFactoryTest", "[NodeClassTest]")
 {
-    fkyaml::Node anchor = fkyaml::Node::StringScalar("alias_test");
+    fkyaml::node anchor = fkyaml::node::string_scalar("alias_test");
 
-    SECTION("Make sure BasicNode::AliasOf() throws an exception without anchor name.")
+    SECTION("Make sure BasicNode::alias_of() throws an exception without anchor name.")
     {
-        REQUIRE_THROWS_AS(fkyaml::Node::AliasOf(anchor), fkyaml::Exception);
+        REQUIRE_THROWS_AS(fkyaml::node::alias_of(anchor), fkyaml::exception);
     }
 
-    SECTION("Make sure BasicNode::AliasOf() throws an exception with an empty anchor name.")
+    SECTION("Make sure BasicNode::alias_of() throws an exception with an empty anchor name.")
     {
-        anchor.AddAnchorName("");
-        REQUIRE_THROWS_AS(fkyaml::Node::AliasOf(anchor), fkyaml::Exception);
+        anchor.add_anchor_name("");
+        REQUIRE_THROWS_AS(fkyaml::node::alias_of(anchor), fkyaml::exception);
     }
 
-    SECTION("Check if BasicNode::AliasOf() does not throw any exception.")
+    SECTION("Check if BasicNode::alias_of() does not throw any exception.")
     {
-        anchor.AddAnchorName("anchor_name");
-        REQUIRE_NOTHROW(fkyaml::Node::AliasOf(anchor));
-        fkyaml::Node alias = fkyaml::Node::AliasOf(anchor);
-        REQUIRE(alias.IsString());
-        REQUIRE(alias.ToString().compare("alias_test") == 0);
+        anchor.add_anchor_name("anchor_name");
+        REQUIRE_NOTHROW(fkyaml::node::alias_of(anchor));
+        fkyaml::node alias = fkyaml::node::alias_of(anchor);
+        REQUIRE(alias.is_string());
+        REQUIRE(alias.to_string().compare("alias_test") == 0);
     }
 }
 
@@ -434,59 +436,59 @@ TEST_CASE("NodeClassTest_StringSubscriptOperatorTest", "[NodeClassTest]")
 {
     SECTION("Test nothrow expected string subscript operators.")
     {
-        fkyaml::NodeMappingType map {{"test", fkyaml::Node()}};
+        fkyaml::node_mapping_type map {{"test", fkyaml::node()}};
 
         SECTION("Test the non-const string subscript operators.")
         {
-            fkyaml::Node node = fkyaml::Node::Mapping(map);
+            fkyaml::node node = fkyaml::node::mapping(map);
 
             SECTION("Test the non-const lvalue string subscript operator.")
             {
                 std::string key = "test";
                 REQUIRE_NOTHROW(node[key]);
-                REQUIRE(node[key].IsNull());
+                REQUIRE(node[key].is_null());
             }
 
             SECTION("Test the non-const alias lvalue string subscript operator.")
             {
                 std::string key = "test";
-                node.AddAnchorName("anchor_name");
-                fkyaml::Node alias = fkyaml::Node::AliasOf(node);
+                node.add_anchor_name("anchor_name");
+                fkyaml::node alias = fkyaml::node::alias_of(node);
                 REQUIRE_NOTHROW(alias[key]);
-                REQUIRE(alias[key].IsNull());
+                REQUIRE(alias[key].is_null());
             }
 
             SECTION("Test the non-const rvalue string subscript operator.")
             {
                 REQUIRE_NOTHROW(node["test"]);
-                REQUIRE(node["test"].IsNull());
+                REQUIRE(node["test"].is_null());
             }
 
             SECTION("Test the const alias lvalue string subscript operator.")
             {
                 std::string key = "test";
-                node.AddAnchorName("anchor_name");
-                const fkyaml::Node alias = fkyaml::Node::AliasOf(node);
+                node.add_anchor_name("anchor_name");
+                const fkyaml::node alias = fkyaml::node::alias_of(node);
                 REQUIRE_NOTHROW(alias[key]);
-                REQUIRE(alias[key].IsNull());
+                REQUIRE(alias[key].is_null());
             }
         }
 
         SECTION("Test the const string subscript operators.")
         {
-            const fkyaml::Node node = fkyaml::Node::Mapping(map);
+            const fkyaml::node node = fkyaml::node::mapping(map);
             std::string key = "test";
 
             SECTION("Test the const lvalue string subscript operator.")
             {
                 REQUIRE_NOTHROW(node[key]);
-                REQUIRE(node[key].IsNull());
+                REQUIRE(node[key].is_null());
             }
 
             SECTION("Test the const rvalue string subscript operator.")
             {
                 REQUIRE_NOTHROW(node["test"]);
-                REQUIRE(node["test"].IsNull());
+                REQUIRE(node["test"].is_null());
             }
         }
     }
@@ -494,35 +496,35 @@ TEST_CASE("NodeClassTest_StringSubscriptOperatorTest", "[NodeClassTest]")
     SECTION("Test throwing expected string subscript operator.")
     {
         auto node = GENERATE(
-            fkyaml::Node::Sequence(),
-            fkyaml::Node(),
-            fkyaml::Node::BooleanScalar(false),
-            fkyaml::Node::IntegerScalar(0),
-            fkyaml::Node::FloatNumberScalar(0.0),
-            fkyaml::Node::StringScalar());
+            fkyaml::node::sequence(),
+            fkyaml::node(),
+            fkyaml::node::boolean_scalar(false),
+            fkyaml::node::integer_scalar(0),
+            fkyaml::node::float_number_scalar(0.0),
+            fkyaml::node::string_scalar());
 
         SECTION("Test non-const lvalue throwing invocation.")
         {
             std::string key = "test";
-            REQUIRE_THROWS_AS(node[key], fkyaml::Exception);
+            REQUIRE_THROWS_AS(node[key], fkyaml::exception);
         }
 
         SECTION("Test const lvalue throwing invocation.")
         {
             std::string key = "test";
-            const fkyaml::Node const_node = node;
-            REQUIRE_THROWS_AS(const_node[key], fkyaml::Exception);
+            const fkyaml::node const_node = node;
+            REQUIRE_THROWS_AS(const_node[key], fkyaml::exception);
         }
 
         SECTION("Test non-const rvalue throwing invocation.")
         {
-            REQUIRE_THROWS_AS(node["test"], fkyaml::Exception);
+            REQUIRE_THROWS_AS(node["test"], fkyaml::exception);
         }
 
         SECTION("Test const rvalue throwing invocation.")
         {
-            const fkyaml::Node const_node = node;
-            REQUIRE_THROWS_AS(const_node["test"], fkyaml::Exception);
+            const fkyaml::node const_node = node;
+            REQUIRE_THROWS_AS(const_node["test"], fkyaml::exception);
         }
     }
 }
@@ -531,8 +533,8 @@ TEST_CASE("NodeClassTest_IntegerSubscriptOperatorTest", "[NodeClassTest]")
 {
     SECTION("Test nothrow expected integer subscript operators.")
     {
-        fkyaml::Node node = fkyaml::Node::Sequence();
-        node.ToSequence().emplace_back();
+        fkyaml::node node = fkyaml::node::sequence();
+        node.to_sequence().emplace_back();
 
         SECTION("Test non-const non-alias integer subscript operators")
         {
@@ -541,21 +543,21 @@ TEST_CASE("NodeClassTest_IntegerSubscriptOperatorTest", "[NodeClassTest]")
 
         SECTION("Test non-const alias integer subscript operators")
         {
-            node.AddAnchorName("anchor_name");
-            fkyaml::Node alias = fkyaml::Node::AliasOf(node);
+            node.add_anchor_name("anchor_name");
+            fkyaml::node alias = fkyaml::node::alias_of(node);
             REQUIRE_NOTHROW(alias[0]);
         }
 
         SECTION("Test const non-alias integer subscript operators")
         {
-            const fkyaml::Node const_node = node;
+            const fkyaml::node const_node = node;
             REQUIRE_NOTHROW(const_node[0]);
         }
 
         SECTION("Test const alias integer subscript operators")
         {
-            node.AddAnchorName("anchor_name");
-            const fkyaml::Node alias = fkyaml::Node::AliasOf(node);
+            node.add_anchor_name("anchor_name");
+            const fkyaml::node alias = fkyaml::node::alias_of(node);
             REQUIRE_NOTHROW(alias[0]);
         }
     }
@@ -563,22 +565,22 @@ TEST_CASE("NodeClassTest_IntegerSubscriptOperatorTest", "[NodeClassTest]")
     SECTION("Test throwing expected integer subscript operator.")
     {
         auto node = GENERATE(
-            fkyaml::Node::Mapping(),
-            fkyaml::Node(),
-            fkyaml::Node::BooleanScalar(false),
-            fkyaml::Node::IntegerScalar(0),
-            fkyaml::Node::FloatNumberScalar(0.0),
-            fkyaml::Node::StringScalar());
+            fkyaml::node::mapping(),
+            fkyaml::node(),
+            fkyaml::node::boolean_scalar(false),
+            fkyaml::node::integer_scalar(0),
+            fkyaml::node::float_number_scalar(0.0),
+            fkyaml::node::string_scalar());
 
         SECTION("Test non-const non-sequence nodes.")
         {
-            REQUIRE_THROWS_AS(node[0], fkyaml::Exception);
+            REQUIRE_THROWS_AS(node[0], fkyaml::exception);
         }
 
         SECTION("Test const non-sequence nodes.")
         {
-            const fkyaml::Node const_node = node;
-            REQUIRE_THROWS_AS(const_node[0], fkyaml::Exception);
+            const fkyaml::node const_node = node;
+            REQUIRE_THROWS_AS(const_node[0], fkyaml::exception);
         }
     }
 }
@@ -589,240 +591,240 @@ TEST_CASE("NodeClassTest_IntegerSubscriptOperatorTest", "[NodeClassTest]")
 
 TEST_CASE("NodeClassTest_TypeGetterTest", "[NodeClassTest]")
 {
-    using NodeTypePair = std::pair<fkyaml::Node, fkyaml::NodeType>;
+    using NodeTypePair = std::pair<fkyaml::node, fkyaml::node_t>;
     auto type_pair = GENERATE(
-        NodeTypePair(fkyaml::Node::Sequence(), fkyaml::NodeType::SEQUENCE),
-        NodeTypePair(fkyaml::Node::Mapping(), fkyaml::NodeType::MAPPING),
-        NodeTypePair(fkyaml::Node(), fkyaml::NodeType::NULL_OBJECT),
-        NodeTypePair(fkyaml::Node::BooleanScalar(false), fkyaml::NodeType::BOOLEAN),
-        NodeTypePair(fkyaml::Node::IntegerScalar(0), fkyaml::NodeType::INTEGER),
-        NodeTypePair(fkyaml::Node::FloatNumberScalar(0.0), fkyaml::NodeType::FLOAT_NUMBER),
-        NodeTypePair(fkyaml::Node::StringScalar(), fkyaml::NodeType::STRING));
+        NodeTypePair(fkyaml::node::sequence(), fkyaml::node_t::SEQUENCE),
+        NodeTypePair(fkyaml::node::mapping(), fkyaml::node_t::MAPPING),
+        NodeTypePair(fkyaml::node(), fkyaml::node_t::NULL_OBJECT),
+        NodeTypePair(fkyaml::node::boolean_scalar(false), fkyaml::node_t::BOOLEAN),
+        NodeTypePair(fkyaml::node::integer_scalar(0), fkyaml::node_t::INTEGER),
+        NodeTypePair(fkyaml::node::float_number_scalar(0.0), fkyaml::node_t::FLOAT_NUMBER),
+        NodeTypePair(fkyaml::node::string_scalar(), fkyaml::node_t::STRING));
 
     SECTION("Test non-alias node types.")
     {
-        REQUIRE(type_pair.first.Type() == type_pair.second);
+        REQUIRE(type_pair.first.type() == type_pair.second);
     }
 
     SECTION("Test alias node types.")
     {
-        type_pair.first.AddAnchorName("anchor_name");
-        fkyaml::Node alias = fkyaml::Node::AliasOf(type_pair.first);
-        REQUIRE(alias.Type() == type_pair.second);
+        type_pair.first.add_anchor_name("anchor_name");
+        fkyaml::node alias = fkyaml::node::alias_of(type_pair.first);
+        REQUIRE(alias.type() == type_pair.second);
     }
 }
 
-TEST_CASE("NodeClassTest_IsSequenceTest", "[NodeClassTest]")
+TEST_CASE("NodeClassTest_is_sequenceTest", "[NodeClassTest]")
 {
     SECTION("Test sequence node type.")
     {
-        fkyaml::Node node = fkyaml::Node::Sequence();
+        fkyaml::node node = fkyaml::node::sequence();
 
         SECTION("Test non-alias sequence node type.")
         {
-            REQUIRE(node.IsSequence());
+            REQUIRE(node.is_sequence());
         }
 
         SECTION("Test alias sequence node type.")
         {
-            node.AddAnchorName("anchor_name");
-            fkyaml::Node alias = fkyaml::Node::AliasOf(node);
-            REQUIRE(alias.IsSequence());
+            node.add_anchor_name("anchor_name");
+            fkyaml::node alias = fkyaml::node::alias_of(node);
+            REQUIRE(alias.is_sequence());
         }
     }
 
     SECTION("Test non-sequence node types.")
     {
         auto node = GENERATE(
-            fkyaml::Node::Mapping(),
-            fkyaml::Node(),
-            fkyaml::Node::BooleanScalar(false),
-            fkyaml::Node::IntegerScalar(0),
-            fkyaml::Node::FloatNumberScalar(0.0),
-            fkyaml::Node::StringScalar());
+            fkyaml::node::mapping(),
+            fkyaml::node(),
+            fkyaml::node::boolean_scalar(false),
+            fkyaml::node::integer_scalar(0),
+            fkyaml::node::float_number_scalar(0.0),
+            fkyaml::node::string_scalar());
 
         SECTION("Test non-alias non-sequence node types")
         {
-            REQUIRE_FALSE(node.IsSequence());
+            REQUIRE_FALSE(node.is_sequence());
         }
 
         SECTION("Test alias non-sequence node types.")
         {
-            node.AddAnchorName("anchor_name");
-            fkyaml::Node alias = fkyaml::Node::AliasOf(node);
-            REQUIRE_FALSE(alias.IsSequence());
+            node.add_anchor_name("anchor_name");
+            fkyaml::node alias = fkyaml::node::alias_of(node);
+            REQUIRE_FALSE(alias.is_sequence());
         }
     }
 }
 
-TEST_CASE("NodeClassTest_IsMappingTest", "[NodeClassTest]")
+TEST_CASE("NodeClassTest_is_mappingTest", "[NodeClassTest]")
 {
     SECTION("Test mapping node type.")
     {
-        fkyaml::Node node = fkyaml::Node::Mapping();
+        fkyaml::node node = fkyaml::node::mapping();
 
         SECTION("Test non-alias mapping node type.")
         {
-            REQUIRE(node.IsMapping());
+            REQUIRE(node.is_mapping());
         }
 
         SECTION("Test alias mapping node type.")
         {
-            node.AddAnchorName("anchor_name");
-            fkyaml::Node alias = fkyaml::Node::AliasOf(node);
-            REQUIRE(alias.IsMapping());
+            node.add_anchor_name("anchor_name");
+            fkyaml::node alias = fkyaml::node::alias_of(node);
+            REQUIRE(alias.is_mapping());
         }
     }
 
     SECTION("Test non-mapping node types.")
     {
         auto node = GENERATE(
-            fkyaml::Node::Sequence(),
-            fkyaml::Node(),
-            fkyaml::Node::BooleanScalar(false),
-            fkyaml::Node::IntegerScalar(0),
-            fkyaml::Node::FloatNumberScalar(0.0),
-            fkyaml::Node::StringScalar());
+            fkyaml::node::sequence(),
+            fkyaml::node(),
+            fkyaml::node::boolean_scalar(false),
+            fkyaml::node::integer_scalar(0),
+            fkyaml::node::float_number_scalar(0.0),
+            fkyaml::node::string_scalar());
 
         SECTION("Test non-alias non-mapping node types")
         {
-            REQUIRE_FALSE(node.IsMapping());
+            REQUIRE_FALSE(node.is_mapping());
         }
 
         SECTION("Test alias non-mapping node types.")
         {
-            node.AddAnchorName("anchor_name");
-            fkyaml::Node alias = fkyaml::Node::AliasOf(node);
-            REQUIRE_FALSE(alias.IsMapping());
+            node.add_anchor_name("anchor_name");
+            fkyaml::node alias = fkyaml::node::alias_of(node);
+            REQUIRE_FALSE(alias.is_mapping());
         }
     }
 }
 
-TEST_CASE("NodeClassTest_IsNullTest", "[NodeClassTest]")
+TEST_CASE("NodeClassTest_is_nullTest", "[NodeClassTest]")
 {
     SECTION("Test null node type.")
     {
-        fkyaml::Node node = fkyaml::Node();
+        fkyaml::node node = fkyaml::node();
 
         SECTION("Test non-alias null node type.")
         {
-            REQUIRE(node.IsNull());
+            REQUIRE(node.is_null());
         }
 
         SECTION("Test alias null node type.")
         {
-            node.AddAnchorName("anchor_name");
-            fkyaml::Node alias = fkyaml::Node::AliasOf(node);
-            REQUIRE(alias.IsNull());
+            node.add_anchor_name("anchor_name");
+            fkyaml::node alias = fkyaml::node::alias_of(node);
+            REQUIRE(alias.is_null());
         }
     }
 
     SECTION("Test non-null node types.")
     {
         auto node = GENERATE(
-            fkyaml::Node::Sequence(),
-            fkyaml::Node::Mapping(),
-            fkyaml::Node::BooleanScalar(false),
-            fkyaml::Node::IntegerScalar(0),
-            fkyaml::Node::FloatNumberScalar(0.0),
-            fkyaml::Node::StringScalar());
+            fkyaml::node::sequence(),
+            fkyaml::node::mapping(),
+            fkyaml::node::boolean_scalar(false),
+            fkyaml::node::integer_scalar(0),
+            fkyaml::node::float_number_scalar(0.0),
+            fkyaml::node::string_scalar());
 
         SECTION("Test non-alias non-null node types")
         {
-            REQUIRE_FALSE(node.IsNull());
+            REQUIRE_FALSE(node.is_null());
         }
 
         SECTION("Test alias non-null node types.")
         {
-            node.AddAnchorName("anchor_name");
-            fkyaml::Node alias = fkyaml::Node::AliasOf(node);
-            REQUIRE_FALSE(alias.IsNull());
+            node.add_anchor_name("anchor_name");
+            fkyaml::node alias = fkyaml::node::alias_of(node);
+            REQUIRE_FALSE(alias.is_null());
         }
     }
 }
 
-TEST_CASE("NodeClassTest_IsBooleanTest", "[NodeClassTest]")
+TEST_CASE("NodeClassTest_is_booleanTest", "[NodeClassTest]")
 {
     SECTION("Test boolean node type.")
     {
-        fkyaml::Node node = fkyaml::Node::BooleanScalar(false);
+        fkyaml::node node = fkyaml::node::boolean_scalar(false);
 
         SECTION("Test non-alias boolean node type.")
         {
-            REQUIRE(node.IsBoolean());
+            REQUIRE(node.is_boolean());
         }
 
         SECTION("Test alias boolean node type.")
         {
-            node.AddAnchorName("anchor_name");
-            fkyaml::Node alias = fkyaml::Node::AliasOf(node);
-            REQUIRE(alias.IsBoolean());
+            node.add_anchor_name("anchor_name");
+            fkyaml::node alias = fkyaml::node::alias_of(node);
+            REQUIRE(alias.is_boolean());
         }
     }
 
     SECTION("Test non-boolean node types.")
     {
         auto node = GENERATE(
-            fkyaml::Node::Sequence(),
-            fkyaml::Node::Mapping(),
-            fkyaml::Node(),
-            fkyaml::Node::IntegerScalar(0),
-            fkyaml::Node::FloatNumberScalar(0.0),
-            fkyaml::Node::StringScalar());
+            fkyaml::node::sequence(),
+            fkyaml::node::mapping(),
+            fkyaml::node(),
+            fkyaml::node::integer_scalar(0),
+            fkyaml::node::float_number_scalar(0.0),
+            fkyaml::node::string_scalar());
 
         SECTION("Test non-alias non-boolean node types")
         {
-            REQUIRE_FALSE(node.IsBoolean());
+            REQUIRE_FALSE(node.is_boolean());
         }
 
         SECTION("Test alias non-boolean node types.")
         {
-            node.AddAnchorName("anchor_name");
-            fkyaml::Node alias = fkyaml::Node::AliasOf(node);
-            REQUIRE_FALSE(alias.IsBoolean());
+            node.add_anchor_name("anchor_name");
+            fkyaml::node alias = fkyaml::node::alias_of(node);
+            REQUIRE_FALSE(alias.is_boolean());
         }
     }
 }
 
-TEST_CASE("NodeClassTest_IsIntegerTest", "[NodeClassTest]")
+TEST_CASE("NodeClassTest_is_integerTest", "[NodeClassTest]")
 {
     SECTION("Test integer node type.")
     {
-        fkyaml::Node node = fkyaml::Node::IntegerScalar(0);
+        fkyaml::node node = fkyaml::node::integer_scalar(0);
 
         SECTION("Test non-alias integer node type.")
         {
-            REQUIRE(node.IsInteger());
+            REQUIRE(node.is_integer());
         }
 
         SECTION("Test alias integer node type.")
         {
-            node.AddAnchorName("anchor_name");
-            fkyaml::Node alias = fkyaml::Node::AliasOf(node);
-            REQUIRE(alias.IsInteger());
+            node.add_anchor_name("anchor_name");
+            fkyaml::node alias = fkyaml::node::alias_of(node);
+            REQUIRE(alias.is_integer());
         }
     }
 
     SECTION("Test non-integer node types.")
     {
         auto node = GENERATE(
-            fkyaml::Node::Sequence(),
-            fkyaml::Node::Mapping(),
-            fkyaml::Node(),
-            fkyaml::Node::BooleanScalar(false),
-            fkyaml::Node::FloatNumberScalar(0.0),
-            fkyaml::Node::StringScalar());
+            fkyaml::node::sequence(),
+            fkyaml::node::mapping(),
+            fkyaml::node(),
+            fkyaml::node::boolean_scalar(false),
+            fkyaml::node::float_number_scalar(0.0),
+            fkyaml::node::string_scalar());
 
         SECTION("Test non-alias non-integer node types")
         {
-            REQUIRE_FALSE(node.IsInteger());
+            REQUIRE_FALSE(node.is_integer());
         }
 
         SECTION("Test alias non-integer node types.")
         {
-            node.AddAnchorName("anchor_name");
-            fkyaml::Node alias = fkyaml::Node::AliasOf(node);
-            REQUIRE_FALSE(alias.IsInteger());
+            node.add_anchor_name("anchor_name");
+            fkyaml::node alias = fkyaml::node::alias_of(node);
+            REQUIRE_FALSE(alias.is_integer());
         }
     }
 }
@@ -831,41 +833,41 @@ TEST_CASE("NodeClassTest_IsFloatNumberTest", "[NodeClassTest]")
 {
     SECTION("Test float number node type.")
     {
-        fkyaml::Node node = fkyaml::Node::FloatNumberScalar(0.0);
+        fkyaml::node node = fkyaml::node::float_number_scalar(0.0);
 
         SECTION("Test non-alias float number node type.")
         {
-            REQUIRE(node.IsFloatNumber());
+            REQUIRE(node.is_float_number());
         }
 
         SECTION("Test alias float number node type.")
         {
-            node.AddAnchorName("anchor_name");
-            fkyaml::Node alias = fkyaml::Node::AliasOf(node);
-            REQUIRE(alias.IsFloatNumber());
+            node.add_anchor_name("anchor_name");
+            fkyaml::node alias = fkyaml::node::alias_of(node);
+            REQUIRE(alias.is_float_number());
         }
     }
 
     SECTION("Test non-float-number node types.")
     {
         auto node = GENERATE(
-            fkyaml::Node::Sequence(),
-            fkyaml::Node::Mapping(),
-            fkyaml::Node(),
-            fkyaml::Node::BooleanScalar(false),
-            fkyaml::Node::IntegerScalar(0),
-            fkyaml::Node::StringScalar());
+            fkyaml::node::sequence(),
+            fkyaml::node::mapping(),
+            fkyaml::node(),
+            fkyaml::node::boolean_scalar(false),
+            fkyaml::node::integer_scalar(0),
+            fkyaml::node::string_scalar());
 
         SECTION("Test non-alias non-float-number node types")
         {
-            REQUIRE_FALSE(node.IsFloatNumber());
+            REQUIRE_FALSE(node.is_float_number());
         }
 
         SECTION("Test alias non-float-number node types.")
         {
-            node.AddAnchorName("anchor_name");
-            fkyaml::Node alias = fkyaml::Node::AliasOf(node);
-            REQUIRE_FALSE(alias.IsFloatNumber());
+            node.add_anchor_name("anchor_name");
+            fkyaml::node alias = fkyaml::node::alias_of(node);
+            REQUIRE_FALSE(alias.is_float_number());
         }
     }
 }
@@ -874,83 +876,83 @@ TEST_CASE("NodeClassTest_IsStringTest", "[NodeClassTest]")
 {
     SECTION("Test string node type.")
     {
-        fkyaml::Node node = fkyaml::Node::StringScalar();
+        fkyaml::node node = fkyaml::node::string_scalar();
 
         SECTION("Test non-alias string node type.")
         {
-            REQUIRE(node.IsString());
+            REQUIRE(node.is_string());
         }
 
         SECTION("Test alias string node type.")
         {
-            node.AddAnchorName("anchor_name");
-            fkyaml::Node alias = fkyaml::Node::AliasOf(node);
-            REQUIRE(alias.IsString());
+            node.add_anchor_name("anchor_name");
+            fkyaml::node alias = fkyaml::node::alias_of(node);
+            REQUIRE(alias.is_string());
         }
     }
 
     SECTION("Test non-string node types.")
     {
         auto node = GENERATE(
-            fkyaml::Node::Sequence(),
-            fkyaml::Node::Mapping(),
-            fkyaml::Node(),
-            fkyaml::Node::BooleanScalar(false),
-            fkyaml::Node::IntegerScalar(0),
-            fkyaml::Node::FloatNumberScalar(0.0));
+            fkyaml::node::sequence(),
+            fkyaml::node::mapping(),
+            fkyaml::node(),
+            fkyaml::node::boolean_scalar(false),
+            fkyaml::node::integer_scalar(0),
+            fkyaml::node::float_number_scalar(0.0));
 
         SECTION("Test non-alias non-string node types")
         {
-            REQUIRE_FALSE(node.IsString());
+            REQUIRE_FALSE(node.is_string());
         }
 
         SECTION("Test alias non-string node types.")
         {
-            node.AddAnchorName("anchor_name");
-            fkyaml::Node alias = fkyaml::Node::AliasOf(node);
-            REQUIRE_FALSE(alias.IsString());
+            node.add_anchor_name("anchor_name");
+            fkyaml::node alias = fkyaml::node::alias_of(node);
+            REQUIRE_FALSE(alias.is_string());
         }
     }
 }
 
-TEST_CASE("NodeClassTest_IsScalarTest", "[NodeClassTest]")
+TEST_CASE("NodeClassTest_is_scalarTest", "[NodeClassTest]")
 {
     SECTION("Test scalar node types.")
     {
         auto node = GENERATE(
-            fkyaml::Node(),
-            fkyaml::Node::BooleanScalar(false),
-            fkyaml::Node::IntegerScalar(0),
-            fkyaml::Node::FloatNumberScalar(0.0),
-            fkyaml::Node::StringScalar());
+            fkyaml::node(),
+            fkyaml::node::boolean_scalar(false),
+            fkyaml::node::integer_scalar(0),
+            fkyaml::node::float_number_scalar(0.0),
+            fkyaml::node::string_scalar());
 
         SECTION("Test non-alias scalar node types.")
         {
-            REQUIRE(node.IsScalar());
+            REQUIRE(node.is_scalar());
         }
 
         SECTION("Test alias scalar node types.")
         {
-            node.AddAnchorName("anchor_name");
-            fkyaml::Node alias = fkyaml::Node::AliasOf(node);
-            REQUIRE(alias.IsScalar());
+            node.add_anchor_name("anchor_name");
+            fkyaml::node alias = fkyaml::node::alias_of(node);
+            REQUIRE(alias.is_scalar());
         }
     }
 
     SECTION("Test non-scalar node types.")
     {
-        auto node = GENERATE(fkyaml::Node::Sequence(), fkyaml::Node::Mapping());
+        auto node = GENERATE(fkyaml::node::sequence(), fkyaml::node::mapping());
 
         SECTION("Test non-alias non-scalar node types")
         {
-            REQUIRE_FALSE(node.IsScalar());
+            REQUIRE_FALSE(node.is_scalar());
         }
 
         SECTION("Test alias non-scalar node types.")
         {
-            node.AddAnchorName("anchor_name");
-            fkyaml::Node alias = fkyaml::Node::AliasOf(node);
-            REQUIRE_FALSE(alias.IsScalar());
+            node.add_anchor_name("anchor_name");
+            fkyaml::node alias = fkyaml::node::alias_of(node);
+            REQUIRE_FALSE(alias.is_scalar());
         }
     }
 }
@@ -958,18 +960,18 @@ TEST_CASE("NodeClassTest_IsScalarTest", "[NodeClassTest]")
 TEST_CASE("NodeClassTest_IsAliasTest", "[NodeClassTest]")
 {
     auto node = GENERATE(
-        fkyaml::Node::Sequence(),
-        fkyaml::Node::Mapping(),
-        fkyaml::Node(),
-        fkyaml::Node::BooleanScalar(false),
-        fkyaml::Node::IntegerScalar(0),
-        fkyaml::Node::FloatNumberScalar(0.0),
-        fkyaml::Node::StringScalar());
+        fkyaml::node::sequence(),
+        fkyaml::node::mapping(),
+        fkyaml::node(),
+        fkyaml::node::boolean_scalar(false),
+        fkyaml::node::integer_scalar(0),
+        fkyaml::node::float_number_scalar(0.0),
+        fkyaml::node::string_scalar());
 
     SECTION("Test alias node types.")
     {
-        node.AddAnchorName("anchor_name");
-        fkyaml::Node alias = fkyaml::Node::AliasOf(node);
+        node.add_anchor_name("anchor_name");
+        fkyaml::node alias = fkyaml::node::alias_of(node);
     }
 }
 
@@ -977,48 +979,48 @@ TEST_CASE("NodeClassTest_IsAliasTest", "[NodeClassTest]")
 // test cases for emptiness checker
 //
 
-TEST_CASE("NodeClassTest_IsEmptyTest", "[NodeClassTest]")
+TEST_CASE("NodeClassTest_emptyTest", "[NodeClassTest]")
 {
     SECTION("Test nothrow expected node emptiness.")
     {
         SECTION("Test empty container node emptiness.")
         {
-            auto node = GENERATE(fkyaml::Node::Sequence(), fkyaml::Node::Mapping(), fkyaml::Node::StringScalar());
+            auto node = GENERATE(fkyaml::node::sequence(), fkyaml::node::mapping(), fkyaml::node::string_scalar());
 
             SECTION("Test empty non-alias container node emptiness.")
             {
-                REQUIRE_NOTHROW(node.IsEmpty());
-                REQUIRE(node.IsEmpty());
+                REQUIRE_NOTHROW(node.empty());
+                REQUIRE(node.empty());
             }
 
             SECTION("Test empty alias container node emptiness.")
             {
-                node.AddAnchorName("anchor_name");
-                fkyaml::Node alias = fkyaml::Node::AliasOf(node);
-                REQUIRE_NOTHROW(alias.IsEmpty());
-                REQUIRE(alias.IsEmpty());
+                node.add_anchor_name("anchor_name");
+                fkyaml::node alias = fkyaml::node::alias_of(node);
+                REQUIRE_NOTHROW(alias.empty());
+                REQUIRE(alias.empty());
             }
         }
 
         SECTION("Test non-empty container node emptiness.")
         {
             auto node = GENERATE(
-                fkyaml::Node::Sequence(fkyaml::NodeSequenceType(3)),
-                fkyaml::Node::Mapping(fkyaml::NodeMappingType {{"test", fkyaml::Node()}}),
-                fkyaml::Node::StringScalar("test"));
+                fkyaml::node::sequence(fkyaml::node_sequence_type(3)),
+                fkyaml::node::mapping(fkyaml::node_mapping_type {{"test", fkyaml::node()}}),
+                fkyaml::node::string_scalar("test"));
 
             SECTION("Test non-empty non-alias container node emptiness.")
             {
-                REQUIRE_NOTHROW(node.IsEmpty());
-                REQUIRE_FALSE(node.IsEmpty());
+                REQUIRE_NOTHROW(node.empty());
+                REQUIRE_FALSE(node.empty());
             }
 
             SECTION("Test non-empty alias container node emptiness.")
             {
-                node.AddAnchorName("anchor_name");
-                fkyaml::Node alias = fkyaml::Node::AliasOf(node);
-                REQUIRE_NOTHROW(alias.IsEmpty());
-                REQUIRE_FALSE(alias.IsEmpty());
+                node.add_anchor_name("anchor_name");
+                fkyaml::node alias = fkyaml::node::alias_of(node);
+                REQUIRE_NOTHROW(alias.empty());
+                REQUIRE_FALSE(alias.empty());
             }
         }
     }
@@ -1026,34 +1028,34 @@ TEST_CASE("NodeClassTest_IsEmptyTest", "[NodeClassTest]")
     SECTION("Test nothrow unexpected node emptiness.")
     {
         auto node = GENERATE(
-            fkyaml::Node(),
-            fkyaml::Node::BooleanScalar(false),
-            fkyaml::Node::IntegerScalar(0),
-            fkyaml::Node::FloatNumberScalar(0.0));
+            fkyaml::node(),
+            fkyaml::node::boolean_scalar(false),
+            fkyaml::node::integer_scalar(0),
+            fkyaml::node::float_number_scalar(0.0));
 
         SECTION("Test non-const non-alias non-container node emptiness.")
         {
-            REQUIRE_THROWS_AS(node.IsEmpty(), fkyaml::Exception);
+            REQUIRE_THROWS_AS(node.empty(), fkyaml::exception);
         }
 
         SECTION("Test const non-alias non-container node emptiness.")
         {
-            const fkyaml::Node const_node = node;
-            REQUIRE_THROWS_AS(const_node.IsEmpty(), fkyaml::Exception);
+            const fkyaml::node const_node = node;
+            REQUIRE_THROWS_AS(const_node.empty(), fkyaml::exception);
         }
 
         SECTION("Test non-const alias non-container node emptiness.")
         {
-            node.AddAnchorName("anchor_name");
-            fkyaml::Node alias = fkyaml::Node::AliasOf(node);
-            REQUIRE_THROWS_AS(alias.IsEmpty(), fkyaml::Exception);
+            node.add_anchor_name("anchor_name");
+            fkyaml::node alias = fkyaml::node::alias_of(node);
+            REQUIRE_THROWS_AS(alias.empty(), fkyaml::exception);
         }
 
         SECTION("Test const alias non-container node emptiness.")
         {
-            node.AddAnchorName("anchor_name");
-            const fkyaml::Node alias = fkyaml::Node::AliasOf(node);
-            REQUIRE_THROWS_AS(alias.IsEmpty(), fkyaml::Exception);
+            node.add_anchor_name("anchor_name");
+            const fkyaml::node alias = fkyaml::node::alias_of(node);
+            REQUIRE_THROWS_AS(alias.empty(), fkyaml::exception);
         }
     }
 }
@@ -1066,67 +1068,67 @@ TEST_CASE("NodeClassTest_ContainsTest", "[NodeClassTest]")
 {
     SECTION("Test mapping node.")
     {
-        fkyaml::Node node = fkyaml::Node::Mapping({{"test", fkyaml::Node()}});
+        fkyaml::node node = fkyaml::node::mapping({{"test", fkyaml::node()}});
         std::string key = "test";
 
         SECTION("Test non-alias mapping node with lvalue key.")
         {
-            REQUIRE(node.Contains(key));
+            REQUIRE(node.contains(key));
         }
 
         SECTION("Test alias mapping node with lvalue key.")
         {
-            node.AddAnchorName("anchor_name");
-            fkyaml::Node alias = fkyaml::Node::AliasOf(node);
-            REQUIRE(node.Contains(key));
+            node.add_anchor_name("anchor_name");
+            fkyaml::node alias = fkyaml::node::alias_of(node);
+            REQUIRE(node.contains(key));
         }
 
         SECTION("Test non-alias mapping node with rvalue key.")
         {
-            REQUIRE(node.Contains(std::move(key)));
+            REQUIRE(node.contains(std::move(key)));
         }
 
         SECTION("Test alias mapping node with rvalue key.")
         {
-            node.AddAnchorName("anchor_name");
-            fkyaml::Node alias = fkyaml::Node::AliasOf(node);
-            REQUIRE(node.Contains(std::move(key)));
+            node.add_anchor_name("anchor_name");
+            fkyaml::node alias = fkyaml::node::alias_of(node);
+            REQUIRE(node.contains(std::move(key)));
         }
     }
 
     SECTION("Test non-mapping node.")
     {
         auto node = GENERATE(
-            fkyaml::Node::Sequence(),
-            fkyaml::Node(),
-            fkyaml::Node::BooleanScalar(false),
-            fkyaml::Node::IntegerScalar(0),
-            fkyaml::Node::FloatNumberScalar(0.0),
-            fkyaml::Node::StringScalar());
+            fkyaml::node::sequence(),
+            fkyaml::node(),
+            fkyaml::node::boolean_scalar(false),
+            fkyaml::node::integer_scalar(0),
+            fkyaml::node::float_number_scalar(0.0),
+            fkyaml::node::string_scalar());
         std::string key = "test";
 
         SECTION("Test non-alias non-mapping node with lvalue key.")
         {
-            REQUIRE_FALSE(node.Contains(key));
+            REQUIRE_FALSE(node.contains(key));
         }
 
         SECTION("Test alias non-mapping node with lvalue key.")
         {
-            node.AddAnchorName("anchor_name");
-            fkyaml::Node alias = fkyaml::Node::AliasOf(node);
-            REQUIRE_FALSE(alias.Contains(key));
+            node.add_anchor_name("anchor_name");
+            fkyaml::node alias = fkyaml::node::alias_of(node);
+            REQUIRE_FALSE(alias.contains(key));
         }
 
         SECTION("Test non-alias non-mapping node with rvalue key.")
         {
-            REQUIRE_FALSE(node.Contains(std::move(key)));
+            REQUIRE_FALSE(node.contains(std::move(key)));
         }
 
         SECTION("Test alias non-mapping node with rvalue key.")
         {
-            node.AddAnchorName("anchor_name");
-            fkyaml::Node alias = fkyaml::Node::AliasOf(node);
-            REQUIRE_FALSE(alias.Contains(std::move(key)));
+            node.add_anchor_name("anchor_name");
+            fkyaml::node alias = fkyaml::node::alias_of(node);
+            REQUIRE_FALSE(alias.contains(std::move(key)));
         }
     }
 }
@@ -1135,76 +1137,76 @@ TEST_CASE("NodeClassTest_ContainsTest", "[NodeClassTest]")
 // test cases for container size getter
 //
 
-TEST_CASE("NodeClassTest_SizeGetterTest", "[NodeClassTest]")
+TEST_CASE("NodeClassTest_sizeGetterTest", "[NodeClassTest]")
 {
     SECTION("Test nothrow expected node size.")
     {
         auto node = GENERATE(
-            fkyaml::Node::Sequence({fkyaml::Node(), fkyaml::Node(), fkyaml::Node()}),
-            fkyaml::Node::Mapping({{"test0", fkyaml::Node()}, {"test1", fkyaml::Node()}, {"test2", fkyaml::Node()}}),
-            fkyaml::Node::StringScalar("tmp"));
+            fkyaml::node::sequence({fkyaml::node(), fkyaml::node(), fkyaml::node()}),
+            fkyaml::node::mapping({{"test0", fkyaml::node()}, {"test1", fkyaml::node()}, {"test2", fkyaml::node()}}),
+            fkyaml::node::string_scalar("tmp"));
 
         SECTION("Test container node size.")
         {
-            REQUIRE_NOTHROW(node.Size());
-            REQUIRE(node.Size() == 3);
+            REQUIRE_NOTHROW(node.size());
+            REQUIRE(node.size() == 3);
         }
 
         SECTION("Test const container node size.")
         {
-            const fkyaml::Node const_node = node;
-            REQUIRE_NOTHROW(node.Size());
-            REQUIRE(const_node.Size() == 3);
+            const fkyaml::node const_node = node;
+            REQUIRE_NOTHROW(node.size());
+            REQUIRE(const_node.size() == 3);
         }
 
         SECTION("Test alias container node size.")
         {
-            node.AddAnchorName("anchor_name");
-            fkyaml::Node alias = fkyaml::Node::AliasOf(node);
-            REQUIRE_NOTHROW(alias.Size());
-            REQUIRE(alias.Size() == 3);
+            node.add_anchor_name("anchor_name");
+            fkyaml::node alias = fkyaml::node::alias_of(node);
+            REQUIRE_NOTHROW(alias.size());
+            REQUIRE(alias.size() == 3);
         }
 
         SECTION("Test const alias container node size.")
         {
-            node.AddAnchorName("anchor_name");
-            const fkyaml::Node alias = fkyaml::Node::AliasOf(node);
-            REQUIRE_NOTHROW(alias.Size());
-            REQUIRE(alias.Size() == 3);
+            node.add_anchor_name("anchor_name");
+            const fkyaml::node alias = fkyaml::node::alias_of(node);
+            REQUIRE_NOTHROW(alias.size());
+            REQUIRE(alias.size() == 3);
         }
     }
 
     SECTION("Test nothrow unexpected node size.")
     {
         auto node = GENERATE(
-            fkyaml::Node(),
-            fkyaml::Node::BooleanScalar(false),
-            fkyaml::Node::IntegerScalar(0),
-            fkyaml::Node::FloatNumberScalar(0.0));
+            fkyaml::node(),
+            fkyaml::node::boolean_scalar(false),
+            fkyaml::node::integer_scalar(0),
+            fkyaml::node::float_number_scalar(0.0));
 
         SECTION("Test non-const non-alias non-container node size.")
         {
-            REQUIRE_THROWS_AS(node.Size(), fkyaml::Exception);
+            REQUIRE_THROWS_AS(node.size(), fkyaml::exception);
         }
 
         SECTION("Test const non-alias non-container node size.")
         {
-            const fkyaml::Node const_node = node;
-            REQUIRE_THROWS_AS(const_node.Size(), fkyaml::Exception);
+            const fkyaml::node const_node = node;
+            REQUIRE_THROWS_AS(const_node.size(), fkyaml::exception);
         }
 
         SECTION("Test non-const alias non-container node size.")
         {
-            node.AddAnchorName("anchor_name");
-            fkyaml::Node alias = fkyaml::Node::AliasOf(node);
-            REQUIRE_THROWS_AS(alias.Size(), fkyaml::Exception);
+            node.add_anchor_name("anchor_name");
+            fkyaml::node alias = fkyaml::node::alias_of(node);
+            REQUIRE_THROWS_AS(alias.size(), fkyaml::exception);
         }
 
         SECTION("Test const alias non-container node size.")
         {
-            node.AddAnchorName("anchor_name");
-            const fkyaml::Node alias = fkyaml::Node::AliasOf(node);
-            REQUIRE_THROWS_AS(alias.Size(), fkyaml::Exception);
+            node.add_anchor_name("anchor_name");
+            const fkyaml::node alias = fkyaml::node::alias_of(node);
+            REQUIRE_THROWS_AS(alias.size(), fkyaml::exception);
         }
     }
 }
@@ -1215,21 +1217,21 @@ TEST_CASE("NodeClassTest_SizeGetterTest", "[NodeClassTest]")
 
 TEST_CASE("NodeClassTest_SetVersionTest", "[NodeClassTest]")
 {
-    fkyaml::Node node;
-    node.SetVersion(fkyaml::YamlVersionType::VER_1_1);
-    REQUIRE(node.GetVersion() == fkyaml::YamlVersionType::VER_1_1);
+    fkyaml::node node;
+    node.set_yaml_version(fkyaml::yaml_version_t::VER_1_1);
+    REQUIRE(node.get_yaml_version() == fkyaml::yaml_version_t::VER_1_1);
 
-    node.SetVersion(fkyaml::YamlVersionType::VER_1_2);
-    REQUIRE(node.GetVersion() == fkyaml::YamlVersionType::VER_1_2);
+    node.set_yaml_version(fkyaml::yaml_version_t::VER_1_2);
+    REQUIRE(node.get_yaml_version() == fkyaml::yaml_version_t::VER_1_2);
 }
 
 TEST_CASE("NodeClassTest_GetVersionTest", "[NodeClassTest]")
 {
-    fkyaml::Node node;
-    REQUIRE(node.GetVersion() == fkyaml::YamlVersionType::VER_1_2);
+    fkyaml::node node;
+    REQUIRE(node.get_yaml_version() == fkyaml::yaml_version_t::VER_1_2);
 
-    node.SetVersion(fkyaml::YamlVersionType::VER_1_1);
-    REQUIRE(node.GetVersion() == fkyaml::YamlVersionType::VER_1_1);
+    node.set_yaml_version(fkyaml::yaml_version_t::VER_1_1);
+    REQUIRE(node.get_yaml_version() == fkyaml::yaml_version_t::VER_1_1);
 }
 
 //
@@ -1238,63 +1240,63 @@ TEST_CASE("NodeClassTest_GetVersionTest", "[NodeClassTest]")
 
 TEST_CASE("NodeClassTest_HasAnchorNameTest", "[NodeClassTest]")
 {
-    fkyaml::Node node;
+    fkyaml::node node;
 
     SECTION("Test node without anchor name.")
     {
-        REQUIRE_FALSE(node.HasAnchorName());
+        REQUIRE_FALSE(node.has_anchor_name());
     }
 
     SECTION("Test node wityh anchor name.")
     {
-        node.AddAnchorName("anchor_name");
-        REQUIRE(node.HasAnchorName());
+        node.add_anchor_name("anchor_name");
+        REQUIRE(node.has_anchor_name());
     }
 }
 
 TEST_CASE("NodeClassTest_GetAnchorNameTest", "[NodeClassTest]")
 {
-    fkyaml::Node node;
+    fkyaml::node node;
 
     SECTION("Test node without anchor name.")
     {
-        REQUIRE_THROWS_AS(node.GetAnchorName(), fkyaml::Exception);
+        REQUIRE_THROWS_AS(node.get_anchor_name(), fkyaml::exception);
     }
 
     SECTION("Test node with anchor name.")
     {
-        node.AddAnchorName("anchor_name");
-        REQUIRE_NOTHROW(node.GetAnchorName());
-        REQUIRE(node.GetAnchorName().compare("anchor_name") == 0);
+        node.add_anchor_name("anchor_name");
+        REQUIRE_NOTHROW(node.get_anchor_name());
+        REQUIRE(node.get_anchor_name().compare("anchor_name") == 0);
     }
 }
 
-TEST_CASE("NodeClassTest_AddAnchorNameTest", "[NodeClassTest]")
+TEST_CASE("NodeClassTest_add_anchor_nameTest", "[NodeClassTest]")
 {
-    fkyaml::Node node;
+    fkyaml::node node;
     std::string anchor_name = "anchor_name";
 
     SECTION("Test lvalue anchor name.")
     {
-        node.AddAnchorName(anchor_name);
-        REQUIRE_NOTHROW(node.GetAnchorName());
-        REQUIRE(node.GetAnchorName().compare("anchor_name") == 0);
+        node.add_anchor_name(anchor_name);
+        REQUIRE_NOTHROW(node.get_anchor_name());
+        REQUIRE(node.get_anchor_name().compare("anchor_name") == 0);
     }
 
     SECTION("Test rvalue anchor name.")
     {
-        node.AddAnchorName(std::move(anchor_name));
-        REQUIRE_NOTHROW(node.GetAnchorName());
-        REQUIRE(node.GetAnchorName().compare("anchor_name") == 0);
+        node.add_anchor_name(std::move(anchor_name));
+        REQUIRE_NOTHROW(node.get_anchor_name());
+        REQUIRE(node.get_anchor_name().compare("anchor_name") == 0);
     }
 
     SECTION("Test overwritten anchor name.")
     {
-        node.AddAnchorName(anchor_name);
-        node.AddAnchorName("overwritten_name");
-        REQUIRE_NOTHROW(node.GetAnchorName());
-        REQUIRE_FALSE(node.GetAnchorName().compare("anchor_name") == 0);
-        REQUIRE(node.GetAnchorName().compare("overwritten_name") == 0);
+        node.add_anchor_name(anchor_name);
+        node.add_anchor_name("overwritten_name");
+        REQUIRE_NOTHROW(node.get_anchor_name());
+        REQUIRE_FALSE(node.get_anchor_name().compare("anchor_name") == 0);
+        REQUIRE(node.get_anchor_name().compare("overwritten_name") == 0);
     }
 }
 
@@ -1302,55 +1304,55 @@ TEST_CASE("NodeClassTest_AddAnchorNameTest", "[NodeClassTest]")
 // test cases for value reference getters
 //
 
-TEST_CASE("NodeClassTest_ToSequenceTest", "[NodeClassTest]")
+TEST_CASE("NodeClassTest_to_sequenceTest", "[NodeClassTest]")
 {
     SECTION("Test nothrow expected nodes.")
     {
-        fkyaml::Node node =
-            fkyaml::Node::Sequence(fkyaml::NodeSequenceType {fkyaml::Node(), fkyaml::Node(), fkyaml::Node()});
+        fkyaml::node node =
+            fkyaml::node::sequence(fkyaml::node_sequence_type {fkyaml::node(), fkyaml::node(), fkyaml::node()});
 
         SECTION("Test non-alias sequence node.")
         {
-            REQUIRE_NOTHROW(node.ToSequence());
-            REQUIRE(node.ToSequence().size() == 3);
+            REQUIRE_NOTHROW(node.to_sequence());
+            REQUIRE(node.to_sequence().size() == 3);
             for (int i = 0; i < 3; ++i)
             {
-                REQUIRE(node.ToSequence()[i].IsNull());
+                REQUIRE(node.to_sequence()[i].is_null());
             }
         }
 
         SECTION("Test const non-alias sequence node.")
         {
-            const fkyaml::Node const_node = node;
-            REQUIRE_NOTHROW(const_node.ToSequence());
-            REQUIRE(const_node.ToSequence().size() == 3);
+            const fkyaml::node const_node = node;
+            REQUIRE_NOTHROW(const_node.to_sequence());
+            REQUIRE(const_node.to_sequence().size() == 3);
             for (int i = 0; i < 3; ++i)
             {
-                REQUIRE(node.ToSequence()[i].IsNull());
+                REQUIRE(node.to_sequence()[i].is_null());
             }
         }
 
         SECTION("Test alias sequence node.")
         {
-            node.AddAnchorName("anchor_name");
-            fkyaml::Node alias = fkyaml::Node::AliasOf(node);
-            REQUIRE_NOTHROW(alias.ToSequence());
-            REQUIRE(alias.ToSequence().size() == 3);
+            node.add_anchor_name("anchor_name");
+            fkyaml::node alias = fkyaml::node::alias_of(node);
+            REQUIRE_NOTHROW(alias.to_sequence());
+            REQUIRE(alias.to_sequence().size() == 3);
             for (int i = 0; i < 3; ++i)
             {
-                REQUIRE(alias.ToSequence()[i].IsNull());
+                REQUIRE(alias.to_sequence()[i].is_null());
             }
         }
 
         SECTION("Test const alias sequence node.")
         {
-            node.AddAnchorName("anchor_name");
-            const fkyaml::Node alias = fkyaml::Node::AliasOf(node);
-            REQUIRE_NOTHROW(alias.ToSequence());
-            REQUIRE(alias.ToSequence().size() == 3);
+            node.add_anchor_name("anchor_name");
+            const fkyaml::node alias = fkyaml::node::alias_of(node);
+            REQUIRE_NOTHROW(alias.to_sequence());
+            REQUIRE(alias.to_sequence().size() == 3);
             for (int i = 0; i < 3; ++i)
             {
-                REQUIRE(alias.ToSequence()[i].IsNull());
+                REQUIRE(alias.to_sequence()[i].is_null());
             }
         }
     }
@@ -1358,36 +1360,36 @@ TEST_CASE("NodeClassTest_ToSequenceTest", "[NodeClassTest]")
     SECTION("Test nothrow unexpected nodes.")
     {
         auto node = GENERATE(
-            fkyaml::Node::Mapping(),
-            fkyaml::Node(),
-            fkyaml::Node::BooleanScalar(false),
-            fkyaml::Node::IntegerScalar(0),
-            fkyaml::Node::FloatNumberScalar(0.0),
-            fkyaml::Node::StringScalar());
+            fkyaml::node::mapping(),
+            fkyaml::node(),
+            fkyaml::node::boolean_scalar(false),
+            fkyaml::node::integer_scalar(0),
+            fkyaml::node::float_number_scalar(0.0),
+            fkyaml::node::string_scalar());
 
         SECTION("Test non-alias non-sequence nodes.")
         {
-            REQUIRE_THROWS_AS(node.ToSequence(), fkyaml::Exception);
+            REQUIRE_THROWS_AS(node.to_sequence(), fkyaml::exception);
         }
 
         SECTION("Test const non-alias non-sequence nodes.")
         {
-            const fkyaml::Node const_node = node;
-            REQUIRE_THROWS_AS(const_node.ToSequence(), fkyaml::Exception);
+            const fkyaml::node const_node = node;
+            REQUIRE_THROWS_AS(const_node.to_sequence(), fkyaml::exception);
         }
 
         SECTION("Test alias non-sequence nodes.")
         {
-            node.AddAnchorName("anchor_name");
-            fkyaml::Node alias = fkyaml::Node::AliasOf(node);
-            REQUIRE_THROWS_AS(alias.ToSequence(), fkyaml::Exception);
+            node.add_anchor_name("anchor_name");
+            fkyaml::node alias = fkyaml::node::alias_of(node);
+            REQUIRE_THROWS_AS(alias.to_sequence(), fkyaml::exception);
         }
 
         SECTION("Test const alias non-sequence nodes.")
         {
-            node.AddAnchorName("anchor_name");
-            const fkyaml::Node alias = fkyaml::Node::AliasOf(node);
-            REQUIRE_THROWS_AS(alias.ToSequence(), fkyaml::Exception);
+            node.add_anchor_name("anchor_name");
+            const fkyaml::node alias = fkyaml::node::alias_of(node);
+            REQUIRE_THROWS_AS(alias.to_sequence(), fkyaml::exception);
         }
     }
 }
@@ -1396,156 +1398,156 @@ TEST_CASE("NodeClassTest_ToMappingTest", "[NodeClassTest]")
 {
     SECTION("Test nothrow expected nodes.")
     {
-        fkyaml::Node node = fkyaml::Node::Mapping(
-            fkyaml::NodeMappingType {{"test0", fkyaml::Node()}, {"test1", fkyaml::Node()}, {"test2", fkyaml::Node()}});
+        fkyaml::node node = fkyaml::node::mapping(fkyaml::node_mapping_type {
+            {"test0", fkyaml::node()}, {"test1", fkyaml::node()}, {"test2", fkyaml::node()}});
 
         SECTION("Test non-alias mapping node.")
         {
-            REQUIRE_NOTHROW(node.ToMapping());
-            REQUIRE(node.ToMapping().size() == 3);
-            REQUIRE(node["test0"].IsNull());
-            REQUIRE(node["test1"].IsNull());
-            REQUIRE(node["test2"].IsNull());
+            REQUIRE_NOTHROW(node.to_mapping());
+            REQUIRE(node.to_mapping().size() == 3);
+            REQUIRE(node["test0"].is_null());
+            REQUIRE(node["test1"].is_null());
+            REQUIRE(node["test2"].is_null());
         }
 
         SECTION("Test const non-alias mapping node.")
         {
-            const fkyaml::Node const_node = node;
-            REQUIRE_NOTHROW(const_node.ToMapping());
-            REQUIRE(const_node.ToMapping().size() == 3);
-            REQUIRE(const_node["test0"].IsNull());
-            REQUIRE(const_node["test1"].IsNull());
-            REQUIRE(const_node["test2"].IsNull());
+            const fkyaml::node const_node = node;
+            REQUIRE_NOTHROW(const_node.to_mapping());
+            REQUIRE(const_node.to_mapping().size() == 3);
+            REQUIRE(const_node["test0"].is_null());
+            REQUIRE(const_node["test1"].is_null());
+            REQUIRE(const_node["test2"].is_null());
         }
 
         SECTION("Test alias mapping node.")
         {
-            node.AddAnchorName("anchor_name");
-            fkyaml::Node alias = fkyaml::Node::AliasOf(node);
-            REQUIRE_NOTHROW(alias.ToMapping());
-            REQUIRE(alias.ToMapping().size() == 3);
-            REQUIRE(alias["test0"].IsNull());
-            REQUIRE(alias["test1"].IsNull());
-            REQUIRE(alias["test2"].IsNull());
+            node.add_anchor_name("anchor_name");
+            fkyaml::node alias = fkyaml::node::alias_of(node);
+            REQUIRE_NOTHROW(alias.to_mapping());
+            REQUIRE(alias.to_mapping().size() == 3);
+            REQUIRE(alias["test0"].is_null());
+            REQUIRE(alias["test1"].is_null());
+            REQUIRE(alias["test2"].is_null());
         }
 
         SECTION("Test const alias mapping node.")
         {
-            node.AddAnchorName("anchor_name");
-            const fkyaml::Node alias = fkyaml::Node::AliasOf(node);
-            REQUIRE_NOTHROW(alias.ToMapping());
-            REQUIRE(alias["test0"].IsNull());
-            REQUIRE(alias["test1"].IsNull());
-            REQUIRE(alias["test2"].IsNull());
+            node.add_anchor_name("anchor_name");
+            const fkyaml::node alias = fkyaml::node::alias_of(node);
+            REQUIRE_NOTHROW(alias.to_mapping());
+            REQUIRE(alias["test0"].is_null());
+            REQUIRE(alias["test1"].is_null());
+            REQUIRE(alias["test2"].is_null());
         }
     }
 
     SECTION("Test nothrow unexpected nodes.")
     {
         auto node = GENERATE(
-            fkyaml::Node::Sequence(),
-            fkyaml::Node(),
-            fkyaml::Node::BooleanScalar(false),
-            fkyaml::Node::IntegerScalar(0),
-            fkyaml::Node::FloatNumberScalar(0.0),
-            fkyaml::Node::StringScalar());
+            fkyaml::node::sequence(),
+            fkyaml::node(),
+            fkyaml::node::boolean_scalar(false),
+            fkyaml::node::integer_scalar(0),
+            fkyaml::node::float_number_scalar(0.0),
+            fkyaml::node::string_scalar());
 
         SECTION("Test non-alias non-mapping nodes.")
         {
-            REQUIRE_THROWS_AS(node.ToMapping(), fkyaml::Exception);
+            REQUIRE_THROWS_AS(node.to_mapping(), fkyaml::exception);
         }
 
         SECTION("Test const non-alias non-mapping nodes.")
         {
-            const fkyaml::Node const_node = node;
-            REQUIRE_THROWS_AS(const_node.ToMapping(), fkyaml::Exception);
+            const fkyaml::node const_node = node;
+            REQUIRE_THROWS_AS(const_node.to_mapping(), fkyaml::exception);
         }
 
         SECTION("Test alias non-mapping nodes.")
         {
-            node.AddAnchorName("anchor_name");
-            fkyaml::Node alias = fkyaml::Node::AliasOf(node);
-            REQUIRE_THROWS_AS(alias.ToMapping(), fkyaml::Exception);
+            node.add_anchor_name("anchor_name");
+            fkyaml::node alias = fkyaml::node::alias_of(node);
+            REQUIRE_THROWS_AS(alias.to_mapping(), fkyaml::exception);
         }
 
         SECTION("Test const alias non-mapping nodes.")
         {
-            node.AddAnchorName("anchor_name");
-            const fkyaml::Node alias = fkyaml::Node::AliasOf(node);
-            REQUIRE_THROWS_AS(alias.ToMapping(), fkyaml::Exception);
+            node.add_anchor_name("anchor_name");
+            const fkyaml::node alias = fkyaml::node::alias_of(node);
+            REQUIRE_THROWS_AS(alias.to_mapping(), fkyaml::exception);
         }
     }
 }
 
-TEST_CASE("NodeClassTest_ToBooleanTest", "[NodeClassTest]")
+TEST_CASE("NodeClassTest_to_booleanTest", "[NodeClassTest]")
 {
     SECTION("Test nothrow expected nodes.")
     {
-        fkyaml::Node node = fkyaml::Node::BooleanScalar(true);
+        fkyaml::node node = fkyaml::node::boolean_scalar(true);
 
         SECTION("Test non-alias boolean node.")
         {
-            REQUIRE_NOTHROW(node.ToBoolean());
-            REQUIRE(node.ToBoolean() == true);
+            REQUIRE_NOTHROW(node.to_boolean());
+            REQUIRE(node.to_boolean() == true);
         }
 
         SECTION("Test const non-alias boolean node.")
         {
-            const fkyaml::Node const_node = node;
-            REQUIRE_NOTHROW(const_node.ToBoolean());
-            REQUIRE(const_node.ToBoolean() == true);
+            const fkyaml::node const_node = node;
+            REQUIRE_NOTHROW(const_node.to_boolean());
+            REQUIRE(const_node.to_boolean() == true);
         }
 
         SECTION("Test alias boolean node.")
         {
-            node.AddAnchorName("anchor_name");
-            fkyaml::Node alias = fkyaml::Node::AliasOf(node);
-            REQUIRE_NOTHROW(alias.ToBoolean());
-            REQUIRE(alias.ToBoolean() == true);
+            node.add_anchor_name("anchor_name");
+            fkyaml::node alias = fkyaml::node::alias_of(node);
+            REQUIRE_NOTHROW(alias.to_boolean());
+            REQUIRE(alias.to_boolean() == true);
         }
 
         SECTION("Test const alias boolean node.")
         {
-            node.AddAnchorName("anchor_name");
-            const fkyaml::Node alias = fkyaml::Node::AliasOf(node);
-            REQUIRE_NOTHROW(alias.ToBoolean());
-            REQUIRE(alias.ToBoolean() == true);
+            node.add_anchor_name("anchor_name");
+            const fkyaml::node alias = fkyaml::node::alias_of(node);
+            REQUIRE_NOTHROW(alias.to_boolean());
+            REQUIRE(alias.to_boolean() == true);
         }
     }
 
     SECTION("Test nothrow unexpected nodes.")
     {
         auto node = GENERATE(
-            fkyaml::Node::Sequence(),
-            fkyaml::Node::Mapping(),
-            fkyaml::Node(),
-            fkyaml::Node::IntegerScalar(0),
-            fkyaml::Node::FloatNumberScalar(0.0),
-            fkyaml::Node::StringScalar());
+            fkyaml::node::sequence(),
+            fkyaml::node::mapping(),
+            fkyaml::node(),
+            fkyaml::node::integer_scalar(0),
+            fkyaml::node::float_number_scalar(0.0),
+            fkyaml::node::string_scalar());
 
         SECTION("Test non-alias non-boolean nodes.")
         {
-            REQUIRE_THROWS_AS(node.ToBoolean(), fkyaml::Exception);
+            REQUIRE_THROWS_AS(node.to_boolean(), fkyaml::exception);
         }
 
         SECTION("Test const non-alias non-boolean nodes.")
         {
-            const fkyaml::Node const_node = node;
-            REQUIRE_THROWS_AS(const_node.ToBoolean(), fkyaml::Exception);
+            const fkyaml::node const_node = node;
+            REQUIRE_THROWS_AS(const_node.to_boolean(), fkyaml::exception);
         }
 
         SECTION("Test alias non-boolean nodes.")
         {
-            node.AddAnchorName("anchor_name");
-            fkyaml::Node alias = fkyaml::Node::AliasOf(node);
-            REQUIRE_THROWS_AS(alias.ToBoolean(), fkyaml::Exception);
+            node.add_anchor_name("anchor_name");
+            fkyaml::node alias = fkyaml::node::alias_of(node);
+            REQUIRE_THROWS_AS(alias.to_boolean(), fkyaml::exception);
         }
 
         SECTION("Test const alias non-boolean nodes.")
         {
-            node.AddAnchorName("anchor_name");
-            const fkyaml::Node alias = fkyaml::Node::AliasOf(node);
-            REQUIRE_THROWS_AS(alias.ToBoolean(), fkyaml::Exception);
+            node.add_anchor_name("anchor_name");
+            const fkyaml::node alias = fkyaml::node::alias_of(node);
+            REQUIRE_THROWS_AS(alias.to_boolean(), fkyaml::exception);
         }
     }
 }
@@ -1554,72 +1556,72 @@ TEST_CASE("NodeClassTest_ToIntegerTest", "[NodeClassTest]")
 {
     SECTION("Test nothrow expected nodes.")
     {
-        fkyaml::NodeIntegerType integer = -123;
-        fkyaml::Node node = fkyaml::Node::IntegerScalar(integer);
+        fkyaml::node_integer_type integer = -123;
+        fkyaml::node node = fkyaml::node::integer_scalar(integer);
 
         SECTION("Test non-alias  integer node.")
         {
-            REQUIRE_NOTHROW(node.ToInteger());
-            REQUIRE(node.ToInteger() == integer);
+            REQUIRE_NOTHROW(node.to_integer());
+            REQUIRE(node.to_integer() == integer);
         }
 
         SECTION("Test const non-alias  integer node.")
         {
-            const fkyaml::Node const_node = node;
-            REQUIRE_NOTHROW(const_node.ToInteger());
-            REQUIRE(const_node.ToInteger() == integer);
+            const fkyaml::node const_node = node;
+            REQUIRE_NOTHROW(const_node.to_integer());
+            REQUIRE(const_node.to_integer() == integer);
         }
 
         SECTION("Test alias  integer node.")
         {
-            node.AddAnchorName("anchor_name");
-            fkyaml::Node alias = fkyaml::Node::AliasOf(node);
-            REQUIRE_NOTHROW(alias.ToInteger());
-            REQUIRE(alias.ToInteger() == integer);
+            node.add_anchor_name("anchor_name");
+            fkyaml::node alias = fkyaml::node::alias_of(node);
+            REQUIRE_NOTHROW(alias.to_integer());
+            REQUIRE(alias.to_integer() == integer);
         }
 
         SECTION("Test const alias  integer node.")
         {
-            node.AddAnchorName("anchor_name");
-            const fkyaml::Node alias = fkyaml::Node::AliasOf(node);
-            REQUIRE_NOTHROW(alias.ToInteger());
-            REQUIRE(alias.ToInteger() == integer);
+            node.add_anchor_name("anchor_name");
+            const fkyaml::node alias = fkyaml::node::alias_of(node);
+            REQUIRE_NOTHROW(alias.to_integer());
+            REQUIRE(alias.to_integer() == integer);
         }
     }
 
     SECTION("Test nothrow unexpected nodes.")
     {
         auto node = GENERATE(
-            fkyaml::Node::Sequence(),
-            fkyaml::Node::Mapping(),
-            fkyaml::Node(),
-            fkyaml::Node::BooleanScalar(false),
-            fkyaml::Node::FloatNumberScalar(0.0),
-            fkyaml::Node::StringScalar());
+            fkyaml::node::sequence(),
+            fkyaml::node::mapping(),
+            fkyaml::node(),
+            fkyaml::node::boolean_scalar(false),
+            fkyaml::node::float_number_scalar(0.0),
+            fkyaml::node::string_scalar());
 
         SECTION("Test non-alias non-integer nodes.")
         {
-            REQUIRE_THROWS_AS(node.ToInteger(), fkyaml::Exception);
+            REQUIRE_THROWS_AS(node.to_integer(), fkyaml::exception);
         }
 
         SECTION("Test const non-alias non-integer nodes.")
         {
-            const fkyaml::Node const_node = node;
-            REQUIRE_THROWS_AS(const_node.ToInteger(), fkyaml::Exception);
+            const fkyaml::node const_node = node;
+            REQUIRE_THROWS_AS(const_node.to_integer(), fkyaml::exception);
         }
 
         SECTION("Test alias non-integer nodes.")
         {
-            node.AddAnchorName("anchor_name");
-            fkyaml::Node alias = fkyaml::Node::AliasOf(node);
-            REQUIRE_THROWS_AS(alias.ToInteger(), fkyaml::Exception);
+            node.add_anchor_name("anchor_name");
+            fkyaml::node alias = fkyaml::node::alias_of(node);
+            REQUIRE_THROWS_AS(alias.to_integer(), fkyaml::exception);
         }
 
         SECTION("Test const alias non-integer nodes.")
         {
-            node.AddAnchorName("anchor_name");
-            const fkyaml::Node alias = fkyaml::Node::AliasOf(node);
-            REQUIRE_THROWS_AS(alias.ToInteger(), fkyaml::Exception);
+            node.add_anchor_name("anchor_name");
+            const fkyaml::node alias = fkyaml::node::alias_of(node);
+            REQUIRE_THROWS_AS(alias.to_integer(), fkyaml::exception);
         }
     }
 }
@@ -1628,146 +1630,146 @@ TEST_CASE("NodeClassTest_ToFloatNumberTest", "[NodeClassTest]")
 {
     SECTION("Test nothrow expected nodes.")
     {
-        fkyaml::NodeFloatNumberType float_val = 123.45;
-        fkyaml::Node node = fkyaml::Node::FloatNumberScalar(float_val);
+        fkyaml::node_float_number_type float_val = 123.45;
+        fkyaml::node node = fkyaml::node::float_number_scalar(float_val);
 
         SECTION("Test non-alias float number node.")
         {
-            REQUIRE_NOTHROW(node.ToFloatNumber());
-            REQUIRE(node.ToFloatNumber() == float_val);
+            REQUIRE_NOTHROW(node.to_float_number());
+            REQUIRE(node.to_float_number() == float_val);
         }
 
         SECTION("Test const non-alias float number node.")
         {
-            const fkyaml::Node const_node = node;
-            REQUIRE_NOTHROW(const_node.ToFloatNumber());
-            REQUIRE(const_node.ToFloatNumber() == float_val);
+            const fkyaml::node const_node = node;
+            REQUIRE_NOTHROW(const_node.to_float_number());
+            REQUIRE(const_node.to_float_number() == float_val);
         }
 
         SECTION("Test alias float number node.")
         {
-            node.AddAnchorName("anchor_name");
-            fkyaml::Node alias = fkyaml::Node::AliasOf(node);
-            REQUIRE_NOTHROW(alias.ToFloatNumber());
-            REQUIRE(alias.ToFloatNumber() == float_val);
+            node.add_anchor_name("anchor_name");
+            fkyaml::node alias = fkyaml::node::alias_of(node);
+            REQUIRE_NOTHROW(alias.to_float_number());
+            REQUIRE(alias.to_float_number() == float_val);
         }
 
         SECTION("Test const alias float number node.")
         {
-            node.AddAnchorName("anchor_name");
-            const fkyaml::Node alias = fkyaml::Node::AliasOf(node);
-            REQUIRE_NOTHROW(alias.ToFloatNumber());
-            REQUIRE(alias.ToFloatNumber() == float_val);
+            node.add_anchor_name("anchor_name");
+            const fkyaml::node alias = fkyaml::node::alias_of(node);
+            REQUIRE_NOTHROW(alias.to_float_number());
+            REQUIRE(alias.to_float_number() == float_val);
         }
     }
 
     SECTION("Test nothrow unexpected nodes.")
     {
         auto node = GENERATE(
-            fkyaml::Node::Sequence(),
-            fkyaml::Node::Mapping(),
-            fkyaml::Node(),
-            fkyaml::Node::BooleanScalar(false),
-            fkyaml::Node::IntegerScalar(0),
-            fkyaml::Node::StringScalar());
+            fkyaml::node::sequence(),
+            fkyaml::node::mapping(),
+            fkyaml::node(),
+            fkyaml::node::boolean_scalar(false),
+            fkyaml::node::integer_scalar(0),
+            fkyaml::node::string_scalar());
 
         SECTION("Test non-alias non-float-number nodes.")
         {
-            REQUIRE_THROWS_AS(node.ToFloatNumber(), fkyaml::Exception);
+            REQUIRE_THROWS_AS(node.to_float_number(), fkyaml::exception);
         }
 
         SECTION("Test const non-alias non-float-number nodes.")
         {
-            const fkyaml::Node const_node = node;
-            REQUIRE_THROWS_AS(const_node.ToFloatNumber(), fkyaml::Exception);
+            const fkyaml::node const_node = node;
+            REQUIRE_THROWS_AS(const_node.to_float_number(), fkyaml::exception);
         }
 
         SECTION("Test alias non-float-number nodes.")
         {
-            node.AddAnchorName("anchor_name");
-            fkyaml::Node alias = fkyaml::Node::AliasOf(node);
-            REQUIRE_THROWS_AS(alias.ToFloatNumber(), fkyaml::Exception);
+            node.add_anchor_name("anchor_name");
+            fkyaml::node alias = fkyaml::node::alias_of(node);
+            REQUIRE_THROWS_AS(alias.to_float_number(), fkyaml::exception);
         }
 
         SECTION("Test const alias non-float-number nodes.")
         {
-            node.AddAnchorName("anchor_name");
-            const fkyaml::Node alias = fkyaml::Node::AliasOf(node);
-            REQUIRE_THROWS_AS(alias.ToFloatNumber(), fkyaml::Exception);
+            node.add_anchor_name("anchor_name");
+            const fkyaml::node alias = fkyaml::node::alias_of(node);
+            REQUIRE_THROWS_AS(alias.to_float_number(), fkyaml::exception);
         }
     }
 }
 
-TEST_CASE("NodeClassTest_ToStringTest", "[NodeClassTest]")
+TEST_CASE("NodeClassTest_to_stringTest", "[NodeClassTest]")
 {
     SECTION("Test nothrow expected nodes.")
     {
-        fkyaml::NodeStringType str = "test";
-        fkyaml::Node node = fkyaml::Node::StringScalar(str);
+        fkyaml::node_string_type str = "test";
+        fkyaml::node node = fkyaml::node::string_scalar(str);
 
         SECTION("Test non-alias string node.")
         {
-            REQUIRE_NOTHROW(node.ToString());
-            REQUIRE(node.ToString() == str);
+            REQUIRE_NOTHROW(node.to_string());
+            REQUIRE(node.to_string() == str);
         }
 
         SECTION("Test const non-alias string node.")
         {
-            const fkyaml::Node const_node = node;
-            REQUIRE_NOTHROW(const_node.ToString());
-            REQUIRE(const_node.ToString() == str);
+            const fkyaml::node const_node = node;
+            REQUIRE_NOTHROW(const_node.to_string());
+            REQUIRE(const_node.to_string() == str);
         }
 
         SECTION("Test alias string node.")
         {
-            node.AddAnchorName("anchor_name");
-            fkyaml::Node alias = fkyaml::Node::AliasOf(node);
-            REQUIRE_NOTHROW(alias.ToString());
-            REQUIRE(alias.ToString() == str);
+            node.add_anchor_name("anchor_name");
+            fkyaml::node alias = fkyaml::node::alias_of(node);
+            REQUIRE_NOTHROW(alias.to_string());
+            REQUIRE(alias.to_string() == str);
         }
 
         SECTION("Test const alias string node.")
         {
-            node.AddAnchorName("anchor_name");
-            const fkyaml::Node alias = fkyaml::Node::AliasOf(node);
-            REQUIRE_NOTHROW(alias.ToString());
-            REQUIRE(alias.ToString() == str);
+            node.add_anchor_name("anchor_name");
+            const fkyaml::node alias = fkyaml::node::alias_of(node);
+            REQUIRE_NOTHROW(alias.to_string());
+            REQUIRE(alias.to_string() == str);
         }
     }
 
     SECTION("Test nothrow unexpected nodes.")
     {
         auto node = GENERATE(
-            fkyaml::Node::Sequence(),
-            fkyaml::Node::Mapping(),
-            fkyaml::Node(),
-            fkyaml::Node::BooleanScalar(false),
-            fkyaml::Node::IntegerScalar(0),
-            fkyaml::Node::FloatNumberScalar(0.0));
+            fkyaml::node::sequence(),
+            fkyaml::node::mapping(),
+            fkyaml::node(),
+            fkyaml::node::boolean_scalar(false),
+            fkyaml::node::integer_scalar(0),
+            fkyaml::node::float_number_scalar(0.0));
 
         SECTION("Test non-alias non-string nodes.")
         {
-            REQUIRE_THROWS_AS(node.ToString(), fkyaml::Exception);
+            REQUIRE_THROWS_AS(node.to_string(), fkyaml::exception);
         }
 
         SECTION("Test const non-alias non-string nodes.")
         {
-            const fkyaml::Node const_node = node;
-            REQUIRE_THROWS_AS(const_node.ToString(), fkyaml::Exception);
+            const fkyaml::node const_node = node;
+            REQUIRE_THROWS_AS(const_node.to_string(), fkyaml::exception);
         }
 
         SECTION("Test alias non-string nodes.")
         {
-            node.AddAnchorName("anchor_name");
-            fkyaml::Node alias = fkyaml::Node::AliasOf(node);
-            REQUIRE_THROWS_AS(alias.ToString(), fkyaml::Exception);
+            node.add_anchor_name("anchor_name");
+            fkyaml::node alias = fkyaml::node::alias_of(node);
+            REQUIRE_THROWS_AS(alias.to_string(), fkyaml::exception);
         }
 
         SECTION("Test const alias non-string nodes.")
         {
-            node.AddAnchorName("anchor_name");
-            const fkyaml::Node alias = fkyaml::Node::AliasOf(node);
-            REQUIRE_THROWS_AS(alias.ToString(), fkyaml::Exception);
+            node.add_anchor_name("anchor_name");
+            const fkyaml::node alias = fkyaml::node::alias_of(node);
+            REQUIRE_THROWS_AS(alias.to_string(), fkyaml::exception);
         }
     }
 }
@@ -1780,31 +1782,31 @@ TEST_CASE("NodeClassTest_BeginTest", "[NodeClassTest]")
 {
     SECTION("Test nothrow expected nodes.")
     {
-        auto node = GENERATE(fkyaml::Node::Sequence(), fkyaml::Node::Mapping());
+        auto node = GENERATE(fkyaml::node::sequence(), fkyaml::node::mapping());
 
         SECTION("Test non-const non-alias container node.")
         {
-            REQUIRE_NOTHROW(node.Begin());
+            REQUIRE_NOTHROW(node.begin());
         }
 
         SECTION("Test const non-alias container node.")
         {
-            const fkyaml::Node const_node = node;
-            REQUIRE_NOTHROW(const_node.Begin());
+            const fkyaml::node const_node = node;
+            REQUIRE_NOTHROW(const_node.begin());
         }
 
         SECTION("Test non-const alias container node.")
         {
-            node.AddAnchorName("anchor_name");
-            fkyaml::Node alias = fkyaml::Node::AliasOf(node);
-            REQUIRE_NOTHROW(alias.Begin());
+            node.add_anchor_name("anchor_name");
+            fkyaml::node alias = fkyaml::node::alias_of(node);
+            REQUIRE_NOTHROW(alias.begin());
         }
 
         SECTION("Test non-const alias container node.")
         {
-            node.AddAnchorName("anchor_name");
-            const fkyaml::Node alias = fkyaml::Node::AliasOf(node);
-            REQUIRE_NOTHROW(alias.Begin());
+            node.add_anchor_name("anchor_name");
+            const fkyaml::node alias = fkyaml::node::alias_of(node);
+            REQUIRE_NOTHROW(alias.begin());
         }
 
         SECTION("Test non-const range-based for-loop compatibility.")
@@ -1814,7 +1816,7 @@ TEST_CASE("NodeClassTest_BeginTest", "[NodeClassTest]")
 
         SECTION("Test const range-based for-loop compatibility.")
         {
-            const fkyaml::Node const_node = node;
+            const fkyaml::node const_node = node;
             REQUIRE_NOTHROW(const_node.begin());
         }
     }
@@ -1822,21 +1824,21 @@ TEST_CASE("NodeClassTest_BeginTest", "[NodeClassTest]")
     SECTION("Test nothrow unexpected nodes.")
     {
         auto node = GENERATE(
-            fkyaml::Node(),
-            fkyaml::Node::BooleanScalar(false),
-            fkyaml::Node::IntegerScalar(0),
-            fkyaml::Node::FloatNumberScalar(0.0),
-            fkyaml::Node::StringScalar());
+            fkyaml::node(),
+            fkyaml::node::boolean_scalar(false),
+            fkyaml::node::integer_scalar(0),
+            fkyaml::node::float_number_scalar(0.0),
+            fkyaml::node::string_scalar());
 
         SECTION("Test non-const throwing node.")
         {
-            REQUIRE_THROWS_AS(node.Begin(), fkyaml::Exception);
+            REQUIRE_THROWS_AS(node.begin(), fkyaml::exception);
         }
 
         SECTION("Test const throwing node.")
         {
-            const fkyaml::Node const_node = node;
-            REQUIRE_THROWS_AS(const_node.Begin(), fkyaml::Exception);
+            const fkyaml::node const_node = node;
+            REQUIRE_THROWS_AS(const_node.begin(), fkyaml::exception);
         }
     }
 }
@@ -1845,31 +1847,31 @@ TEST_CASE("NodeClassTest_EndTest", "[NodeClassTest]")
 {
     SECTION("Test nothrow expected nodes.")
     {
-        auto node = GENERATE(fkyaml::Node::Sequence(), fkyaml::Node::Mapping());
+        auto node = GENERATE(fkyaml::node::sequence(), fkyaml::node::mapping());
 
         SECTION("Test non-const non-alias container node.")
         {
-            REQUIRE_NOTHROW(node.End());
+            REQUIRE_NOTHROW(node.end());
         }
 
         SECTION("Test const non-alias container node.")
         {
-            const fkyaml::Node const_node = node;
-            REQUIRE_NOTHROW(const_node.End());
+            const fkyaml::node const_node = node;
+            REQUIRE_NOTHROW(const_node.end());
         }
 
         SECTION("Test non-const alias container node.")
         {
-            node.AddAnchorName("anchor_name");
-            fkyaml::Node alias = fkyaml::Node::AliasOf(node);
-            REQUIRE_NOTHROW(alias.End());
+            node.add_anchor_name("anchor_name");
+            fkyaml::node alias = fkyaml::node::alias_of(node);
+            REQUIRE_NOTHROW(alias.end());
         }
 
         SECTION("Test non-const alias container node.")
         {
-            node.AddAnchorName("anchor_name");
-            const fkyaml::Node alias = fkyaml::Node::AliasOf(node);
-            REQUIRE_NOTHROW(alias.End());
+            node.add_anchor_name("anchor_name");
+            const fkyaml::node alias = fkyaml::node::alias_of(node);
+            REQUIRE_NOTHROW(alias.end());
         }
 
         SECTION("Test non-const range-based for-loop compatibility.")
@@ -1879,7 +1881,7 @@ TEST_CASE("NodeClassTest_EndTest", "[NodeClassTest]")
 
         SECTION("Test const range-based for-loop compatibility.")
         {
-            const fkyaml::Node const_node = node;
+            const fkyaml::node const_node = node;
             REQUIRE_NOTHROW(const_node.end());
         }
     }
@@ -1887,21 +1889,21 @@ TEST_CASE("NodeClassTest_EndTest", "[NodeClassTest]")
     SECTION("Test nothrow unexpected nodes.")
     {
         auto node = GENERATE(
-            fkyaml::Node(),
-            fkyaml::Node::BooleanScalar(false),
-            fkyaml::Node::IntegerScalar(0),
-            fkyaml::Node::FloatNumberScalar(0.0),
-            fkyaml::Node::StringScalar());
+            fkyaml::node(),
+            fkyaml::node::boolean_scalar(false),
+            fkyaml::node::integer_scalar(0),
+            fkyaml::node::float_number_scalar(0.0),
+            fkyaml::node::string_scalar());
 
         SECTION("Test non-const throwing node.")
         {
-            REQUIRE_THROWS_AS(node.End(), fkyaml::Exception);
+            REQUIRE_THROWS_AS(node.end(), fkyaml::exception);
         }
 
         SECTION("Test const throwing node.")
         {
-            const fkyaml::Node const_node = node;
-            REQUIRE_THROWS_AS(const_node.End(), fkyaml::Exception);
+            const fkyaml::node const_node = node;
+            REQUIRE_THROWS_AS(const_node.end(), fkyaml::exception);
         }
     }
 }
@@ -1912,22 +1914,22 @@ TEST_CASE("NodeClassTest_EndTest", "[NodeClassTest]")
 
 TEST_CASE("NodeClassTest_SwapTest", "[NodeClassTest]")
 {
-    fkyaml::Node lhs_node = fkyaml::Node::BooleanScalar(true);
-    fkyaml::Node rhs_node = fkyaml::Node::IntegerScalar(123);
-    lhs_node.Swap(rhs_node);
-    REQUIRE(lhs_node.IsInteger());
-    REQUIRE(lhs_node.ToInteger() == 123);
-    REQUIRE(rhs_node.IsBoolean());
-    REQUIRE(rhs_node.ToBoolean() == true);
+    fkyaml::node lhs_node = fkyaml::node::boolean_scalar(true);
+    fkyaml::node rhs_node = fkyaml::node::integer_scalar(123);
+    lhs_node.swap(rhs_node);
+    REQUIRE(lhs_node.is_integer());
+    REQUIRE(lhs_node.to_integer() == 123);
+    REQUIRE(rhs_node.is_boolean());
+    REQUIRE(rhs_node.to_boolean() == true);
 }
 
 TEST_CASE("NodeClassTest_StdSwapTest", "[NodeClassTest]")
 {
-    fkyaml::Node lhs_node = fkyaml::Node::BooleanScalar(true);
-    fkyaml::Node rhs_node = fkyaml::Node::IntegerScalar(123);
+    fkyaml::node lhs_node = fkyaml::node::boolean_scalar(true);
+    fkyaml::node rhs_node = fkyaml::node::integer_scalar(123);
     std::swap(lhs_node, rhs_node);
-    REQUIRE(lhs_node.IsInteger());
-    REQUIRE(lhs_node.ToInteger() == 123);
-    REQUIRE(rhs_node.IsBoolean());
-    REQUIRE(rhs_node.ToBoolean() == true);
+    REQUIRE(lhs_node.is_integer());
+    REQUIRE(lhs_node.to_integer() == 123);
+    REQUIRE(rhs_node.is_boolean());
+    REQUIRE(rhs_node.to_boolean() == true);
 }

--- a/test/unit_test/OrderedMapClassTest.cpp
+++ b/test/unit_test/OrderedMapClassTest.cpp
@@ -14,20 +14,20 @@
 
 TEST_CASE("OrderedMapClassTest_DefaultCtorTest", "[OrderedMapClassTest]")
 {
-    fkyaml::OrderedMap<std::string, bool> map;
+    fkyaml::ordered_map<std::string, bool> map;
     REQUIRE(map.empty());
 }
 
 TEST_CASE("OrderedMapClassTest_InitListCtorTest", "[OrderedMapClassTest]")
 {
-    fkyaml::OrderedMap<std::string, bool> map {{"foo", true}, {"bar", false}};
+    fkyaml::ordered_map<std::string, bool> map {{"foo", true}, {"bar", false}};
     REQUIRE_FALSE(map.empty());
     REQUIRE(map.size() == 2);
     REQUIRE(map["foo"] == true);
     REQUIRE(map["bar"] == false);
     REQUIRE_NOTHROW(map.at("foo"));
     REQUIRE_NOTHROW(map.at("bar"));
-    REQUIRE_THROWS_AS(map.at("buz"), fkyaml::Exception);
+    REQUIRE_THROWS_AS(map.at("buz"), fkyaml::exception);
     auto itr = map.begin();
     REQUIRE(itr->first == "foo");
     REQUIRE(itr->second == true);
@@ -38,7 +38,7 @@ TEST_CASE("OrderedMapClassTest_InitListCtorTest", "[OrderedMapClassTest]")
 
 TEST_CASE("OrderedMapClassTest_SubscriptOperatorTest", "[OrderedMapClassTest]")
 {
-    fkyaml::OrderedMap<std::string, bool> map {{"foo", true}, {"buz", false}};
+    fkyaml::ordered_map<std::string, bool> map {{"foo", true}, {"buz", false}};
     REQUIRE(map["foo"] == true);
     REQUIRE(map["bar"] == false);
     REQUIRE(map["buz"] == false);
@@ -48,7 +48,7 @@ TEST_CASE("OrderedMapClassTest_SubscriptOperatorTest", "[OrderedMapClassTest]")
 
 TEST_CASE("OrderedMapClassTest_EmplaceTest", "[OrderedMapClassTest]")
 {
-    fkyaml::OrderedMap<std::string, bool> map;
+    fkyaml::ordered_map<std::string, bool> map;
     REQUIRE(map.emplace("foo", true).second == true);
     REQUIRE(map.emplace("foo", false).second == false);
     REQUIRE(map["foo"] == true);
@@ -58,30 +58,30 @@ TEST_CASE("OrderedMapClassTest_EmplaceTest", "[OrderedMapClassTest]")
 
 TEST_CASE("OrderedMapClassTest_NonConstAtTest", "[OrderedMapClassTest]")
 {
-    fkyaml::OrderedMap<std::string, bool> map;
-    REQUIRE_THROWS_AS(map.at("foo"), fkyaml::Exception);
+    fkyaml::ordered_map<std::string, bool> map;
+    REQUIRE_THROWS_AS(map.at("foo"), fkyaml::exception);
     map.emplace("foo", true);
     REQUIRE_NOTHROW(map.at("foo"));
     REQUIRE(map.at("foo") == true);
-    REQUIRE_THROWS_AS(map.at("bar"), fkyaml::Exception);
+    REQUIRE_THROWS_AS(map.at("bar"), fkyaml::exception);
 }
 
 TEST_CASE("OrderedMapClassTest_ConstAtTest", "[OrderedMapClassTest]")
 {
-    const fkyaml::OrderedMap<std::string, bool> map;
-    REQUIRE_THROWS_AS(map.at("foo"), fkyaml::Exception);
-    fkyaml::OrderedMap<std::string, bool> map_ = map;
+    const fkyaml::ordered_map<std::string, bool> map;
+    REQUIRE_THROWS_AS(map.at("foo"), fkyaml::exception);
+    fkyaml::ordered_map<std::string, bool> map_ = map;
     map_.emplace("buz", false);
     map_.emplace("foo", true);
-    const fkyaml::OrderedMap<std::string, bool> map__ = map_;
+    const fkyaml::ordered_map<std::string, bool> map__ = map_;
     REQUIRE_NOTHROW(map__.at("foo"));
     REQUIRE(map__.at("foo") == true);
-    REQUIRE_THROWS_AS(map__.at("bar"), fkyaml::Exception);
+    REQUIRE_THROWS_AS(map__.at("bar"), fkyaml::exception);
 }
 
 TEST_CASE("OrderedMapClassTest_NonConstFindTest", "[OrderedMapClassTest]")
 {
-    fkyaml::OrderedMap<std::string, bool> map;
+    fkyaml::ordered_map<std::string, bool> map;
     REQUIRE(map.find("foo") == map.end());
     map.emplace("foo", true);
     REQUIRE(map.find("foo") != map.end());
@@ -92,11 +92,11 @@ TEST_CASE("OrderedMapClassTest_NonConstFindTest", "[OrderedMapClassTest]")
 
 TEST_CASE("OrderedMapClassTest_ConstFindTest", "[OrderedMapClassTest]")
 {
-    const fkyaml::OrderedMap<std::string, bool> map;
+    const fkyaml::ordered_map<std::string, bool> map;
     REQUIRE(map.find("foo") == map.end());
-    fkyaml::OrderedMap<std::string, bool> map_ = map;
+    fkyaml::ordered_map<std::string, bool> map_ = map;
     map_.emplace("foo", true);
-    const fkyaml::OrderedMap<std::string, bool> map__ = map_;
+    const fkyaml::ordered_map<std::string, bool> map__ = map_;
     REQUIRE(map__.find("foo") != map__.end());
     REQUIRE(map__.find("foo")->first == "foo");
     REQUIRE(map__.find("foo")->second == true);

--- a/test/unit_test/SerializerClassTest.cpp
+++ b/test/unit_test/SerializerClassTest.cpp
@@ -15,85 +15,85 @@
 
 TEST_CASE("SerializerClassTest_SerializeSequenceNode", "[SerializerClassTest]")
 {
-    using NodeStrPair = std::pair<fkyaml::Node, std::string>;
+    using NodeStrPair = std::pair<fkyaml::node, std::string>;
     auto node_str_pair = GENERATE(
         NodeStrPair(
-            fkyaml::Node::Sequence({fkyaml::Node::BooleanScalar(true), fkyaml::Node::BooleanScalar(false)}),
+            fkyaml::node::sequence({fkyaml::node::boolean_scalar(true), fkyaml::node::boolean_scalar(false)}),
             "- true\n- false\n"),
         NodeStrPair(
-            fkyaml::Node::Sequence(
-                {fkyaml::Node::Mapping({{"foo", fkyaml::Node::IntegerScalar(-1234)}, {"bar", fkyaml::Node()}})}),
+            fkyaml::node::sequence(
+                {fkyaml::node::mapping({{"foo", fkyaml::node::integer_scalar(-1234)}, {"bar", fkyaml::node()}})}),
             "-\n  foo: -1234\n  bar: null\n"));
-    fkyaml::Serializer serializer;
-    REQUIRE(serializer.Serialize(node_str_pair.first) == node_str_pair.second);
+    fkyaml::serializer serializer;
+    REQUIRE(serializer.serialize(node_str_pair.first) == node_str_pair.second);
 }
 
 TEST_CASE("SerializerClassTest_SerializeMappingNode", "[SerializerClassTest]")
 {
-    using NodeStrPair = std::pair<fkyaml::Node, std::string>;
+    using NodeStrPair = std::pair<fkyaml::node, std::string>;
     auto node_str_pair = GENERATE(
         NodeStrPair(
-            fkyaml::Node::Mapping({{"foo", fkyaml::Node::IntegerScalar(-1234)}, {"bar", fkyaml::Node()}}),
+            fkyaml::node::mapping({{"foo", fkyaml::node::integer_scalar(-1234)}, {"bar", fkyaml::node()}}),
             "foo: -1234\nbar: null\n"),
         NodeStrPair(
-            fkyaml::Node::Mapping(
+            fkyaml::node::mapping(
                 {{"foo",
-                  fkyaml::Node::Sequence({fkyaml::Node::BooleanScalar(true), fkyaml::Node::BooleanScalar(false)})}}),
+                  fkyaml::node::sequence({fkyaml::node::boolean_scalar(true), fkyaml::node::boolean_scalar(false)})}}),
             "foo:\n  - true\n  - false\n"));
-    fkyaml::Serializer serializer;
-    REQUIRE(serializer.Serialize(node_str_pair.first) == node_str_pair.second);
+    fkyaml::serializer serializer;
+    REQUIRE(serializer.serialize(node_str_pair.first) == node_str_pair.second);
 }
 
 TEST_CASE("SerializerClassTest_SerializeNullNode", "[SerializerClassTest]")
 {
-    fkyaml::Serializer serializer;
-    fkyaml::Node node;
-    REQUIRE(serializer.Serialize(node) == "null");
+    fkyaml::serializer serializer;
+    fkyaml::node node;
+    REQUIRE(serializer.serialize(node) == "null");
 }
 
 TEST_CASE("SerializerClassTest_SerializeBooleanNode", "[SerializerClassTest]")
 {
-    using NodeStrPair = std::pair<fkyaml::Node, std::string>;
+    using NodeStrPair = std::pair<fkyaml::node, std::string>;
     auto node_str_pair = GENERATE(
-        NodeStrPair(fkyaml::Node::BooleanScalar(false), "false"),
-        NodeStrPair(fkyaml::Node::BooleanScalar(true), "true"));
-    fkyaml::Serializer serializer;
-    REQUIRE(serializer.Serialize(node_str_pair.first) == node_str_pair.second);
+        NodeStrPair(fkyaml::node::boolean_scalar(false), "false"),
+        NodeStrPair(fkyaml::node::boolean_scalar(true), "true"));
+    fkyaml::serializer serializer;
+    REQUIRE(serializer.serialize(node_str_pair.first) == node_str_pair.second);
 }
 
 TEST_CASE("SerializerClassTest_SerializeIntegerNode", "[SerializerClassTest]")
 {
-    using NodeStrPair = std::pair<fkyaml::Node, std::string>;
+    using NodeStrPair = std::pair<fkyaml::node, std::string>;
     auto node_str_pair = GENERATE(
-        NodeStrPair(fkyaml::Node::IntegerScalar(-1234), "-1234"),
-        NodeStrPair(fkyaml::Node::IntegerScalar(5678), "5678"));
-    fkyaml::Serializer serializer;
-    REQUIRE(serializer.Serialize(node_str_pair.first) == node_str_pair.second);
+        NodeStrPair(fkyaml::node::integer_scalar(-1234), "-1234"),
+        NodeStrPair(fkyaml::node::integer_scalar(5678), "5678"));
+    fkyaml::serializer serializer;
+    REQUIRE(serializer.serialize(node_str_pair.first) == node_str_pair.second);
 }
 
 TEST_CASE("SerializeClassTest_SerializeFloatNumberNode", "[SerializeClassTest]")
 {
-    using NodeStrPair = std::pair<fkyaml::Node, std::string>;
+    using NodeStrPair = std::pair<fkyaml::node, std::string>;
     auto node_str_pair = GENERATE(
-        NodeStrPair(fkyaml::Node::FloatNumberScalar(3.14), "3.14"),
-        NodeStrPair(fkyaml::Node::FloatNumberScalar(-53.97), "-53.97"),
+        NodeStrPair(fkyaml::node::float_number_scalar(3.14), "3.14"),
+        NodeStrPair(fkyaml::node::float_number_scalar(-53.97), "-53.97"),
         NodeStrPair(
-            fkyaml::Node::FloatNumberScalar(std::numeric_limits<fkyaml::NodeFloatNumberType>::infinity()), ".inf"),
+            fkyaml::node::float_number_scalar(std::numeric_limits<fkyaml::node_float_number_type>::infinity()), ".inf"),
         NodeStrPair(
-            fkyaml::Node::FloatNumberScalar(-1 * std::numeric_limits<fkyaml::NodeFloatNumberType>::infinity()),
+            fkyaml::node::float_number_scalar(-1 * std::numeric_limits<fkyaml::node_float_number_type>::infinity()),
             "-.inf"),
-        NodeStrPair(fkyaml::Node::FloatNumberScalar(std::nan("")), ".nan"));
-    fkyaml::Serializer serializer;
-    REQUIRE(serializer.Serialize(node_str_pair.first) == node_str_pair.second);
+        NodeStrPair(fkyaml::node::float_number_scalar(std::nan("")), ".nan"));
+    fkyaml::serializer serializer;
+    REQUIRE(serializer.serialize(node_str_pair.first) == node_str_pair.second);
 }
 
 TEST_CASE("SerializerClassTest_SerializeStringNode", "[SerializerClassTest]")
 {
-    using NodeStrPair = std::pair<fkyaml::Node, std::string>;
+    using node_str_pair_t = std::pair<fkyaml::node, std::string>;
     auto node_str_pair = GENERATE(
-        NodeStrPair(fkyaml::Node::StringScalar("test"), "test"),
-        NodeStrPair(fkyaml::Node::StringScalar("foo bar"), "foo bar"));
+        node_str_pair_t(fkyaml::node::string_scalar("test"), "test"),
+        node_str_pair_t(fkyaml::node::string_scalar("foo bar"), "foo bar"));
 
-    fkyaml::Serializer serializer;
-    REQUIRE(serializer.Serialize(node_str_pair.first) == node_str_pair.second);
+    fkyaml::serializer serializer;
+    REQUIRE(serializer.serialize(node_str_pair.first) == node_str_pair.second);
 }


### PR DESCRIPTION
To enhance compatibility of naming conventions with existing STL implementation, almost all custom types in the project have been changed to the lower_snake_case format.  
One exception is applied to template arguments because they are conventionally named in UpperCamelCase format.  
Additionally, example codes in the README.md have also been changed to follow the changes in naming conventions.  
The above changes gurantee no compatibility with the earlier version of the fkYAML library.  

#123 