### PR TITLE
#150 Excluded unreachable lines in serializer class test from coverage data

### DIFF
--- a/include/fkYAML/detail/output/serializer.hpp
+++ b/include/fkYAML/detail/output/serializer.hpp
@@ -58,7 +58,7 @@ public:
         std::string str {};
         serialize_node(node, 0, str);
         return str;
-    }
+    } // LCOV_EXCL_LINE
 
 private:
     /**
@@ -152,8 +152,8 @@ private:
         case node_t::STRING:
             str += node.to_string();
             break;
-        default:
-            throw fkyaml::exception("Unsupported node type found.");
+        default:                                                     // LCOV_EXCL_LINE
+            throw fkyaml::exception("Unsupported node type found."); // LCOV_EXCL_LINE
         }
     }
 


### PR DESCRIPTION
Some unreachable lines in serializer class have been changed to get excluded from coverage data.  
I have no idea on how to reproduce such a line but it does happen.  
So, as a work-around, I just make lcov ignore those lines in generating coverage data.  

Related links: #150  
