### PR TITLE
#133 refactor lexer

### DIFF
--- a/include/fkYAML/detail/conversions/from_string.hpp
+++ b/include/fkYAML/detail/conversions/from_string.hpp
@@ -82,6 +82,25 @@ inline bool from_string(const std::string& s, type_tag<bool> /*unused*/)
 }
 
 /**
+ * @brief Specialization of from_string() for long values with std::string.
+ *
+ * @tparam  N/A
+ */
+template <>
+inline long from_string(const std::string& s, type_tag<long> /*unused*/)
+{
+    char* endptr = nullptr;
+    const auto ret = std::strtol(s.data(), &endptr, 0);
+
+    if (endptr != s.data() + s.size() || errno == ERANGE)
+    {
+        throw exception("Failed to convert a string into a long value.");
+    }
+
+    return ret;
+}
+
+/**
  * @brief Specialization of from_string() for long long values with std::string.
  *
  * @tparam  N/A
@@ -94,7 +113,7 @@ inline long long from_string(const std::string& s, type_tag<long long> /*unused*
 
     if (endptr != s.data() + s.size() || errno == ERANGE)
     {
-        throw exception("Failed to convert a string into an integer value.");
+        throw exception("Failed to convert a string into a long long value.");
     }
 
     return ret;
@@ -109,17 +128,37 @@ template <typename SignedIntType>
 inline enable_if_t<
     conjunction<
         is_non_bool_integral<SignedIntType>, std::is_signed<SignedIntType>,
+        negation<std::is_same<SignedIntType, long>>,
         negation<std::is_same<SignedIntType, long long>>>::value,
     SignedIntType>
 from_string(const std::string& s, type_tag<SignedIntType> /*unused*/)
 {
-    const auto tmp_ret = from_string(s, type_tag<long long> {});
+    const auto tmp_ret = from_string(s, type_tag<long> {});
     if (static_cast<long long>(std::numeric_limits<SignedIntType>::max()) < tmp_ret)
     {
         throw exception("Failed to convert a long long value into a SignedIntegerType value.");
     }
 
     return static_cast<SignedIntType>(tmp_ret);
+}
+
+/**
+ * @brief Specialization of from_string() for unsigned long values with std::string.
+ *
+ * @tparam  N/A
+ */
+template <>
+inline unsigned long from_string(const std::string& s, type_tag<unsigned long> /*unused*/)
+{
+    char* endptr = nullptr;
+    const auto ret = std::strtoul(s.data(), &endptr, 0);
+
+    if (endptr != s.data() + s.size() || errno == ERANGE)
+    {
+        throw exception("Failed to convert a string into an unsigned long value.");
+    }
+
+    return ret;
 }
 
 /**
@@ -150,11 +189,12 @@ template <typename UnsignedIntType>
 inline enable_if_t<
     conjunction<
         is_non_bool_integral<UnsignedIntType>, std::is_unsigned<UnsignedIntType>,
+        negation<std::is_same<UnsignedIntType, unsigned long>>,
         negation<std::is_same<UnsignedIntType, unsigned long long>>>::value,
     UnsignedIntType>
 from_string(const std::string& s, type_tag<UnsignedIntType> /*unused*/)
 {
-    const auto tmp_ret = from_string(s, type_tag<unsigned long long> {});
+    const auto tmp_ret = from_string(s, type_tag<unsigned long> {});
     if (static_cast<long long>(std::numeric_limits<UnsignedIntType>::max()) < tmp_ret)
     {
         throw exception("Failed to convert an unsigned long long into an UnsignedInteger value.");

--- a/include/fkYAML/detail/conversions/from_string.hpp
+++ b/include/fkYAML/detail/conversions/from_string.hpp
@@ -64,6 +64,20 @@ inline bool from_string(const std::string& s, type_tag<bool> /*unused*/)
     throw exception("Cannot convert a string into a boolean value.");
 }
 
+template <>
+inline long long from_string(const std::string& s, type_tag<long long> /*unused*/)
+{
+    char* endptr = nullptr;
+    const auto ret = std::strtoll(s.data(), &endptr, 0);
+
+    if (endptr != s.data() + s.size() || errno != 0)
+    {
+        throw exception("Failed to convert a string into an integer value.");
+    }
+
+    return ret;
+}
+
 template <typename SignedIntType>
 inline enable_if_t<
     conjunction<
@@ -82,10 +96,10 @@ from_string(const std::string& s, type_tag<SignedIntType> /*unused*/)
 }
 
 template <>
-inline long long from_string(const std::string& s, type_tag<long long> /*unused*/)
+inline unsigned long long from_string(const std::string& s, type_tag<unsigned long long> /*unused*/)
 {
     char* endptr = nullptr;
-    const auto ret = std::strtoll(s.data(), &endptr, 0);
+    const auto ret = std::strtoull(s.data(), &endptr, 0);
 
     if (endptr != s.data() + s.size() || errno != 0)
     {
@@ -110,20 +124,6 @@ from_string(const std::string& s, type_tag<UnsignedIntType> /*unused*/)
     }
 
     return static_cast<UnsignedIntType>(tmp_ret);
-}
-
-template <>
-inline unsigned long long from_string(const std::string& s, type_tag<unsigned long long> /*unused*/)
-{
-    char* endptr = nullptr;
-    const auto ret = std::strtoull(s.data(), &endptr, 0);
-
-    if (endptr != s.data() + s.size() || errno != 0)
-    {
-        throw exception("Failed to convert a string into an integer value.");
-    }
-
-    return ret;
 }
 
 template <>

--- a/include/fkYAML/detail/conversions/from_string.hpp
+++ b/include/fkYAML/detail/conversions/from_string.hpp
@@ -65,13 +65,14 @@ inline bool from_string(const std::string& s, type_tag<bool> /*unused*/)
 }
 
 template <typename SignedIntType>
-inline enable_if_t<conjunction<
-    is_non_bool_integral<SignedIntType>,
-    std::is_signed<SignedIntType>,
-    negation<std::is_same<SignedIntType, long long>>>::value, SignedIntType>
+inline enable_if_t<
+    conjunction<
+        is_non_bool_integral<SignedIntType>, std::is_signed<SignedIntType>,
+        negation<std::is_same<SignedIntType, long long>>>::value,
+    SignedIntType>
 from_string(const std::string& s, type_tag<SignedIntType> /*unused*/)
 {
-    const auto tmp_ret = from_string(s, type_tag<long long>{});
+    const auto tmp_ret = from_string(s, type_tag<long long> {});
     if (static_cast<long long>(std::numeric_limits<SignedIntType>::max()) < tmp_ret)
     {
         throw exception("Failed to convert a string into an integer value.");
@@ -95,13 +96,14 @@ inline long long from_string(const std::string& s, type_tag<long long> /*unused*
 }
 
 template <typename UnsignedIntType>
-inline enable_if_t<conjunction<
-    is_non_bool_integral<UnsignedIntType>,
-    std::is_unsigned<UnsignedIntType>,
-    negation<std::is_same<UnsignedIntType, unsigned long long>>>::value, UnsignedIntType>
+inline enable_if_t<
+    conjunction<
+        is_non_bool_integral<UnsignedIntType>, std::is_unsigned<UnsignedIntType>,
+        negation<std::is_same<UnsignedIntType, unsigned long long>>>::value,
+    UnsignedIntType>
 from_string(const std::string& s, type_tag<UnsignedIntType> /*unused*/)
 {
-    const auto tmp_ret = from_string(s, type_tag<unsigned long long>{});
+    const auto tmp_ret = from_string(s, type_tag<unsigned long long> {});
     if (static_cast<long long>(std::numeric_limits<UnsignedIntType>::max()) < tmp_ret)
     {
         throw exception("Failed to convert a string into an integer value.");
@@ -127,91 +129,91 @@ inline unsigned long long from_string(const std::string& s, type_tag<unsigned lo
 template <>
 inline float from_string(const std::string& s, type_tag<float> /*unused*/)
 {
-        if (s == ".inf" || s == ".Inf" || s == ".INF")
-        {
-            return std::numeric_limits<float>::infinity();
-        }
+    if (s == ".inf" || s == ".Inf" || s == ".INF")
+    {
+        return std::numeric_limits<float>::infinity();
+    }
 
-        if (s == "-.inf" || s == "-.Inf" || s == "-.INF")
-        {
-            static_assert(std::numeric_limits<float>::is_iec559, "IEEE 754 required.");
-            return -1 * std::numeric_limits<float>::infinity();
-        }
+    if (s == "-.inf" || s == "-.Inf" || s == "-.INF")
+    {
+        static_assert(std::numeric_limits<float>::is_iec559, "IEEE 754 required.");
+        return -1 * std::numeric_limits<float>::infinity();
+    }
 
-        if (s == ".nan" || s == ".NaN" || s == ".NAN")
-        {
-            return std::nanf("");
-        }
+    if (s == ".nan" || s == ".NaN" || s == ".NAN")
+    {
+        return std::nanf("");
+    }
 
-        char* endptr = nullptr;
-        const auto ret = std::strtof(s.data(), &endptr);
+    char* endptr = nullptr;
+    const auto ret = std::strtof(s.data(), &endptr);
 
-        if (endptr != s.data() + s.size())
-        {
-            throw exception("Failed to a string into a floating point number value.");
-        }
+    if (endptr != s.data() + s.size())
+    {
+        throw exception("Failed to a string into a floating point number value.");
+    }
 
-        return ret;
+    return ret;
 }
 
 template <>
 inline double from_string(const std::string& s, type_tag<double> /*unused*/)
 {
-        if (s == ".inf" || s == ".Inf" || s == ".INF")
-        {
-            return std::numeric_limits<double>::infinity();
-        }
+    if (s == ".inf" || s == ".Inf" || s == ".INF")
+    {
+        return std::numeric_limits<double>::infinity();
+    }
 
-        if (s == "-.inf" || s == "-.Inf" || s == "-.INF")
-        {
-            static_assert(std::numeric_limits<double>::is_iec559, "IEEE 754 required.");
-            return -1 * std::numeric_limits<double>::infinity();
-        }
+    if (s == "-.inf" || s == "-.Inf" || s == "-.INF")
+    {
+        static_assert(std::numeric_limits<double>::is_iec559, "IEEE 754 required.");
+        return -1 * std::numeric_limits<double>::infinity();
+    }
 
-        if (s == ".nan" || s == ".NaN" || s == ".NAN")
-        {
-            return std::nan("");
-        }
+    if (s == ".nan" || s == ".NaN" || s == ".NAN")
+    {
+        return std::nan("");
+    }
 
-        char* endptr = nullptr;
-        const auto ret = std::strtod(s.data(), &endptr);
+    char* endptr = nullptr;
+    const auto ret = std::strtod(s.data(), &endptr);
 
-        if (endptr != s.data() + s.size())
-        {
-            throw exception("Failed to a string into a floating point number value.");
-        }
+    if (endptr != s.data() + s.size())
+    {
+        throw exception("Failed to a string into a floating point number value.");
+    }
 
-        return ret;
+    return ret;
 }
 
 template <>
 inline long double from_string(const std::string& s, type_tag<long double> /*unused*/)
 {
-        if (s == ".inf" || s == ".Inf" || s == ".INF")
-        {
-            return std::numeric_limits<long double>::infinity();
-        }
+    if (s == ".inf" || s == ".Inf" || s == ".INF")
+    {
+        return std::numeric_limits<long double>::infinity();
+    }
 
-        if (s == "-.inf" || s == "-.Inf" || s == "-.INF")
-        {
-            static_assert(std::numeric_limits<long double>::is_iec559, "IEEE 754 required.");
-            return -1 * std::numeric_limits<long double>::infinity();
-        }
+    if (s == "-.inf" || s == "-.Inf" || s == "-.INF")
+    {
+        static_assert(std::numeric_limits<long double>::is_iec559, "IEEE 754 required.");
+        return -1 * std::numeric_limits<long double>::infinity();
+    }
 
-        if (s == ".nan" || s == ".NaN" || s == ".NAN")
-        {
-            return std::nanl("");
-        }
+    if (s == ".nan" || s == ".NaN" || s == ".NAN")
+    {
+        return std::nanl("");
+    }
 
-        char* endptr = nullptr;
-        const auto ret = std::strtold(s.data(), &endptr);
+    char* endptr = nullptr;
+    const auto ret = std::strtold(s.data(), &endptr);
 
-        if (endptr != s.data() + s.size())
-        {
-            throw exception("Failed to a string into a floating point number value.");
-        }
+    if (endptr != s.data() + s.size())
+    {
+        throw exception("Failed to a string into a floating point number value.");
+    }
 
-        return ret;
+    return ret;
 }
 
 } // namespace detail

--- a/include/fkYAML/detail/conversions/from_string.hpp
+++ b/include/fkYAML/detail/conversions/from_string.hpp
@@ -14,6 +14,7 @@
 #define FK_YAML_DETAIL_CONVERSIONS_FROM_STRING_HPP_
 
 #include <cmath>
+#include <cstdlib>
 #include <limits>
 #include <string>
 #include <type_traits>

--- a/include/fkYAML/detail/conversions/from_string.hpp
+++ b/include/fkYAML/detail/conversions/from_string.hpp
@@ -71,7 +71,7 @@ inline long long from_string(const std::string& s, type_tag<long long> /*unused*
     char* endptr = nullptr;
     const auto ret = std::strtoll(s.data(), &endptr, 0);
 
-    if (endptr != s.data() + s.size() || errno != 0)
+    if (endptr != s.data() + s.size() || errno == ERANGE)
     {
         throw exception("Failed to convert a string into an integer value.");
     }
@@ -102,7 +102,7 @@ inline unsigned long long from_string(const std::string& s, type_tag<unsigned lo
     char* endptr = nullptr;
     const auto ret = std::strtoull(s.data(), &endptr, 0);
 
-    if (endptr != s.data() + s.size() || errno != 0)
+    if (endptr != s.data() + s.size() || errno == ERANGE)
     {
         throw exception("Failed to convert a string into an integer value.");
     }

--- a/include/fkYAML/detail/conversions/from_string.hpp
+++ b/include/fkYAML/detail/conversions/from_string.hpp
@@ -89,7 +89,7 @@ from_string(const std::string& s, type_tag<SignedIntType> /*unused*/)
     const auto tmp_ret = from_string(s, type_tag<long long> {});
     if (static_cast<long long>(std::numeric_limits<SignedIntType>::max()) < tmp_ret)
     {
-        throw exception("Failed to convert a string into an integer value.");
+        throw exception("Failed to convert a long long value into a SignedIntegerType value.");
     }
 
     return static_cast<SignedIntType>(tmp_ret);
@@ -120,7 +120,7 @@ from_string(const std::string& s, type_tag<UnsignedIntType> /*unused*/)
     const auto tmp_ret = from_string(s, type_tag<unsigned long long> {});
     if (static_cast<long long>(std::numeric_limits<UnsignedIntType>::max()) < tmp_ret)
     {
-        throw exception("Failed to convert a string into an integer value.");
+        throw exception("Failed to convert an unsigned long long into an UnsignedInteger value.");
     }
 
     return static_cast<UnsignedIntType>(tmp_ret);

--- a/include/fkYAML/detail/conversions/from_string.hpp
+++ b/include/fkYAML/detail/conversions/from_string.hpp
@@ -1,0 +1,221 @@
+/**
+ *  _______   __ __   __  _____   __  __  __
+ * |   __| |_/  |  \_/  |/  _  \ /  \/  \|  |     fkYAML: A C++ header-only YAML library
+ * |   __|  _  < \_   _/|  ___  |    _   |  |___  version 0.1.1
+ * |__|  |_| \__|  |_|  |_|   |_|___||___|______| https://github.com/fktn-k/fkYAML
+ *
+ * SPDX-FileCopyrightText: 2023 Kensuke Fukutani <fktn.dev@gmail.com>
+ * SPDX-License-Identifier: MIT
+ *
+ * @file
+ */
+
+#ifndef FK_YAML_DETAIL_CONVERSIONS_FROM_STRING_HPP_
+#define FK_YAML_DETAIL_CONVERSIONS_FROM_STRING_HPP_
+
+#include <cmath>
+#include <limits>
+#include <string>
+#include <type_traits>
+
+#include <fkYAML/detail/macros/version_macros.hpp>
+#include <fkYAML/detail/meta/stl_supplement.hpp>
+#include <fkYAML/detail/meta/type_traits.hpp>
+#include <fkYAML/exception.hpp>
+
+FK_YAML_NAMESPACE_BEGIN
+
+/**
+ * @namespace detail
+ * @brief namespace for internal implementations of fkYAML library.
+ */
+namespace detail
+{
+
+using fkyaml::exception;
+
+template <typename ValueType, typename CharType>
+inline ValueType from_string(const std::basic_string<CharType>& s, type_tag<ValueType> /*unused*/);
+
+template <>
+inline std::nullptr_t from_string(const std::string& s, type_tag<std::nullptr_t> /*unused*/)
+{
+    if (s == "null" || s == "Null" || s == "NULL" || s == "~")
+    {
+        return nullptr;
+    }
+
+    throw exception("Cannot convert a string into a null value.");
+}
+
+template <>
+inline bool from_string(const std::string& s, type_tag<bool> /*unused*/)
+{
+    if (s == "true" || s == "True" || s == "TRUE")
+    {
+        return true;
+    }
+
+    if (s == "false" || s == "False" || s == "FALSE")
+    {
+        return false;
+    }
+
+    throw exception("Cannot convert a string into a boolean value.");
+}
+
+template <typename SignedIntType>
+inline enable_if_t<conjunction<
+    is_non_bool_integral<SignedIntType>,
+    std::is_signed<SignedIntType>,
+    negation<std::is_same<SignedIntType, long long>>>::value, SignedIntType>
+from_string(const std::string& s, type_tag<SignedIntType> /*unused*/)
+{
+    const auto tmp_ret = from_string(s, type_tag<long long>{});
+    if (static_cast<long long>(std::numeric_limits<SignedIntType>::max()) < tmp_ret)
+    {
+        throw exception("Failed to convert a string into an integer value.");
+    }
+
+    return static_cast<SignedIntType>(tmp_ret);
+}
+
+template <>
+inline long long from_string(const std::string& s, type_tag<long long> /*unused*/)
+{
+    char* endptr = nullptr;
+    const auto ret = std::strtoll(s.data(), &endptr, 0);
+
+    if (endptr != s.data() + s.size() || errno != 0)
+    {
+        throw exception("Failed to convert a string into an integer value.");
+    }
+
+    return ret;
+}
+
+template <typename UnsignedIntType>
+inline enable_if_t<conjunction<
+    is_non_bool_integral<UnsignedIntType>,
+    std::is_unsigned<UnsignedIntType>,
+    negation<std::is_same<UnsignedIntType, unsigned long long>>>::value, UnsignedIntType>
+from_string(const std::string& s, type_tag<UnsignedIntType> /*unused*/)
+{
+    const auto tmp_ret = from_string(s, type_tag<unsigned long long>{});
+    if (static_cast<long long>(std::numeric_limits<UnsignedIntType>::max()) < tmp_ret)
+    {
+        throw exception("Failed to convert a string into an integer value.");
+    }
+
+    return static_cast<UnsignedIntType>(tmp_ret);
+}
+
+template <>
+inline unsigned long long from_string(const std::string& s, type_tag<unsigned long long> /*unused*/)
+{
+    char* endptr = nullptr;
+    const auto ret = std::strtoull(s.data(), &endptr, 0);
+
+    if (endptr != s.data() + s.size() || errno != 0)
+    {
+        throw exception("Failed to convert a string into an integer value.");
+    }
+
+    return ret;
+}
+
+template <>
+inline float from_string(const std::string& s, type_tag<float> /*unused*/)
+{
+        if (s == ".inf" || s == ".Inf" || s == ".INF")
+        {
+            return std::numeric_limits<float>::infinity();
+        }
+
+        if (s == "-.inf" || s == "-.Inf" || s == "-.INF")
+        {
+            static_assert(std::numeric_limits<float>::is_iec559, "IEEE 754 required.");
+            return -1 * std::numeric_limits<float>::infinity();
+        }
+
+        if (s == ".nan" || s == ".NaN" || s == ".NAN")
+        {
+            return std::nanf("");
+        }
+
+        char* endptr = nullptr;
+        const auto ret = std::strtof(s.data(), &endptr);
+
+        if (endptr != s.data() + s.size())
+        {
+            throw exception("Failed to a string into a floating point number value.");
+        }
+
+        return ret;
+}
+
+template <>
+inline double from_string(const std::string& s, type_tag<double> /*unused*/)
+{
+        if (s == ".inf" || s == ".Inf" || s == ".INF")
+        {
+            return std::numeric_limits<double>::infinity();
+        }
+
+        if (s == "-.inf" || s == "-.Inf" || s == "-.INF")
+        {
+            static_assert(std::numeric_limits<double>::is_iec559, "IEEE 754 required.");
+            return -1 * std::numeric_limits<double>::infinity();
+        }
+
+        if (s == ".nan" || s == ".NaN" || s == ".NAN")
+        {
+            return std::nan("");
+        }
+
+        char* endptr = nullptr;
+        const auto ret = std::strtod(s.data(), &endptr);
+
+        if (endptr != s.data() + s.size())
+        {
+            throw exception("Failed to a string into a floating point number value.");
+        }
+
+        return ret;
+}
+
+template <>
+inline long double from_string(const std::string& s, type_tag<long double> /*unused*/)
+{
+        if (s == ".inf" || s == ".Inf" || s == ".INF")
+        {
+            return std::numeric_limits<long double>::infinity();
+        }
+
+        if (s == "-.inf" || s == "-.Inf" || s == "-.INF")
+        {
+            static_assert(std::numeric_limits<long double>::is_iec559, "IEEE 754 required.");
+            return -1 * std::numeric_limits<long double>::infinity();
+        }
+
+        if (s == ".nan" || s == ".NaN" || s == ".NAN")
+        {
+            return std::nanl("");
+        }
+
+        char* endptr = nullptr;
+        const auto ret = std::strtold(s.data(), &endptr);
+
+        if (endptr != s.data() + s.size())
+        {
+            throw exception("Failed to a string into a floating point number value.");
+        }
+
+        return ret;
+}
+
+} // namespace detail
+
+FK_YAML_NAMESPACE_END
+
+#endif /* FK_YAML_DETAIL_CONVERSIONS_FROM_STRING_HPP_ */

--- a/include/fkYAML/detail/conversions/from_string.hpp
+++ b/include/fkYAML/detail/conversions/from_string.hpp
@@ -35,9 +35,20 @@ namespace detail
 
 using fkyaml::exception;
 
+/**
+ * @brief Convert a string YAML token to a ValueType object.
+ *
+ * @tparam ValueType A target value type.
+ * @tparam CharType The type of characters in a source string.
+ */
 template <typename ValueType, typename CharType>
 inline ValueType from_string(const std::basic_string<CharType>& s, type_tag<ValueType> /*unused*/);
 
+/**
+ * @brief Specialization of from_string() for null values with std::string
+ *
+ * @tparam  N/A
+ */
 template <>
 inline std::nullptr_t from_string(const std::string& s, type_tag<std::nullptr_t> /*unused*/)
 {
@@ -49,6 +60,11 @@ inline std::nullptr_t from_string(const std::string& s, type_tag<std::nullptr_t>
     throw exception("Cannot convert a string into a null value.");
 }
 
+/**
+ * @brief Specialization of from_string() for boolean values with std::string.
+ *
+ * @tparam  N/A
+ */
 template <>
 inline bool from_string(const std::string& s, type_tag<bool> /*unused*/)
 {
@@ -65,6 +81,11 @@ inline bool from_string(const std::string& s, type_tag<bool> /*unused*/)
     throw exception("Cannot convert a string into a boolean value.");
 }
 
+/**
+ * @brief Specialization of from_string() for long long values with std::string.
+ *
+ * @tparam  N/A
+ */
 template <>
 inline long long from_string(const std::string& s, type_tag<long long> /*unused*/)
 {
@@ -79,6 +100,11 @@ inline long long from_string(const std::string& s, type_tag<long long> /*unused*
     return ret;
 }
 
+/**
+ * @brief Partial specialization of from_string() for signed integer values (not long long) with std::string.
+ *
+ * @tparam SignedIntType A signed integer type other than long long.
+ */
 template <typename SignedIntType>
 inline enable_if_t<
     conjunction<
@@ -96,6 +122,11 @@ from_string(const std::string& s, type_tag<SignedIntType> /*unused*/)
     return static_cast<SignedIntType>(tmp_ret);
 }
 
+/**
+ * @brief Specialization of from_string() for unsigned long long values with std::string.
+ *
+ * @tparam  N/A
+ */
 template <>
 inline unsigned long long from_string(const std::string& s, type_tag<unsigned long long> /*unused*/)
 {
@@ -110,6 +141,11 @@ inline unsigned long long from_string(const std::string& s, type_tag<unsigned lo
     return ret;
 }
 
+/**
+ * @brief Partial specialization of from_string() for unsigned integer values (not unsigned long long) with std::string.
+ *
+ * @tparam UnsignedIntType An unsigned integer type other than unsigned long long.
+ */
 template <typename UnsignedIntType>
 inline enable_if_t<
     conjunction<
@@ -127,6 +163,11 @@ from_string(const std::string& s, type_tag<UnsignedIntType> /*unused*/)
     return static_cast<UnsignedIntType>(tmp_ret);
 }
 
+/**
+ * @brief Specialization of from_string() for float values with std::string.
+ *
+ * @tparam  N/A
+ */
 template <>
 inline float from_string(const std::string& s, type_tag<float> /*unused*/)
 {
@@ -157,6 +198,11 @@ inline float from_string(const std::string& s, type_tag<float> /*unused*/)
     return ret;
 }
 
+/**
+ * @brief Specialization of from_string() for double values with std::string.
+ *
+ * @tparam  N/A
+ */
 template <>
 inline double from_string(const std::string& s, type_tag<double> /*unused*/)
 {
@@ -187,6 +233,11 @@ inline double from_string(const std::string& s, type_tag<double> /*unused*/)
     return ret;
 }
 
+/**
+ * @brief Specialization of from_string() for long double values with std::string.
+ *
+ * @tparam  N/A
+ */
 template <>
 inline long double from_string(const std::string& s, type_tag<long double> /*unused*/)
 {

--- a/include/fkYAML/detail/input/deserializer.hpp
+++ b/include/fkYAML/detail/input/deserializer.hpp
@@ -21,6 +21,7 @@
 #include <fkYAML/detail/meta/input_adapter_traits.hpp>
 #include <fkYAML/detail/meta/node_traits.hpp>
 #include <fkYAML/detail/meta/stl_supplement.hpp>
+#include <fkYAML/detail/types/lexical_token_t.hpp>
 #include <fkYAML/detail/types/yaml_version_t.hpp>
 #include <fkYAML/exception.hpp>
 

--- a/include/fkYAML/detail/input/input_handler.hpp
+++ b/include/fkYAML/detail/input/input_handler.hpp
@@ -36,7 +36,7 @@ namespace detail
 
 /**
  * @brief An input buffer handler.
- * 
+ *
  * @tparam InputAdapterType The type of the input adapter.
  */
 template <typename InputAdapterType, enable_if_t<is_input_adapter<InputAdapterType>::value, int> = 0>
@@ -54,7 +54,7 @@ public:
 
     /**
      * @brief Construct a new input_handler object.
-     * 
+     *
      * @param input_adapter An input adapter object
      */
     explicit input_handler(InputAdapterType&& input_adapter)
@@ -67,7 +67,7 @@ public:
 
     /**
      * @brief Get the character at the current position.
-     * 
+     *
      * @return int_type A character or EOF.
      */
     int_type get_current()
@@ -77,7 +77,7 @@ public:
 
     /**
      * @brief Get the character at next position.
-     * 
+     *
      * @return int_type A character or EOF.
      */
     int_type get_next()
@@ -101,7 +101,7 @@ public:
 
     /**
      * @brief Get the characters in the given range.
-     * 
+     *
      * @param length The length of characters retrieved from the current position.
      * @param str A string which will contain the resulting characters.
      * @return int_type 0 (for success) or EOF (for error).
@@ -145,7 +145,7 @@ public:
 
     /**
      * @brief Move backward the current position to the given range.
-     * 
+     *
      * @param length The length of moving backward.
      */
     void unget_range(size_t length)

--- a/include/fkYAML/detail/input/input_handler.hpp
+++ b/include/fkYAML/detail/input/input_handler.hpp
@@ -168,10 +168,14 @@ public:
     }
 
 private:
+    //!< The value of EOF for the target character type.
     static constexpr int_type end_of_input = char_traits_type::eof();
 
+    //!< An input adapter object.
     InputAdapterType m_input_adapter;
+    //!< Cached characters retrieved from an input adapter object.
     std::vector<int_type> m_cache;
+    //!< The current position in an input buffer.
     size_t m_cur_pos;
 };
 

--- a/include/fkYAML/detail/input/input_handler.hpp
+++ b/include/fkYAML/detail/input/input_handler.hpp
@@ -1,0 +1,182 @@
+/**
+ *  _______   __ __   __  _____   __  __  __
+ * |   __| |_/  |  \_/  |/  _  \ /  \/  \|  |     fkYAML: A C++ header-only YAML library
+ * |   __|  _  < \_   _/|  ___  |    _   |  |___  version 0.1.1
+ * |__|  |_| \__|  |_|  |_|   |_|___||___|______| https://github.com/fktn-k/fkYAML
+ *
+ * SPDX-FileCopyrightText: 2023 Kensuke Fukutani <fktn.dev@gmail.com>
+ * SPDX-License-Identifier: MIT
+ *
+ * @file
+ */
+
+#ifndef FK_YAML_DETAIL_INPUT_INPUT_HANDLER_HPP_
+#define FK_YAML_DETAIL_INPUT_INPUT_HANDLER_HPP_
+
+#include <string>
+#include <utility>
+#include <vector>
+
+#include <fkYAML/detail/macros/version_macros.hpp>
+#include <fkYAML/detail/meta/input_adapter_traits.hpp>
+#include <fkYAML/detail/meta/stl_supplement.hpp>
+
+/**
+ * @namespace fkyaml
+ * @brief namespace for fkYAML library.
+ */
+FK_YAML_NAMESPACE_BEGIN
+
+/**
+ * @namespace detail
+ * @brief namespace for internal implementations of fkYAML library.
+ */
+namespace detail
+{
+
+/**
+ * @brief An input buffer handler.
+ * 
+ * @tparam InputAdapterType The type of the input adapter.
+ */
+template <typename InputAdapterType, enable_if_t<is_input_adapter<InputAdapterType>::value, int> = 0>
+class input_handler
+{
+public:
+    //!< The type of character traits of the input buffer.
+    using char_traits_type = std::char_traits<typename InputAdapterType::char_type>;
+    //!< The type of characters of the input buffer.
+    using char_type = typename char_traits_type::char_type;
+    //!< The type of integers for the input buffer.
+    using int_type = typename char_traits_type::int_type;
+    //!< The type of strings of the input buffer.
+    using string_type = std::basic_string<char_type>;
+
+    /**
+     * @brief Construct a new input_handler object.
+     * 
+     * @param input_adapter An input adapter object
+     */
+    explicit input_handler(InputAdapterType&& input_adapter)
+        : m_input_adapter(std::move(input_adapter)),
+          m_cur_pos(0)
+    {
+        get_next();
+        m_cur_pos = 0;
+    }
+
+    /**
+     * @brief Get the character at the current position.
+     * 
+     * @return int_type A character or EOF.
+     */
+    int_type get_current()
+    {
+        return m_cache[m_cur_pos];
+    }
+
+    /**
+     * @brief Get the character at next position.
+     * 
+     * @return int_type A character or EOF.
+     */
+    int_type get_next()
+    {
+        // if already cached, return the cached value.
+        if (m_cur_pos + 1 < m_cache.size())
+        {
+            return m_cache[++m_cur_pos];
+        }
+
+        int_type ret = m_input_adapter.get_character();
+        if (ret != end_of_input || m_cache[m_cur_pos] != end_of_input)
+        {
+            // cache the return value for possible later use.
+            m_cache.push_back(ret);
+            ++m_cur_pos;
+        }
+        return ret;
+        // return m_input_adapter.get_character();
+    }
+
+    /**
+     * @brief Get the characters in the given range.
+     * 
+     * @param length The length of characters retrieved from the current position.
+     * @param str A string which will contain the resulting characters.
+     * @return int_type 0 (for success) or EOF (for error).
+     */
+    int_type get_range(size_t length, string_type& str)
+    {
+        str.clear();
+
+        if (get_current() == end_of_input)
+        {
+            return end_of_input;
+        }
+
+        str += char_traits_type::to_char_type(get_current());
+
+        for (size_t i = 1; i < length; i++)
+        {
+            if (get_next() == end_of_input)
+            {
+                m_cur_pos -= i;
+                str.clear();
+                return end_of_input;
+            }
+            str += char_traits_type::to_char_type(get_current());
+        }
+
+        return 0;
+    }
+
+    /**
+     * @brief Move backward the current position.
+     */
+    void unget()
+    {
+        if (m_cur_pos > 0)
+        {
+            // just move back the cursor. (no action for adapter)
+            --m_cur_pos;
+        }
+    }
+
+    /**
+     * @brief Move backward the current position to the given range.
+     * 
+     * @param length The length of moving backward.
+     */
+    void unget_range(size_t length)
+    {
+        m_cur_pos = (m_cur_pos > length) ? m_cur_pos - length : 0;
+    }
+
+    /**
+     * @brief Check if the next character is the expected one.
+     *
+     * @param expected An expected next character.
+     * @return true The next character is the expected one.
+     * @return false The next character is not the expected one.
+     */
+    bool test_next_char(char_type expected)
+    {
+        bool ret = char_traits_type::eq(char_traits_type::to_char_type(get_next()), expected);
+        --m_cur_pos;
+        return ret;
+    }
+
+private:
+    static constexpr int_type end_of_input = char_traits_type::eof();
+
+    InputAdapterType m_input_adapter;
+    std::vector<int_type> m_cache;
+    size_t m_cur_pos;
+};
+
+} // namespace detail
+
+FK_YAML_NAMESPACE_END
+
+#endif /* FK_YAML_DETAIL_INPUT_INPUT_HANDLER_HPP_ */

--- a/include/fkYAML/detail/input/lexical_analyzer.hpp
+++ b/include/fkYAML/detail/input/lexical_analyzer.hpp
@@ -338,7 +338,7 @@ public:
     std::nullptr_t get_null() const
     {
         FK_YAML_ASSERT(!m_value_buffer.empty());
-        return from_string(m_value_buffer, type_tag<std::nullptr_t>{});
+        return from_string(m_value_buffer, type_tag<std::nullptr_t> {});
     }
 
     /**
@@ -350,7 +350,7 @@ public:
     boolean_type get_boolean() const
     {
         FK_YAML_ASSERT(!m_value_buffer.empty());
-        return from_string(m_value_buffer, type_tag<boolean_type>{});
+        return from_string(m_value_buffer, type_tag<boolean_type> {});
     }
 
     /**
@@ -361,7 +361,7 @@ public:
     integer_type get_integer() const
     {
         FK_YAML_ASSERT(!m_value_buffer.empty());
-        return from_string(m_value_buffer, type_tag<integer_type>{});
+        return from_string(m_value_buffer, type_tag<integer_type> {});
     }
 
     /**
@@ -372,7 +372,7 @@ public:
     float_number_type get_float_number() const
     {
         FK_YAML_ASSERT(!m_value_buffer.empty());
-        return from_string(m_value_buffer, type_tag<float_number_type>{});
+        return from_string(m_value_buffer, type_tag<float_number_type> {});
     }
 
     /**

--- a/include/fkYAML/detail/input/lexical_analyzer.hpp
+++ b/include/fkYAML/detail/input/lexical_analyzer.hpp
@@ -1230,6 +1230,7 @@ private:
     }
 
 private:
+    //!< The value of EOF for the target characters.
     static constexpr char_int_type end_of_input = char_traits_type::eof();
 
     //!< An input buffer adapter to be analyzed.

--- a/include/fkYAML/detail/input/lexical_analyzer.hpp
+++ b/include/fkYAML/detail/input/lexical_analyzer.hpp
@@ -1002,11 +1002,18 @@ private:
                     m_value_buffer.push_back(byte);
                     break;
                 }
-                // Multibyte characters are currently unsupported.
+                // TODO: Multibyte characters are not yet supported.
                 // Thus \N, \_, \L, \P \uXX, \UXXXX are currently unavailable.
                 default:
                     throw fkyaml::exception("Unsupported escape sequence found in a string token.");
                 }
+                continue;
+            }
+
+            // Handle unescaped control characters.
+            if (0x00 <= current && current <= 0x1F)
+            {
+                handle_unescaped_control_char(current);
                 continue;
             }
 
@@ -1017,76 +1024,84 @@ private:
                 continue;
             }
 
-            // Handle unescaped control characters.
-            switch (current)
-            {
-            // 0x00(NULL) has already been handled above.
-            case 0x01:
-                throw fkyaml::exception("Control character U+0001 (SOH) must be escaped to \\u0001.");
-            case 0x02:
-                throw fkyaml::exception("Control character U+0002 (STX) must be escaped to \\u0002.");
-            case 0x03:
-                throw fkyaml::exception("Control character U+0003 (ETX) must be escaped to \\u0003.");
-            case 0x04:
-                throw fkyaml::exception("Control character U+0004 (EOT) must be escaped to \\u0004.");
-            case 0x05:
-                throw fkyaml::exception("Control character U+0005 (ENQ) must be escaped to \\u0005.");
-            case 0x06:
-                throw fkyaml::exception("Control character U+0006 (ACK) must be escaped to \\u0006.");
-            case 0x07:
-                throw fkyaml::exception("Control character U+0007 (BEL) must be escaped to \\a or \\u0007.");
-            case 0x08:
-                throw fkyaml::exception("Control character U+0008 (BS) must be escaped to \\b or \\u0008.");
-            case 0x09: // HT
-                m_value_buffer.push_back(current);
-                break;
-            // 0x0A(LF) has already been handled above.
-            case 0x0B:
-                throw fkyaml::exception("Control character U+000B (VT) must be escaped to \\v or \\u000B.");
-            case 0x0C:
-                throw fkyaml::exception("Control character U+000C (FF) must be escaped to \\f or \\u000C.");
-            // 0x0D(CR) has already been handled above.
-            case 0x0E:
-                throw fkyaml::exception("Control character U+000E (SO) must be escaped to \\u000E.");
-            case 0x0F:
-                throw fkyaml::exception("Control character U+000F (SI) must be escaped to \\u000F.");
-            case 0x10:
-                throw fkyaml::exception("Control character U+0010 (DLE) must be escaped to \\u0010.");
-            case 0x11:
-                throw fkyaml::exception("Control character U+0011 (DC1) must be escaped to \\u0011.");
-            case 0x12:
-                throw fkyaml::exception("Control character U+0012 (DC2) must be escaped to \\u0012.");
-            case 0x13:
-                throw fkyaml::exception("Control character U+0013 (DC3) must be escaped to \\u0013.");
-            case 0x14:
-                throw fkyaml::exception("Control character U+0014 (DC4) must be escaped to \\u0014.");
-            case 0x15:
-                throw fkyaml::exception("Control character U+0015 (NAK) must be escaped to \\u0015.");
-            case 0x16:
-                throw fkyaml::exception("Control character U+0016 (SYN) must be escaped to \\u0016.");
-            case 0x17:
-                throw fkyaml::exception("Control character U+0017 (ETB) must be escaped to \\u0017.");
-            case 0x18:
-                throw fkyaml::exception("Control character U+0018 (CAN) must be escaped to \\u0018.");
-            case 0x19:
-                throw fkyaml::exception("Control character U+0019 (EM) must be escaped to \\u0019.");
-            case 0x1A:
-                throw fkyaml::exception("Control character U+001A (SUB) must be escaped to \\u001A.");
-            case 0x1B:
-                throw fkyaml::exception("Control character U+001B (ESC) must be escaped to \\e or \\u001B.");
-            case 0x1C:
-                throw fkyaml::exception("Control character U+001C (FS) must be escaped to \\u001C.");
-            case 0x1D:
-                throw fkyaml::exception("Control character U+001D (GS) must be escaped to \\u001D.");
-            case 0x1E:
-                throw fkyaml::exception("Control character U+001E (RS) must be escaped to \\u001E.");
-            case 0x1F:
-                throw fkyaml::exception("Control character U+001F (US) must be escaped to \\u001F.");
-            // 0x20('0')~0x7E('~') have already been handled above.
-            // 16bit, 32bit characters are currently not supported.
-            default:
-                throw fkyaml::exception("Unsupported multibytes character found.");
-            }
+            // TODO: multibyte characters are not yet supported.
+            throw fkyaml::exception("Unsupported multibytes character found.");
+        }
+    }
+
+    /**
+     * @brief Handle unescaped control characters.
+     * 
+     * @param c A target character.
+     */
+    void handle_unescaped_control_char(char_int_type c)
+    {
+        FK_YAML_ASSERT(0x00 <= c && c <= 0x1F);
+
+        switch (c)
+        {
+        // 0x00(NULL) has already been handled above.
+        case 0x01:
+            throw fkyaml::exception("Control character U+0001 (SOH) must be escaped to \\u0001.");
+        case 0x02:
+            throw fkyaml::exception("Control character U+0002 (STX) must be escaped to \\u0002.");
+        case 0x03:
+            throw fkyaml::exception("Control character U+0003 (ETX) must be escaped to \\u0003.");
+        case 0x04:
+            throw fkyaml::exception("Control character U+0004 (EOT) must be escaped to \\u0004.");
+        case 0x05:
+            throw fkyaml::exception("Control character U+0005 (ENQ) must be escaped to \\u0005.");
+        case 0x06:
+            throw fkyaml::exception("Control character U+0006 (ACK) must be escaped to \\u0006.");
+        case 0x07:
+            throw fkyaml::exception("Control character U+0007 (BEL) must be escaped to \\a or \\u0007.");
+        case 0x08:
+            throw fkyaml::exception("Control character U+0008 (BS) must be escaped to \\b or \\u0008.");
+        case 0x09: // HT
+            m_value_buffer.push_back(c);
+            break;
+        // 0x0A(LF) has already been handled above.
+        case 0x0B:
+            throw fkyaml::exception("Control character U+000B (VT) must be escaped to \\v or \\u000B.");
+        case 0x0C:
+            throw fkyaml::exception("Control character U+000C (FF) must be escaped to \\f or \\u000C.");
+        // 0x0D(CR) has already been handled above.
+        case 0x0E:
+            throw fkyaml::exception("Control character U+000E (SO) must be escaped to \\u000E.");
+        case 0x0F:
+            throw fkyaml::exception("Control character U+000F (SI) must be escaped to \\u000F.");
+        case 0x10:
+            throw fkyaml::exception("Control character U+0010 (DLE) must be escaped to \\u0010.");
+        case 0x11:
+            throw fkyaml::exception("Control character U+0011 (DC1) must be escaped to \\u0011.");
+        case 0x12:
+            throw fkyaml::exception("Control character U+0012 (DC2) must be escaped to \\u0012.");
+        case 0x13:
+            throw fkyaml::exception("Control character U+0013 (DC3) must be escaped to \\u0013.");
+        case 0x14:
+            throw fkyaml::exception("Control character U+0014 (DC4) must be escaped to \\u0014.");
+        case 0x15:
+            throw fkyaml::exception("Control character U+0015 (NAK) must be escaped to \\u0015.");
+        case 0x16:
+            throw fkyaml::exception("Control character U+0016 (SYN) must be escaped to \\u0016.");
+        case 0x17:
+            throw fkyaml::exception("Control character U+0017 (ETB) must be escaped to \\u0017.");
+        case 0x18:
+            throw fkyaml::exception("Control character U+0018 (CAN) must be escaped to \\u0018.");
+        case 0x19:
+            throw fkyaml::exception("Control character U+0019 (EM) must be escaped to \\u0019.");
+        case 0x1A:
+            throw fkyaml::exception("Control character U+001A (SUB) must be escaped to \\u001A.");
+        case 0x1B:
+            throw fkyaml::exception("Control character U+001B (ESC) must be escaped to \\e or \\u001B.");
+        case 0x1C:
+            throw fkyaml::exception("Control character U+001C (FS) must be escaped to \\u001C.");
+        case 0x1D:
+            throw fkyaml::exception("Control character U+001D (GS) must be escaped to \\u001D.");
+        case 0x1E:
+            throw fkyaml::exception("Control character U+001E (RS) must be escaped to \\u001E.");
+        case 0x1F:
+            throw fkyaml::exception("Control character U+001F (US) must be escaped to \\u001F.");
         }
     }
 

--- a/include/fkYAML/detail/input/lexical_analyzer.hpp
+++ b/include/fkYAML/detail/input/lexical_analyzer.hpp
@@ -1245,8 +1245,6 @@ private:
 
     //!< An input buffer adapter to be analyzed.
     input_handler_type m_input_handler;
-    //!< A flag to determine whether the first input char has been retrieved.
-    bool m_is_first_input_char {true};
     //!< A temporal buffer to store a string to be parsed to an actual datum.
     input_string_type m_value_buffer;
     //!< The information set for input buffer.

--- a/include/fkYAML/detail/input/lexical_analyzer.hpp
+++ b/include/fkYAML/detail/input/lexical_analyzer.hpp
@@ -23,6 +23,7 @@
 
 #include <fkYAML/detail/macros/version_macros.hpp>
 #include <fkYAML/detail/assert.hpp>
+#include <fkYAML/detail/conversions/from_string.hpp>
 #include <fkYAML/detail/input/input_handler.hpp>
 #include <fkYAML/detail/meta/input_adapter_traits.hpp>
 #include <fkYAML/detail/meta/node_traits.hpp>
@@ -337,13 +338,7 @@ public:
     std::nullptr_t get_null() const
     {
         FK_YAML_ASSERT(!m_value_buffer.empty());
-
-        if (m_value_buffer == "null" || m_value_buffer == "Null" || m_value_buffer == "NULL" || m_value_buffer == "~")
-        {
-            return nullptr;
-        }
-
-        throw fkyaml::exception("Invalid request for a null value.");
+        return from_string(m_value_buffer, type_tag<std::nullptr_t>{});
     }
 
     /**
@@ -355,18 +350,7 @@ public:
     boolean_type get_boolean() const
     {
         FK_YAML_ASSERT(!m_value_buffer.empty());
-
-        if (m_value_buffer == "true" || m_value_buffer == "True" || m_value_buffer == "TRUE")
-        {
-            return static_cast<boolean_type>(true);
-        }
-
-        if (m_value_buffer == "false" || m_value_buffer == "False" || m_value_buffer == "FALSE")
-        {
-            return static_cast<boolean_type>(false);
-        }
-
-        throw fkyaml::exception("Invalid request for a boolean value.");
+        return from_string(m_value_buffer, type_tag<boolean_type>{});
     }
 
     /**
@@ -377,13 +361,7 @@ public:
     integer_type get_integer() const
     {
         FK_YAML_ASSERT(!m_value_buffer.empty());
-
-        char* endptr = nullptr;
-        const auto tmp_val = std::strtoll(m_value_buffer.data(), &endptr, 0);
-
-        FK_YAML_ASSERT(endptr == m_value_buffer.data() + m_value_buffer.size());
-
-        return static_cast<integer_type>(tmp_val);
+        return from_string(m_value_buffer, type_tag<integer_type>{});
     }
 
     /**
@@ -394,29 +372,7 @@ public:
     float_number_type get_float_number() const
     {
         FK_YAML_ASSERT(!m_value_buffer.empty());
-
-        if (m_value_buffer == ".inf" || m_value_buffer == ".Inf" || m_value_buffer == ".INF")
-        {
-            return std::numeric_limits<float_number_type>::infinity();
-        }
-
-        if (m_value_buffer == "-.inf" || m_value_buffer == "-.Inf" || m_value_buffer == "-.INF")
-        {
-            static_assert(std::numeric_limits<float_number_type>::is_iec559, "IEEE 754 required.");
-            return -1 * std::numeric_limits<float_number_type>::infinity();
-        }
-
-        if (m_value_buffer == ".nan" || m_value_buffer == ".NaN" || m_value_buffer == ".NAN")
-        {
-            return std::nan("");
-        }
-
-        char* endptr = nullptr;
-        const double value = std::strtod(m_value_buffer.data(), &endptr);
-
-        FK_YAML_ASSERT(endptr == m_value_buffer.data() + m_value_buffer.size());
-
-        return static_cast<float_number_type>(value);
+        return from_string(m_value_buffer, type_tag<float_number_type>{});
     }
 
     /**

--- a/include/fkYAML/detail/input/lexical_analyzer.hpp
+++ b/include/fkYAML/detail/input/lexical_analyzer.hpp
@@ -768,7 +768,7 @@ private:
 
         if (next == '.')
         {
-            if (m_value_buffer.find(next) != std::string::npos) // NOLINT(abseil-string-find-str-contains)
+            if (m_value_buffer.find(next) != string_type::npos) // NOLINT(abseil-string-find-str-contains)
             {
                 // TODO: support this use case (e.g. version info like 1.0.0)
                 throw fkyaml::exception("Multiple decimal points found in a token.");
@@ -1182,7 +1182,7 @@ private:
      * @return true Succeeded in getting strings.
      * @return false Failed to get strings.
      */
-    bool get_string_from_input(const int count, std::string& str) noexcept
+    bool get_string_from_input(const int count, string_type& str) noexcept
     {
         str.clear();
         char_int_type backup = m_last_char;

--- a/include/fkYAML/detail/input/lexical_analyzer.hpp
+++ b/include/fkYAML/detail/input/lexical_analyzer.hpp
@@ -237,7 +237,6 @@ public:
                 m_input_handler.unget_range(3);
                 return m_last_token_type = scan_string();
             }
-
         }
         case 'F':
         case 'f': {

--- a/include/fkYAML/detail/input/lexical_analyzer.hpp
+++ b/include/fkYAML/detail/input/lexical_analyzer.hpp
@@ -139,7 +139,6 @@ public:
 
         switch (current)
         {
-        case '\0':
         case char_traits_type::eof(): // end of input buffer
             return lexical_token_t::END_OF_BUFFER;
         case ':': // key separater

--- a/include/fkYAML/detail/input/lexical_analyzer.hpp
+++ b/include/fkYAML/detail/input/lexical_analyzer.hpp
@@ -28,6 +28,7 @@
 #include <fkYAML/detail/meta/input_adapter_traits.hpp>
 #include <fkYAML/detail/meta/node_traits.hpp>
 #include <fkYAML/detail/meta/stl_supplement.hpp>
+#include <fkYAML/detail/types/lexical_token_t.hpp>
 #include <fkYAML/exception.hpp>
 
 /**
@@ -42,34 +43,6 @@ FK_YAML_NAMESPACE_BEGIN
  */
 namespace detail
 {
-
-/**
- * @enum lexical_token_t
- * @brief Definition of lexical token types.
- */
-enum class lexical_token_t
-{
-    END_OF_BUFFER,         //!< the end of input buffer.
-    KEY_SEPARATOR,         //!< the key separater `:`
-    VALUE_SEPARATOR,       //!< the value separater `,`
-    ANCHOR_PREFIX,         //!< the character for anchor prefix `&`
-    ALIAS_PREFIX,          //!< the character for alias prefix `*`
-    COMMENT_PREFIX,        //!< the character for comment prefix `#`
-    YAML_VER_DIRECTIVE,    //!< a YAML version directive found. use get_yaml_version() to get a value.
-    TAG_DIRECTIVE,         //!< a TAG directive found. use GetTagInfo() to get the tag information.
-    INVALID_DIRECTIVE,     //!< an invalid directive found. do not try to get the value.
-    SEQUENCE_BLOCK_PREFIX, //!< the character for sequence block prefix `- `
-    SEQUENCE_FLOW_BEGIN,   //!< the character for sequence flow begin `[`
-    SEQUENCE_FLOW_END,     //!< the character for sequence flow end `]`
-    MAPPING_BLOCK_PREFIX,  //!< the character for mapping block prefix `:`
-    MAPPING_FLOW_BEGIN,    //!< the character for mapping begin `{`
-    MAPPING_FLOW_END,      //!< the character for mapping end `}`
-    NULL_VALUE,            //!< a null value found. use get_null() to get a value.
-    BOOLEAN_VALUE,         //!< a boolean value found. use get_boolean() to get a value.
-    INTEGER_VALUE,         //!< an integer value found. use get_integer() to get a value.
-    FLOAT_NUMBER_VALUE,    //!< a float number value found. use get_float_number() to get a value.
-    STRING_VALUE,          //!< the character for string begin `"` or any character except the above ones
-};
 
 /**
  * @class lexical_analyzer

--- a/include/fkYAML/detail/meta/type_traits.hpp
+++ b/include/fkYAML/detail/meta/type_traits.hpp
@@ -199,6 +199,17 @@ template <typename T>
 constexpr T static_const<T>::value;
 #endif
 
+/**
+ * @brief A helper structure for tag dispatch.
+ * 
+ * @tparam T A tag type.
+ */
+template <typename T>
+struct type_tag
+{
+    using type = T;
+};
+
 } // namespace detail
 
 FK_YAML_NAMESPACE_END

--- a/include/fkYAML/detail/meta/type_traits.hpp
+++ b/include/fkYAML/detail/meta/type_traits.hpp
@@ -201,7 +201,7 @@ constexpr T static_const<T>::value;
 
 /**
  * @brief A helper structure for tag dispatch.
- * 
+ *
  * @tparam T A tag type.
  */
 template <typename T>

--- a/include/fkYAML/detail/types/lexical_token_t.hpp
+++ b/include/fkYAML/detail/types/lexical_token_t.hpp
@@ -1,0 +1,63 @@
+/**
+ *  _______   __ __   __  _____   __  __  __
+ * |   __| |_/  |  \_/  |/  _  \ /  \/  \|  |     fkYAML: A C++ header-only YAML library
+ * |   __|  _  < \_   _/|  ___  |    _   |  |___  version 0.1.1
+ * |__|  |_| \__|  |_|  |_|   |_|___||___|______| https://github.com/fktn-k/fkYAML
+ *
+ * SPDX-FileCopyrightText: 2023 Kensuke Fukutani <fktn.dev@gmail.com>
+ * SPDX-License-Identifier: MIT
+ *
+ * @file
+ */
+
+#ifndef FK_YAML_DETAIL_TYPES_LEXICAL_TOKEN_T_HPP_
+#define FK_YAML_DETAIL_TYPES_LEXICAL_TOKEN_T_HPP_
+
+#include <fkYAML/detail/macros/version_macros.hpp>
+
+/**
+ * @namespace fkyaml
+ * @brief namespace for fkYAML library.
+ */
+FK_YAML_NAMESPACE_BEGIN
+
+/**
+ * @namespace detail
+ * @brief namespace for internal implementations of fkYAML library.
+ */
+namespace detail
+{
+
+/**
+ * @enum lexical_token_t
+ * @brief Definition of lexical token types.
+ */
+enum class lexical_token_t
+{
+    END_OF_BUFFER,         //!< the end of input buffer.
+    KEY_SEPARATOR,         //!< the key separater `:`
+    VALUE_SEPARATOR,       //!< the value separater `,`
+    ANCHOR_PREFIX,         //!< the character for anchor prefix `&`
+    ALIAS_PREFIX,          //!< the character for alias prefix `*`
+    COMMENT_PREFIX,        //!< the character for comment prefix `#`
+    YAML_VER_DIRECTIVE,    //!< a YAML version directive found. use get_yaml_version() to get a value.
+    TAG_DIRECTIVE,         //!< a TAG directive found. use GetTagInfo() to get the tag information.
+    INVALID_DIRECTIVE,     //!< an invalid directive found. do not try to get the value.
+    SEQUENCE_BLOCK_PREFIX, //!< the character for sequence block prefix `- `
+    SEQUENCE_FLOW_BEGIN,   //!< the character for sequence flow begin `[`
+    SEQUENCE_FLOW_END,     //!< the character for sequence flow end `]`
+    MAPPING_BLOCK_PREFIX,  //!< the character for mapping block prefix `:`
+    MAPPING_FLOW_BEGIN,    //!< the character for mapping begin `{`
+    MAPPING_FLOW_END,      //!< the character for mapping end `}`
+    NULL_VALUE,            //!< a null value found. use get_null() to get a value.
+    BOOLEAN_VALUE,         //!< a boolean value found. use get_boolean() to get a value.
+    INTEGER_VALUE,         //!< an integer value found. use get_integer() to get a value.
+    FLOAT_NUMBER_VALUE,    //!< a float number value found. use get_float_number() to get a value.
+    STRING_VALUE,          //!< the character for string begin `"` or any character except the above ones
+};
+
+} // namespace detail
+
+FK_YAML_NAMESPACE_END
+
+#endif /* FK_YAML_DETAIL_TYPES_LEXICAL_TOKEN_T_HPP_ */

--- a/test/unit_test/CMakeLists.txt
+++ b/test/unit_test/CMakeLists.txt
@@ -58,6 +58,7 @@ add_executable(
   ${TEST_TARGET}
   test_deserializer_class.cpp
   test_exception_class.cpp
+  test_from_string.cpp
   test_iterator_class.cpp
   test_lexical_analyzer_class.cpp
   test_node_class.cpp

--- a/test/unit_test/test_from_string.cpp
+++ b/test/unit_test/test_from_string.cpp
@@ -182,8 +182,7 @@ TEST_CASE("FromStringTest_FloatTest", "[FromStringTest]")
         REQUIRE(std::abs(fkyaml::detail::from_string(input, fkyaml::detail::type_tag<float> {}) - 3.14f) < FLT_EPSILON);
 
         input = "3.40282347e+39";
-        REQUIRE_THROWS_AS(
-            fkyaml::detail::from_string(input, fkyaml::detail::type_tag<float> {}), fkyaml::exception);
+        REQUIRE_THROWS_AS(fkyaml::detail::from_string(input, fkyaml::detail::type_tag<float> {}), fkyaml::exception);
     }
 }
 
@@ -219,7 +218,6 @@ TEST_CASE("FromStringTest_DoubleTest", "[FromStringTest]")
         REQUIRE(std::abs(fkyaml::detail::from_string(input, fkyaml::detail::type_tag<double> {}) - 3.14) < DBL_EPSILON);
 
         input = "1.7976931348623157E+309";
-        REQUIRE_THROWS_AS(
-            fkyaml::detail::from_string(input, fkyaml::detail::type_tag<double> {}), fkyaml::exception);
+        REQUIRE_THROWS_AS(fkyaml::detail::from_string(input, fkyaml::detail::type_tag<double> {}), fkyaml::exception);
     }
 }

--- a/test/unit_test/test_from_string.cpp
+++ b/test/unit_test/test_from_string.cpp
@@ -1,0 +1,225 @@
+//  _______   __ __   __  _____   __  __  __
+// |   __| |_/  |  \_/  |/  _  \ /  \/  \|  |     fkYAML: A C++ header-only YAML library (supporting code)
+// |   __|  _  < \_   _/|  ___  |    _   |  |___  version 0.1.1
+// |__|  |_| \__|  |_|  |_|   |_|___||___|______| https://github.com/fktn-k/fkYAML
+//
+// SPDX-FileCopyrightText: 2023 Kensuke Fukutani <fktn.dev@gmail.com>
+// SPDX-License-Identifier: MIT
+
+#include <cfloat>
+#include <string>
+#include <utility>
+
+#include <catch2/catch.hpp>
+
+#include <fkYAML/detail/conversions/from_string.hpp>
+
+TEST_CASE("FromStringTest_NullptrTest", "[FromStringTest]")
+{
+    SECTION("nothrow expected tests")
+    {
+        auto input = GENERATE(std::string("null"), std::string("Null"), std::string("NULL"), std::string("~"));
+        REQUIRE(fkyaml::detail::from_string(input, fkyaml::detail::type_tag<std::nullptr_t> {}) == nullptr);
+    }
+
+    SECTION("nothrow unexpected test")
+    {
+        std::string input("test");
+        REQUIRE_THROWS_AS(
+            fkyaml::detail::from_string(input, fkyaml::detail::type_tag<std::nullptr_t> {}), fkyaml::exception);
+    }
+}
+
+TEST_CASE("FromStringTest_BoolTest", "[FromStringTest]")
+{
+    SECTION("true value expected tests")
+    {
+        auto input = GENERATE(std::string("true"), std::string("True"), std::string("TRUE"));
+        REQUIRE(fkyaml::detail::from_string(input, fkyaml::detail::type_tag<bool> {}) == true);
+    }
+
+    SECTION("false value expected tests")
+    {
+        auto input = GENERATE(std::string("false"), std::string("False"), std::string("FALSE"));
+        REQUIRE(fkyaml::detail::from_string(input, fkyaml::detail::type_tag<bool> {}) == false);
+    }
+
+    SECTION("nothrow unexpected test")
+    {
+        std::string input("test");
+        REQUIRE_THROWS_AS(fkyaml::detail::from_string(input, fkyaml::detail::type_tag<bool> {}), fkyaml::exception);
+    }
+}
+
+TEST_CASE("FromStringTest_IntegerTest", "[FromStringTest]")
+{
+    SECTION("char type tests")
+    {
+        std::string input("-64");
+        REQUIRE(fkyaml::detail::from_string(input, fkyaml::detail::type_tag<char> {}) == -64);
+
+        input = "256";
+        REQUIRE_THROWS_AS(fkyaml::detail::from_string(input, fkyaml::detail::type_tag<char> {}), fkyaml::exception);
+    }
+
+    SECTION("unsigned char type tests")
+    {
+        std::string input("64");
+        REQUIRE(fkyaml::detail::from_string(input, fkyaml::detail::type_tag<unsigned char> {}) == 64);
+
+        input = "512";
+        REQUIRE_THROWS_AS(
+            fkyaml::detail::from_string(input, fkyaml::detail::type_tag<unsigned char> {}), fkyaml::exception);
+    }
+
+    SECTION("short type tests")
+    {
+        std::string input("-15464");
+        REQUIRE(fkyaml::detail::from_string(input, fkyaml::detail::type_tag<short> {}) == -15464);
+
+        input = "45464";
+        REQUIRE_THROWS_AS(fkyaml::detail::from_string(input, fkyaml::detail::type_tag<short> {}), fkyaml::exception);
+    }
+
+    SECTION("unsigned short type tests")
+    {
+        std::string input("15464");
+        REQUIRE(fkyaml::detail::from_string(input, fkyaml::detail::type_tag<unsigned short> {}) == 15464);
+
+        input = "-1";
+        REQUIRE_THROWS_AS(
+            fkyaml::detail::from_string(input, fkyaml::detail::type_tag<unsigned short> {}), fkyaml::exception);
+    }
+
+    SECTION("int type tests")
+    {
+        std::string input("-1154357464");
+        REQUIRE(fkyaml::detail::from_string(input, fkyaml::detail::type_tag<int> {}) == -1154357464);
+
+        input = "3154357464";
+        REQUIRE_THROWS_AS(fkyaml::detail::from_string(input, fkyaml::detail::type_tag<int> {}), fkyaml::exception);
+    }
+
+    SECTION("unsigned int type tests")
+    {
+        std::string input("3154357464");
+        REQUIRE(fkyaml::detail::from_string(input, fkyaml::detail::type_tag<unsigned int> {}) == 3154357464u);
+
+        input = "999999999999999999999999";
+        REQUIRE_THROWS_AS(
+            fkyaml::detail::from_string(input, fkyaml::detail::type_tag<unsigned int> {}), fkyaml::exception);
+    }
+
+    SECTION("long type tests")
+    {
+        std::string input("-1154357464");
+        REQUIRE(fkyaml::detail::from_string(input, fkyaml::detail::type_tag<long> {}) == -1154357464l);
+
+        input = "9413456789012123456";
+        REQUIRE_THROWS_AS(fkyaml::detail::from_string(input, fkyaml::detail::type_tag<long> {}), fkyaml::exception);
+    }
+
+    SECTION("unsigned long type tests")
+    {
+        std::string input("317464");
+        REQUIRE(fkyaml::detail::from_string(input, fkyaml::detail::type_tag<unsigned long> {}) == 317464ul);
+
+        input = "999999999999999999999999";
+        REQUIRE_THROWS_AS(
+            fkyaml::detail::from_string(input, fkyaml::detail::type_tag<unsigned long> {}), fkyaml::exception);
+    }
+
+    SECTION("long long type tests")
+    {
+        std::string input("-1154357464");
+        REQUIRE(fkyaml::detail::from_string(input, fkyaml::detail::type_tag<long long> {}) == -1154357464ll);
+
+        input = "18413456789012123456";
+        REQUIRE_THROWS_AS(
+            fkyaml::detail::from_string(input, fkyaml::detail::type_tag<long long> {}), fkyaml::exception);
+    }
+
+    SECTION("unsigned long long type tests")
+    {
+        std::string input("3154357464");
+        REQUIRE(fkyaml::detail::from_string(input, fkyaml::detail::type_tag<unsigned long long> {}) == 3154357464ull);
+
+        input = "999999999999999999999999";
+        REQUIRE_THROWS_AS(
+            fkyaml::detail::from_string(input, fkyaml::detail::type_tag<unsigned long long> {}), fkyaml::exception);
+    }
+}
+
+TEST_CASE("FromStringTest_FloatTest", "[FromStringTest]")
+{
+    SECTION("positive infinity test")
+    {
+        auto input = GENERATE(std::string(".inf"), std::string(".Inf"), std::string(".INF"));
+        REQUIRE(
+            fkyaml::detail::from_string(input, fkyaml::detail::type_tag<float> {}) ==
+            std::numeric_limits<float>::infinity());
+    }
+
+    SECTION("negative infinity test")
+    {
+        auto input = GENERATE(std::string("-.inf"), std::string("-.Inf"), std::string("-.INF"));
+        REQUIRE(
+            fkyaml::detail::from_string(input, fkyaml::detail::type_tag<float> {}) ==
+            -1 * std::numeric_limits<float>::infinity());
+    }
+
+    SECTION("NaN test")
+    {
+        auto input = GENERATE(std::string(".nan"), std::string(".NaN"), std::string(".NAN"));
+        float ret = 0.0f;
+        REQUIRE_NOTHROW(ret = fkyaml::detail::from_string(input, fkyaml::detail::type_tag<float> {}));
+        REQUIRE(std::isnan(ret));
+    }
+
+    SECTION("value conversion tests")
+    {
+        std::string input("3.14");
+        REQUIRE(std::abs(fkyaml::detail::from_string(input, fkyaml::detail::type_tag<float> {}) - 3.14f) < FLT_EPSILON);
+
+        input = "3.40282347e+39";
+        REQUIRE_THROWS_AS(
+            fkyaml::detail::from_string(input, fkyaml::detail::type_tag<float> {}), fkyaml::exception);
+    }
+}
+
+TEST_CASE("FromStringTest_DoubleTest", "[FromStringTest]")
+{
+    SECTION("positive infinity test")
+    {
+        auto input = GENERATE(std::string(".inf"), std::string(".Inf"), std::string(".INF"));
+        REQUIRE(
+            fkyaml::detail::from_string(input, fkyaml::detail::type_tag<double> {}) ==
+            std::numeric_limits<double>::infinity());
+    }
+
+    SECTION("negative infinity test")
+    {
+        auto input = GENERATE(std::string("-.inf"), std::string("-.Inf"), std::string("-.INF"));
+        REQUIRE(
+            fkyaml::detail::from_string(input, fkyaml::detail::type_tag<double> {}) ==
+            -1 * std::numeric_limits<double>::infinity());
+    }
+
+    SECTION("NaN test")
+    {
+        auto input = GENERATE(std::string(".nan"), std::string(".NaN"), std::string(".NAN"));
+        double ret = 0.0;
+        REQUIRE_NOTHROW(ret = fkyaml::detail::from_string(input, fkyaml::detail::type_tag<double> {}));
+        REQUIRE(std::isnan(ret));
+    }
+
+    SECTION("value conversion tests")
+    {
+        std::string input("3.14");
+        REQUIRE(std::abs(fkyaml::detail::from_string(input, fkyaml::detail::type_tag<double> {}) - 3.14) < DBL_EPSILON);
+
+        input = "1.7976931348623157E+309";
+        REQUIRE_THROWS_AS(
+            fkyaml::detail::from_string(input, fkyaml::detail::type_tag<double> {}), fkyaml::exception);
+    }
+}

--- a/test/unit_test/test_lexical_analyzer_class.cpp
+++ b/test/unit_test/test_lexical_analyzer_class.cpp
@@ -517,7 +517,7 @@ TEST_CASE("LexicalAnalyzerClassTest_ScanReservedIndicatorTokenTest", "[LexicalAn
     REQUIRE_THROWS_AS(lexer.get_next_token(), fkyaml::exception);
 }
 
-TEST_CASE("LexicalAnalyzerClassTest_ScanKeyBooleanvalue_pair_tTokenTest", "[LexicalAnalyzerClassTest]")
+TEST_CASE("LexicalAnalyzerClassTest_ScanKeyBooleanValuePairTokenTest", "[LexicalAnalyzerClassTest]")
 {
     pchar_lexer_t lexer(fkyaml::detail::input_adapter("test: true"));
     fkyaml::detail::lexical_token_t token;
@@ -539,7 +539,7 @@ TEST_CASE("LexicalAnalyzerClassTest_ScanKeyBooleanvalue_pair_tTokenTest", "[Lexi
     REQUIRE(token == fkyaml::detail::lexical_token_t::END_OF_BUFFER);
 }
 
-TEST_CASE("LexicalAnalyzerClassTest_ScanKeyIntegervalue_pair_tTokenTest", "[LexicalAnalyzerClassTest]")
+TEST_CASE("LexicalAnalyzerClassTest_ScanKeyIntegerValuePairTokenTest", "[LexicalAnalyzerClassTest]")
 {
     pchar_lexer_t lexer(fkyaml::detail::input_adapter("test: -5784"));
     fkyaml::detail::lexical_token_t token;
@@ -561,7 +561,7 @@ TEST_CASE("LexicalAnalyzerClassTest_ScanKeyIntegervalue_pair_tTokenTest", "[Lexi
     REQUIRE(token == fkyaml::detail::lexical_token_t::END_OF_BUFFER);
 }
 
-TEST_CASE("LexicalAnalyzerClassTest_ScanKeyFloatNumbervalue_pair_tTokenTest", "[LexicalAnalyzerClassTest]")
+TEST_CASE("LexicalAnalyzerClassTest_ScanKeyFloatNumberValuePairTokenTest", "[LexicalAnalyzerClassTest]")
 {
     pchar_lexer_t lexer(fkyaml::detail::input_adapter("test: -5.58e-3"));
     fkyaml::detail::lexical_token_t token;
@@ -583,7 +583,7 @@ TEST_CASE("LexicalAnalyzerClassTest_ScanKeyFloatNumbervalue_pair_tTokenTest", "[
     REQUIRE(token == fkyaml::detail::lexical_token_t::END_OF_BUFFER);
 }
 
-TEST_CASE("LexicalAnalyzerClassTest_ScanKeyStringvalue_pair_tTokenTest", "[LexicalAnalyzerClassTest]")
+TEST_CASE("LexicalAnalyzerClassTest_ScanKeyStringValuePairTokenTest", "[LexicalAnalyzerClassTest]")
 {
     pchar_lexer_t lexer(fkyaml::detail::input_adapter("test: \"some value\""));
     fkyaml::detail::lexical_token_t token;


### PR DESCRIPTION
In this PR, the `lexical_analyzer` class has been refactored by:
- implementing the `input_handler` class as a handler of an input adapter,
- implementing `from_string` template functions to generalize conversions from string tokens to native data type values,
- and deleting duplicate conversion checks for resulting token values.

Furthermore, some small fixes have also been applied such as typos in test case labels or splitting some too complicated functions into somewhat understandably sized ones.  

With the changes described above, backward compatibility is still guranteed since previous v0.1 releases.  