### PR TITLE
#158 Added to_string() for serialization of YAML nodes.

### DIFF
--- a/include/fkYAML/detail/conversions/to_string.hpp
+++ b/include/fkYAML/detail/conversions/to_string.hpp
@@ -1,0 +1,91 @@
+/**
+ *  _______   __ __   __  _____   __  __  __
+ * |   __| |_/  |  \_/  |/  _  \ /  \/  \|  |     fkYAML: A C++ header-only YAML library
+ * |   __|  _  < \_   _/|  ___  |    _   |  |___  version 0.1.2
+ * |__|  |_| \__|  |_|  |_|   |_|___||___|______| https://github.com/fktn-k/fkYAML
+ *
+ * SPDX-FileCopyrightText: 2023 Kensuke Fukutani <fktn.dev@gmail.com>
+ * SPDX-License-Identifier: MIT
+ *
+ * @file
+ */
+
+#ifndef TO__string_HPP_
+#define TO__string_HPP_
+
+#include <cmath>
+#include <limits>
+#include <string>
+#include <sstream>
+#include <type_traits>
+
+#include <fkYAML/detail/macros/version_macros.hpp>
+#include <fkYAML/detail/meta/stl_supplement.hpp>
+#include <fkYAML/detail/meta/type_traits.hpp>
+
+/**
+ * @namespace fkyaml
+ * @brief namespace for fkYAML library.
+ */
+FK_YAML_NAMESPACE_BEGIN
+
+/**
+ * @namespace detail
+ * @brief namespace for internal implementations of fkYAML library.
+ */
+namespace detail
+{
+
+template <typename ValueType, typename CharType>
+inline void to_string(std::basic_string<CharType>& s, ValueType);
+
+template <>
+inline void to_string(std::string& s, std::nullptr_t /*unused*/)
+{
+    s = "null";
+}
+
+template <>
+inline void to_string(std::string& s, bool b)
+{
+    s = b ? "true" : "false";
+}
+
+template <typename IntegerType>
+inline enable_if_t<is_non_bool_integral<IntegerType>::value> to_string(std::string& s, IntegerType i)
+{
+    s = std::to_string(i);
+}
+
+template <typename FloatType>
+inline enable_if_t<std::is_floating_point<FloatType>::value> to_string(std::string& s, FloatType f)
+{
+    if (std::isnan(f))
+    {
+        s = ".nan";
+        return;
+    }
+
+    if (std::isinf(f))
+    {
+        if (f == std::numeric_limits<FloatType>::infinity())
+        {
+            s = ".inf";
+        }
+        else
+        {
+            s = "-.inf";
+        }
+        return;
+    }
+
+    std::ostringstream oss;
+    oss << f;
+    s = oss.str();
+}
+
+} // namespace detail
+
+FK_YAML_NAMESPACE_END
+
+#endif /* TO__string_HPP_ */

--- a/include/fkYAML/detail/output/serializer.hpp
+++ b/include/fkYAML/detail/output/serializer.hpp
@@ -18,6 +18,7 @@
 #include <string>
 
 #include <fkYAML/detail/macros/version_macros.hpp>
+#include <fkYAML/detail/conversions/to_string.hpp>
 #include <fkYAML/detail/meta/node_traits.hpp>
 #include <fkYAML/detail/types/node_t.hpp>
 #include <fkYAML/exception.hpp>
@@ -111,44 +112,20 @@ private:
             }
             break;
         case node_t::NULL_OBJECT:
-            str += "null";
+            to_string(m_tmp_str_buff, nullptr);
+            str += m_tmp_str_buff;
             break;
         case node_t::BOOLEAN:
-            if (node.to_boolean())
-            {
-                str += "true";
-            }
-            else
-            {
-                str += "false";
-            }
+            to_string(m_tmp_str_buff, node.to_boolean());
+            str += m_tmp_str_buff;
             break;
         case node_t::INTEGER:
-            str += std::to_string(node.to_integer());
+            to_string(m_tmp_str_buff, node.to_integer());
+            str += m_tmp_str_buff;
             break;
         case node_t::FLOAT_NUMBER: {
-            typename BasicNodeType::float_number_type float_val = node.to_float_number();
-            if (std::isnan(float_val))
-            {
-                str += ".nan";
-            }
-            else if (std::isinf(float_val))
-            {
-                if (float_val == std::numeric_limits<typename BasicNodeType::float_number_type>::infinity())
-                {
-                    str += ".inf";
-                }
-                else
-                {
-                    str += "-.inf";
-                }
-            }
-            else
-            {
-                std::stringstream ss;
-                ss << node.to_float_number();
-                str += ss.str();
-            }
+            to_string(m_tmp_str_buff, node.to_float_number());
+            str += m_tmp_str_buff;
             break;
         }
         case node_t::STRING:
@@ -183,6 +160,10 @@ private:
             str += " ";
         }
     }
+
+private:
+    /** A temporal buffer for conversion from a scalar to a string. */
+    std::string m_tmp_str_buff;
 };
 
 } // namespace detail


### PR DESCRIPTION
Before this PR, `basic_serializer` class implements conversions from native data type values to strings.  
So, to_string() template functions have been added to abstract too concrete serialization process.  

This is assumed to be a foundation for outputs in the form of multi-byte strings. (Not implemented)  