### PR TITLE
#150 Covered a missing branch in ordered_map class

### DIFF
--- a/test/unit_test/test_ordered_map_class.cpp
+++ b/test/unit_test/test_ordered_map_class.cpp
@@ -74,9 +74,12 @@ TEST_CASE("OrderedMapClassTest_ConstAtTest", "[OrderedMapClassTest]")
     map_.emplace("buz", false);
     map_.emplace("foo", true);
     const fkyaml::ordered_map<std::string, bool> map__ = map_;
+    REQUIRE_NOTHROW(map__.at("buz"));
+    REQUIRE(map__.at("buz") == false);
     REQUIRE_NOTHROW(map__.at("foo"));
     REQUIRE(map__.at("foo") == true);
-    REQUIRE_THROWS_AS(map__.at("bar"), fkyaml::exception);
+    std::string key("bar");
+    REQUIRE_THROWS_AS(map__.at(key), fkyaml::exception);
 }
 
 TEST_CASE("OrderedMapClassTest_NonConstFindTest", "[OrderedMapClassTest]")


### PR DESCRIPTION
I have modified a unit test case to cover a missing branch path in const version of `ordered_map::at()`.  
I guess this is a bug but I made a workaround without modifying any public API.  
Backward compatibility is, of course, still guranteed.  