### PR TITLE
#167 Use std::map as the default mapping node type

### DIFF
--- a/include/fkYAML/node.hpp
+++ b/include/fkYAML/node.hpp
@@ -17,6 +17,7 @@
 #include <cstdint>
 #include <cstring>
 #include <initializer_list>
+#include <map>
 #include <memory>
 #include <string>
 #include <type_traits>
@@ -58,7 +59,7 @@ FK_YAML_NAMESPACE_BEGIN
  */
 template <
     template <typename, typename...> class SequenceType = std::vector,
-    template <typename, typename, typename...> class MappingType = ordered_map, typename BooleanType = bool,
+    template <typename, typename, typename...> class MappingType = std::map, typename BooleanType = bool,
     typename IntegerType = std::int64_t, typename FloatNumberType = double, typename StringType = std::string,
     template <typename, typename = void> class ConverterType = node_value_converter>
 class basic_node
@@ -71,7 +72,10 @@ public:
 
     /** A type for sequence basic_node values. */
     using sequence_type = SequenceType<basic_node, std::allocator<basic_node>>;
-    /** A type for mapping basic_node values. */
+    /**
+     * @brief A type for mapping basic_node values.
+     * @note std::unordered_map is not supported since it does not allow incomplete types.
+     */
     using mapping_type = MappingType<StringType, basic_node>;
     /** A type for boolean basic_node values. */
     using boolean_type = BooleanType;

--- a/test/unit_test/test_ordered_map_class.cpp
+++ b/test/unit_test/test_ordered_map_class.cpp
@@ -63,7 +63,8 @@ TEST_CASE("OrderedMapClassTest_NonConstAtTest", "[OrderedMapClassTest]")
     map.emplace("foo", true);
     REQUIRE_NOTHROW(map.at("foo"));
     REQUIRE(map.at("foo") == true);
-    REQUIRE_THROWS_AS(map.at("bar"), fkyaml::exception);
+    std::string key("bar");
+    REQUIRE_THROWS_AS(map.at(key), fkyaml::exception);
 }
 
 TEST_CASE("OrderedMapClassTest_ConstAtTest", "[OrderedMapClassTest]")

--- a/test/unit_test/test_serializer_class.cpp
+++ b/test/unit_test/test_serializer_class.cpp
@@ -23,7 +23,7 @@ TEST_CASE("SerializerClassTest_SerializeSequenceNode", "[SerializerClassTest]")
         NodeStrPair(
             fkyaml::node::sequence(
                 {fkyaml::node::mapping({{"foo", fkyaml::node::integer_scalar(-1234)}, {"bar", fkyaml::node()}})}),
-            "-\n  foo: -1234\n  bar: null\n"));
+            "-\n  bar: null\n  foo: -1234\n"));
     fkyaml::detail::basic_serializer<fkyaml::node> serializer;
     REQUIRE(serializer.serialize(node_str_pair.first) == node_str_pair.second);
 }
@@ -34,7 +34,7 @@ TEST_CASE("SerializerClassTest_SerializeMappingNode", "[SerializerClassTest]")
     auto node_str_pair = GENERATE(
         NodeStrPair(
             fkyaml::node::mapping({{"foo", fkyaml::node::integer_scalar(-1234)}, {"bar", fkyaml::node()}}),
-            "foo: -1234\nbar: null\n"),
+            "bar: null\nfoo: -1234\n"),
         NodeStrPair(
             fkyaml::node::mapping(
                 {{"foo",


### PR DESCRIPTION
Currently, mapping nodes preserves the order of insertions by using ordere_map class.  
However, I noticed that YAML specification 1.2.2 defines mapping as “an unordered association of unique keys to values“.  
(See for more information [here](https://yaml.org/spec/1.2.2/#3221-mapping-key-order).)  

To follow the specification, basic_node class will be changed to use std::map as mapping container class by default.  
Note that std::unordered_map is not supported since it does not support the use of incomplete types on template instantiation.  

This change will change the serialization/deserialization results, but bring the fkYAML library more efficiency in performance.  

Lastly, the `ordered_map` class will still be available as an optional mapping container type for customization(, rather than using a sequence of mapping node as the specification suggests).  
```cpp
#include <fkYAML/node.hpp>
using ordered_node = fkyaml::basic_node<std::vector, fkyaml::ordered_map>;
```