### PR TITLE
#177 Add test for input adapters only

### DIFF
--- a/include/fkYAML/detail/meta/input_adapter_traits.hpp
+++ b/include/fkYAML/detail/meta/input_adapter_traits.hpp
@@ -53,14 +53,6 @@ template <typename T>
 using get_character_fn_t = decltype(std::declval<T>().get_character());
 
 /**
- * @brief A type which respresents unget_character function.
- *
- * @tparam T A target type.
- */
-template <typename T>
-using unget_character_fn_t = decltype(std::declval<T>().unget_character());
-
-/**
  * @brief Type traits to check if T has char_type as its member.
  *
  * @tparam T A target type.
@@ -107,28 +99,6 @@ struct has_get_character<InputAdapterType, enable_if_t<is_detected<get_character
 {
 };
 
-/**
- * @brief Type traits to check if InputAdapterType has unget_character member function.
- *
- * @tparam InputAdapterType A type of a target input adapter.
- * @tparam typename N/A
- */
-template <typename InputAdapterType, typename = void>
-struct has_unget_character : std::false_type
-{
-};
-
-/**
- * @brief A partial specialization of has_unget_character if InputAdapterType has unget_character member function.
- *
- * @tparam InputAdapterType
- */
-template <typename InputAdapterType>
-struct has_unget_character<InputAdapterType, enable_if_t<is_detected<unget_character_fn_t, InputAdapterType>::value>>
-    : std::true_type
-{
-};
-
 ////////////////////////////////
 //   is_input_adapter traits
 ////////////////////////////////
@@ -151,9 +121,9 @@ struct is_input_adapter : std::false_type
  */
 template <typename InputAdapterType>
 struct is_input_adapter<
-    InputAdapterType, enable_if_t<conjunction<
-                          has_char_type<InputAdapterType>, has_get_character<InputAdapterType>,
-                          has_unget_character<InputAdapterType>>::value>> : std::true_type
+    InputAdapterType,
+    enable_if_t<conjunction<has_char_type<InputAdapterType>, has_get_character<InputAdapterType>>::value>>
+    : std::true_type
 {
 };
 

--- a/include/fkYAML/node.hpp
+++ b/include/fkYAML/node.hpp
@@ -510,6 +510,12 @@ public:
             detail::input_adapter(std::forward<ItrType>(begin), std::forward<ItrType>(end)));
     }
 
+    template <typename PtrType, detail::enable_if_t<std::is_pointer<PtrType>::value, int> = 0>
+    static basic_node deserialize(PtrType&& ptr, std::size_t size)
+    {
+        return deserializer_type().deserialize(detail::input_adapter(std::forward<PtrType>(ptr), size));
+    }
+
     /**
      * @brief Serialize a basic_node object into a string.
      *

--- a/test/unit_test/CMakeLists.txt
+++ b/test/unit_test/CMakeLists.txt
@@ -141,6 +141,7 @@ add_executable(
   test_deserializer_class.cpp
   test_exception_class.cpp
   test_from_string.cpp
+  test_input_adapter.cpp
   test_input_handler.cpp
   test_iterator_class.cpp
   test_lexical_analyzer_class.cpp
@@ -156,6 +157,11 @@ include(Catch)
 catch_discover_tests(${TEST_TARGET})
 
 add_dependencies(${TEST_TARGET} ${FK_YAML_TARGET_NAME})
+
+add_custom_command(
+  TARGET ${TEST_TARGET} POST_BUILD
+  COMMAND ${CMAKE_COMMAND} -E copy_directory ${CMAKE_CURRENT_SOURCE_DIR}/test_data $<TARGET_FILE_DIR:${TEST_TARGET}>/test_data
+)
 
 ############################################
 #   Configure custom target for coverage   #

--- a/test/unit_test/CMakeLists.txt
+++ b/test/unit_test/CMakeLists.txt
@@ -50,11 +50,23 @@ if(NOT compiler_supports_cxx_${FK_YAML_TEST_TARGET_CXX_STANDARD})
   return()
 endif()
 
+######################################
+#   Prepare to use test data files   #
+######################################
+
+# While executing CTest on Windows, just specifying a relative path seems not working.
+# This is a workaround to resolve the issue. (Delete it when a better solution is found.)
+file(WRITE  ${CMAKE_CURRENT_BINARY_DIR}/include/test_data.hpp "#ifndef FK_YAML_TEST_TEST_DATA_HPP_\n")
+file(APPEND ${CMAKE_CURRENT_BINARY_DIR}/include/test_data.hpp "#define FK_YAML_TEST_TEST_DATA_HPP_\n\n")
+file(APPEND ${CMAKE_CURRENT_BINARY_DIR}/include/test_data.hpp "#define FK_YAML_TEST_DATA_DIR \"${CMAKE_CURRENT_SOURCE_DIR}/test_data\"\n\n")
+file(APPEND ${CMAKE_CURRENT_BINARY_DIR}/include/test_data.hpp "#endif /* FK_YAML_TEST_TEST_DATA_HPP_ */\n")
+
 #################################
 #   Configure compile options   #
 #################################
 
 add_library(unit_test_config INTERFACE)
+target_include_directories(unit_test_config INTERFACE ${CMAKE_CURRENT_BINARY_DIR}/include)
 target_link_libraries(unit_test_config INTERFACE Catch2::Catch2 ${FK_YAML_TARGET_NAME})
 target_compile_features(unit_test_config INTERFACE cxx_std_${FK_YAML_TEST_TARGET_CXX_STANDARD})
 set_target_properties(unit_test_config PROPERTIES CXX_EXTENTIONS OFF)

--- a/test/unit_test/test_data/input_adapter_test_data.txt
+++ b/test/unit_test/test_data/input_adapter_test_data.txt
@@ -1,0 +1,1 @@
+test source.

--- a/test/unit_test/test_input_adapter.cpp
+++ b/test/unit_test/test_input_adapter.cpp
@@ -42,8 +42,8 @@ TEST_CASE("InputAdapterTest_IteratorInputAdapterProviderTest", "[InputAdapterTes
     {
         std::string input_str(input);
         auto input_adapter = fkyaml::detail::input_adapter(input_str);
-        REQUIRE(
-            std::is_same<decltype(input_adapter), fkyaml::detail::iterator_input_adapter<std::string::iterator>>::value);
+        using iterator_type = typename std::string::iterator;
+        REQUIRE(std::is_same<decltype(input_adapter), fkyaml::detail::iterator_input_adapter<iterator_type>>::value);
     }
 }
 

--- a/test/unit_test/test_input_adapter.cpp
+++ b/test/unit_test/test_input_adapter.cpp
@@ -6,6 +6,7 @@
 // SPDX-FileCopyrightText: 2023 Kensuke Fukutani <fktn.dev@gmail.com>
 // SPDX-License-Identifier: MIT
 
+
 #include <cstdio>
 #include <fstream>
 #include <string>
@@ -16,6 +17,15 @@
 
 // generated in test/unit_test/CMakeLists.txt
 #include <test_data.hpp>
+
+#ifdef _MSC_VER
+    #define DISABLE_C4996 __pragma(warning(push)) __pragma(warning(disable:4996))
+    #define ENABLE_C4996  __pragma(warning(pop))
+#else
+    #define DISABLE_C4996
+    #define ENABLE_C4996
+#endif
+
 
 static constexpr char input_file_path[] = FK_YAML_TEST_DATA_DIR "/input_adapter_test_data.txt";
 
@@ -60,7 +70,10 @@ TEST_CASE("InputAdapterTest_FileInputAdapterProviderTest", "[InputAdapterTest]")
 
     SECTION("valie FILE object pointer")
     {
+DISABLE_C4996
         FILE* p_file = std::fopen(input_file_path, "r");
+ENABLE_C4996
+
         REQUIRE(p_file != nullptr);
         auto input_adapter = fkyaml::detail::input_adapter(p_file);
         REQUIRE(std::is_same<decltype(input_adapter), fkyaml::detail::file_input_adapter>::value);
@@ -102,7 +115,10 @@ TEST_CASE("InputAdapterTest_GetCharacterTest", "[InputAdapterTest]")
 
     SECTION("file_input_adapter")
     {
+DISABLE_C4996
         FILE* p_file = std::fopen(input_file_path, "r");
+ENABLE_C4996
+
         auto input_adapter = fkyaml::detail::input_adapter(p_file);
         REQUIRE(std::is_same<decltype(input_adapter), fkyaml::detail::file_input_adapter>::value);
 

--- a/test/unit_test/test_input_adapter.cpp
+++ b/test/unit_test/test_input_adapter.cpp
@@ -1,0 +1,145 @@
+//  _______   __ __   __  _____   __  __  __
+// |   __| |_/  |  \_/  |/  _  \ /  \/  \|  |     fkYAML: A C++ header-only YAML library (supporting code)
+// |   __|  _  < \_   _/|  ___  |    _   |  |___  version 0.1.3
+// |__|  |_| \__|  |_|  |_|   |_|___||___|______| https://github.com/fktn-k/fkYAML
+//
+// SPDX-FileCopyrightText: 2023 Kensuke Fukutani <fktn.dev@gmail.com>
+// SPDX-License-Identifier: MIT
+
+#include <cstdio>
+#include <fstream>
+#include <string>
+
+#include <catch2/catch.hpp>
+
+#include <fkYAML/detail/input/input_adapter.hpp>
+
+static constexpr char input_file_path[] = "test_data/input_adapter_test_data.txt";
+
+TEST_CASE("InputAdapterTest_IteratorInputAdapterProviderTest", "[InputAdapterTest]")
+{
+    char input[] = "test";
+
+    SECTION("c-style char array")
+    {
+        auto input_adapter = fkyaml::detail::input_adapter(input);
+        REQUIRE(std::is_same<decltype(input_adapter), fkyaml::detail::iterator_input_adapter<char*>>::value);
+    }
+
+    SECTION("char pointer and size")
+    {
+        auto input_adapter = fkyaml::detail::input_adapter(&input[0], sizeof(input));
+        REQUIRE(std::is_same<decltype(input_adapter), fkyaml::detail::iterator_input_adapter<char*>>::value);
+    }
+
+    SECTION("char pointers for beginning/end")
+    {
+        auto input_adapter = fkyaml::detail::input_adapter(&input[0], &input[sizeof(input) - 1]);
+        REQUIRE(std::is_same<decltype(input_adapter), fkyaml::detail::iterator_input_adapter<char*>>::value);
+    }
+
+    SECTION("std::string")
+    {
+        std::string input_str(input);
+        auto input_adapter = fkyaml::detail::input_adapter(input_str);
+        REQUIRE(
+            std::is_same<decltype(input_adapter), fkyaml::detail::iterator_input_adapter<std::string::iterator>>::value);
+    }
+}
+
+TEST_CASE("InputAdapterTest_FileInputAdapterProviderTest", "[InputAdapterTest]")
+{
+    SECTION("invalid FILE object pointer")
+    {
+        FILE* p_file = nullptr;
+        REQUIRE_THROWS_AS(fkyaml::detail::input_adapter(p_file), fkyaml::exception);
+    }
+
+    SECTION("valie FILE object pointer")
+    {
+        FILE* p_file = std::fopen(input_file_path, "r");
+        REQUIRE(p_file != nullptr);
+        auto input_adapter = fkyaml::detail::input_adapter(p_file);
+        REQUIRE(std::is_same<decltype(input_adapter), fkyaml::detail::file_input_adapter>::value);
+    }
+}
+
+TEST_CASE("InputAdapterTest_StreamInputAdapterProviderTest", "[InputAdapterTest]")
+{
+    std::ifstream ifs(input_file_path);
+    REQUIRE(ifs);
+    auto input_adapter = fkyaml::detail::input_adapter(ifs);
+    REQUIRE(std::is_same<decltype(input_adapter), fkyaml::detail::stream_input_adapter>::value);
+}
+
+TEST_CASE("InputAdapterTest_GetCharacterTest", "[InputAdapterTest]")
+{
+    SECTION("iterator_input_adapter")
+    {
+        char input[] = "test source.";
+        auto input_adapter = fkyaml::detail::input_adapter(input);
+        REQUIRE(std::is_same<decltype(input_adapter), fkyaml::detail::iterator_input_adapter<char*>>::value);
+
+        using char_traits_type = std::char_traits<typename decltype(input_adapter)::char_type>;
+
+        REQUIRE(input_adapter.get_character() == 't');
+        REQUIRE(input_adapter.get_character() == 'e');
+        REQUIRE(input_adapter.get_character() == 's');
+        REQUIRE(input_adapter.get_character() == 't');
+        REQUIRE(input_adapter.get_character() == ' ');
+        REQUIRE(input_adapter.get_character() == 's');
+        REQUIRE(input_adapter.get_character() == 'o');
+        REQUIRE(input_adapter.get_character() == 'u');
+        REQUIRE(input_adapter.get_character() == 'r');
+        REQUIRE(input_adapter.get_character() == 'c');
+        REQUIRE(input_adapter.get_character() == 'e');
+        REQUIRE(input_adapter.get_character() == '.');
+        REQUIRE(input_adapter.get_character() == char_traits_type::eof());
+    }
+
+    SECTION("file_input_adapter")
+    {
+        FILE* p_file = std::fopen(input_file_path, "r");
+        auto input_adapter = fkyaml::detail::input_adapter(p_file);
+        REQUIRE(std::is_same<decltype(input_adapter), fkyaml::detail::file_input_adapter>::value);
+
+        using char_traits_type = std::char_traits<typename decltype(input_adapter)::char_type>;
+
+        REQUIRE(input_adapter.get_character() == 't');
+        REQUIRE(input_adapter.get_character() == 'e');
+        REQUIRE(input_adapter.get_character() == 's');
+        REQUIRE(input_adapter.get_character() == 't');
+        REQUIRE(input_adapter.get_character() == ' ');
+        REQUIRE(input_adapter.get_character() == 's');
+        REQUIRE(input_adapter.get_character() == 'o');
+        REQUIRE(input_adapter.get_character() == 'u');
+        REQUIRE(input_adapter.get_character() == 'r');
+        REQUIRE(input_adapter.get_character() == 'c');
+        REQUIRE(input_adapter.get_character() == 'e');
+        REQUIRE(input_adapter.get_character() == '.');
+        REQUIRE(input_adapter.get_character() == char_traits_type::eof());
+    }
+
+    SECTION("stream_input_adapter")
+    {
+        std::ifstream ifs(input_file_path);
+        auto input_adapter = fkyaml::detail::input_adapter(ifs);
+        REQUIRE(std::is_same<decltype(input_adapter), fkyaml::detail::stream_input_adapter>::value);
+
+        using char_traits_type = std::char_traits<typename decltype(input_adapter)::char_type>;
+
+        REQUIRE(input_adapter.get_character() == 't');
+        REQUIRE(input_adapter.get_character() == 'e');
+        REQUIRE(input_adapter.get_character() == 's');
+        REQUIRE(input_adapter.get_character() == 't');
+        REQUIRE(input_adapter.get_character() == ' ');
+        REQUIRE(input_adapter.get_character() == 's');
+        REQUIRE(input_adapter.get_character() == 'o');
+        REQUIRE(input_adapter.get_character() == 'u');
+        REQUIRE(input_adapter.get_character() == 'r');
+        REQUIRE(input_adapter.get_character() == 'c');
+        REQUIRE(input_adapter.get_character() == 'e');
+        REQUIRE(input_adapter.get_character() == '.');
+        REQUIRE(input_adapter.get_character() == char_traits_type::eof());
+    }
+}

--- a/test/unit_test/test_input_adapter.cpp
+++ b/test/unit_test/test_input_adapter.cpp
@@ -6,7 +6,6 @@
 // SPDX-FileCopyrightText: 2023 Kensuke Fukutani <fktn.dev@gmail.com>
 // SPDX-License-Identifier: MIT
 
-
 #include <cstdio>
 #include <fstream>
 #include <string>
@@ -19,13 +18,12 @@
 #include <test_data.hpp>
 
 #ifdef _MSC_VER
-    #define DISABLE_C4996 __pragma(warning(push)) __pragma(warning(disable:4996))
-    #define ENABLE_C4996  __pragma(warning(pop))
+    #define DISABLE_C4996 __pragma(warning(push)) __pragma(warning(disable : 4996))
+    #define ENABLE_C4996 __pragma(warning(pop))
 #else
     #define DISABLE_C4996
     #define ENABLE_C4996
 #endif
-
 
 static constexpr char input_file_path[] = FK_YAML_TEST_DATA_DIR "/input_adapter_test_data.txt";
 
@@ -70,9 +68,9 @@ TEST_CASE("InputAdapterTest_FileInputAdapterProviderTest", "[InputAdapterTest]")
 
     SECTION("valie FILE object pointer")
     {
-DISABLE_C4996
+        DISABLE_C4996
         FILE* p_file = std::fopen(input_file_path, "r");
-ENABLE_C4996
+        ENABLE_C4996
 
         REQUIRE(p_file != nullptr);
         auto input_adapter = fkyaml::detail::input_adapter(p_file);
@@ -115,9 +113,9 @@ TEST_CASE("InputAdapterTest_GetCharacterTest", "[InputAdapterTest]")
 
     SECTION("file_input_adapter")
     {
-DISABLE_C4996
+        DISABLE_C4996
         FILE* p_file = std::fopen(input_file_path, "r");
-ENABLE_C4996
+        ENABLE_C4996
 
         auto input_adapter = fkyaml::detail::input_adapter(p_file);
         REQUIRE(std::is_same<decltype(input_adapter), fkyaml::detail::file_input_adapter>::value);

--- a/test/unit_test/test_input_adapter.cpp
+++ b/test/unit_test/test_input_adapter.cpp
@@ -14,7 +14,10 @@
 
 #include <fkYAML/detail/input/input_adapter.hpp>
 
-static constexpr char input_file_path[] = "test_data/input_adapter_test_data.txt";
+// generated in test/unit_test/CMakeLists.txt
+#include <test_data.hpp>
+
+static constexpr char input_file_path[] = FK_YAML_TEST_DATA_DIR "/input_adapter_test_data.txt";
 
 TEST_CASE("InputAdapterTest_IteratorInputAdapterProviderTest", "[InputAdapterTest]")
 {

--- a/test/unit_test/test_node_class.cpp
+++ b/test/unit_test/test_node_class.cpp
@@ -375,7 +375,8 @@ TEST_CASE("NodeClassTest_DeserializeTest", "[NodeClassTest]")
 
     fkyaml::node node = GENERATE_REF(
         fkyaml::node::deserialize("foo: bar"),
-        fkyaml::node::deserialize(&source[0]),
+        fkyaml::node::deserialize(source),
+        fkyaml::node::deserialize(&source[0], sizeof(source)),
         fkyaml::node::deserialize(&source[0], &source[8]),
         fkyaml::node::deserialize(std::string(source)),
         fkyaml::node::deserialize(ss));


### PR DESCRIPTION
Before this PR, there were no test cases only for input adapters.
To ensure that input adapters work as they are expected with no dependencies on the other classes, new test cases for input adapters have been added with some test data files.  

Along with the above implementation, some unused members in input adapter classes have been deleted.  