### PR TITLE
#175 support detecting indentation in deserialization

### DIFF
--- a/include/fkYAML/detail/input/deserializer.hpp
+++ b/include/fkYAML/detail/input/deserializer.hpp
@@ -341,8 +341,8 @@ private:
     }
 
 private:
-    BasicNodeType* m_current_node {nullptr};                 /** The currently focused YAML node. */
-    std::vector<BasicNodeType*> m_node_stack {};             /** The stack of YAML nodes. */
+    BasicNodeType* m_current_node {nullptr};     /** The currently focused YAML node. */
+    std::vector<BasicNodeType*> m_node_stack {}; /** The stack of YAML nodes. */
     std::vector<std::size_t> m_indent_stack {};
     yaml_version_t m_yaml_version {yaml_version_t::VER_1_2}; /** The YAML version specification type. */
     bool m_needs_anchor_impl {false}; /** A flag to determine the need for YAML anchor node implementation */

--- a/include/fkYAML/detail/input/input_handler.hpp
+++ b/include/fkYAML/detail/input/input_handler.hpp
@@ -53,10 +53,16 @@ public:
     using string_type = std::basic_string<char_type>;
 
 private:
+    /**
+     * @brief A set of information on the current position in an input buffer.
+     */
     struct position
     {
+        //!< The current position from the beginning of an input buffer.
         std::size_t cur_pos {0};
+        //!< The current position in the current line.
         std::size_t cur_pos_in_line {0};
+        //!< The number of lines which have already been read.
         std::size_t lines_read {0};
     };
 
@@ -224,11 +230,21 @@ public:
         return ret;
     }
 
+    /**
+     * @brief Get the current position in the current line.
+     *
+     * @return std::size_t The current position in the current line.
+     */
     std::size_t get_cur_pos_in_line() const noexcept
     {
         return m_position.cur_pos_in_line;
     }
 
+    /**
+     * @brief Get the number of lines which have already been read.
+     *
+     * @return std::size_t The number of lines which have already been read.
+     */
     std::size_t get_lines_read() const noexcept
     {
         return m_position.lines_read;

--- a/include/fkYAML/detail/input/input_handler.hpp
+++ b/include/fkYAML/detail/input/input_handler.hpp
@@ -52,6 +52,15 @@ public:
     //!< The type of strings of the input buffer.
     using string_type = std::basic_string<char_type>;
 
+private:
+    struct position
+    {
+        std::size_t cur_pos {0};
+        std::size_t cur_pos_in_line {0};
+        std::size_t lines_read {0};
+    };
+
+public:
     /**
      * @brief Construct a new input_handler object.
      *
@@ -61,7 +70,7 @@ public:
         : m_input_adapter(std::move(input_adapter))
     {
         get_next();
-        m_cur_pos = 0;
+        m_position.cur_pos = m_position.cur_pos_in_line = m_position.lines_read = 0;
     }
 
     /**
@@ -71,7 +80,7 @@ public:
      */
     int_type get_current()
     {
-        return m_cache[m_cur_pos];
+        return m_cache[m_position.cur_pos];
     }
 
     /**
@@ -81,19 +90,32 @@ public:
      */
     int_type get_next()
     {
+        int_type ret = end_of_input;
+
         // if already cached, return the cached value.
-        if (m_cur_pos + 1 < m_cache.size())
+        if (m_position.cur_pos + 1 < m_cache.size())
         {
-            return m_cache[++m_cur_pos];
+            ret = m_cache[++m_position.cur_pos];
+            ++m_position.cur_pos_in_line;
+        }
+        else
+        {
+            ret = m_input_adapter.get_character();
+            if (ret != end_of_input || m_cache[m_position.cur_pos] != end_of_input)
+            {
+                // cache the return value for possible later use.
+                m_cache.push_back(ret);
+                ++m_position.cur_pos;
+                ++m_position.cur_pos_in_line;
+            }
         }
 
-        int_type ret = m_input_adapter.get_character();
-        if (ret != end_of_input || m_cache[m_cur_pos] != end_of_input)
+        if (m_cache[m_position.cur_pos - 1] == '\n')
         {
-            // cache the return value for possible later use.
-            m_cache.push_back(ret);
-            ++m_cur_pos;
+            m_position.cur_pos_in_line = 0;
+            ++m_position.lines_read;
         }
+
         return ret;
     }
 
@@ -104,7 +126,7 @@ public:
      * @param str A string which will contain the resulting characters.
      * @return int_type 0 (for success) or EOF (for error).
      */
-    int_type get_range(size_t length, string_type& str)
+    int_type get_range(std::size_t length, string_type& str)
     {
         str.clear();
 
@@ -115,11 +137,15 @@ public:
 
         str += char_traits_type::to_char_type(get_current());
 
-        for (size_t i = 1; i < length; i++)
+        for (std::size_t i = 1; i < length; i++)
         {
             if (get_next() == end_of_input)
             {
-                m_cur_pos -= i;
+                // m_cur_pos -= i;
+                for (std::size_t j = i; j > 0; j--)
+                {
+                    unget();
+                }
                 str.clear();
                 return end_of_input;
             }
@@ -134,10 +160,28 @@ public:
      */
     void unget()
     {
-        if (m_cur_pos > 0)
+        if (m_position.cur_pos > 0)
         {
             // just move back the cursor. (no action for adapter)
-            --m_cur_pos;
+            --m_position.cur_pos;
+            --m_position.cur_pos_in_line;
+            if (m_cache[m_position.cur_pos] == '\n')
+            {
+                --m_position.lines_read;
+                m_position.cur_pos_in_line = 0;
+                if (m_position.cur_pos > 0)
+                {
+                    for (std::size_t i = m_position.cur_pos - 1; m_cache[i] != '\n'; i--)
+                    {
+                        if (i == 0)
+                        {
+                            m_position.cur_pos_in_line = m_position.cur_pos;
+                            break;
+                        }
+                        ++m_position.cur_pos_in_line;
+                    }
+                }
+            }
         }
     }
 
@@ -146,9 +190,12 @@ public:
      *
      * @param length The length of moving backward.
      */
-    void unget_range(size_t length)
+    void unget_range(std::size_t length)
     {
-        m_cur_pos = (m_cur_pos > length) ? m_cur_pos - length : 0;
+        for (std::size_t i = 0; i < length; i++)
+        {
+            unget();
+        }
     }
 
     /**
@@ -173,8 +220,18 @@ public:
         }
 
         bool ret = char_traits_type::eq(char_traits_type::to_char_type(next), expected);
-        --m_cur_pos;
+        unget();
         return ret;
+    }
+
+    std::size_t get_cur_pos_in_line() const noexcept
+    {
+        return m_position.cur_pos_in_line;
+    }
+
+    std::size_t get_lines_read() const noexcept
+    {
+        return m_position.lines_read;
     }
 
 private:
@@ -186,7 +243,7 @@ private:
     //!< Cached characters retrieved from an input adapter object.
     std::vector<int_type> m_cache {};
     //!< The current position in an input buffer.
-    size_t m_cur_pos {0};
+    position m_position {};
 };
 
 } // namespace detail

--- a/include/fkYAML/detail/input/lexical_analyzer.hpp
+++ b/include/fkYAML/detail/input/lexical_analyzer.hpp
@@ -86,6 +86,7 @@ public:
         skip_white_spaces();
 
         char_int_type current = m_input_handler.get_current();
+        m_last_token_begin_pos = m_input_handler.get_cur_pos_in_line();
 
         if (0x00 <= current && current <= 0x7F && isdigit(current))
         {
@@ -296,6 +297,16 @@ public:
         default:
             return m_last_token_type = scan_string();
         }
+    }
+
+    /**
+     * @brief Get the beginning position of a last token.
+     *
+     * @return std::size_t The beginning position of a last token.
+     */
+    std::size_t get_last_token_begin_pos() const noexcept
+    {
+        return m_last_token_begin_pos;
     }
 
     /**
@@ -1141,6 +1152,7 @@ private:
     input_handler_type m_input_handler;
     //!< A temporal buffer to store a string to be parsed to an actual datum.
     input_string_type m_value_buffer {};
+    std::size_t m_last_token_begin_pos {0};
     //!< The last found token type.
     lexical_token_t m_last_token_type {lexical_token_t::END_OF_BUFFER};
     //!< A temporal bool holder.

--- a/test/unit_test/test_deserializer_class.cpp
+++ b/test/unit_test/test_deserializer_class.cpp
@@ -87,7 +87,9 @@ TEST_CASE("DeserializerClassTest_DeserializeInvalidIndentation", "[DeserializerC
     fkyaml::detail::basic_deserializer<fkyaml::node> deserializer;
     fkyaml::node root;
 
-    REQUIRE_THROWS_AS(root = deserializer.deserialize(fkyaml::detail::input_adapter("foo:\n  bar: baz\n qux: true")), fkyaml::exception);
+    REQUIRE_THROWS_AS(
+        root = deserializer.deserialize(fkyaml::detail::input_adapter("foo:\n  bar: baz\n qux: true")),
+        fkyaml::exception);
 }
 
 TEST_CASE("DeserializerClassTest_DeserializeBlockSequenceTest", "[DeserializerClassTest]")
@@ -519,7 +521,8 @@ TEST_CASE("DeserializerClassTest_DeserializeBlockMappingTest", "[DeserializerCla
     SECTION("Input source No.8.")
     {
         REQUIRE_NOTHROW(
-            root = deserializer.deserialize(fkyaml::detail::input_adapter("foo:\n  bar: baz\nqux: 123\nquux:\n  corge: grault")));
+            root = deserializer.deserialize(
+                fkyaml::detail::input_adapter("foo:\n  bar: baz\nqux: 123\nquux:\n  corge: grault")));
 
         REQUIRE(root.is_mapping());
         REQUIRE(root.size() == 3);

--- a/test/unit_test/test_input_handler.cpp
+++ b/test/unit_test/test_input_handler.cpp
@@ -21,6 +21,8 @@ TEST_CASE("InputHandlerTest_InitialStateTest", "[InputHandlerTest]")
     pchar_input_handler handler(fkyaml::detail::input_adapter(input));
 
     REQUIRE(handler.get_current() == 't');
+    REQUIRE(handler.get_cur_pos_in_line() == 0);
+    REQUIRE(handler.get_lines_read() == 0);
 }
 
 TEST_CASE("InputHandlerTest_GetCurrentTest", "[InputHandlerTest]")
@@ -29,16 +31,33 @@ TEST_CASE("InputHandlerTest_GetCurrentTest", "[InputHandlerTest]")
     pchar_input_handler handler(fkyaml::detail::input_adapter(input));
 
     REQUIRE(handler.get_current() == 't');
+    REQUIRE(handler.get_cur_pos_in_line() == 0);
+    REQUIRE(handler.get_lines_read() == 0);
+
     REQUIRE(handler.get_next() == 'e');
     REQUIRE(handler.get_current() == 'e');
+    REQUIRE(handler.get_cur_pos_in_line() == 1);
+    REQUIRE(handler.get_lines_read() == 0);
+
     REQUIRE(handler.get_next() == 's');
     REQUIRE(handler.get_current() == 's');
+    REQUIRE(handler.get_cur_pos_in_line() == 2);
+    REQUIRE(handler.get_lines_read() == 0);
+
     REQUIRE(handler.get_next() == 't');
     REQUIRE(handler.get_current() == 't');
+    REQUIRE(handler.get_cur_pos_in_line() == 3);
+    REQUIRE(handler.get_lines_read() == 0);
+
     REQUIRE(handler.get_next() == pchar_input_handler::char_traits_type::eof());
     REQUIRE(handler.get_current() == pchar_input_handler::char_traits_type::eof());
+    REQUIRE(handler.get_cur_pos_in_line() == 4);
+    REQUIRE(handler.get_lines_read() == 0);
+
     REQUIRE(handler.get_next() == pchar_input_handler::char_traits_type::eof());
     REQUIRE(handler.get_current() == pchar_input_handler::char_traits_type::eof());
+    REQUIRE(handler.get_cur_pos_in_line() == 4);
+    REQUIRE(handler.get_lines_read() == 0);
 }
 
 TEST_CASE("InputHandlerTest_GetNextTest", "[InputHandlerTest]")
@@ -47,10 +66,24 @@ TEST_CASE("InputHandlerTest_GetNextTest", "[InputHandlerTest]")
     pchar_input_handler handler(fkyaml::detail::input_adapter(input));
 
     REQUIRE(handler.get_next() == 'e');
+    REQUIRE(handler.get_cur_pos_in_line() == 1);
+    REQUIRE(handler.get_lines_read() == 0);
+
     REQUIRE(handler.get_next() == 's');
+    REQUIRE(handler.get_cur_pos_in_line() == 2);
+    REQUIRE(handler.get_lines_read() == 0);
+
     REQUIRE(handler.get_next() == 't');
+    REQUIRE(handler.get_cur_pos_in_line() == 3);
+    REQUIRE(handler.get_lines_read() == 0);
+
     REQUIRE(handler.get_next() == pchar_input_handler::char_traits_type::eof());
+    REQUIRE(handler.get_cur_pos_in_line() == 4);
+    REQUIRE(handler.get_lines_read() == 0);
+
     REQUIRE(handler.get_next() == pchar_input_handler::char_traits_type::eof());
+    REQUIRE(handler.get_cur_pos_in_line() == 4);
+    REQUIRE(handler.get_lines_read() == 0);
 }
 
 TEST_CASE("InputHandlerTest_GetRangeTest", "[InputHandlerTest]")
@@ -62,13 +95,22 @@ TEST_CASE("InputHandlerTest_GetRangeTest", "[InputHandlerTest]")
     REQUIRE(handler.get_range(4, str) == 0);
     REQUIRE(str == "test");
     REQUIRE(handler.get_current() == 't');
+    REQUIRE(handler.get_cur_pos_in_line() == 3);
+    REQUIRE(handler.get_lines_read() == 0);
 
     REQUIRE(handler.get_range(2, str) == pchar_input_handler::char_traits_type::eof());
     REQUIRE(handler.get_current() == 't');
+    REQUIRE(handler.get_cur_pos_in_line() == 3);
+    REQUIRE(handler.get_lines_read() == 0);
 
     REQUIRE(handler.get_next() == pchar_input_handler::char_traits_type::eof());
+    REQUIRE(handler.get_cur_pos_in_line() == 4);
+    REQUIRE(handler.get_lines_read() == 0);
+
     REQUIRE(handler.get_range(0, str) == pchar_input_handler::char_traits_type::eof());
     REQUIRE(handler.get_current() == pchar_input_handler::char_traits_type::eof());
+    REQUIRE(handler.get_cur_pos_in_line() == 4);
+    REQUIRE(handler.get_lines_read() == 0);
 }
 
 TEST_CASE("InputHandlerTest_UngetTest", "[InputHandlerTest]")
@@ -77,12 +119,19 @@ TEST_CASE("InputHandlerTest_UngetTest", "[InputHandlerTest]")
     pchar_input_handler handler(fkyaml::detail::input_adapter(input));
 
     REQUIRE(handler.get_current() == 't');
+    REQUIRE(handler.get_cur_pos_in_line() == 0);
+    REQUIRE(handler.get_lines_read() == 0);
+
     handler.unget();
     REQUIRE(handler.get_current() == 't');
+    REQUIRE(handler.get_cur_pos_in_line() == 0);
+    REQUIRE(handler.get_lines_read() == 0);
 
     REQUIRE(handler.get_next() == 'e');
     handler.unget();
     REQUIRE(handler.get_current() == 't');
+    REQUIRE(handler.get_cur_pos_in_line() == 0);
+    REQUIRE(handler.get_lines_read() == 0);
 
     REQUIRE(handler.get_next() == 'e');
     REQUIRE(handler.get_next() == 's');
@@ -90,6 +139,8 @@ TEST_CASE("InputHandlerTest_UngetTest", "[InputHandlerTest]")
     REQUIRE(handler.get_next() == pchar_input_handler::char_traits_type::eof());
     handler.unget();
     REQUIRE(handler.get_current() == 't');
+    REQUIRE(handler.get_cur_pos_in_line() == 3);
+    REQUIRE(handler.get_lines_read() == 0);
 }
 
 TEST_CASE("InputHandlerTest_UngetRangeTest", "[InputHandlerTest]")
@@ -100,19 +151,28 @@ TEST_CASE("InputHandlerTest_UngetRangeTest", "[InputHandlerTest]")
     REQUIRE(handler.get_current() == 't');
     handler.unget_range(4);
     REQUIRE(handler.get_current() == 't');
+    REQUIRE(handler.get_cur_pos_in_line() == 0);
+    REQUIRE(handler.get_lines_read() == 0);
 
     REQUIRE(handler.get_next() == 'e');
     REQUIRE(handler.get_next() == 's');
     handler.unget_range(1);
     REQUIRE(handler.get_current() == 'e');
+    REQUIRE(handler.get_cur_pos_in_line() == 1);
+    REQUIRE(handler.get_lines_read() == 0);
+
     handler.unget_range(0);
     REQUIRE(handler.get_current() == 'e');
+    REQUIRE(handler.get_cur_pos_in_line() == 1);
+    REQUIRE(handler.get_lines_read() == 0);
 
     REQUIRE(handler.get_next() == 's');
     REQUIRE(handler.get_next() == 't');
     REQUIRE(handler.get_next() == pchar_input_handler::char_traits_type::eof());
     handler.unget_range(2);
     REQUIRE(handler.get_current() == 's');
+    REQUIRE(handler.get_cur_pos_in_line() == 2);
+    REQUIRE(handler.get_lines_read() == 0);
 }
 
 TEST_CASE("InputHandlerTest_TestNextCharTest", "[InputHandlerTest]")
@@ -121,18 +181,82 @@ TEST_CASE("InputHandlerTest_TestNextCharTest", "[InputHandlerTest]")
     pchar_input_handler handler(fkyaml::detail::input_adapter(input));
 
     REQUIRE(handler.test_next_char('e') == true);
+    REQUIRE(handler.get_cur_pos_in_line() == 0);
+    REQUIRE(handler.get_lines_read() == 0);
 
     REQUIRE(handler.get_next() == 'e');
     REQUIRE(handler.test_next_char('s') == true);
     REQUIRE(handler.test_next_char('t') == false);
+    REQUIRE(handler.get_cur_pos_in_line() == 1);
+    REQUIRE(handler.get_lines_read() == 0);
 
     REQUIRE(handler.get_next() == 's');
     REQUIRE(handler.get_next() == 't');
     REQUIRE(handler.get_next() == pchar_input_handler::char_traits_type::eof());
     REQUIRE(handler.test_next_char('t') == false);
+    REQUIRE(handler.get_cur_pos_in_line() == 4);
+    REQUIRE(handler.get_lines_read() == 0);
 
     pchar_input_handler::char_type char_eof =
         pchar_input_handler::char_traits_type::to_char_type(pchar_input_handler::char_traits_type::eof());
     REQUIRE(handler.test_next_char(char_eof) == false);
     REQUIRE(handler.get_current() == pchar_input_handler::char_traits_type::eof());
+}
+
+TEST_CASE("InputHandlerTest_TestMultipleLinesTest", "[InputHandlerTest]")
+{
+    SECTION("first character is not a newline code.")
+    {
+        char input[] = "test\nfoo";
+        pchar_input_handler::string_type str;
+        pchar_input_handler handler(fkyaml::detail::input_adapter(input));
+
+        REQUIRE(handler.get_range(4, str) == 0);
+        REQUIRE(handler.get_cur_pos_in_line() == 3);
+        REQUIRE(handler.get_lines_read() == 0);
+
+        REQUIRE(handler.get_next() == '\n');
+        REQUIRE(handler.get_cur_pos_in_line() == 4);
+        REQUIRE(handler.get_lines_read() == 0);
+
+        REQUIRE(handler.get_next() == 'f');
+        REQUIRE(handler.get_cur_pos_in_line() == 0);
+        REQUIRE(handler.get_lines_read() == 1);
+
+        handler.unget();
+        REQUIRE(handler.get_cur_pos_in_line() == 4);
+        REQUIRE(handler.get_lines_read() == 0);
+    }
+
+    SECTION("first character is a newline code.")
+    {
+        char input[] = "\ntest\nfoo";
+        pchar_input_handler::string_type str;
+        pchar_input_handler handler(fkyaml::detail::input_adapter(input));
+
+        REQUIRE(handler.get_next() == 't');
+        REQUIRE(handler.get_cur_pos_in_line() == 0);
+        REQUIRE(handler.get_lines_read() == 1);
+
+        handler.unget();
+        REQUIRE(handler.get_cur_pos_in_line() == 0);
+        REQUIRE(handler.get_lines_read() == 0);
+
+        REQUIRE(handler.get_range(5, str) == 0);
+        REQUIRE(handler.get_cur_pos_in_line() == 3);
+        REQUIRE(handler.get_lines_read() == 1);
+
+        REQUIRE(handler.get_next() == '\n');
+        REQUIRE(handler.get_cur_pos_in_line() == 4);
+        REQUIRE(handler.get_lines_read() == 1);
+
+        REQUIRE(handler.get_next() == 'f');
+        REQUIRE(handler.get_cur_pos_in_line() == 0);
+        REQUIRE(handler.get_lines_read() == 2);
+
+        handler.unget();
+        REQUIRE(handler.get_cur_pos_in_line() == 4);
+        REQUIRE(handler.get_lines_read() == 1);
+    }
+
 }

--- a/test/unit_test/test_input_handler.cpp
+++ b/test/unit_test/test_input_handler.cpp
@@ -258,5 +258,4 @@ TEST_CASE("InputHandlerTest_TestMultipleLinesTest", "[InputHandlerTest]")
         REQUIRE(handler.get_cur_pos_in_line() == 4);
         REQUIRE(handler.get_lines_read() == 1);
     }
-
 }


### PR DESCRIPTION
Before this PR, the fkYAML library couldn't detect indentation width before each token of input buffers.  
Which resulted in wrong deserialization outputs with the following YAML formatted string:  
  ```yaml
  foo:
    bar: 123
  baz: true   # This was the part of "foo" mapping node.
  ```
This PR has corrected the above issue and support multiple mapping nodes at different levels.  