### PR TITLE
#150 added/modified unit tests for lexical_analyzer test

### DIFF
--- a/test/unit_test/test_lexical_analyzer_class.cpp
+++ b/test/unit_test/test_lexical_analyzer_class.cpp
@@ -88,9 +88,7 @@ TEST_CASE("LexicalAnalyzerClassTest_ScanTagDirectiveTest", "[LexicalAnalyzerClas
 
     SECTION("Test nothrow expected tokens with invalid content.")
     {
-        auto buffer = GENERATE(
-            std::string("%TUB"),
-            std::string("%TAC"));
+        auto buffer = GENERATE(std::string("%TUB"), std::string("%TAC"));
 
         str_lexer_t lexer(fkyaml::detail::input_adapter(buffer));
         REQUIRE_NOTHROW(token = lexer.get_next_token());


### PR DESCRIPTION
Unit test cases for missing lines/branches of lexical_analyzer class implementation, have been added/modified.  
To clean up implementation, unused functions/members have also been deleted.  
They might be re-implemented as a fixed version in some later PRs.  

Related links: #150 