### PR TITLE
#105 Support std::initializer_list in basic_node constructors

### DIFF
--- a/include/fkYAML/detail/meta/node_traits.hpp
+++ b/include/fkYAML/detail/meta/node_traits.hpp
@@ -74,6 +74,23 @@ struct is_basic_node<
 {
 };
 
+///////////////////////////////////
+//   is_node_ref_storage traits
+///////////////////////////////////
+
+template <typename>
+class node_ref_storage;
+
+template <typename T>
+struct is_node_ref_storage : std::false_type
+{
+};
+
+template <typename T>
+struct is_node_ref_storage<node_ref_storage<T>> : std::true_type
+{
+};
+
 ///////////////////////////////////////////////////////
 //   basic_node conversion API representative types
 ///////////////////////////////////////////////////////

--- a/include/fkYAML/detail/meta/type_traits.hpp
+++ b/include/fkYAML/detail/meta/type_traits.hpp
@@ -210,6 +210,45 @@ struct type_tag
     using type = T;
 };
 
+/**
+ * @brief A utility struct to retrieve the first type in variadic template arguments.
+ * 
+ * @tparam Types Types of variadic template arguments.
+ */
+template <typename... Types>
+struct get_head_type;
+
+/**
+ * @brief A specialization of get_head_type if variadic template has no arguments.
+ * 
+ * @tparam  N/A
+ */
+template <>
+struct get_head_type<>
+{
+    using type = void;
+};
+
+/**
+ * @brief A partial specialization of get_head_type if variadic template has one or more argument(s).
+ * 
+ * @tparam First The first type in the arguments
+ * @tparam Rest The rest of the types in the arguments.
+ */
+template <typename First, typename... Rest>
+struct get_head_type<First, Rest...>
+{
+    using type = First;
+};
+
+/**
+ * @brief An alias template to retrieve the first type in variadic template arguments.
+ * 
+ * @tparam Types Types of variadic template arguments.
+ */
+template <typename... Types>
+using head_type = typename get_head_type<Types...>::type;
+
 } // namespace detail
 
 FK_YAML_NAMESPACE_END

--- a/include/fkYAML/detail/meta/type_traits.hpp
+++ b/include/fkYAML/detail/meta/type_traits.hpp
@@ -212,7 +212,7 @@ struct type_tag
 
 /**
  * @brief A utility struct to retrieve the first type in variadic template arguments.
- * 
+ *
  * @tparam Types Types of variadic template arguments.
  */
 template <typename... Types>
@@ -220,7 +220,7 @@ struct get_head_type;
 
 /**
  * @brief A specialization of get_head_type if variadic template has no arguments.
- * 
+ *
  * @tparam  N/A
  */
 template <>
@@ -231,7 +231,7 @@ struct get_head_type<>
 
 /**
  * @brief A partial specialization of get_head_type if variadic template has one or more argument(s).
- * 
+ *
  * @tparam First The first type in the arguments
  * @tparam Rest The rest of the types in the arguments.
  */
@@ -243,7 +243,7 @@ struct get_head_type<First, Rest...>
 
 /**
  * @brief An alias template to retrieve the first type in variadic template arguments.
- * 
+ *
  * @tparam Types Types of variadic template arguments.
  */
 template <typename... Types>

--- a/include/fkYAML/detail/node_ref_storage.hpp
+++ b/include/fkYAML/detail/node_ref_storage.hpp
@@ -84,7 +84,9 @@ public:
      * @tparam Args Types of arguments to construct a basic_node object.
      * @param args Arguments to construct a basic_node object.
      */
-    template <typename... Args, enable_if_t<std::is_constructible<node_type, Args...>::value, int> = 0>
+    template <typename... Args, enable_if_t<conjunction<
+        negation<std::is_lvalue_reference<head_type<Args...>>>,
+        std::is_constructible<node_type, Args...>>::value, int> = 0>
     node_ref_storage(Args&&... args)
         : owned_value(std::forward<Args>(args)...)
     {

--- a/include/fkYAML/detail/node_ref_storage.hpp
+++ b/include/fkYAML/detail/node_ref_storage.hpp
@@ -50,7 +50,7 @@ class node_ref_storage
 public:
     /**
      * @brief Construct a new node ref storage object with an rvalue basic_node object.
-     * 
+     *
      * @param n An rvalue basic_node object.
      */
     node_ref_storage(node_type&& n)
@@ -60,7 +60,7 @@ public:
 
     /**
      * @brief Construct a new node ref storage object with an lvalue basic_node object.
-     * 
+     *
      * @param n An lvalue basic_node object.
      */
     node_ref_storage(const node_type& n)
@@ -70,7 +70,7 @@ public:
 
     /**
      * @brief Construct a new node ref storage object with a std::initializer_list object.
-     * 
+     *
      * @param init A std::initializer_list object.
      */
     node_ref_storage(std::initializer_list<node_ref_storage> init)
@@ -80,13 +80,16 @@ public:
 
     /**
      * @brief Construct a new node ref storage object with variadic template arguments
-     * 
+     *
      * @tparam Args Types of arguments to construct a basic_node object.
      * @param args Arguments to construct a basic_node object.
      */
-    template <typename... Args, enable_if_t<conjunction<
-        negation<std::is_lvalue_reference<head_type<Args...>>>,
-        std::is_constructible<node_type, Args...>>::value, int> = 0>
+    template <
+        typename... Args, enable_if_t<
+                              conjunction<
+                                  negation<std::is_lvalue_reference<head_type<Args...>>>,
+                                  std::is_constructible<node_type, Args...>>::value,
+                              int> = 0>
     node_ref_storage(Args&&... args)
         : owned_value(std::forward<Args>(args)...)
     {
@@ -101,7 +104,7 @@ public:
 public:
     /**
      * @brief An arrow operator for node_ref_storage objects.
-     * 
+     *
      * @return const node_type* A constant pointer to a basic_node object.
      */
     const node_type* operator->() const
@@ -111,7 +114,7 @@ public:
 
     /**
      * @brief Releases a basic_node object internally held.
-     * 
+     *
      * @return node_type A basic_node object internally held.
      */
     node_type release() const

--- a/include/fkYAML/detail/node_ref_storage.hpp
+++ b/include/fkYAML/detail/node_ref_storage.hpp
@@ -53,7 +53,7 @@ public:
      *
      * @param n An rvalue basic_node object.
      */
-    node_ref_storage(node_type&& n)
+    explicit node_ref_storage(node_type&& n)
         : owned_value(std::move(n))
     {
     }
@@ -63,7 +63,7 @@ public:
      *
      * @param n An lvalue basic_node object.
      */
-    node_ref_storage(const node_type& n)
+    explicit node_ref_storage(const node_type& n)
         : value_ref(&n)
     {
     }

--- a/include/fkYAML/detail/node_ref_storage.hpp
+++ b/include/fkYAML/detail/node_ref_storage.hpp
@@ -1,0 +1,131 @@
+/**
+ *  _______   __ __   __  _____   __  __  __
+ * |   __| |_/  |  \_/  |/  _  \ /  \/  \|  |     fkYAML: A C++ header-only YAML library
+ * |   __|  _  < \_   _/|  ___  |    _   |  |___  version 0.1.2
+ * |__|  |_| \__|  |_|  |_|   |_|___||___|______| https://github.com/fktn-k/fkYAML
+ *
+ * SPDX-FileCopyrightText: 2023 Kensuke Fukutani <fktn.dev@gmail.com>
+ * SPDX-License-Identifier: MIT
+ *
+ * @file
+ */
+
+#ifndef FK_YAML_DETAIL_NODE_REF_STORAGE_HPP_
+#define FK_YAML_DETAIL_NODE_REF_STORAGE_HPP_
+
+#include <initializer_list>
+#include <type_traits>
+#include <utility>
+
+#include <fkYAML/detail/macros/version_macros.hpp>
+#include <fkYAML/detail/meta/node_traits.hpp>
+#include <fkYAML/detail/meta/stl_supplement.hpp>
+
+/**
+ * @namespace fkyaml
+ * @brief namespace for fkYAML library.
+ */
+FK_YAML_NAMESPACE_BEGIN
+
+/**
+ * @namespace detail
+ * @brief namespace for internal implementations of fkYAML library.
+ */
+namespace detail
+{
+
+/**
+ * @brief A temporal storage for basic_node class objects.
+ * @note This class makes it easier to handle lvalue basic_node objects in basic_node ctor with std::initializer_list.
+ *
+ * @tparam BasicNodeType A basic_node template instance type.
+ */
+template <typename BasicNodeType>
+class node_ref_storage
+{
+    static_assert(is_basic_node<BasicNodeType>::value, "node_ref_storage only accepts basic_node<...>");
+
+    using node_type = BasicNodeType;
+
+public:
+    /**
+     * @brief Construct a new node ref storage object with an rvalue basic_node object.
+     * 
+     * @param n An rvalue basic_node object.
+     */
+    node_ref_storage(node_type&& n)
+        : owned_value(std::move(n))
+    {
+    }
+
+    /**
+     * @brief Construct a new node ref storage object with an lvalue basic_node object.
+     * 
+     * @param n An lvalue basic_node object.
+     */
+    node_ref_storage(const node_type& n)
+        : value_ref(&n)
+    {
+    }
+
+    /**
+     * @brief Construct a new node ref storage object with a std::initializer_list object.
+     * 
+     * @param init A std::initializer_list object.
+     */
+    node_ref_storage(std::initializer_list<node_ref_storage> init)
+        : owned_value(init)
+    {
+    }
+
+    /**
+     * @brief Construct a new node ref storage object with variadic template arguments
+     * 
+     * @tparam Args Types of arguments to construct a basic_node object.
+     * @param args Arguments to construct a basic_node object.
+     */
+    template <typename... Args, enable_if_t<std::is_constructible<node_type, Args...>::value, int> = 0>
+    node_ref_storage(Args&&... args)
+        : owned_value(std::forward<Args>(args)...)
+    {
+    }
+
+    // allow only move construct/assignment
+    node_ref_storage(const node_ref_storage&) = delete;
+    node_ref_storage(node_ref_storage&&) = default;
+    node_ref_storage& operator=(const node_ref_storage&) = delete;
+    node_ref_storage& operator=(node_ref_storage&&) = default;
+
+public:
+    /**
+     * @brief An arrow operator for node_ref_storage objects.
+     * 
+     * @return const node_type* A constant pointer to a basic_node object.
+     */
+    const node_type* operator->() const
+    {
+        return value_ref ? value_ref : &owned_value;
+    }
+
+    /**
+     * @brief Releases a basic_node object internally held.
+     * 
+     * @return node_type A basic_node object internally held.
+     */
+    node_type release() const
+    {
+        return value_ref ? *value_ref : std::move(owned_value);
+    }
+
+private:
+    /** A storage for a basic_node object given with rvalue reference. */
+    mutable node_type owned_value = nullptr;
+    /** A pointer to a basic_node object given with lvalue reference. */
+    const node_type* value_ref = nullptr;
+};
+
+} // namespace detail
+
+FK_YAML_NAMESPACE_END
+
+#endif /* FK_YAML_DETAIL_NODE_REF_STORAGE_HPP_ */

--- a/include/fkYAML/node.hpp
+++ b/include/fkYAML/node.hpp
@@ -402,7 +402,7 @@ public:
 
     /**
      * @brief Construct a new basic_node object from a value of compatible types.
-     * 
+     *
      * @tparam CompatibleType A type of native data which is compatible with node values.
      * @tparam U A type of compatible native data type without qualifiers.
      * @param val The value of compatible native data type.
@@ -411,8 +411,8 @@ public:
         typename CompatibleType, typename U = detail::remove_cvref_t<CompatibleType>,
         detail::enable_if_t<
             detail::conjunction<
-                detail::negation<detail::is_basic_node<U>>, detail::disjunction<
-                                                                detail::is_node_compatible_type<basic_node, U>>>::value,
+                detail::negation<detail::is_basic_node<U>>,
+                detail::disjunction<detail::is_node_compatible_type<basic_node, U>>>::value,
             int> = 0>
     basic_node(CompatibleType&& val) noexcept(
         noexcept(ConverterType<U>::to_node(std::declval<basic_node&>(), std::declval<CompatibleType>())))
@@ -422,7 +422,7 @@ public:
 
     /**
      * @brief Construct a new basic node object with a node_ref_storage object.
-     * 
+     *
      * @tparam NodeRefStorageType A node_ref_storage template instance type.
      * @param node_ref_storage A node_ref_storage object.
      */
@@ -436,7 +436,7 @@ public:
 
     /**
      * @brief Construct a new basic node object with std::initializer_list.
-     * 
+     *
      * @param init An initializer list object.
      */
     basic_node(initializer_list_t init)

--- a/include/fkYAML/node.hpp
+++ b/include/fkYAML/node.hpp
@@ -13,8 +13,10 @@
 #ifndef FK_YAML_NODE_HPP_
 #define FK_YAML_NODE_HPP_
 
+#include <algorithm>
 #include <cstdint>
 #include <cstring>
+#include <initializer_list>
 #include <memory>
 #include <string>
 #include <type_traits>
@@ -28,6 +30,7 @@
 #include <fkYAML/detail/meta/node_traits.hpp>
 #include <fkYAML/detail/meta/stl_supplement.hpp>
 #include <fkYAML/detail/meta/type_traits.hpp>
+#include <fkYAML/detail/node_ref_storage.hpp>
 #include <fkYAML/detail/output/serializer.hpp>
 #include <fkYAML/detail/types/node_t.hpp>
 #include <fkYAML/detail/types/yaml_version_t.hpp>
@@ -99,6 +102,8 @@ private:
     using deserializer_type = detail::basic_deserializer<basic_node>;
     /** A type for YAML docs serializers. */
     using serializer_type = detail::basic_serializer<basic_node>;
+    /** An alias type for std::initializer_list. */
+    using initializer_list_t = std::initializer_list<detail::node_ref_storage<basic_node>>;
 
     /**
      * @union node_value
@@ -395,18 +400,70 @@ public:
         rhs.m_anchor_name = nullptr;
     }
 
+    /**
+     * @brief Construct a new basic_node object from a value of compatible types.
+     * 
+     * @tparam CompatibleType A type of native data which is compatible with node values.
+     * @tparam U A type of compatible native data type without qualifiers.
+     * @param val The value of compatible native data type.
+     */
     template <
         typename CompatibleType, typename U = detail::remove_cvref_t<CompatibleType>,
         detail::enable_if_t<
             detail::conjunction<
                 detail::negation<detail::is_basic_node<U>>, detail::disjunction<
-                                                                std::is_same<CompatibleType, std::nullptr_t>,
                                                                 detail::is_node_compatible_type<basic_node, U>>>::value,
             int> = 0>
-    explicit basic_node(CompatibleType&& val) noexcept(
+    basic_node(CompatibleType&& val) noexcept(
         noexcept(ConverterType<U>::to_node(std::declval<basic_node&>(), std::declval<CompatibleType>())))
     {
         ConverterType<U>::to_node(*this, std::forward<CompatibleType>(val));
+    }
+
+    /**
+     * @brief Construct a new basic node object with a node_ref_storage object.
+     * 
+     * @tparam NodeRefStorageType A node_ref_storage template instance type.
+     * @param node_ref_storage A node_ref_storage object.
+     */
+    template <
+        typename NodeRefStorageType,
+        detail::enable_if_t<detail::is_node_ref_storage<NodeRefStorageType>::value, int> = 0>
+    basic_node(const NodeRefStorageType& node_ref_storage)
+        : basic_node(node_ref_storage.release())
+    {
+    }
+
+    /**
+     * @brief Construct a new basic node object with std::initializer_list.
+     * 
+     * @param init An initializer list object.
+     */
+    basic_node(initializer_list_t init)
+    {
+        bool is_mapping =
+            std::all_of(init.begin(), init.end(), [](const detail::node_ref_storage<basic_node>& node_ref) {
+                return node_ref->is_sequence() && node_ref->size() == 2 && node_ref->operator[](0).is_string();
+            });
+
+        if (is_mapping)
+        {
+            m_node_type = node_t::MAPPING;
+            m_node_value.p_mapping = create_object<mapping_type>();
+
+            for (auto& elem_ref : init)
+            {
+                auto elem = elem_ref.release();
+                m_node_value.p_mapping->emplace(
+                    std::move(*((*(elem.m_node_value.p_sequence))[0].m_node_value.p_string)),
+                    std::move((*(elem.m_node_value.p_sequence))[1]));
+            }
+        }
+        else
+        {
+            m_node_type = node_t::SEQUENCE;
+            m_node_value.p_sequence = create_object<sequence_type>(init.begin(), init.end());
+        }
     }
 
     /**

--- a/test/unit_test/CMakeLists.txt
+++ b/test/unit_test/CMakeLists.txt
@@ -145,6 +145,7 @@ add_executable(
   test_iterator_class.cpp
   test_lexical_analyzer_class.cpp
   test_node_class.cpp
+  test_node_ref_storage_class.cpp
   test_ordered_map_class.cpp
   test_serializer_class.cpp
   main.cpp)

--- a/test/unit_test/test_node_class.cpp
+++ b/test/unit_test/test_node_class.cpp
@@ -340,11 +340,10 @@ TEST_CASE("NodeClassTest_AliasMoveCtorTest", "[NodeClassTest]")
 
 TEST_CASE("NodeClassTest_InitializerListCtorTest", "[NodeClassTest]")
 {
-    fkyaml::node node =
-    {
-        { std::string("foo"), 3.14 },
-        { std::string("bar"), 123 },
-        { std::string("baz"), { true, false } },
+    fkyaml::node node = {
+        {std::string("foo"), 3.14},
+        {std::string("bar"), 123},
+        {std::string("baz"), {true, false}},
     };
 
     REQUIRE(node.contains("foo"));

--- a/test/unit_test/test_node_class.cpp
+++ b/test/unit_test/test_node_class.cpp
@@ -89,7 +89,7 @@ TEST_CASE("NodeClassTest_ThrowingSpecializationTypeCtorTest", "[NodeClassTest]")
 
 TEST_CASE("NodeClassTest_SequenceCtorTest", "[NodeClassTest]")
 {
-    fkyaml::node node(fkyaml::node_sequence_type {fkyaml::node {true}, fkyaml::node {false}});
+    fkyaml::node node(fkyaml::node_sequence_type {fkyaml::node(true), fkyaml::node(false)});
     REQUIRE(node.type() == fkyaml::node::node_t::SEQUENCE);
     REQUIRE(node.is_sequence());
     REQUIRE(node.size() == 2);
@@ -101,7 +101,7 @@ TEST_CASE("NodeClassTest_SequenceCtorTest", "[NodeClassTest]")
 
 TEST_CASE("NodeClassTest_MappingCtorTest", "[NodeClassTest]")
 {
-    fkyaml::node node(fkyaml::node_mapping_type {{"test", fkyaml::node {true}}});
+    fkyaml::node node(fkyaml::node_mapping_type {{"test", fkyaml::node(true)}});
     REQUIRE(node.type() == fkyaml::node::node_t::MAPPING);
     REQUIRE(node.is_mapping());
     REQUIRE(node.size() == 1);
@@ -336,6 +336,32 @@ TEST_CASE("NodeClassTest_AliasMoveCtorTest", "[NodeClassTest]")
     REQUIRE(alias.is_boolean());
     REQUIRE_NOTHROW(alias.to_boolean());
     REQUIRE(alias.to_boolean() == true);
+}
+
+TEST_CASE("NodeClassTest_InitializerListCtorTest", "[NodeClassTest]")
+{
+    fkyaml::node node =
+    {
+        { std::string("foo"), 3.14 },
+        { std::string("bar"), 123 },
+        { std::string("baz"), { true, false } },
+    };
+
+    REQUIRE(node.contains("foo"));
+    REQUIRE(node["foo"].is_float_number());
+    REQUIRE(node["foo"].to_float_number() == 3.14);
+
+    REQUIRE(node.contains("bar"));
+    REQUIRE(node["bar"].is_integer());
+    REQUIRE(node["bar"].to_integer() == 123);
+
+    REQUIRE(node.contains("baz"));
+    REQUIRE(node["baz"].is_sequence());
+    REQUIRE(node["baz"].size() == 2);
+    REQUIRE(node["baz"].to_sequence()[0].is_boolean());
+    REQUIRE(node["baz"].to_sequence()[0].to_boolean() == true);
+    REQUIRE(node["baz"].to_sequence()[1].is_boolean());
+    REQUIRE(node["baz"].to_sequence()[1].to_boolean() == false);
 }
 
 //

--- a/test/unit_test/test_node_ref_storage_class.cpp
+++ b/test/unit_test/test_node_ref_storage_class.cpp
@@ -1,0 +1,66 @@
+//  _______   __ __   __  _____   __  __  __
+// |   __| |_/  |  \_/  |/  _  \ /  \/  \|  |     fkYAML: A C++ header-only YAML library (supporting code)
+// |   __|  _  < \_   _/|  ___  |    _   |  |___  version 0.1.3
+// |__|  |_| \__|  |_|  |_|   |_|___||___|______| https://github.com/fktn-k/fkYAML
+//
+// SPDX-FileCopyrightText: 2023 Kensuke Fukutani <fktn.dev@gmail.com>
+// SPDX-License-Identifier: MIT
+
+#include <utility>
+
+#include <catch2/catch.hpp>
+
+#include <fkYAML/detail/node_ref_storage.hpp>
+#include <fkYAML/node.hpp>
+
+TEST_CASE("NodeRefStorageTest_CtorWithLvalueNodeTest", "[NodeRefStorageTest]")
+{
+    fkyaml::node node = true;
+    fkyaml::detail::node_ref_storage<fkyaml::node> storage(node);
+    REQUIRE(node.is_boolean());
+
+    fkyaml::node retrieved_node = storage.release();
+    REQUIRE(retrieved_node.is_boolean());
+    REQUIRE(retrieved_node.to_boolean() == true);
+}
+
+TEST_CASE("NodeRefStorageTest_CtorWithRvalueNodeTest", "[NodeRefStorageTest]")
+{
+    fkyaml::node node = 3.14;
+    fkyaml::detail::node_ref_storage<fkyaml::node> storage(std::move(node));
+    REQUIRE(node.is_null());
+
+    fkyaml::node retrieved_node = storage.release();
+    REQUIRE(retrieved_node.is_float_number());
+    REQUIRE(retrieved_node.to_float_number() == 3.14);
+}
+
+TEST_CASE("NodeRefStorageTest_ArrowOperatorTest", "[NodeRefStorageTest]")
+{
+    fkyaml::node node = 123;
+    fkyaml::detail::node_ref_storage<fkyaml::node> storage(node);
+    REQUIRE(storage.operator->() == &node);
+    REQUIRE(storage->is_integer());
+    REQUIRE(storage->to_integer() == 123);
+
+    fkyaml::node node2 = { true, false };
+    fkyaml::detail::node_ref_storage<fkyaml::node> storage2(std::move(node2));
+    REQUIRE(storage2->is_sequence());
+    REQUIRE(storage2->size() == 2);
+}
+
+TEST_CASE("NodeRefStorageTest_ReleaseTest", "[NodeRefStorageTest]")
+{
+    fkyaml::node node = 123;
+    fkyaml::detail::node_ref_storage<fkyaml::node> storage(node);
+    fkyaml::node released_node = storage.release();
+    REQUIRE(&released_node != &node);
+    REQUIRE(released_node.is_integer());
+    REQUIRE(released_node.to_integer() == 123);
+
+    fkyaml::node node2 = { true, false };
+    fkyaml::detail::node_ref_storage<fkyaml::node> storage2(std::move(node2));
+    fkyaml::node released_node2 = storage2.release();
+    REQUIRE(released_node2.is_sequence());
+    REQUIRE(released_node2.size() == 2);
+}

--- a/test/unit_test/test_node_ref_storage_class.cpp
+++ b/test/unit_test/test_node_ref_storage_class.cpp
@@ -43,7 +43,7 @@ TEST_CASE("NodeRefStorageTest_ArrowOperatorTest", "[NodeRefStorageTest]")
     REQUIRE(storage->is_integer());
     REQUIRE(storage->to_integer() == 123);
 
-    fkyaml::node node2 = { true, false };
+    fkyaml::node node2 = {true, false};
     fkyaml::detail::node_ref_storage<fkyaml::node> storage2(std::move(node2));
     REQUIRE(storage2->is_sequence());
     REQUIRE(storage2->size() == 2);
@@ -58,7 +58,7 @@ TEST_CASE("NodeRefStorageTest_ReleaseTest", "[NodeRefStorageTest]")
     REQUIRE(released_node.is_integer());
     REQUIRE(released_node.to_integer() == 123);
 
-    fkyaml::node node2 = { true, false };
+    fkyaml::node node2 = {true, false};
     fkyaml::detail::node_ref_storage<fkyaml::node> storage2(std::move(node2));
     fkyaml::node released_node2 = storage2.release();
     REQUIRE(released_node2.is_sequence());


### PR DESCRIPTION
It has been supported to construct basic_node objects with std::initializer_list object.  
As a helper class, node_ref_storage class has also been implemented to wrap basic_node {l|r}values in std::initializer_list objects, which aims to increase memory efficiency and thus performance in constructing a new basic_node object.  

Furthermore, Test cases for newly added public/private APIs have been added to cover the whole parts of the fkYAML library's implementation.  

Related items: #105.