### PR TITLE
Fix version_macros.hpp file path in Makefile

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,4 @@
-.PHONY: CHANGELOG.md update-version
+.PHONY: update-version-macros CHANGELOG.md update-version
 
 #################
 #   variables   #
@@ -18,7 +18,7 @@ TARGET_MAJOR_VERSION := 0
 TARGET_MINOR_VERSION := 1
 TARGET_PATCH_VERSION := 1
 TARGET_VERSION_FULL := $(TARGET_MAJOR_VERSION).$(TARGET_MINOR_VERSION).$(TARGET_PATCH_VERSION)
-VERSION_MACRO_FILE := include/fkYAML/VersioningMacros.hpp
+VERSION_MACRO_FILE := include/fkYAML/detail/macros/version_macros.hpp
 
 # system
 JOBS = $(($(shell grep cpu.cores /proc/cpuinfo | sort -u | sed 's/[^0-9]//g') + 1))

--- a/include/fkYAML/detail/macros/version_macros.hpp
+++ b/include/fkYAML/detail/macros/version_macros.hpp
@@ -12,7 +12,7 @@
 
 // Check version definitions if already defined.
 #if defined(FK_YAML_MAJOR_VERSION) && defined(FK_YAML_MINOR_VERSION) && defined(FK_YAML_PATCH_VERSION)
-    #if FK_YAML_MAJOR_VERSION != 0 || FK_YAML_MINOR_VERSION != 0 || FK_YAML_PATCH_VERSION != 1
+    #if FK_YAML_MAJOR_VERSION != 0 || FK_YAML_MINOR_VERSION != 1 || FK_YAML_PATCH_VERSION != 1
         #warning Already included a different version of the fkYAML library!
     #else
         // define macros to skip defining macros down below.
@@ -23,7 +23,7 @@
 #ifndef FK_YAML_VERCHECK_SUCCEEDED
 
     #define FK_YAML_MAJOR_VERSION 0
-    #define FK_YAML_MINOR_VERSION 0
+    #define FK_YAML_MINOR_VERSION 1
     #define FK_YAML_PATCH_VERSION 1
 
     #define FK_YAML_NAMESPACE_VERSION_CONCAT_IMPL(major, minor, patch) v##major##_##minor##_##patch


### PR DESCRIPTION
Due to the change in locations of internal implementations, Makefile mistakingly assume the version_macros.hpp file path.  
Which makes internal library version checks executed wrongly.  
In this PR, I have fixed the wrong path in the Makefile.  