### PR TITLE
#145 Expand swap() support for basic node

### DIFF
--- a/include/fkYAML/detail/meta/node_traits.hpp
+++ b/include/fkYAML/detail/meta/node_traits.hpp
@@ -28,7 +28,7 @@ FK_YAML_NAMESPACE_BEGIN
 template <
     template <typename, typename...> class SequenceType, template <typename, typename, typename...> class MappingType,
     typename BooleanType, typename IntegerType, typename FloatNumberType, typename StringType,
-    template <typename, typename> class Converter>
+    template <typename, typename> class ConverterType>
 class basic_node;
 
 /**

--- a/include/fkYAML/node.hpp
+++ b/include/fkYAML/node.hpp
@@ -1370,6 +1370,18 @@ private:
     std::string* m_anchor_name;
 };
 
+template <
+    template <typename, typename...> class SequenceType, template <typename, typename, typename...> class MappingType,
+    typename BooleanType, typename IntegerType, typename FloatNumberType, typename StringType,
+    template <typename, typename = void> class ConverterType>
+inline void swap(
+    basic_node<SequenceType, MappingType, BooleanType, IntegerType, FloatNumberType, StringType, ConverterType>& lhs,
+    basic_node<SequenceType, MappingType, BooleanType, IntegerType, FloatNumberType, StringType, ConverterType>&
+        rhs) noexcept(noexcept(lhs.swap(rhs)))
+{
+    lhs.swap(rhs);
+}
+
 /**
  * @brief default YAML node value container.
  */
@@ -1394,23 +1406,5 @@ using node_float_number_type = typename node::float_number_type;
 using node_string_type = typename node::string_type;
 
 FK_YAML_NAMESPACE_END
-
-namespace std
-{
-
-/**
- * @brief A specialization of std::swap for Node class.
- *
- * @tparam N/A
- * @param lhs A Node object of left-hand-side.
- * @param rhs A Node object of right-hand-side.
- */
-template <>
-inline void swap<fkyaml::node>(fkyaml::node& lhs, fkyaml::node& rhs) noexcept(noexcept(lhs.swap(rhs)))
-{
-    lhs.swap(rhs);
-}
-
-} // namespace std
 
 #endif /* FK_YAML_NODE_HPP_ */

--- a/include/fkYAML/node.hpp
+++ b/include/fkYAML/node.hpp
@@ -415,13 +415,13 @@ public:
                                                                 detail::is_node_compatible_type<basic_node, U>>>::value,
             int> = 0>
     explicit basic_node(CompatibleType&& val) noexcept(
-        noexcept(Converter<U>::to_node(std::declval<basic_node&>(), std::declval<CompatibleType>())))
+        noexcept(ConverterType<U>::to_node(std::declval<basic_node&>(), std::declval<CompatibleType>())))
         : m_node_type(node_t::NULL_OBJECT),
           m_yaml_version_type(yaml_version_t::VER_1_2),
           m_node_value(),
           m_anchor_name(nullptr)
     {
-        Converter<U>::to_node(*this, std::forward<CompatibleType>(val));
+        ConverterType<U>::to_node(*this, std::forward<CompatibleType>(val));
     }
 
     /**
@@ -1051,10 +1051,10 @@ public:
                 std::is_default_constructible<ValueType>, detail::has_from_node<basic_node, ValueType>>::value,
             int> = 0>
     T get_value() const noexcept(
-        noexcept(Converter<ValueType>::from_node(std::declval<const basic_node&>(), std::declval<ValueType&>())))
+        noexcept(ConverterType<ValueType>::from_node(std::declval<const basic_node&>(), std::declval<ValueType&>())))
     {
         auto ret = ValueType();
-        Converter<ValueType>::from_node(*this, ret);
+        ConverterType<ValueType>::from_node(*this, ret);
         return ret;
     }
 

--- a/include/fkYAML/node.hpp
+++ b/include/fkYAML/node.hpp
@@ -57,7 +57,7 @@ template <
     template <typename, typename...> class SequenceType = std::vector,
     template <typename, typename, typename...> class MappingType = ordered_map, typename BooleanType = bool,
     typename IntegerType = std::int64_t, typename FloatNumberType = double, typename StringType = std::string,
-    template <typename, typename = void> class Converter = node_value_converter>
+    template <typename, typename = void> class ConverterType = node_value_converter>
 class basic_node
 {
 public:
@@ -86,7 +86,7 @@ public:
      * @tparam SFINAE A type placeholder for SFINAE
      */
     template <typename T, typename SFINAE>
-    using value_converter_type = Converter<T, SFINAE>;
+    using value_converter_type = ConverterType<T, SFINAE>;
 
     using node_t = detail::node_t;
     using yaml_version_t = detail::yaml_version_t;

--- a/test/unit_test/test_node_class.cpp
+++ b/test/unit_test/test_node_class.cpp
@@ -2227,11 +2227,14 @@ TEST_CASE("NodeClassTest_SwapTest", "[NodeClassTest]")
     REQUIRE(rhs_node.to_boolean() == true);
 }
 
-TEST_CASE("NodeClassTest_StdSwapTest", "[NodeClassTest]")
+TEST_CASE("NodeClassTest_ADLSwapTest", "[NodeClassTest]")
 {
     fkyaml::node lhs_node = fkyaml::node::boolean_scalar(true);
     fkyaml::node rhs_node = fkyaml::node::integer_scalar(123);
-    std::swap(lhs_node, rhs_node);
+
+    using std::swap;
+    swap(lhs_node, rhs_node);
+
     REQUIRE(lhs_node.is_integer());
     REQUIRE(lhs_node.to_integer() == 123);
     REQUIRE(rhs_node.is_boolean());


### PR DESCRIPTION
Before this PR, non-default `basic_node` template instance classes are not specialized for `swap()`.  
To improve the quality of user-defined customization of `basic_node` template class, I have replaced the overloaded version of `std::swap()` with the one defined in the `fkyaml` namespace.  
The library users will still be able to call swap() for `fkyaml::node` instances just as they did before this PR, which means that backward compatibility is still guranteed.  