### PR TITLE
#136 Auto-generate a helper source file for the clang-tidy tool

### DIFF
--- a/tool/clang_tidy/CMakeLists.txt
+++ b/tool/clang_tidy/CMakeLists.txt
@@ -1,3 +1,4 @@
+# find the clang-tidy tool.
 find_program(CLANG_TIDY_EXE NAMES clang-tidy REQUIRED)
 execute_process(
   COMMAND ${CLANG_TIDY_EXE} --version
@@ -6,13 +7,26 @@ execute_process(
 string(REGEX MATCH "[0-9]+(\\.[0-9]+)+" CLANG_TIDY_VERSION "${CLANG_TIDY_VERSION}")
 message(STATUS "Found clang-tidy. location: ${CLANG_TIDY_EXE} version: ${CLANG_TIDY_VERSION}")
 
-set(CMAKE_CXX_CLANG_TIDY "${CLANG_TIDY_EXE};-header-filter=../*")
+# generate a helper souce file with library source file paths.
+set(HELPER_FILE_PATH "${CMAKE_CURRENT_BINARY_DIR}/clang_tidy_helper.cpp")
+file(GLOB_RECURSE SRC_FILES ${PROJECT_SOURCE_DIR}/include/fkYAML/*.hpp)
+foreach(SRC_FILE ${SRC_FILES})
+  file(RELATIVE_PATH REL_SRC_FILE "${PROJECT_SOURCE_DIR}/include" ${SRC_FILE})
+  file(APPEND ${HELPER_FILE_PATH} "#include <${REL_SRC_FILE}>\n")
+endforeach()
+file(APPEND ${HELPER_FILE_PATH} "\nint main() {\n    return 0;\n}")
+
+# set options for the clang-tidy tool.
+set(CMAKE_CXX_CLANG_TIDY "${CLANG_TIDY_EXE}")
 set(CMAKE_EXPORT_COMPILE_COMMANDS ON)
 
-add_executable(ClangTidyHelper clang_tidy_helper.cpp)
+# build the helper source file to run the clang-tidy tool
+add_executable(ClangTidyHelper ${HELPER_FILE_PATH})
 target_include_directories(ClangTidyHelper PUBLIC ${FK_YAML_INCLUDE_BUILD_DIR})
 target_compile_options(ClangTidyHelper PUBLIC -O0) # no optimization
 
+# create an alias target.
 add_custom_target(run_clang_tidy DEPENDS ClangTidyHelper)
 
+# make the library source build depends on the execution of the clang-tidy tool.
 add_dependencies(${FK_YAML_TARGET_NAME} run_clang_tidy)


### PR DESCRIPTION
With increase in the number of library source files, it has been more and more difficult to properly maintain clang_tidy_helper.hpp file.  
To decrease such an issue, the helper file has changed to be auto-generated depending on the existing .hpp files under include directory.  
