### PR TITLE
#164 Use default initial values for class member variables

### DIFF
--- a/include/fkYAML/detail/input/deserializer.hpp
+++ b/include/fkYAML/detail/input/deserializer.hpp
@@ -313,13 +313,13 @@ private:
     }
 
 private:
-    BasicNodeType* m_current_node = nullptr;                 /** The currently focused YAML node. */
-    std::vector<BasicNodeType*> m_node_stack = {};           /** The stack of YAML nodes. */
-    yaml_version_t m_yaml_version = yaml_version_t::VER_1_2; /** The YAML version specification type. */
-    uint32_t m_current_indent_width = 0;                     /** The current indentation width. */
-    bool m_needs_anchor_impl = false; /** A flag to determine the need for YAML anchor node implementation */
+    BasicNodeType* m_current_node {nullptr};                 /** The currently focused YAML node. */
+    std::vector<BasicNodeType*> m_node_stack {};             /** The stack of YAML nodes. */
+    yaml_version_t m_yaml_version {yaml_version_t::VER_1_2}; /** The YAML version specification type. */
+    uint32_t m_current_indent_width {0};                     /** The current indentation width. */
+    bool m_needs_anchor_impl {false}; /** A flag to determine the need for YAML anchor node implementation */
     string_type m_anchor_name {};     /** The last YAML anchor name. */
-    std::unordered_map<std::string, BasicNodeType> m_anchor_table = {}; /** The table of YAML anchor nodes. */
+    std::unordered_map<std::string, BasicNodeType> m_anchor_table {}; /** The table of YAML anchor nodes. */
 };
 
 } // namespace detail

--- a/include/fkYAML/detail/input/deserializer.hpp
+++ b/include/fkYAML/detail/input/deserializer.hpp
@@ -316,7 +316,6 @@ private:
     BasicNodeType* m_current_node {nullptr};                 /** The currently focused YAML node. */
     std::vector<BasicNodeType*> m_node_stack {};             /** The stack of YAML nodes. */
     yaml_version_t m_yaml_version {yaml_version_t::VER_1_2}; /** The YAML version specification type. */
-    uint32_t m_current_indent_width {0};                     /** The current indentation width. */
     bool m_needs_anchor_impl {false}; /** A flag to determine the need for YAML anchor node implementation */
     string_type m_anchor_name {};     /** The last YAML anchor name. */
     std::unordered_map<std::string, BasicNodeType> m_anchor_table {}; /** The table of YAML anchor nodes. */

--- a/include/fkYAML/detail/input/input_adapter.hpp
+++ b/include/fkYAML/detail/input/input_adapter.hpp
@@ -100,9 +100,9 @@ public:
     }
 
 private:
-    IterType m_current;
-    IterType m_begin;
-    IterType m_end;
+    IterType m_current {};
+    IterType m_begin {};
+    IterType m_end {};
 };
 
 /**
@@ -156,7 +156,7 @@ public:
     }
 
 private:
-    std::FILE* m_file;
+    std::FILE* m_file {nullptr};
 };
 
 /**
@@ -243,7 +243,7 @@ public:
     }
 
 private:
-    std::istream* m_istream;
+    std::istream* m_istream {nullptr};
 };
 
 ///////////////////////////////////

--- a/include/fkYAML/detail/input/input_handler.hpp
+++ b/include/fkYAML/detail/input/input_handler.hpp
@@ -58,8 +58,7 @@ public:
      * @param input_adapter An input adapter object
      */
     explicit input_handler(InputAdapterType&& input_adapter)
-        : m_input_adapter(std::move(input_adapter)),
-          m_cur_pos(0)
+        : m_input_adapter(std::move(input_adapter))
     {
         get_next();
         m_cur_pos = 0;
@@ -183,11 +182,11 @@ private:
     static constexpr int_type end_of_input = char_traits_type::eof();
 
     //!< An input adapter object.
-    InputAdapterType m_input_adapter;
+    InputAdapterType m_input_adapter {};
     //!< Cached characters retrieved from an input adapter object.
-    std::vector<int_type> m_cache;
+    std::vector<int_type> m_cache {};
     //!< The current position in an input buffer.
-    size_t m_cur_pos;
+    size_t m_cur_pos {0};
 };
 
 } // namespace detail

--- a/include/fkYAML/detail/input/lexical_analyzer.hpp
+++ b/include/fkYAML/detail/input/lexical_analyzer.hpp
@@ -76,13 +76,13 @@ private:
     struct position
     {
         //!< The total read char counts from the input buffer.
-        size_t total_read_char_counts = 0;
+        size_t total_read_char_counts {0};
         //!< The total read line counts.
-        size_t total_read_line_counts = 0;
+        size_t total_read_line_counts {0};
         //!< The total read char counts in the current line.
-        size_t read_char_counts_in_line = 0;
+        size_t read_char_counts_in_line {0};
         //!< The total char counts in the previous line.
-        size_t prev_char_counts_in_line = 0;
+        size_t prev_char_counts_in_line {0};
     };
 
 public:
@@ -90,9 +90,7 @@ public:
      * @brief Construct a new lexical_analyzer object.
      */
     explicit lexical_analyzer(InputAdapterType&& input_adapter)
-        : m_input_handler(std::move(input_adapter)),
-          m_value_buffer(),
-          m_position_info()
+        : m_input_handler(std::move(input_adapter))
     {
     }
 
@@ -1167,19 +1165,19 @@ private:
     static constexpr char_int_type end_of_input = char_traits_type::eof();
 
     //!< An input buffer adapter to be analyzed.
-    input_handler_type m_input_handler;
+    input_handler_type m_input_handler {};
     //!< A temporal buffer to store a string to be parsed to an actual datum.
-    input_string_type m_value_buffer;
+    input_string_type m_value_buffer {};
     //!< The information set for input buffer.
-    position m_position_info;
+    position m_position_info {};
     //!< The last found token type.
-    lexical_token_t m_last_token_type;
+    lexical_token_t m_last_token_type {lexical_token_t::END_OF_BUFFER};
     //!< A temporal bool holder.
-    boolean_type m_boolean_val;
+    boolean_type m_boolean_val {false};
     //!< A temporal integer holder.
-    integer_type m_integer_val;
+    integer_type m_integer_val {0};
     //!< A temporal floating point number holder.
-    float_number_type m_float_val;
+    float_number_type m_float_val {0.0};
 };
 
 } // namespace detail

--- a/include/fkYAML/detail/input/lexical_analyzer.hpp
+++ b/include/fkYAML/detail/input/lexical_analyzer.hpp
@@ -68,24 +68,6 @@ public:
     using float_number_type = typename BasicNodeType::float_number_type;
     using string_type = typename BasicNodeType::string_type;
 
-private:
-    /**
-     * @struct position
-     * @brief Information set of analyzed data counters.
-     */
-    struct position
-    {
-        //!< The total read char counts from the input buffer.
-        size_t total_read_char_counts {0};
-        //!< The total read line counts.
-        size_t total_read_line_counts {0};
-        //!< The total read char counts in the current line.
-        size_t read_char_counts_in_line {0};
-        //!< The total char counts in the previous line.
-        size_t prev_char_counts_in_line {0};
-    };
-
-public:
     /**
      * @brief Construct a new lexical_analyzer object.
      */
@@ -94,7 +76,6 @@ public:
     {
     }
 
-public:
     /**
      * @brief Get the next lexical token type by scanning the left of the input buffer.
      *
@@ -798,7 +779,6 @@ private:
 
         const bool needs_last_double_quote = (m_input_handler.get_current() == '\"');
         const bool needs_last_single_quote = (m_input_handler.get_current() == '\'');
-        size_t start_pos_backup = m_position_info.total_read_char_counts;
         char_int_type current = (needs_last_double_quote || needs_last_single_quote) ? m_input_handler.get_next()
                                                                                      : m_input_handler.get_current();
 
@@ -886,13 +866,6 @@ private:
                 {
                     m_value_buffer.push_back(char_traits_type::to_char_type(current));
                     continue;
-                }
-
-                if (next == '\r' || next == '\n')
-                {
-                    size_t current_pos_backup = m_position_info.total_read_char_counts;
-                    m_position_info.total_read_char_counts = start_pos_backup;
-                    m_position_info.total_read_char_counts = current_pos_backup;
                 }
 
                 return lexical_token_t::STRING_VALUE;
@@ -1168,8 +1141,6 @@ private:
     input_handler_type m_input_handler;
     //!< A temporal buffer to store a string to be parsed to an actual datum.
     input_string_type m_value_buffer {};
-    //!< The information set for input buffer.
-    position m_position_info {};
     //!< The last found token type.
     lexical_token_t m_last_token_type {lexical_token_t::END_OF_BUFFER};
     //!< A temporal bool holder.

--- a/include/fkYAML/detail/input/lexical_analyzer.hpp
+++ b/include/fkYAML/detail/input/lexical_analyzer.hpp
@@ -1165,7 +1165,7 @@ private:
     static constexpr char_int_type end_of_input = char_traits_type::eof();
 
     //!< An input buffer adapter to be analyzed.
-    input_handler_type m_input_handler {};
+    input_handler_type m_input_handler;
     //!< A temporal buffer to store a string to be parsed to an actual datum.
     input_string_type m_value_buffer {};
     //!< The information set for input buffer.

--- a/include/fkYAML/detail/iterator.hpp
+++ b/include/fkYAML/detail/iterator.hpp
@@ -570,9 +570,9 @@ public:
 
 private:
     /** A type of the internally-held iterator. */
-    iterator_t m_inner_iterator_type;
+    iterator_t m_inner_iterator_type {iterator_t::SEQUENCE};
     /** A holder of actual iterators. */
-    mutable iterator_holder m_iterator_holder;
+    mutable iterator_holder m_iterator_holder {};
 };
 
 } // namespace detail

--- a/include/fkYAML/node.hpp
+++ b/include/fkYAML/node.hpp
@@ -221,7 +221,7 @@ private:
         /** A pointer to the value of sequence type. */
         sequence_type* p_sequence;
         /** A pointer to the value of mapping type. This pointer is also used when node type is null. */
-        mapping_type* p_mapping;
+        mapping_type* p_mapping {nullptr};
         /** A value of boolean type. */
         boolean_type boolean;
         /** A value of integer type. */
@@ -283,13 +283,7 @@ public:
     /**
      * @brief Construct a new basic_node object of null type.
      */
-    basic_node() noexcept
-        : m_node_type(node_t::NULL_OBJECT),
-          m_yaml_version_type(yaml_version_t::VER_1_2),
-          m_node_value(),
-          m_anchor_name(nullptr)
-    {
-    }
+    basic_node() = default;
 
     /**
      * @brief Construct a new basic_node object with a specified type.
@@ -299,9 +293,7 @@ public:
      */
     explicit basic_node(const node_t type)
         : m_node_type(type),
-          m_yaml_version_type(yaml_version_t::VER_1_2),
-          m_node_value(type),
-          m_anchor_name(nullptr)
+          m_node_value(type)
     {
     }
 
@@ -312,8 +304,7 @@ public:
      */
     basic_node(const basic_node& rhs)
         : m_node_type(rhs.m_node_type),
-          m_yaml_version_type(rhs.m_yaml_version_type),
-          m_anchor_name(nullptr)
+          m_yaml_version_type(rhs.m_yaml_version_type)
     {
         switch (m_node_type)
         {
@@ -414,10 +405,6 @@ public:
             int> = 0>
     explicit basic_node(CompatibleType&& val) noexcept(
         noexcept(ConverterType<U>::to_node(std::declval<basic_node&>(), std::declval<CompatibleType>())))
-        : m_node_type(node_t::NULL_OBJECT),
-          m_yaml_version_type(yaml_version_t::VER_1_2),
-          m_node_value(),
-          m_anchor_name(nullptr)
     {
         ConverterType<U>::to_node(*this, std::forward<CompatibleType>(val));
     }
@@ -1359,13 +1346,13 @@ public:
 
 private:
     /** The current node value type. */
-    node_t m_node_type;
+    node_t m_node_type {node_t::NULL_OBJECT};
     /** The YAML version specification. */
-    yaml_version_t m_yaml_version_type;
+    yaml_version_t m_yaml_version_type {yaml_version_t::VER_1_2};
     /** The current node value. */
-    node_value m_node_value;
+    node_value m_node_value {};
     /** The anchor name for this node. */
-    std::string* m_anchor_name;
+    std::string* m_anchor_name {nullptr};
 };
 
 template <

--- a/include/fkYAML/ordered_map.hpp
+++ b/include/fkYAML/ordered_map.hpp
@@ -65,8 +65,7 @@ public:
      * @brief Construct a new ordered_map object.
      */
     ordered_map() noexcept(noexcept(Container()))
-        : Container(),
-          m_compare()
+        : Container()
     {
     }
 
@@ -76,8 +75,7 @@ public:
      * @param init An initializer list to construct the inner container object.
      */
     ordered_map(std::initializer_list<value_type> init)
-        : Container {init},
-          m_compare()
+        : Container {init}
     {
     }
 
@@ -210,7 +208,8 @@ public:
     }
 
 private:
-    key_compare m_compare; /** The object for comparing keys. */
+    /** The object for comparing keys. */
+    key_compare m_compare {};
 };
 
 FK_YAML_NAMESPACE_END


### PR DESCRIPTION
Before this PR, some classes do not have default initial values for their own member variables.  
For such a class, each constructor should have　its member initializer list, and those list tend to be the same in every constructor.  
Sometimes those those classes have some uninitialized values at their constructors, which would potentially and unexpectedly cause undefined behaviours.  

To avoid duplicating boilerplates as well as missing initialization, I would like to introduce default initial values for member variables where they are missing.  

Related items: #164.