### PR TITLE
#180 clean up public apis

### DIFF
--- a/README.md
+++ b/README.md
@@ -201,14 +201,11 @@ The `Serializer` class provides an API for serializing YAML node values into a s
 
 // ...
 
-fkyaml::node root = fkyaml::node::Mapping({
-    { "foo", fkyaml::node::string_scalar("test") },
-    { "bar", fkyaml::node::sequence({
-        fkyaml::node(3.14),
-        fkyaml::node(std::nan(""))
-    }) },
-    { "baz", fkyaml::node(true) }
-});
+fkyaml::node root = {
+    { std::string("foo"), std::string("test") },
+    { std::string("bar"), { 3.14, std::nan("") } },
+    { std::string("baz"), true }
+};
 
 std::string str = fkyaml::node::serialize(root);
 // foo: test
@@ -236,33 +233,27 @@ The `node` class provides APIs for building YAML nodes programatically.
 fkyaml::node root = fkyaml::node::mapping();
 
 // Add a string scalar node.
-root["foo"] = fkyaml::node(std::string("test"));
+root["foo"] = std::string("test");
 
 // Add a sequence node containing floating number scalar nodes.
-root["bar"] = fkyaml::node::sequence({ 
-    fkyaml::node(3.14),
-    fkyaml::node(std::nan(""))
-});
+root["bar"] = { 3.14, std::nan("") };
 
 // Add a boolean node.
-root["baz"] = fkyaml::node(true);
+root["baz"] = true;
 
 // Instead, you can build YAML nodes all at once.
-fkyaml::node another_root = fkyaml::node::mapping({
-    { "foo", fkyaml::node(std::string("test")) },
-    { "bar", fkyaml::node::sequence({
-        fkyaml::node(3.14),
-        fkyaml::node(std::nan(""))
-    }) },
-    { "baz", fkyaml::node(true) }
-});
+fkyaml::node another_root = {
+    { std::string("foo"), std::string("test") },
+    { std::string("bar"), { 3.14, std::nan("") } },
+    { std::string("baz"), true }
+};
 ```
 
 </div></details>
 
 ### Customize serialization/deserialization
 
-To make your own custom types convertible from/to ``fkyaml::node`` type, you can implement your own `to_node()` & `from_node()` **outside** of the fkyaml namespace.
+To make your own custom types convertible from/to `fkyaml::node` type, you can implement your own `to_node()` & `from_node()` **outside** of the fkyaml namespace.
 (Those functions will be called when you use `fkyaml::node::get_value\<CustomType\>` to get a CustomType object out of a `fkyaml::node` object.)
 
 <details>

--- a/include/fkYAML/detail/input/deserializer.hpp
+++ b/include/fkYAML/detail/input/deserializer.hpp
@@ -202,7 +202,7 @@ public:
                     add_new_key(lexer.get_string(), cur_indent);
                     break;
                 }
-                assign_node_value(BasicNodeType::boolean_scalar(lexer.get_boolean()));
+                assign_node_value(BasicNodeType(lexer.get_boolean()));
                 break;
             case lexical_token_t::INTEGER_VALUE:
                 if (m_current_node->is_mapping())
@@ -210,7 +210,7 @@ public:
                     add_new_key(lexer.get_string(), cur_indent);
                     break;
                 }
-                assign_node_value(BasicNodeType::integer_scalar(lexer.get_integer()));
+                assign_node_value(BasicNodeType(lexer.get_integer()));
                 break;
             case lexical_token_t::FLOAT_NUMBER_VALUE:
                 if (m_current_node->is_mapping())
@@ -218,7 +218,7 @@ public:
                     add_new_key(lexer.get_string(), cur_indent);
                     break;
                 }
-                assign_node_value(BasicNodeType::float_number_scalar(lexer.get_float_number()));
+                assign_node_value(BasicNodeType(lexer.get_float_number()));
                 break;
             case lexical_token_t::STRING_VALUE:
                 if (m_current_node->is_mapping())
@@ -226,7 +226,7 @@ public:
                     add_new_key(lexer.get_string(), cur_indent);
                     break;
                 }
-                assign_node_value(BasicNodeType::string_scalar(lexer.get_string()));
+                assign_node_value(BasicNodeType(lexer.get_string()));
                 break;
             default:                                                         // LCOV_EXCL_LINE
                 throw fkyaml::exception("Unsupported lexical token found."); // LCOV_EXCL_LINE

--- a/include/fkYAML/detail/input/input_adapter.hpp
+++ b/include/fkYAML/detail/input/input_adapter.hpp
@@ -219,32 +219,6 @@ inline iterator_input_adapter<ItrType> input_adapter(ItrType begin, ItrType end)
 }
 
 /**
- * @brief A factory method for iterator_input_adapter objects with char* objects.
- * @note This function assumes a null-terminated string as an argument.
- *
- * @tparam CharPtrType A pointer type for char.
- * @param ptr A pointer to the beginning of a target null-terminated string.
- * @return decltype(input_adapter(ptr, ptr + std::strlen(ptr)))
- */
-template <
-    typename CharPtrType, enable_if_t<
-                              conjunction<
-                                  std::is_pointer<CharPtrType>, negation<std::is_array<CharPtrType>>,
-                                  std::is_integral<remove_pointer_t<CharPtrType>>,
-                                  bool_constant<sizeof(remove_pointer_t<CharPtrType>) == sizeof(char)>>::value,
-                              int> = 0>
-inline auto input_adapter(CharPtrType ptr, std::size_t size) -> decltype(input_adapter(ptr, ptr + size))
-{
-    // get the actual buffer size.
-    std::size_t i = 0;
-    for (; i < size && *(ptr + i) != '\0'; i++)
-    {
-    }
-    size = (i < size) ? i : size;
-    return input_adapter(ptr, ptr + size);
-}
-
-/**
  * @brief A factory method for iterator_input_adapter objects with C-style arrays.
  *
  * @tparam T A type of arrayed objects.

--- a/include/fkYAML/node.hpp
+++ b/include/fkYAML/node.hpp
@@ -144,7 +144,7 @@ private:
                 float_val = static_cast<float_number_type>(0.0);
                 break;
             case node_t::STRING:
-                p_string = create_object<string_type>("");
+                p_string = create_object<string_type>();
                 break;
             default:                                                     // LCOV_EXCL_LINE
                 throw fkyaml::exception("Unsupported node value type."); // LCOV_EXCL_LINE
@@ -537,69 +537,6 @@ public:
         node.m_node_type = node_t::MAPPING;
         node.m_node_value.p_mapping = create_object<mapping_type>(std::move(map));
         FK_YAML_ASSERT(node.m_node_value.p_mapping != nullptr);
-        return node;
-    } // LCOV_EXCL_LINE
-
-    /// @brief A factory method for boolean scalar basic_node objects.
-    /// @todo delete this API b/c this can be achieved with constructor with std::initializer_list.
-    static basic_node boolean_scalar(const boolean_type boolean) noexcept
-    {
-        basic_node node;
-        node.m_node_type = node_t::BOOLEAN;
-        node.m_node_value.boolean = boolean;
-        return node;
-    }
-
-    /// @brief A factory method for integer scalar basic_node objects.
-    /// @todo delete this API b/c this can be achieved with constructor with std::initializer_list.
-    static basic_node integer_scalar(const integer_type integer) noexcept
-    {
-        basic_node node;
-        node.m_node_type = node_t::INTEGER;
-        node.m_node_value.integer = integer;
-        return node;
-    }
-
-    /// @brief A factory method for float number scalar basic_node objects.
-    /// @todo delete this API b/c this can be achieved with constructor with std::initializer_list.
-    static basic_node float_number_scalar(const float_number_type float_val) noexcept
-    {
-        basic_node node;
-        node.m_node_type = node_t::FLOAT_NUMBER;
-        node.m_node_value.float_val = float_val;
-        return node;
-    }
-
-    /// @brief A factory method for string basic_node objects without string_type objects.
-    /// @todo delete this API b/c this can be achieved with constructor with std::initializer_list.
-    static basic_node string_scalar()
-    {
-        basic_node node;
-        node.m_node_type = node_t::STRING;
-        node.m_node_value.p_string = create_object<string_type>();
-        FK_YAML_ASSERT(node.m_node_value.p_string != nullptr);
-        return node;
-    } // LCOV_EXCL_LINE
-
-    /// @brief A factory method for string basic_node objects with lvalue string_type objects.
-    /// @todo delete this API b/c this can be achieved with constructor with std::initializer_list.
-    static basic_node string_scalar(const string_type& str)
-    {
-        basic_node node;
-        node.m_node_type = node_t::STRING;
-        node.m_node_value.p_string = create_object<string_type>(str);
-        FK_YAML_ASSERT(node.m_node_value.p_string != nullptr);
-        return node;
-    } // LCOV_EXCL_LINE
-
-    /// @brief A factory method for string basic_node objects with rvalue string_type objects.
-    /// @todo delete this API b/c this can be achieved with constructor with std::initializer_list.
-    static basic_node string_scalar(string_type&& str)
-    {
-        basic_node node;
-        node.m_node_type = node_t::STRING;
-        node.m_node_value.p_string = create_object<string_type>(std::move(str));
-        FK_YAML_ASSERT(node.m_node_value.p_string != nullptr);
         return node;
     } // LCOV_EXCL_LINE
 

--- a/include/fkYAML/node.hpp
+++ b/include/fkYAML/node.hpp
@@ -459,14 +459,6 @@ public:
             detail::input_adapter(std::forward<ItrType>(begin), std::forward<ItrType>(end)));
     }
 
-    /// @brief Deserialize an input string specified with a pointer and a size.
-    /// @todo Delete this API b/c this can be achieved with iterators and possibly yield undefined behavior.
-    template <typename PtrType, detail::enable_if_t<std::is_pointer<PtrType>::value, int> = 0>
-    static basic_node deserialize(PtrType&& ptr, std::size_t size)
-    {
-        return deserializer_type().deserialize(detail::input_adapter(std::forward<PtrType>(ptr), size));
-    }
-
     /// @brief Serialize a basic_node object into a string.
     /// @sa https://fktn-k.github.io/fkYAML/api/basic_node/serialize/
     static std::string serialize(const basic_node& node)

--- a/test/unit_test/test_input_adapter.cpp
+++ b/test/unit_test/test_input_adapter.cpp
@@ -37,12 +37,6 @@ TEST_CASE("InputAdapterTest_IteratorInputAdapterProviderTest", "[InputAdapterTes
         REQUIRE(std::is_same<decltype(input_adapter), fkyaml::detail::iterator_input_adapter<char*>>::value);
     }
 
-    SECTION("char pointer and size")
-    {
-        auto input_adapter = fkyaml::detail::input_adapter(&input[0], sizeof(input));
-        REQUIRE(std::is_same<decltype(input_adapter), fkyaml::detail::iterator_input_adapter<char*>>::value);
-    }
-
     SECTION("char pointers for beginning/end")
     {
         auto input_adapter = fkyaml::detail::input_adapter(&input[0], &input[sizeof(input) - 1]);

--- a/test/unit_test/test_iterator_class.cpp
+++ b/test/unit_test/test_iterator_class.cpp
@@ -50,7 +50,7 @@ TEST_CASE("IteratorClassTest_MappingCopyCtorTest", "[IteratorClassTest]")
 
 TEST_CASE("IteratorClassTest_SequenceMoveCtorTest", "[IteratorClassTest]")
 {
-    fkyaml::node sequence = fkyaml::node::sequence({fkyaml::node::string_scalar("test")});
+    fkyaml::node sequence = {std::string("test")};
     fkyaml::detail::iterator<fkyaml::node> moved(
         fkyaml::detail::sequence_iterator_tag {}, sequence.to_sequence().begin());
     fkyaml::detail::iterator<fkyaml::node> iterator(std::move(moved));
@@ -94,10 +94,10 @@ TEST_CASE("IteratorClassTest_AssignmentOperatorTest", "[IteratorClassTest]")
 
     SECTION("Test sequence iterators.")
     {
-        fkyaml::node copied_seq = fkyaml::node::sequence({fkyaml::node::string_scalar("test")});
+        fkyaml::node copied_seq = {std::string("test")};
         fkyaml::detail::iterator<fkyaml::node> copied_itr(
             fkyaml::detail::sequence_iterator_tag {}, copied_seq.to_sequence().begin());
-        fkyaml::node sequence = fkyaml::node::sequence({fkyaml::node::boolean_scalar(false)});
+        fkyaml::node sequence = {false};
         fkyaml::detail::iterator<fkyaml::node> iterator(
             fkyaml::detail::sequence_iterator_tag {}, sequence.to_sequence().begin());
 
@@ -120,10 +120,10 @@ TEST_CASE("IteratorClassTest_AssignmentOperatorTest", "[IteratorClassTest]")
 
     SECTION("Test mapping iterators.")
     {
-        fkyaml::node copied_map = fkyaml::node::mapping({{"key", fkyaml::node::string_scalar("test")}});
+        fkyaml::node copied_map = {{std::string("key"), std::string("test")}};
         fkyaml::detail::iterator<fkyaml::node> copied_itr(
             fkyaml::detail::mapping_iterator_tag {}, copied_map.to_mapping().begin());
-        fkyaml::node map = fkyaml::node::mapping({{"foo", fkyaml::node::boolean_scalar(false)}});
+        fkyaml::node map = {{std::string("foo"), false}};
         fkyaml::detail::iterator<fkyaml::node> iterator(
             fkyaml::detail::mapping_iterator_tag {}, map.to_mapping().begin());
 
@@ -151,7 +151,7 @@ TEST_CASE("IteratorClassTest_ArrowOperatorTest", "[IteratorClassTest]")
 {
     SECTION("Test sequence iterator.")
     {
-        fkyaml::node seq = fkyaml::node::sequence({fkyaml::node::string_scalar("test")});
+        fkyaml::node seq = {std::string("test")};
         fkyaml::detail::iterator<fkyaml::node> iterator(
             fkyaml::detail::sequence_iterator_tag {}, seq.to_sequence().begin());
         REQUIRE(iterator.operator->() == &(seq.to_sequence().operator[](0)));
@@ -159,7 +159,7 @@ TEST_CASE("IteratorClassTest_ArrowOperatorTest", "[IteratorClassTest]")
 
     SECTION("Test mapping iterator.")
     {
-        fkyaml::node map = fkyaml::node::mapping({{"key", fkyaml::node::string_scalar("test")}});
+        fkyaml::node map = {{std::string("key"), std::string("test")}};
         fkyaml::detail::iterator<fkyaml::node> iterator(
             fkyaml::detail::mapping_iterator_tag {}, map.to_mapping().begin());
         REQUIRE(iterator.operator->() == &(map.to_mapping().operator[]("key")));
@@ -170,7 +170,7 @@ TEST_CASE("IteratorClassTest_DereferenceOperatorTest", "[IteratorClassTest]")
 {
     SECTION("Test sequence iterator.")
     {
-        fkyaml::node seq = fkyaml::node::sequence({fkyaml::node::string_scalar("test")});
+        fkyaml::node seq = {std::string("test")};
         fkyaml::detail::iterator<fkyaml::node> iterator(
             fkyaml::detail::sequence_iterator_tag {}, seq.to_sequence().begin());
         REQUIRE(&(iterator.operator*()) == &(seq.to_sequence().operator[](0)));
@@ -178,7 +178,7 @@ TEST_CASE("IteratorClassTest_DereferenceOperatorTest", "[IteratorClassTest]")
 
     SECTION("Test mapping iterator.")
     {
-        fkyaml::node map = fkyaml::node::mapping({{"key", fkyaml::node::string_scalar("test")}});
+        fkyaml::node map = fkyaml::node::mapping({{"key", std::string("test")}});
         fkyaml::detail::iterator<fkyaml::node> iterator(
             fkyaml::detail::mapping_iterator_tag {}, map.to_mapping().begin());
         REQUIRE(&(iterator.operator*()) == &(map.to_mapping().operator[]("key")));
@@ -189,8 +189,7 @@ TEST_CASE("IteratorClassTest_CompoundAssignmentOperatorBySumTest", "[IteratorCla
 {
     SECTION("Test sequence iterator.")
     {
-        fkyaml::node sequence =
-            fkyaml::node::sequence({fkyaml::node::boolean_scalar(false), fkyaml::node::boolean_scalar(true)});
+        fkyaml::node sequence = {false, true};
         fkyaml::detail::iterator<fkyaml::node> iterator(
             fkyaml::detail::sequence_iterator_tag {}, sequence.to_sequence().begin());
         iterator += 1;
@@ -200,8 +199,7 @@ TEST_CASE("IteratorClassTest_CompoundAssignmentOperatorBySumTest", "[IteratorCla
 
     SECTION("Test mapping iterator.")
     {
-        fkyaml::node mapping = fkyaml::node::mapping(
-            {{"test0", fkyaml::node::boolean_scalar(false)}, {"test1", fkyaml::node::boolean_scalar(true)}});
+        fkyaml::node mapping = {{std::string("test0"), false}, {std::string("test1"), true}};
         fkyaml::detail::iterator<fkyaml::node> iterator(
             fkyaml::detail::mapping_iterator_tag {}, mapping.to_mapping().begin());
         iterator += 1;
@@ -215,8 +213,7 @@ TEST_CASE("IteratorClassTest_PlusOperatorTest", "[IteratorClassTest]")
 {
     SECTION("Test sequence iterator.")
     {
-        fkyaml::node sequence =
-            fkyaml::node::sequence({fkyaml::node::boolean_scalar(false), fkyaml::node::boolean_scalar(true)});
+        fkyaml::node sequence = {false, true};
         fkyaml::detail::iterator<fkyaml::node> iterator(
             fkyaml::detail::sequence_iterator_tag {}, sequence.to_sequence().begin());
         fkyaml::detail::iterator<fkyaml::node> after_plus_itr = iterator + 1;
@@ -226,8 +223,7 @@ TEST_CASE("IteratorClassTest_PlusOperatorTest", "[IteratorClassTest]")
 
     SECTION("Test mapping iterator.")
     {
-        fkyaml::node mapping = fkyaml::node::mapping(
-            {{"test0", fkyaml::node::boolean_scalar(false)}, {"test1", fkyaml::node::boolean_scalar(true)}});
+        fkyaml::node mapping = {{std::string("test0"), false}, {std::string("test1"), true}};
         fkyaml::detail::iterator<fkyaml::node> iterator(
             fkyaml::detail::mapping_iterator_tag {}, mapping.to_mapping().begin());
         fkyaml::detail::iterator<fkyaml::node> after_plus_itr = iterator + 1;
@@ -241,8 +237,7 @@ TEST_CASE("IteratorClassTest_PreIncrementOperatorTest", "[IteratorClassTest]")
 {
     SECTION("Test sequence iterator.")
     {
-        fkyaml::node sequence =
-            fkyaml::node::sequence({fkyaml::node::boolean_scalar(false), fkyaml::node::boolean_scalar(true)});
+        fkyaml::node sequence = {false, true};
         fkyaml::detail::iterator<fkyaml::node> iterator(
             fkyaml::detail::sequence_iterator_tag {}, sequence.to_sequence().begin());
         ++iterator;
@@ -252,8 +247,7 @@ TEST_CASE("IteratorClassTest_PreIncrementOperatorTest", "[IteratorClassTest]")
 
     SECTION("Test mapping iterator.")
     {
-        fkyaml::node mapping = fkyaml::node::mapping(
-            {{"test0", fkyaml::node::boolean_scalar(false)}, {"test1", fkyaml::node::boolean_scalar(true)}});
+        fkyaml::node mapping = {{std::string("test0"), false}, {std::string("test1"), true}};
         fkyaml::detail::iterator<fkyaml::node> iterator(
             fkyaml::detail::mapping_iterator_tag {}, mapping.to_mapping().begin());
         ++iterator;
@@ -267,8 +261,7 @@ TEST_CASE("IteratorClassTest_PostIncrementOperatorTest", "[IteratorClassTest]")
 {
     SECTION("Test sequence iterator.")
     {
-        fkyaml::node sequence =
-            fkyaml::node::sequence({fkyaml::node::boolean_scalar(false), fkyaml::node::boolean_scalar(true)});
+        fkyaml::node sequence = {false, true};
         fkyaml::detail::iterator<fkyaml::node> iterator(
             fkyaml::detail::sequence_iterator_tag {}, sequence.to_sequence().begin());
         iterator++;
@@ -278,8 +271,7 @@ TEST_CASE("IteratorClassTest_PostIncrementOperatorTest", "[IteratorClassTest]")
 
     SECTION("Test mapping iterator.")
     {
-        fkyaml::node mapping = fkyaml::node::mapping(
-            {{"test0", fkyaml::node::boolean_scalar(false)}, {"test1", fkyaml::node::boolean_scalar(true)}});
+        fkyaml::node mapping = {{std::string("test0"), false}, {std::string("test1"), true}};
         fkyaml::detail::iterator<fkyaml::node> iterator(
             fkyaml::detail::mapping_iterator_tag {}, mapping.to_mapping().begin());
         iterator++;
@@ -289,14 +281,11 @@ TEST_CASE("IteratorClassTest_PostIncrementOperatorTest", "[IteratorClassTest]")
     }
 }
 
-// FIXME
-
 TEST_CASE("IteratorClassTest_CompoundAssignmentOperatorByDifferenceTest", "[IteratorClassTest]")
 {
     SECTION("Test sequence iterator.")
     {
-        fkyaml::node sequence =
-            fkyaml::node::sequence({fkyaml::node::boolean_scalar(false), fkyaml::node::boolean_scalar(true)});
+        fkyaml::node sequence = {false, true};
         fkyaml::detail::iterator<fkyaml::node> iterator(
             fkyaml::detail::sequence_iterator_tag {}, sequence.to_sequence().end());
         iterator -= 1;
@@ -306,8 +295,7 @@ TEST_CASE("IteratorClassTest_CompoundAssignmentOperatorByDifferenceTest", "[Iter
 
     SECTION("Test mapping iterator.")
     {
-        fkyaml::node mapping = fkyaml::node::mapping(
-            {{"test0", fkyaml::node::boolean_scalar(false)}, {"test1", fkyaml::node::boolean_scalar(true)}});
+        fkyaml::node mapping = {{std::string("test0"), false}, {std::string("test1"), true}};
         fkyaml::detail::iterator<fkyaml::node> iterator(
             fkyaml::detail::mapping_iterator_tag {}, mapping.to_mapping().end());
         iterator -= 1;
@@ -321,8 +309,7 @@ TEST_CASE("IteratorClassTest_MinusOperatorTest", "[IteratorClassTest]")
 {
     SECTION("Test sequence iterator.")
     {
-        fkyaml::node sequence =
-            fkyaml::node::sequence({fkyaml::node::boolean_scalar(false), fkyaml::node::boolean_scalar(true)});
+        fkyaml::node sequence = {false, true};
         fkyaml::detail::iterator<fkyaml::node> iterator(
             fkyaml::detail::sequence_iterator_tag {}, sequence.to_sequence().end());
         fkyaml::detail::iterator<fkyaml::node> after_minus_itr = iterator - 1;
@@ -332,8 +319,7 @@ TEST_CASE("IteratorClassTest_MinusOperatorTest", "[IteratorClassTest]")
 
     SECTION("Test mapping iterator.")
     {
-        fkyaml::node mapping = fkyaml::node::mapping(
-            {{"test0", fkyaml::node::boolean_scalar(false)}, {"test1", fkyaml::node::boolean_scalar(true)}});
+        fkyaml::node mapping = {{std::string("test0"), false}, {std::string("test1"), true}};
         fkyaml::detail::iterator<fkyaml::node> iterator(
             fkyaml::detail::mapping_iterator_tag {}, mapping.to_mapping().end());
         fkyaml::detail::iterator<fkyaml::node> after_minus_itr = iterator - 1;
@@ -347,8 +333,7 @@ TEST_CASE("IteratorClassTest_PreDecrementOperatorTest", "[IteratorClassTest]")
 {
     SECTION("Test sequence iterator.")
     {
-        fkyaml::node sequence =
-            fkyaml::node::sequence({fkyaml::node::boolean_scalar(false), fkyaml::node::boolean_scalar(true)});
+        fkyaml::node sequence = {false, true};
         fkyaml::detail::iterator<fkyaml::node> iterator(
             fkyaml::detail::sequence_iterator_tag {}, sequence.to_sequence().end());
         --iterator;
@@ -358,8 +343,7 @@ TEST_CASE("IteratorClassTest_PreDecrementOperatorTest", "[IteratorClassTest]")
 
     SECTION("Test mapping iterator.")
     {
-        fkyaml::node mapping = fkyaml::node::mapping(
-            {{"test0", fkyaml::node::boolean_scalar(false)}, {"test1", fkyaml::node::boolean_scalar(true)}});
+        fkyaml::node mapping = {{std::string("test0"), false}, {std::string("test1"), true}};
         fkyaml::detail::iterator<fkyaml::node> iterator(
             fkyaml::detail::mapping_iterator_tag {}, mapping.to_mapping().end());
         --iterator;
@@ -373,8 +357,7 @@ TEST_CASE("IteratorClassTest_PostDecrementOperatorTest", "[IteratorClassTest]")
 {
     SECTION("Test sequence iterator.")
     {
-        fkyaml::node sequence =
-            fkyaml::node::sequence({fkyaml::node::boolean_scalar(false), fkyaml::node::boolean_scalar(true)});
+        fkyaml::node sequence = {false, true};
         fkyaml::detail::iterator<fkyaml::node> iterator(
             fkyaml::detail::sequence_iterator_tag {}, sequence.to_sequence().end());
         iterator--;
@@ -384,8 +367,7 @@ TEST_CASE("IteratorClassTest_PostDecrementOperatorTest", "[IteratorClassTest]")
 
     SECTION("Test mapping iterator.")
     {
-        fkyaml::node mapping = fkyaml::node::mapping(
-            {{"test0", fkyaml::node::boolean_scalar(false)}, {"test1", fkyaml::node::boolean_scalar(true)}});
+        fkyaml::node mapping = {{std::string("test0"), false}, {std::string("test1"), true}};
         fkyaml::detail::iterator<fkyaml::node> iterator(
             fkyaml::detail::mapping_iterator_tag {}, mapping.to_mapping().end());
         iterator--;
@@ -399,8 +381,7 @@ TEST_CASE("IteratorClassTest_EqualToOperatorTest", "[IteratorClassTest]")
 {
     SECTION("Test sequence iterator.")
     {
-        fkyaml::node sequence =
-            fkyaml::node::sequence({fkyaml::node::boolean_scalar(false), fkyaml::node::boolean_scalar(true)});
+        fkyaml::node sequence = {false, true};
         fkyaml::detail::iterator<fkyaml::node> lhs(
             fkyaml::detail::sequence_iterator_tag {}, sequence.to_sequence().begin());
         fkyaml::detail::iterator<fkyaml::node> rhs(
@@ -410,8 +391,7 @@ TEST_CASE("IteratorClassTest_EqualToOperatorTest", "[IteratorClassTest]")
 
     SECTION("Test mapping iterator.")
     {
-        fkyaml::node mapping = fkyaml::node::mapping(
-            {{"test0", fkyaml::node::boolean_scalar(false)}, {"test1", fkyaml::node::boolean_scalar(true)}});
+        fkyaml::node mapping = {{std::string("test0"), false}, {std::string("test1"), true}};
         fkyaml::detail::iterator<fkyaml::node> lhs(
             fkyaml::detail::mapping_iterator_tag {}, mapping.to_mapping().begin());
         fkyaml::detail::iterator<fkyaml::node> rhs(
@@ -421,12 +401,10 @@ TEST_CASE("IteratorClassTest_EqualToOperatorTest", "[IteratorClassTest]")
 
     SECTION("Test equality check between different type iterators.")
     {
-        fkyaml::node sequence =
-            fkyaml::node::sequence({fkyaml::node::boolean_scalar(false), fkyaml::node::boolean_scalar(true)});
+        fkyaml::node sequence = {false, true};
         fkyaml::detail::iterator<fkyaml::node> lhs(
             fkyaml::detail::sequence_iterator_tag {}, sequence.to_sequence().begin());
-        fkyaml::node mapping = fkyaml::node::mapping(
-            {{"test0", fkyaml::node::boolean_scalar(false)}, {"test1", fkyaml::node::boolean_scalar(true)}});
+        fkyaml::node mapping = {{std::string("test0"), false}, {std::string("test1"), true}};
         fkyaml::detail::iterator<fkyaml::node> rhs(
             fkyaml::detail::mapping_iterator_tag {}, mapping.to_mapping().begin());
         REQUIRE_THROWS_AS(lhs == rhs, fkyaml::exception);
@@ -437,8 +415,7 @@ TEST_CASE("IteratorClassTest_NotEqualToOperatorTest", "[IteratorClassTest]")
 {
     SECTION("Test sequence iterator.")
     {
-        fkyaml::node sequence =
-            fkyaml::node::sequence({fkyaml::node::boolean_scalar(false), fkyaml::node::boolean_scalar(true)});
+        fkyaml::node sequence = {false, true};
         fkyaml::detail::iterator<fkyaml::node> lhs(
             fkyaml::detail::sequence_iterator_tag {}, sequence.to_sequence().begin());
         fkyaml::detail::iterator<fkyaml::node> rhs(
@@ -449,8 +426,7 @@ TEST_CASE("IteratorClassTest_NotEqualToOperatorTest", "[IteratorClassTest]")
 
     SECTION("Test mapping iterator.")
     {
-        fkyaml::node mapping = fkyaml::node::mapping(
-            {{"test0", fkyaml::node::boolean_scalar(false)}, {"test1", fkyaml::node::boolean_scalar(true)}});
+        fkyaml::node mapping = {{std::string("test0"), false}, {std::string("test1"), true}};
         fkyaml::detail::iterator<fkyaml::node> lhs(
             fkyaml::detail::mapping_iterator_tag {}, mapping.to_mapping().begin());
         fkyaml::detail::iterator<fkyaml::node> rhs(
@@ -461,12 +437,10 @@ TEST_CASE("IteratorClassTest_NotEqualToOperatorTest", "[IteratorClassTest]")
 
     SECTION("Test equality check between different type iterators.")
     {
-        fkyaml::node sequence =
-            fkyaml::node::sequence({fkyaml::node::boolean_scalar(false), fkyaml::node::boolean_scalar(true)});
+        fkyaml::node sequence = {false, true};
         fkyaml::detail::iterator<fkyaml::node> lhs(
             fkyaml::detail::sequence_iterator_tag {}, sequence.to_sequence().begin());
-        fkyaml::node mapping = fkyaml::node::mapping(
-            {{"test0", fkyaml::node::boolean_scalar(false)}, {"test1", fkyaml::node::boolean_scalar(true)}});
+        fkyaml::node mapping = {{std::string("test0"), false}, {std::string("test1"), true}};
         fkyaml::detail::iterator<fkyaml::node> rhs(
             fkyaml::detail::mapping_iterator_tag {}, mapping.to_mapping().begin());
         REQUIRE_THROWS_AS(lhs == rhs, fkyaml::exception);
@@ -477,8 +451,7 @@ TEST_CASE("IteratorClassTest_LessThanOperatorTest", "[IteratorClassTest]")
 {
     SECTION("Test sequence iterator.")
     {
-        fkyaml::node sequence =
-            fkyaml::node::sequence({fkyaml::node::boolean_scalar(false), fkyaml::node::boolean_scalar(true)});
+        fkyaml::node sequence = {false, true};
         fkyaml::detail::iterator<fkyaml::node> lhs(
             fkyaml::detail::sequence_iterator_tag {}, sequence.to_sequence().begin());
         fkyaml::detail::iterator<fkyaml::node> rhs(
@@ -490,8 +463,7 @@ TEST_CASE("IteratorClassTest_LessThanOperatorTest", "[IteratorClassTest]")
 
     SECTION("Test mapping iterator.")
     {
-        fkyaml::node mapping = fkyaml::node::mapping(
-            {{"test0", fkyaml::node::boolean_scalar(false)}, {"test1", fkyaml::node::boolean_scalar(true)}});
+        fkyaml::node mapping = {{std::string("test0"), false}, {std::string("test1"), true}};
         fkyaml::detail::iterator<fkyaml::node> lhs(
             fkyaml::detail::mapping_iterator_tag {}, mapping.to_mapping().begin());
         fkyaml::detail::iterator<fkyaml::node> rhs(
@@ -501,12 +473,10 @@ TEST_CASE("IteratorClassTest_LessThanOperatorTest", "[IteratorClassTest]")
 
     SECTION("Test less-than check between different type iterators.")
     {
-        fkyaml::node sequence =
-            fkyaml::node::sequence({fkyaml::node::boolean_scalar(false), fkyaml::node::boolean_scalar(true)});
+        fkyaml::node sequence = {false, true};
         fkyaml::detail::iterator<fkyaml::node> lhs(
             fkyaml::detail::sequence_iterator_tag {}, sequence.to_sequence().begin());
-        fkyaml::node mapping = fkyaml::node::mapping(
-            {{"test0", fkyaml::node::boolean_scalar(false)}, {"test1", fkyaml::node::boolean_scalar(true)}});
+        fkyaml::node mapping = {{std::string("test0"), false}, {std::string("test1"), true}};
         fkyaml::detail::iterator<fkyaml::node> rhs(
             fkyaml::detail::mapping_iterator_tag {}, mapping.to_mapping().begin());
         REQUIRE_THROWS_AS(lhs < rhs, fkyaml::exception);
@@ -517,8 +487,7 @@ TEST_CASE("IteratorClassTest_LessThanOrEqualToOperatorTest", "[IteratorClassTest
 {
     SECTION("Test sequence iterator.")
     {
-        fkyaml::node sequence =
-            fkyaml::node::sequence({fkyaml::node::boolean_scalar(false), fkyaml::node::boolean_scalar(true)});
+        fkyaml::node sequence = {false, true};
         fkyaml::detail::iterator<fkyaml::node> lhs(
             fkyaml::detail::sequence_iterator_tag {}, sequence.to_sequence().begin());
         fkyaml::detail::iterator<fkyaml::node> rhs(
@@ -533,8 +502,7 @@ TEST_CASE("IteratorClassTest_LessThanOrEqualToOperatorTest", "[IteratorClassTest
 
     SECTION("Test mapping iterator.")
     {
-        fkyaml::node mapping = fkyaml::node::mapping(
-            {{"test0", fkyaml::node::boolean_scalar(false)}, {"test1", fkyaml::node::boolean_scalar(true)}});
+        fkyaml::node mapping = {{std::string("test0"), false}, {std::string("test1"), true}};
         fkyaml::detail::iterator<fkyaml::node> lhs(
             fkyaml::detail::mapping_iterator_tag {}, mapping.to_mapping().begin());
         fkyaml::detail::iterator<fkyaml::node> rhs(
@@ -544,12 +512,10 @@ TEST_CASE("IteratorClassTest_LessThanOrEqualToOperatorTest", "[IteratorClassTest
 
     SECTION("Test less-than-or-equal-to check between different type iterators.")
     {
-        fkyaml::node sequence =
-            fkyaml::node::sequence({fkyaml::node::boolean_scalar(false), fkyaml::node::boolean_scalar(true)});
+        fkyaml::node sequence = {false, true};
         fkyaml::detail::iterator<fkyaml::node> lhs(
             fkyaml::detail::sequence_iterator_tag {}, sequence.to_sequence().begin());
-        fkyaml::node mapping = fkyaml::node::mapping(
-            {{"test0", fkyaml::node::boolean_scalar(false)}, {"test1", fkyaml::node::boolean_scalar(true)}});
+        fkyaml::node mapping = {{std::string("test0"), false}, {std::string("test1"), true}};
         fkyaml::detail::iterator<fkyaml::node> rhs(
             fkyaml::detail::mapping_iterator_tag {}, mapping.to_mapping().begin());
         REQUIRE_THROWS_AS(lhs <= rhs, fkyaml::exception);
@@ -560,8 +526,7 @@ TEST_CASE("IteratorClassTest_GreaterThanOperatorTest", "[IteratorClassTest]")
 {
     SECTION("Test sequence iterator.")
     {
-        fkyaml::node sequence =
-            fkyaml::node::sequence({fkyaml::node::boolean_scalar(false), fkyaml::node::boolean_scalar(true)});
+        fkyaml::node sequence = {false, true};
         fkyaml::detail::iterator<fkyaml::node> lhs(
             fkyaml::detail::sequence_iterator_tag {}, sequence.to_sequence().begin());
         fkyaml::detail::iterator<fkyaml::node> rhs(
@@ -573,8 +538,7 @@ TEST_CASE("IteratorClassTest_GreaterThanOperatorTest", "[IteratorClassTest]")
 
     SECTION("Test mapping iterator.")
     {
-        fkyaml::node mapping = fkyaml::node::mapping(
-            {{"test0", fkyaml::node::boolean_scalar(false)}, {"test1", fkyaml::node::boolean_scalar(true)}});
+        fkyaml::node mapping = {{std::string("test0"), false}, {std::string("test1"), true}};
         fkyaml::detail::iterator<fkyaml::node> lhs(
             fkyaml::detail::mapping_iterator_tag {}, mapping.to_mapping().begin());
         fkyaml::detail::iterator<fkyaml::node> rhs(
@@ -584,12 +548,10 @@ TEST_CASE("IteratorClassTest_GreaterThanOperatorTest", "[IteratorClassTest]")
 
     SECTION("Test greater-than check between different type iterators.")
     {
-        fkyaml::node sequence =
-            fkyaml::node::sequence({fkyaml::node::boolean_scalar(false), fkyaml::node::boolean_scalar(true)});
+        fkyaml::node sequence = {false, true};
         fkyaml::detail::iterator<fkyaml::node> lhs(
             fkyaml::detail::sequence_iterator_tag {}, sequence.to_sequence().begin());
-        fkyaml::node mapping = fkyaml::node::mapping(
-            {{"test0", fkyaml::node::boolean_scalar(false)}, {"test1", fkyaml::node::boolean_scalar(true)}});
+        fkyaml::node mapping = {{std::string("test0"), false}, {std::string("test1"), true}};
         fkyaml::detail::iterator<fkyaml::node> rhs(
             fkyaml::detail::mapping_iterator_tag {}, mapping.to_mapping().begin());
         REQUIRE_THROWS_AS(lhs > rhs, fkyaml::exception);
@@ -600,8 +562,7 @@ TEST_CASE("IteratorClassTest_GreaterThanOrEqualToOperatorTest", "[IteratorClassT
 {
     SECTION("Test sequence iterator.")
     {
-        fkyaml::node sequence =
-            fkyaml::node::sequence({fkyaml::node::boolean_scalar(false), fkyaml::node::boolean_scalar(true)});
+        fkyaml::node sequence = {false, true};
         fkyaml::detail::iterator<fkyaml::node> lhs(
             fkyaml::detail::sequence_iterator_tag {}, sequence.to_sequence().begin());
         fkyaml::detail::iterator<fkyaml::node> rhs(
@@ -616,8 +577,7 @@ TEST_CASE("IteratorClassTest_GreaterThanOrEqualToOperatorTest", "[IteratorClassT
 
     SECTION("Test mapping iterator.")
     {
-        fkyaml::node mapping = fkyaml::node::mapping(
-            {{"test0", fkyaml::node::boolean_scalar(false)}, {"test1", fkyaml::node::boolean_scalar(true)}});
+        fkyaml::node mapping = {{std::string("test0"), false}, {std::string("test1"), true}};
         fkyaml::detail::iterator<fkyaml::node> lhs(
             fkyaml::detail::mapping_iterator_tag {}, mapping.to_mapping().begin());
         fkyaml::detail::iterator<fkyaml::node> rhs(
@@ -627,12 +587,10 @@ TEST_CASE("IteratorClassTest_GreaterThanOrEqualToOperatorTest", "[IteratorClassT
 
     SECTION("Test greater-than-or-equal-to check between different type iterators.")
     {
-        fkyaml::node sequence =
-            fkyaml::node::sequence({fkyaml::node::boolean_scalar(false), fkyaml::node::boolean_scalar(true)});
+        fkyaml::node sequence = {false, true};
         fkyaml::detail::iterator<fkyaml::node> lhs(
             fkyaml::detail::sequence_iterator_tag {}, sequence.to_sequence().begin());
-        fkyaml::node mapping = fkyaml::node::mapping(
-            {{"test0", fkyaml::node::boolean_scalar(false)}, {"test1", fkyaml::node::boolean_scalar(true)}});
+        fkyaml::node mapping = {{std::string("test0"), false}, {std::string("test1"), true}};
         fkyaml::detail::iterator<fkyaml::node> rhs(
             fkyaml::detail::mapping_iterator_tag {}, mapping.to_mapping().begin());
         REQUIRE_THROWS_AS(lhs >= rhs, fkyaml::exception);
@@ -643,8 +601,7 @@ TEST_CASE("IteratorClassTest_TypeGetterTest", "[IteratorClassTest]")
 {
     SECTION("Test sequence iterator.")
     {
-        fkyaml::node sequence =
-            fkyaml::node::sequence({fkyaml::node::boolean_scalar(false), fkyaml::node::boolean_scalar(true)});
+        fkyaml::node sequence = {false, true};
         fkyaml::detail::iterator<fkyaml::node> iterator(
             fkyaml::detail::sequence_iterator_tag {}, sequence.to_sequence().begin());
         REQUIRE(iterator.type() == fkyaml::detail::iterator_t::SEQUENCE);
@@ -652,8 +609,7 @@ TEST_CASE("IteratorClassTest_TypeGetterTest", "[IteratorClassTest]")
 
     SECTION("Test mapping iterator.")
     {
-        fkyaml::node mapping = fkyaml::node::mapping(
-            {{"test0", fkyaml::node::boolean_scalar(false)}, {"test1", fkyaml::node::boolean_scalar(true)}});
+        fkyaml::node mapping = {{std::string("test0"), false}, {std::string("test1"), true}};
         fkyaml::detail::iterator<fkyaml::node> iterator(
             fkyaml::detail::mapping_iterator_tag {}, mapping.to_mapping().begin());
         REQUIRE(iterator.type() == fkyaml::detail::iterator_t::MAPPING);
@@ -664,8 +620,7 @@ TEST_CASE("IteratorClassTest_KeyGetterTest", "[IteratorClassTest]")
 {
     SECTION("Test sequence iterator.")
     {
-        fkyaml::node sequence =
-            fkyaml::node::sequence({fkyaml::node::boolean_scalar(false), fkyaml::node::boolean_scalar(true)});
+        fkyaml::node sequence = {false, true};
         fkyaml::detail::iterator<fkyaml::node> iterator(
             fkyaml::detail::sequence_iterator_tag {}, sequence.to_sequence().begin());
         REQUIRE_THROWS_AS(iterator.key(), fkyaml::exception);
@@ -673,8 +628,7 @@ TEST_CASE("IteratorClassTest_KeyGetterTest", "[IteratorClassTest]")
 
     SECTION("Test mapping iterator.")
     {
-        fkyaml::node mapping = fkyaml::node::mapping(
-            {{"test0", fkyaml::node::boolean_scalar(false)}, {"test1", fkyaml::node::boolean_scalar(true)}});
+        fkyaml::node mapping = {{std::string("test0"), false}, {std::string("test1"), true}};
         fkyaml::detail::iterator<fkyaml::node> iterator(
             fkyaml::detail::mapping_iterator_tag {}, mapping.to_mapping().begin());
         REQUIRE_NOTHROW(iterator.key());
@@ -686,8 +640,7 @@ TEST_CASE("IteratorClassTest_ValueGetterTest", "[IteratorClassTest]")
 {
     SECTION("Test sequence iterator.")
     {
-        fkyaml::node sequence =
-            fkyaml::node::sequence({fkyaml::node::boolean_scalar(false), fkyaml::node::boolean_scalar(true)});
+        fkyaml::node sequence = {false, true};
         fkyaml::detail::iterator<fkyaml::node> iterator(
             fkyaml::detail::sequence_iterator_tag {}, sequence.to_sequence().begin());
         REQUIRE(iterator.value().is_boolean());
@@ -696,8 +649,7 @@ TEST_CASE("IteratorClassTest_ValueGetterTest", "[IteratorClassTest]")
 
     SECTION("Test mapping iterator.")
     {
-        fkyaml::node mapping = fkyaml::node::mapping(
-            {{"test0", fkyaml::node::boolean_scalar(false)}, {"test1", fkyaml::node::boolean_scalar(true)}});
+        fkyaml::node mapping = {{std::string("test0"), false}, {std::string("test1"), true}};
         fkyaml::detail::iterator<fkyaml::node> iterator(
             fkyaml::detail::mapping_iterator_tag {}, mapping.to_mapping().begin());
         REQUIRE(iterator.value().is_boolean());

--- a/test/unit_test/test_node_class.cpp
+++ b/test/unit_test/test_node_class.cpp
@@ -84,7 +84,7 @@ TEST_CASE("NodeClassTest_ThrowingSpecializationTypeCtorTest", "[NodeClassTest]")
     };
 
     using NodeType = fkyaml::basic_node<std::vector, std::map, bool, int64_t, double, String>;
-    REQUIRE_THROWS_AS(NodeType::string_scalar(), fkyaml::exception);
+    REQUIRE_THROWS_AS(NodeType(NodeType::node_t::STRING), fkyaml::exception);
 }
 
 TEST_CASE("NodeClassTest_SequenceCtorTest", "[NodeClassTest]")
@@ -152,8 +152,7 @@ TEST_CASE("NodeClassTest_StringCtorTest", "[NodeClassTest]")
 
 TEST_CASE("NodeClassTest_SequenceCopyCtorTest", "[NodeClassTest]")
 {
-    fkyaml::node copied =
-        fkyaml::node::sequence({fkyaml::node::boolean_scalar(true), fkyaml::node::string_scalar("test")});
+    fkyaml::node copied = {true, std::string("test")};
     fkyaml::node node(copied);
     REQUIRE(node.is_sequence());
     REQUIRE_NOTHROW(node.size());
@@ -172,8 +171,7 @@ TEST_CASE("NodeClassTest_SequenceCopyCtorTest", "[NodeClassTest]")
 
 TEST_CASE("NodeClassTest_MappingCopyCtorTest", "[NodeClassTest]")
 {
-    fkyaml::node copied = fkyaml::node::mapping(
-        {{"test0", fkyaml::node::integer_scalar(123)}, {"test1", fkyaml::node::float_number_scalar(3.14)}});
+    fkyaml::node copied = {{std::string("test0"), 123}, {std::string("test1"), 3.14}};
     fkyaml::node node(copied);
     REQUIRE(node.is_mapping());
     REQUIRE_NOTHROW(node.size());
@@ -197,7 +195,7 @@ TEST_CASE("NodeClassTest_NullCopyCtorTest", "[NodeClassTest]")
 
 TEST_CASE("NodeClassTest_BooleanCopyCtorTest", "[NodeClassTest]")
 {
-    fkyaml::node copied = fkyaml::node::boolean_scalar(true);
+    fkyaml::node copied = true;
     fkyaml::node node(copied);
     REQUIRE(node.is_boolean());
     REQUIRE_NOTHROW(node.to_boolean());
@@ -206,7 +204,7 @@ TEST_CASE("NodeClassTest_BooleanCopyCtorTest", "[NodeClassTest]")
 
 TEST_CASE("NodeClassTest_IntegerCopyCtorTest", "[NodeClassTest]")
 {
-    fkyaml::node copied = fkyaml::node::integer_scalar(123);
+    fkyaml::node copied = 123;
     fkyaml::node node(copied);
     REQUIRE(node.is_integer());
     REQUIRE_NOTHROW(node.to_integer());
@@ -215,7 +213,7 @@ TEST_CASE("NodeClassTest_IntegerCopyCtorTest", "[NodeClassTest]")
 
 TEST_CASE("NodeClassTest_FloatNumberCopyCtorTest", "[NodeClassTest]")
 {
-    fkyaml::node copied = fkyaml::node::float_number_scalar(3.14);
+    fkyaml::node copied = 3.14;
     fkyaml::node node(copied);
     REQUIRE(node.is_float_number());
     REQUIRE_NOTHROW(node.to_float_number());
@@ -224,7 +222,7 @@ TEST_CASE("NodeClassTest_FloatNumberCopyCtorTest", "[NodeClassTest]")
 
 TEST_CASE("NodeClassTest_StringCopyCtorTest", "[NodeClassTest]")
 {
-    fkyaml::node copied = fkyaml::node::string_scalar("test");
+    fkyaml::node copied = std::string("test");
     fkyaml::node node(copied);
     REQUIRE(node.is_string());
     REQUIRE_NOTHROW(node.size());
@@ -235,7 +233,7 @@ TEST_CASE("NodeClassTest_StringCopyCtorTest", "[NodeClassTest]")
 
 TEST_CASE("NodeClassTest_AliasCopyCtorTest", "[NodeClassTest]")
 {
-    fkyaml::node tmp = fkyaml::node::boolean_scalar(true);
+    fkyaml::node tmp = true;
     tmp.add_anchor_name("anchor_name");
     fkyaml::node tmp_alias = fkyaml::node::alias_of(tmp);
     fkyaml::node alias(tmp_alias);
@@ -246,8 +244,7 @@ TEST_CASE("NodeClassTest_AliasCopyCtorTest", "[NodeClassTest]")
 
 TEST_CASE("NodeClassTest_SequenceMoveCtorTest", "[NodeClassTest]")
 {
-    fkyaml::node moved =
-        fkyaml::node::sequence({fkyaml::node::boolean_scalar(true), fkyaml::node::string_scalar("test")});
+    fkyaml::node moved = {true, std::string("test")};
     fkyaml::node node(std::move(moved));
     REQUIRE(node.is_sequence());
     REQUIRE_NOTHROW(node.size());
@@ -266,8 +263,7 @@ TEST_CASE("NodeClassTest_SequenceMoveCtorTest", "[NodeClassTest]")
 
 TEST_CASE("NodeClassTest_MappingMoveCtorTest", "[NodeClassTest]")
 {
-    fkyaml::node moved = fkyaml::node::mapping(
-        {{"test0", fkyaml::node::integer_scalar(123)}, {"test1", fkyaml::node::float_number_scalar(3.14)}});
+    fkyaml::node moved = {{std::string("test0"), 123}, {std::string("test1"), 3.14}};
     fkyaml::node node(std::move(moved));
     REQUIRE(node.is_mapping());
     REQUIRE_NOTHROW(node.size());
@@ -291,7 +287,7 @@ TEST_CASE("NodeClassTest_NullMoveCtorTest", "[NodeClassTest]")
 
 TEST_CASE("NodeClassTest_BooleanMoveCtorTest", "[NodeClassTest]")
 {
-    fkyaml::node moved = fkyaml::node::boolean_scalar(true);
+    fkyaml::node moved = true;
     fkyaml::node node(std::move(moved));
     REQUIRE(node.is_boolean());
     REQUIRE_NOTHROW(node.to_boolean());
@@ -300,7 +296,7 @@ TEST_CASE("NodeClassTest_BooleanMoveCtorTest", "[NodeClassTest]")
 
 TEST_CASE("NodeClassTest_IntegerMoveCtorTest", "[NodeClassTest]")
 {
-    fkyaml::node moved = fkyaml::node::integer_scalar(123);
+    fkyaml::node moved = 123;
     fkyaml::node node(std::move(moved));
     REQUIRE(node.is_integer());
     REQUIRE_NOTHROW(node.to_integer());
@@ -309,7 +305,7 @@ TEST_CASE("NodeClassTest_IntegerMoveCtorTest", "[NodeClassTest]")
 
 TEST_CASE("NodeClassTest_FloatNumberMoveCtorTest", "[NodeClassTest]")
 {
-    fkyaml::node moved = fkyaml::node::float_number_scalar(3.14);
+    fkyaml::node moved = 3.14;
     fkyaml::node node(std::move(moved));
     REQUIRE(node.is_float_number());
     REQUIRE_NOTHROW(node.to_float_number());
@@ -318,7 +314,7 @@ TEST_CASE("NodeClassTest_FloatNumberMoveCtorTest", "[NodeClassTest]")
 
 TEST_CASE("NodeClassTest_StringMoveCtorTest", "[NodeClassTest]")
 {
-    fkyaml::node moved = fkyaml::node::string_scalar("test");
+    fkyaml::node moved = std::string("test");
     fkyaml::node node(std::move(moved));
     REQUIRE(node.is_string());
     REQUIRE_NOTHROW(node.size());
@@ -329,7 +325,7 @@ TEST_CASE("NodeClassTest_StringMoveCtorTest", "[NodeClassTest]")
 
 TEST_CASE("NodeClassTest_AliasMoveCtorTest", "[NodeClassTest]")
 {
-    fkyaml::node tmp = fkyaml::node::boolean_scalar(true);
+    fkyaml::node tmp = true;
     tmp.add_anchor_name("anchor_name");
     fkyaml::node tmp_alias = fkyaml::node::alias_of(tmp);
     fkyaml::node alias(std::move(tmp_alias));
@@ -344,6 +340,7 @@ TEST_CASE("NodeClassTest_InitializerListCtorTest", "[NodeClassTest]")
         {std::string("foo"), 3.14},
         {std::string("bar"), 123},
         {std::string("baz"), {true, false}},
+        {std::string("qux"), nullptr},
     };
 
     REQUIRE(node.contains("foo"));
@@ -361,6 +358,9 @@ TEST_CASE("NodeClassTest_InitializerListCtorTest", "[NodeClassTest]")
     REQUIRE(node["baz"].to_sequence()[0].to_boolean() == true);
     REQUIRE(node["baz"].to_sequence()[1].is_boolean());
     REQUIRE(node["baz"].to_sequence()[1].to_boolean() == false);
+
+    REQUIRE(node.contains("qux"));
+    REQUIRE(node["qux"].is_null());
 }
 
 //
@@ -446,7 +446,7 @@ TEST_CASE("NodeClassTest_MappingNodeFactoryTest", "[NodeClassTest]")
 
     SECTION("Test non-empty mapping node factory methods.")
     {
-        fkyaml::node_mapping_type map {{std::string("test"), fkyaml::node::boolean_scalar(true)}};
+        fkyaml::node_mapping_type map {{std::string("test"), true}};
 
         SECTION("Test lvalue mapping node factory method.")
         {
@@ -471,7 +471,7 @@ TEST_CASE("NodeClassTest_MappingNodeFactoryTest", "[NodeClassTest]")
 TEST_CASE("NodeClassTest_BooleanNodeFactoryTest", "[NodeClassTest]")
 {
     auto boolean = GENERATE(true, false);
-    fkyaml::node node = fkyaml::node::boolean_scalar(boolean);
+    fkyaml::node node = boolean;
     REQUIRE(node.is_boolean());
     REQUIRE(node.to_boolean() == boolean);
 }
@@ -482,7 +482,7 @@ TEST_CASE("NodeClassTest_IntegerNodeFactoryTest", "[NodeClassTest]")
         std::numeric_limits<fkyaml::node_integer_type>::min(),
         0,
         std::numeric_limits<fkyaml::node_integer_type>::max());
-    fkyaml::node node = fkyaml::node::integer_scalar(integer);
+    fkyaml::node node = integer;
     REQUIRE(node.is_integer());
     REQUIRE(node.to_integer() == integer);
 }
@@ -493,7 +493,7 @@ TEST_CASE("NodeClassTest_FloatNumberNodeFactoryTest", "[NodeClassTest]")
         std::numeric_limits<fkyaml::node_float_number_type>::min(),
         3.141592,
         std::numeric_limits<fkyaml::node_float_number_type>::max());
-    fkyaml::node node = fkyaml::node::float_number_scalar(float_val);
+    fkyaml::node node = float_val;
     REQUIRE(node.is_float_number());
     REQUIRE(node.to_float_number() == float_val);
 }
@@ -502,7 +502,7 @@ TEST_CASE("NodeClassTest_StringNodeFactoryTest", "[NodeClassTest]")
 {
     SECTION("Test empty string node factory method.")
     {
-        fkyaml::node node = fkyaml::node::string_scalar();
+        fkyaml::node node = std::string();
         REQUIRE(node.is_string());
         REQUIRE(node.size() == 0);
     }
@@ -510,7 +510,7 @@ TEST_CASE("NodeClassTest_StringNodeFactoryTest", "[NodeClassTest]")
     SECTION("Test lvalue string node factory method.")
     {
         fkyaml::node_string_type str("test");
-        fkyaml::node node = fkyaml::node::string_scalar(str);
+        fkyaml::node node = std::string(str);
         REQUIRE(node.is_string());
         REQUIRE(node.size() == str.size());
         REQUIRE(node.to_string() == str);
@@ -518,7 +518,7 @@ TEST_CASE("NodeClassTest_StringNodeFactoryTest", "[NodeClassTest]")
 
     SECTION("Test rvalue string node factory method.")
     {
-        fkyaml::node node = fkyaml::node::string_scalar("test");
+        fkyaml::node node = std::string("test");
         REQUIRE(node.is_string());
         REQUIRE(node.size() == 4);
         REQUIRE(node.to_string().compare("test") == 0);
@@ -527,7 +527,7 @@ TEST_CASE("NodeClassTest_StringNodeFactoryTest", "[NodeClassTest]")
 
 TEST_CASE("NodeClassTest_AliasNodeFactoryTest", "[NodeClassTest]")
 {
-    fkyaml::node anchor = fkyaml::node::string_scalar("alias_test");
+    fkyaml::node anchor = std::string("alias_test");
 
     SECTION("Make sure BasicNode::alias_of() throws an exception without anchor name.")
     {
@@ -620,10 +620,10 @@ TEST_CASE("NodeClassTest_StringSubscriptOperatorTest", "[NodeClassTest]")
         auto node = GENERATE(
             fkyaml::node::sequence(),
             fkyaml::node(),
-            fkyaml::node::boolean_scalar(false),
-            fkyaml::node::integer_scalar(0),
-            fkyaml::node::float_number_scalar(0.0),
-            fkyaml::node::string_scalar());
+            fkyaml::node(false),
+            fkyaml::node(0),
+            fkyaml::node(0.0),
+            fkyaml::node(std::string()));
 
         SECTION("Test non-const lvalue throwing invocation.")
         {
@@ -689,10 +689,10 @@ TEST_CASE("NodeClassTest_IntegerSubscriptOperatorTest", "[NodeClassTest]")
         auto node = GENERATE(
             fkyaml::node::mapping(),
             fkyaml::node(),
-            fkyaml::node::boolean_scalar(false),
-            fkyaml::node::integer_scalar(0),
-            fkyaml::node::float_number_scalar(0.0),
-            fkyaml::node::string_scalar());
+            fkyaml::node(false),
+            fkyaml::node(0),
+            fkyaml::node(0.0),
+            fkyaml::node(std::string()));
 
         SECTION("Test non-const non-sequence nodes.")
         {
@@ -718,10 +718,10 @@ TEST_CASE("NodeClassTest_TypeGetterTest", "[NodeClassTest]")
         NodeTypePair(fkyaml::node::sequence(), fkyaml::node::node_t::SEQUENCE),
         NodeTypePair(fkyaml::node::mapping(), fkyaml::node::node_t::MAPPING),
         NodeTypePair(fkyaml::node(), fkyaml::node::node_t::NULL_OBJECT),
-        NodeTypePair(fkyaml::node::boolean_scalar(false), fkyaml::node::node_t::BOOLEAN),
-        NodeTypePair(fkyaml::node::integer_scalar(0), fkyaml::node::node_t::INTEGER),
-        NodeTypePair(fkyaml::node::float_number_scalar(0.0), fkyaml::node::node_t::FLOAT_NUMBER),
-        NodeTypePair(fkyaml::node::string_scalar(), fkyaml::node::node_t::STRING));
+        NodeTypePair(fkyaml::node(false), fkyaml::node::node_t::BOOLEAN),
+        NodeTypePair(fkyaml::node(0), fkyaml::node::node_t::INTEGER),
+        NodeTypePair(fkyaml::node(0.0), fkyaml::node::node_t::FLOAT_NUMBER),
+        NodeTypePair(fkyaml::node(std::string()), fkyaml::node::node_t::STRING));
 
     SECTION("Test non-alias node types.")
     {
@@ -760,10 +760,10 @@ TEST_CASE("NodeClassTest_is_sequenceTest", "[NodeClassTest]")
         auto node = GENERATE(
             fkyaml::node::mapping(),
             fkyaml::node(),
-            fkyaml::node::boolean_scalar(false),
-            fkyaml::node::integer_scalar(0),
-            fkyaml::node::float_number_scalar(0.0),
-            fkyaml::node::string_scalar());
+            fkyaml::node(false),
+            fkyaml::node(0),
+            fkyaml::node(0.0),
+            fkyaml::node(std::string()));
 
         SECTION("Test non-alias non-sequence node types")
         {
@@ -803,10 +803,10 @@ TEST_CASE("NodeClassTest_is_mappingTest", "[NodeClassTest]")
         auto node = GENERATE(
             fkyaml::node::sequence(),
             fkyaml::node(),
-            fkyaml::node::boolean_scalar(false),
-            fkyaml::node::integer_scalar(0),
-            fkyaml::node::float_number_scalar(0.0),
-            fkyaml::node::string_scalar());
+            fkyaml::node(false),
+            fkyaml::node(0),
+            fkyaml::node(0.0),
+            fkyaml::node(std::string()));
 
         SECTION("Test non-alias non-mapping node types")
         {
@@ -846,10 +846,10 @@ TEST_CASE("NodeClassTest_is_nullTest", "[NodeClassTest]")
         auto node = GENERATE(
             fkyaml::node::sequence(),
             fkyaml::node::mapping(),
-            fkyaml::node::boolean_scalar(false),
-            fkyaml::node::integer_scalar(0),
-            fkyaml::node::float_number_scalar(0.0),
-            fkyaml::node::string_scalar());
+            fkyaml::node(false),
+            fkyaml::node(0),
+            fkyaml::node(0.0),
+            fkyaml::node(std::string()));
 
         SECTION("Test non-alias non-null node types")
         {
@@ -869,7 +869,7 @@ TEST_CASE("NodeClassTest_is_booleanTest", "[NodeClassTest]")
 {
     SECTION("Test boolean node type.")
     {
-        fkyaml::node node = fkyaml::node::boolean_scalar(false);
+        fkyaml::node node = false;
 
         SECTION("Test non-alias boolean node type.")
         {
@@ -890,9 +890,9 @@ TEST_CASE("NodeClassTest_is_booleanTest", "[NodeClassTest]")
             fkyaml::node::sequence(),
             fkyaml::node::mapping(),
             fkyaml::node(),
-            fkyaml::node::integer_scalar(0),
-            fkyaml::node::float_number_scalar(0.0),
-            fkyaml::node::string_scalar());
+            fkyaml::node(0),
+            fkyaml::node(0.0),
+            fkyaml::node(std::string()));
 
         SECTION("Test non-alias non-boolean node types")
         {
@@ -912,7 +912,7 @@ TEST_CASE("NodeClassTest_is_integerTest", "[NodeClassTest]")
 {
     SECTION("Test integer node type.")
     {
-        fkyaml::node node = fkyaml::node::integer_scalar(0);
+        fkyaml::node node = 0;
 
         SECTION("Test non-alias integer node type.")
         {
@@ -933,9 +933,9 @@ TEST_CASE("NodeClassTest_is_integerTest", "[NodeClassTest]")
             fkyaml::node::sequence(),
             fkyaml::node::mapping(),
             fkyaml::node(),
-            fkyaml::node::boolean_scalar(false),
-            fkyaml::node::float_number_scalar(0.0),
-            fkyaml::node::string_scalar());
+            fkyaml::node(false),
+            fkyaml::node(0.0),
+            fkyaml::node(std::string()));
 
         SECTION("Test non-alias non-integer node types")
         {
@@ -955,7 +955,7 @@ TEST_CASE("NodeClassTest_IsFloatNumberTest", "[NodeClassTest]")
 {
     SECTION("Test float number node type.")
     {
-        fkyaml::node node = fkyaml::node::float_number_scalar(0.0);
+        fkyaml::node node = 0.0;
 
         SECTION("Test non-alias float number node type.")
         {
@@ -976,9 +976,9 @@ TEST_CASE("NodeClassTest_IsFloatNumberTest", "[NodeClassTest]")
             fkyaml::node::sequence(),
             fkyaml::node::mapping(),
             fkyaml::node(),
-            fkyaml::node::boolean_scalar(false),
-            fkyaml::node::integer_scalar(0),
-            fkyaml::node::string_scalar());
+            fkyaml::node(false),
+            fkyaml::node(0),
+            fkyaml::node(std::string()));
 
         SECTION("Test non-alias non-float-number node types")
         {
@@ -998,7 +998,7 @@ TEST_CASE("NodeClassTest_IsStringTest", "[NodeClassTest]")
 {
     SECTION("Test string node type.")
     {
-        fkyaml::node node = fkyaml::node::string_scalar();
+        fkyaml::node node = std::string();
 
         SECTION("Test non-alias string node type.")
         {
@@ -1019,9 +1019,9 @@ TEST_CASE("NodeClassTest_IsStringTest", "[NodeClassTest]")
             fkyaml::node::sequence(),
             fkyaml::node::mapping(),
             fkyaml::node(),
-            fkyaml::node::boolean_scalar(false),
-            fkyaml::node::integer_scalar(0),
-            fkyaml::node::float_number_scalar(0.0));
+            fkyaml::node(false),
+            fkyaml::node(0),
+            fkyaml::node(0.0));
 
         SECTION("Test non-alias non-string node types")
         {
@@ -1043,10 +1043,10 @@ TEST_CASE("NodeClassTest_is_scalarTest", "[NodeClassTest]")
     {
         auto node = GENERATE(
             fkyaml::node(),
-            fkyaml::node::boolean_scalar(false),
-            fkyaml::node::integer_scalar(0),
-            fkyaml::node::float_number_scalar(0.0),
-            fkyaml::node::string_scalar());
+            fkyaml::node(false),
+            fkyaml::node(0),
+            fkyaml::node(0.0),
+            fkyaml::node(std::string()));
 
         SECTION("Test non-alias scalar node types.")
         {
@@ -1085,10 +1085,10 @@ TEST_CASE("NodeClassTest_IsAliasTest", "[NodeClassTest]")
         fkyaml::node::sequence(),
         fkyaml::node::mapping(),
         fkyaml::node(),
-        fkyaml::node::boolean_scalar(false),
-        fkyaml::node::integer_scalar(0),
-        fkyaml::node::float_number_scalar(0.0),
-        fkyaml::node::string_scalar());
+        fkyaml::node(false),
+        fkyaml::node(0),
+        fkyaml::node(0.0),
+        fkyaml::node(std::string()));
 
     SECTION("Test alias node types.")
     {
@@ -1107,7 +1107,7 @@ TEST_CASE("NodeClassTest_emptyTest", "[NodeClassTest]")
     {
         SECTION("Test empty container node emptiness.")
         {
-            auto node = GENERATE(fkyaml::node::sequence(), fkyaml::node::mapping(), fkyaml::node::string_scalar());
+            auto node = GENERATE(fkyaml::node::sequence(), fkyaml::node::mapping(), fkyaml::node(std::string()));
 
             SECTION("Test empty non-alias container node emptiness.")
             {
@@ -1129,7 +1129,7 @@ TEST_CASE("NodeClassTest_emptyTest", "[NodeClassTest]")
             auto node = GENERATE(
                 fkyaml::node::sequence(fkyaml::node_sequence_type(3)),
                 fkyaml::node::mapping(fkyaml::node_mapping_type {{"test", fkyaml::node()}}),
-                fkyaml::node::string_scalar("test"));
+                fkyaml::node(std::string("test")));
 
             SECTION("Test non-empty non-alias container node emptiness.")
             {
@@ -1151,9 +1151,9 @@ TEST_CASE("NodeClassTest_emptyTest", "[NodeClassTest]")
     {
         auto node = GENERATE(
             fkyaml::node(),
-            fkyaml::node::boolean_scalar(false),
-            fkyaml::node::integer_scalar(0),
-            fkyaml::node::float_number_scalar(0.0));
+            fkyaml::node(false),
+            fkyaml::node(0),
+            fkyaml::node(0.0));
 
         SECTION("Test non-const non-alias non-container node emptiness.")
         {
@@ -1223,10 +1223,10 @@ TEST_CASE("NodeClassTest_ContainsTest", "[NodeClassTest]")
         auto node = GENERATE(
             fkyaml::node::sequence(),
             fkyaml::node(),
-            fkyaml::node::boolean_scalar(false),
-            fkyaml::node::integer_scalar(0),
-            fkyaml::node::float_number_scalar(0.0),
-            fkyaml::node::string_scalar());
+            fkyaml::node(false),
+            fkyaml::node(0),
+            fkyaml::node(0.0),
+            fkyaml::node(std::string()));
         std::string key = "test";
 
         SECTION("Test non-alias non-mapping node with lvalue key.")
@@ -1266,7 +1266,7 @@ TEST_CASE("NodeClassTest_sizeGetterTest", "[NodeClassTest]")
         auto node = GENERATE(
             fkyaml::node::sequence({fkyaml::node(), fkyaml::node(), fkyaml::node()}),
             fkyaml::node::mapping({{"test0", fkyaml::node()}, {"test1", fkyaml::node()}, {"test2", fkyaml::node()}}),
-            fkyaml::node::string_scalar("tmp"));
+            fkyaml::node(std::string("tmp")));
 
         SECTION("Test container node size.")
         {
@@ -1302,9 +1302,9 @@ TEST_CASE("NodeClassTest_sizeGetterTest", "[NodeClassTest]")
     {
         auto node = GENERATE(
             fkyaml::node(),
-            fkyaml::node::boolean_scalar(false),
-            fkyaml::node::integer_scalar(0),
-            fkyaml::node::float_number_scalar(0.0));
+            fkyaml::node(false),
+            fkyaml::node(0),
+            fkyaml::node(0.0));
 
         SECTION("Test non-const non-alias non-container node size.")
         {
@@ -1692,10 +1692,10 @@ TEST_CASE("NodeClassTest_ToSequenceTest", "[NodeClassTest]")
         auto node = GENERATE(
             fkyaml::node::mapping(),
             fkyaml::node(),
-            fkyaml::node::boolean_scalar(false),
-            fkyaml::node::integer_scalar(0),
-            fkyaml::node::float_number_scalar(0.0),
-            fkyaml::node::string_scalar());
+            fkyaml::node(false),
+            fkyaml::node(0),
+            fkyaml::node(0.0),
+            fkyaml::node(std::string()));
 
         SECTION("Test non-alias non-sequence nodes.")
         {
@@ -1777,10 +1777,10 @@ TEST_CASE("NodeClassTest_ToMappingTest", "[NodeClassTest]")
         auto node = GENERATE(
             fkyaml::node::sequence(),
             fkyaml::node(),
-            fkyaml::node::boolean_scalar(false),
-            fkyaml::node::integer_scalar(0),
-            fkyaml::node::float_number_scalar(0.0),
-            fkyaml::node::string_scalar());
+            fkyaml::node(false),
+            fkyaml::node(0),
+            fkyaml::node(0.0),
+            fkyaml::node(std::string()));
 
         SECTION("Test non-alias non-mapping nodes.")
         {
@@ -1813,7 +1813,7 @@ TEST_CASE("NodeClassTest_ToBooleanTest", "[NodeClassTest]")
 {
     SECTION("Test nothrow expected nodes.")
     {
-        fkyaml::node node = fkyaml::node::boolean_scalar(true);
+        fkyaml::node node = true;
 
         SECTION("Test non-alias boolean node.")
         {
@@ -1851,9 +1851,9 @@ TEST_CASE("NodeClassTest_ToBooleanTest", "[NodeClassTest]")
             fkyaml::node::sequence(),
             fkyaml::node::mapping(),
             fkyaml::node(),
-            fkyaml::node::integer_scalar(0),
-            fkyaml::node::float_number_scalar(0.0),
-            fkyaml::node::string_scalar());
+            fkyaml::node(0),
+            fkyaml::node(0.0),
+            fkyaml::node(std::string()));
 
         SECTION("Test non-alias non-boolean nodes.")
         {
@@ -1887,7 +1887,7 @@ TEST_CASE("NodeClassTest_ToIntegerTest", "[NodeClassTest]")
     SECTION("Test nothrow expected nodes.")
     {
         fkyaml::node_integer_type integer = -123;
-        fkyaml::node node = fkyaml::node::integer_scalar(integer);
+        fkyaml::node node = integer;
 
         SECTION("Test non-alias  integer node.")
         {
@@ -1925,9 +1925,9 @@ TEST_CASE("NodeClassTest_ToIntegerTest", "[NodeClassTest]")
             fkyaml::node::sequence(),
             fkyaml::node::mapping(),
             fkyaml::node(),
-            fkyaml::node::boolean_scalar(false),
-            fkyaml::node::float_number_scalar(0.0),
-            fkyaml::node::string_scalar());
+            fkyaml::node(false),
+            fkyaml::node(0.0),
+            fkyaml::node(std::string()));
 
         SECTION("Test non-alias non-integer nodes.")
         {
@@ -1961,7 +1961,7 @@ TEST_CASE("NodeClassTest_ToFloatNumberTest", "[NodeClassTest]")
     SECTION("Test nothrow expected nodes.")
     {
         fkyaml::node_float_number_type float_val = 123.45;
-        fkyaml::node node = fkyaml::node::float_number_scalar(float_val);
+        fkyaml::node node = float_val;
 
         SECTION("Test non-alias float number node.")
         {
@@ -1999,9 +1999,9 @@ TEST_CASE("NodeClassTest_ToFloatNumberTest", "[NodeClassTest]")
             fkyaml::node::sequence(),
             fkyaml::node::mapping(),
             fkyaml::node(),
-            fkyaml::node::boolean_scalar(false),
-            fkyaml::node::integer_scalar(0),
-            fkyaml::node::string_scalar());
+            fkyaml::node(false),
+            fkyaml::node(0),
+            fkyaml::node(std::string()));
 
         SECTION("Test non-alias non-float-number nodes.")
         {
@@ -2035,7 +2035,7 @@ TEST_CASE("NodeClassTest_ToStringTest", "[NodeClassTest]")
     SECTION("Test nothrow expected nodes.")
     {
         fkyaml::node_string_type str = "test";
-        fkyaml::node node = fkyaml::node::string_scalar(str);
+        fkyaml::node node = str;
 
         SECTION("Test non-alias string node.")
         {
@@ -2073,9 +2073,9 @@ TEST_CASE("NodeClassTest_ToStringTest", "[NodeClassTest]")
             fkyaml::node::sequence(),
             fkyaml::node::mapping(),
             fkyaml::node(),
-            fkyaml::node::boolean_scalar(false),
-            fkyaml::node::integer_scalar(0),
-            fkyaml::node::float_number_scalar(0.0));
+            fkyaml::node(false),
+            fkyaml::node(0),
+            fkyaml::node(0.0));
 
         SECTION("Test non-alias non-string nodes.")
         {
@@ -2155,10 +2155,10 @@ TEST_CASE("NodeClassTest_BeginTest", "[NodeClassTest]")
     {
         auto node = GENERATE(
             fkyaml::node(),
-            fkyaml::node::boolean_scalar(false),
-            fkyaml::node::integer_scalar(0),
-            fkyaml::node::float_number_scalar(0.0),
-            fkyaml::node::string_scalar());
+            fkyaml::node(false),
+            fkyaml::node(0),
+            fkyaml::node(0.0),
+            fkyaml::node(std::string()));
 
         SECTION("Test non-const throwing node.")
         {
@@ -2220,10 +2220,10 @@ TEST_CASE("NodeClassTest_EndTest", "[NodeClassTest]")
     {
         auto node = GENERATE(
             fkyaml::node(),
-            fkyaml::node::boolean_scalar(false),
-            fkyaml::node::integer_scalar(0),
-            fkyaml::node::float_number_scalar(0.0),
-            fkyaml::node::string_scalar());
+            fkyaml::node(false),
+            fkyaml::node(0),
+            fkyaml::node(0.0),
+            fkyaml::node(std::string()));
 
         SECTION("Test non-const throwing node.")
         {
@@ -2244,8 +2244,8 @@ TEST_CASE("NodeClassTest_EndTest", "[NodeClassTest]")
 
 TEST_CASE("NodeClassTest_SwapTest", "[NodeClassTest]")
 {
-    fkyaml::node lhs_node = fkyaml::node::boolean_scalar(true);
-    fkyaml::node rhs_node = fkyaml::node::integer_scalar(123);
+    fkyaml::node lhs_node = true;
+    fkyaml::node rhs_node = 123;
     lhs_node.swap(rhs_node);
     REQUIRE(lhs_node.is_integer());
     REQUIRE(lhs_node.to_integer() == 123);
@@ -2255,8 +2255,8 @@ TEST_CASE("NodeClassTest_SwapTest", "[NodeClassTest]")
 
 TEST_CASE("NodeClassTest_ADLSwapTest", "[NodeClassTest]")
 {
-    fkyaml::node lhs_node = fkyaml::node::boolean_scalar(true);
-    fkyaml::node rhs_node = fkyaml::node::integer_scalar(123);
+    fkyaml::node lhs_node = true;
+    fkyaml::node rhs_node = 123;
 
     using std::swap;
     swap(lhs_node, rhs_node);

--- a/test/unit_test/test_node_class.cpp
+++ b/test/unit_test/test_node_class.cpp
@@ -1041,11 +1041,7 @@ TEST_CASE("NodeClassTest_is_scalarTest", "[NodeClassTest]")
     SECTION("Test scalar node types.")
     {
         auto node = GENERATE(
-            fkyaml::node(),
-            fkyaml::node(false),
-            fkyaml::node(0),
-            fkyaml::node(0.0),
-            fkyaml::node(std::string()));
+            fkyaml::node(), fkyaml::node(false), fkyaml::node(0), fkyaml::node(0.0), fkyaml::node(std::string()));
 
         SECTION("Test non-alias scalar node types.")
         {
@@ -1148,11 +1144,7 @@ TEST_CASE("NodeClassTest_emptyTest", "[NodeClassTest]")
 
     SECTION("Test nothrow unexpected node emptiness.")
     {
-        auto node = GENERATE(
-            fkyaml::node(),
-            fkyaml::node(false),
-            fkyaml::node(0),
-            fkyaml::node(0.0));
+        auto node = GENERATE(fkyaml::node(), fkyaml::node(false), fkyaml::node(0), fkyaml::node(0.0));
 
         SECTION("Test non-const non-alias non-container node emptiness.")
         {
@@ -1299,11 +1291,7 @@ TEST_CASE("NodeClassTest_sizeGetterTest", "[NodeClassTest]")
 
     SECTION("Test nothrow unexpected node size.")
     {
-        auto node = GENERATE(
-            fkyaml::node(),
-            fkyaml::node(false),
-            fkyaml::node(0),
-            fkyaml::node(0.0));
+        auto node = GENERATE(fkyaml::node(), fkyaml::node(false), fkyaml::node(0), fkyaml::node(0.0));
 
         SECTION("Test non-const non-alias non-container node size.")
         {
@@ -2153,11 +2141,7 @@ TEST_CASE("NodeClassTest_BeginTest", "[NodeClassTest]")
     SECTION("Test nothrow unexpected nodes.")
     {
         auto node = GENERATE(
-            fkyaml::node(),
-            fkyaml::node(false),
-            fkyaml::node(0),
-            fkyaml::node(0.0),
-            fkyaml::node(std::string()));
+            fkyaml::node(), fkyaml::node(false), fkyaml::node(0), fkyaml::node(0.0), fkyaml::node(std::string()));
 
         SECTION("Test non-const throwing node.")
         {
@@ -2218,11 +2202,7 @@ TEST_CASE("NodeClassTest_EndTest", "[NodeClassTest]")
     SECTION("Test nothrow unexpected nodes.")
     {
         auto node = GENERATE(
-            fkyaml::node(),
-            fkyaml::node(false),
-            fkyaml::node(0),
-            fkyaml::node(0.0),
-            fkyaml::node(std::string()));
+            fkyaml::node(), fkyaml::node(false), fkyaml::node(0), fkyaml::node(0.0), fkyaml::node(std::string()));
 
         SECTION("Test non-const throwing node.")
         {

--- a/test/unit_test/test_node_class.cpp
+++ b/test/unit_test/test_node_class.cpp
@@ -376,7 +376,6 @@ TEST_CASE("NodeClassTest_DeserializeTest", "[NodeClassTest]")
     fkyaml::node node = GENERATE_REF(
         fkyaml::node::deserialize("foo: bar"),
         fkyaml::node::deserialize(source),
-        fkyaml::node::deserialize(&source[0], sizeof(source)),
         fkyaml::node::deserialize(&source[0], &source[8]),
         fkyaml::node::deserialize(std::string(source)),
         fkyaml::node::deserialize(ss));

--- a/test/unit_test/test_serializer_class.cpp
+++ b/test/unit_test/test_serializer_class.cpp
@@ -17,12 +17,9 @@ TEST_CASE("SerializerClassTest_SerializeSequenceNode", "[SerializerClassTest]")
 {
     using NodeStrPair = std::pair<fkyaml::node, std::string>;
     auto node_str_pair = GENERATE(
+        NodeStrPair({true, false}, "- true\n- false\n"),
         NodeStrPair(
-            fkyaml::node::sequence({fkyaml::node::boolean_scalar(true), fkyaml::node::boolean_scalar(false)}),
-            "- true\n- false\n"),
-        NodeStrPair(
-            fkyaml::node::sequence(
-                {fkyaml::node::mapping({{"foo", fkyaml::node::integer_scalar(-1234)}, {"bar", fkyaml::node()}})}),
+            {{{std::string("foo"), -1234}, {std::string("bar"), nullptr}}},
             "-\n  bar: null\n  foo: -1234\n"));
     fkyaml::detail::basic_serializer<fkyaml::node> serializer;
     REQUIRE(serializer.serialize(node_str_pair.first) == node_str_pair.second);
@@ -33,13 +30,9 @@ TEST_CASE("SerializerClassTest_SerializeMappingNode", "[SerializerClassTest]")
     using NodeStrPair = std::pair<fkyaml::node, std::string>;
     auto node_str_pair = GENERATE(
         NodeStrPair(
-            fkyaml::node::mapping({{"foo", fkyaml::node::integer_scalar(-1234)}, {"bar", fkyaml::node()}}),
+            {{std::string("foo"), -1234}, {std::string("bar"), nullptr}},
             "bar: null\nfoo: -1234\n"),
-        NodeStrPair(
-            fkyaml::node::mapping(
-                {{"foo",
-                  fkyaml::node::sequence({fkyaml::node::boolean_scalar(true), fkyaml::node::boolean_scalar(false)})}}),
-            "foo:\n  - true\n  - false\n"));
+        NodeStrPair({{std::string("foo"), {true, false}}}, "foo:\n  - true\n  - false\n"));
     fkyaml::detail::basic_serializer<fkyaml::node> serializer;
     REQUIRE(serializer.serialize(node_str_pair.first) == node_str_pair.second);
 }
@@ -55,8 +48,8 @@ TEST_CASE("SerializerClassTest_SerializeBooleanNode", "[SerializerClassTest]")
 {
     using NodeStrPair = std::pair<fkyaml::node, std::string>;
     auto node_str_pair = GENERATE(
-        NodeStrPair(fkyaml::node::boolean_scalar(false), "false"),
-        NodeStrPair(fkyaml::node::boolean_scalar(true), "true"));
+        NodeStrPair(fkyaml::node(false), "false"),
+        NodeStrPair(fkyaml::node(true), "true"));
     fkyaml::detail::basic_serializer<fkyaml::node> serializer;
     REQUIRE(serializer.serialize(node_str_pair.first) == node_str_pair.second);
 }
@@ -65,8 +58,8 @@ TEST_CASE("SerializerClassTest_SerializeIntegerNode", "[SerializerClassTest]")
 {
     using NodeStrPair = std::pair<fkyaml::node, std::string>;
     auto node_str_pair = GENERATE(
-        NodeStrPair(fkyaml::node::integer_scalar(-1234), "-1234"),
-        NodeStrPair(fkyaml::node::integer_scalar(5678), "5678"));
+        NodeStrPair(fkyaml::node(-1234), "-1234"),
+        NodeStrPair(fkyaml::node(5678), "5678"));
     fkyaml::detail::basic_serializer<fkyaml::node> serializer;
     REQUIRE(serializer.serialize(node_str_pair.first) == node_str_pair.second);
 }
@@ -75,14 +68,14 @@ TEST_CASE("SerializeClassTest_SerializeFloatNumberNode", "[SerializeClassTest]")
 {
     using NodeStrPair = std::pair<fkyaml::node, std::string>;
     auto node_str_pair = GENERATE(
-        NodeStrPair(fkyaml::node::float_number_scalar(3.14), "3.14"),
-        NodeStrPair(fkyaml::node::float_number_scalar(-53.97), "-53.97"),
+        NodeStrPair(fkyaml::node(3.14), "3.14"),
+        NodeStrPair(fkyaml::node(-53.97), "-53.97"),
         NodeStrPair(
-            fkyaml::node::float_number_scalar(std::numeric_limits<fkyaml::node_float_number_type>::infinity()), ".inf"),
+            fkyaml::node(std::numeric_limits<fkyaml::node_float_number_type>::infinity()), ".inf"),
         NodeStrPair(
-            fkyaml::node::float_number_scalar(-1 * std::numeric_limits<fkyaml::node_float_number_type>::infinity()),
+            fkyaml::node(-1 * std::numeric_limits<fkyaml::node_float_number_type>::infinity()),
             "-.inf"),
-        NodeStrPair(fkyaml::node::float_number_scalar(std::nan("")), ".nan"));
+        NodeStrPair(fkyaml::node(std::nan("")), ".nan"));
     fkyaml::detail::basic_serializer<fkyaml::node> serializer;
     REQUIRE(serializer.serialize(node_str_pair.first) == node_str_pair.second);
 }
@@ -91,8 +84,8 @@ TEST_CASE("SerializerClassTest_SerializeStringNode", "[SerializerClassTest]")
 {
     using node_str_pair_t = std::pair<fkyaml::node, std::string>;
     auto node_str_pair = GENERATE(
-        node_str_pair_t(fkyaml::node::string_scalar("test"), "test"),
-        node_str_pair_t(fkyaml::node::string_scalar("foo bar"), "foo bar"));
+        node_str_pair_t(fkyaml::node(std::string("test")), "test"),
+        node_str_pair_t(fkyaml::node(std::string("foo bar")), "foo bar"));
 
     fkyaml::detail::basic_serializer<fkyaml::node> serializer;
     REQUIRE(serializer.serialize(node_str_pair.first) == node_str_pair.second);

--- a/test/unit_test/test_serializer_class.cpp
+++ b/test/unit_test/test_serializer_class.cpp
@@ -18,9 +18,7 @@ TEST_CASE("SerializerClassTest_SerializeSequenceNode", "[SerializerClassTest]")
     using NodeStrPair = std::pair<fkyaml::node, std::string>;
     auto node_str_pair = GENERATE(
         NodeStrPair({true, false}, "- true\n- false\n"),
-        NodeStrPair(
-            {{{std::string("foo"), -1234}, {std::string("bar"), nullptr}}},
-            "-\n  bar: null\n  foo: -1234\n"));
+        NodeStrPair({{{std::string("foo"), -1234}, {std::string("bar"), nullptr}}}, "-\n  bar: null\n  foo: -1234\n"));
     fkyaml::detail::basic_serializer<fkyaml::node> serializer;
     REQUIRE(serializer.serialize(node_str_pair.first) == node_str_pair.second);
 }
@@ -29,9 +27,7 @@ TEST_CASE("SerializerClassTest_SerializeMappingNode", "[SerializerClassTest]")
 {
     using NodeStrPair = std::pair<fkyaml::node, std::string>;
     auto node_str_pair = GENERATE(
-        NodeStrPair(
-            {{std::string("foo"), -1234}, {std::string("bar"), nullptr}},
-            "bar: null\nfoo: -1234\n"),
+        NodeStrPair({{std::string("foo"), -1234}, {std::string("bar"), nullptr}}, "bar: null\nfoo: -1234\n"),
         NodeStrPair({{std::string("foo"), {true, false}}}, "foo:\n  - true\n  - false\n"));
     fkyaml::detail::basic_serializer<fkyaml::node> serializer;
     REQUIRE(serializer.serialize(node_str_pair.first) == node_str_pair.second);
@@ -47,9 +43,7 @@ TEST_CASE("SerializerClassTest_SerializeNullNode", "[SerializerClassTest]")
 TEST_CASE("SerializerClassTest_SerializeBooleanNode", "[SerializerClassTest]")
 {
     using NodeStrPair = std::pair<fkyaml::node, std::string>;
-    auto node_str_pair = GENERATE(
-        NodeStrPair(fkyaml::node(false), "false"),
-        NodeStrPair(fkyaml::node(true), "true"));
+    auto node_str_pair = GENERATE(NodeStrPair(fkyaml::node(false), "false"), NodeStrPair(fkyaml::node(true), "true"));
     fkyaml::detail::basic_serializer<fkyaml::node> serializer;
     REQUIRE(serializer.serialize(node_str_pair.first) == node_str_pair.second);
 }
@@ -57,9 +51,7 @@ TEST_CASE("SerializerClassTest_SerializeBooleanNode", "[SerializerClassTest]")
 TEST_CASE("SerializerClassTest_SerializeIntegerNode", "[SerializerClassTest]")
 {
     using NodeStrPair = std::pair<fkyaml::node, std::string>;
-    auto node_str_pair = GENERATE(
-        NodeStrPair(fkyaml::node(-1234), "-1234"),
-        NodeStrPair(fkyaml::node(5678), "5678"));
+    auto node_str_pair = GENERATE(NodeStrPair(fkyaml::node(-1234), "-1234"), NodeStrPair(fkyaml::node(5678), "5678"));
     fkyaml::detail::basic_serializer<fkyaml::node> serializer;
     REQUIRE(serializer.serialize(node_str_pair.first) == node_str_pair.second);
 }
@@ -70,11 +62,8 @@ TEST_CASE("SerializeClassTest_SerializeFloatNumberNode", "[SerializeClassTest]")
     auto node_str_pair = GENERATE(
         NodeStrPair(fkyaml::node(3.14), "3.14"),
         NodeStrPair(fkyaml::node(-53.97), "-53.97"),
-        NodeStrPair(
-            fkyaml::node(std::numeric_limits<fkyaml::node_float_number_type>::infinity()), ".inf"),
-        NodeStrPair(
-            fkyaml::node(-1 * std::numeric_limits<fkyaml::node_float_number_type>::infinity()),
-            "-.inf"),
+        NodeStrPair(fkyaml::node(std::numeric_limits<fkyaml::node_float_number_type>::infinity()), ".inf"),
+        NodeStrPair(fkyaml::node(-1 * std::numeric_limits<fkyaml::node_float_number_type>::infinity()), "-.inf"),
         NodeStrPair(fkyaml::node(std::nan("")), ".nan"));
     fkyaml::detail::basic_serializer<fkyaml::node> serializer;
     REQUIRE(serializer.serialize(node_str_pair.first) == node_str_pair.second);


### PR DESCRIPTION
Along with developing the fkYAML library, some public APIs have become unnecessarily public.  
Taht is because more convenient APIs are introduced, such as basic_node constructor with `std::initializer_list` has covered factory methods of basic_node objects.  
Also, deserialization API overload has been removed which could possibly cause undefined behaviors.  
So, this PR has removed those APIs so that the fkYAML library will have more readable & understandable APIs.  
