### PR TITLE
#180 Generalize getter APIs for node value references

### DIFF
--- a/README.md
+++ b/README.md
@@ -176,9 +176,9 @@ assert(root["bar"].is_float_number());
 assert(root["baz"].is_boolean());
 
 // You can get references to YAML node values like the followings:
-assert(root["foo"].to_string() == "test");
-assert(root["bar"].to_float_number() == 3.14);
-assert(root["baz"].to_boolean() == true);
+assert(root["foo"].get_value_ref<std::string&>() == "test");
+assert(root["bar"].get_value_ref<double&>() == 3.14);
+assert(root["baz"].get_value_ref<bool&>() == true);
 
 // You can get values of YAML node like the followings:
 assert(root["foo"].get_value<std::string>() == "test");
@@ -285,7 +285,7 @@ void to_node(fkyaml::node& n, const CustomType& c)
 // overload from_node() with the CustomType type.
 void from_node(const fkyaml::node& n, CustomType& c)
 {
-    c.foo = n.get_value<std::string>();
+    c.foo = n.get_value_ref<const std::string&>();
     c.bar = n.get_value<bool>();
     c.baz = n.get_value<double>();
 }

--- a/include/fkYAML/detail/conversions/from_node.hpp
+++ b/include/fkYAML/detail/conversions/from_node.hpp
@@ -57,7 +57,7 @@ inline void from_node(const BasicNodeType& n, typename BasicNodeType::sequence_t
     {
         throw exception("The target node value type is not sequence type.");
     }
-    s = n.to_sequence();
+    s = n.template get_value_ref<const typename BasicNodeType::sequence_type&>();
 }
 
 /**
@@ -75,7 +75,7 @@ inline void from_node(const BasicNodeType& n, typename BasicNodeType::mapping_ty
         throw exception("The target node value type is not mapping type.");
     }
 
-    for (auto pair : n.to_mapping())
+    for (auto pair : n.template get_value_ref<const typename BasicNodeType::mapping_type&>())
     {
         m.emplace(pair.first, pair.second);
     }
@@ -113,7 +113,7 @@ inline void from_node(const BasicNodeType& n, typename BasicNodeType::boolean_ty
     {
         throw exception("The target node value type is not boolean type.");
     }
-    b = n.to_boolean();
+    b = n.template get_value_ref<const typename BasicNodeType::boolean_type&>();
 }
 
 /**
@@ -130,7 +130,7 @@ inline void from_node(const BasicNodeType& n, typename BasicNodeType::integer_ty
     {
         throw exception("The target node value type is not integer type.");
     }
-    i = n.to_integer();
+    i = n.template get_value_ref<const typename BasicNodeType::integer_type&>();
 }
 
 /**
@@ -156,12 +156,13 @@ inline void from_node(const BasicNodeType& n, IntegerType& i)
     }
 
     // under/overflow check.
-    typename BasicNodeType::integer_type tmp_int = n.to_integer();
-    if (tmp_int < static_cast<typename BasicNodeType::integer_type>(std::numeric_limits<IntegerType>::min()))
+    using node_int_type = typename BasicNodeType::integer_type;
+    node_int_type tmp_int = n.template get_value_ref<const node_int_type&>();
+    if (tmp_int < static_cast<node_int_type>(std::numeric_limits<IntegerType>::min()))
     {
         throw exception("Integer value underflow detected.");
     }
-    if (static_cast<typename BasicNodeType::integer_type>(std::numeric_limits<IntegerType>::max()) < tmp_int)
+    if (static_cast<node_int_type>(std::numeric_limits<IntegerType>::max()) < tmp_int)
     {
         throw exception("Integer value overflow detected.");
     }
@@ -183,7 +184,7 @@ inline void from_node(const BasicNodeType& n, typename BasicNodeType::float_numb
     {
         throw exception("The target node value type is not float number type.");
     }
-    f = n.to_float_number();
+    f = n.template get_value_ref<const typename BasicNodeType::float_number_type&>();
 }
 
 /**
@@ -208,7 +209,7 @@ inline void from_node(const BasicNodeType& n, FloatType& f)
         throw exception("The target node value type is not float number type.");
     }
 
-    typename BasicNodeType::float_number_type tmp_float = n.to_float_number();
+    auto tmp_float = n.template get_value_ref<const typename BasicNodeType::float_number_type&>();
     if (tmp_float < std::numeric_limits<FloatType>::min())
     {
         throw exception("Floating point value underflow detected.");
@@ -235,7 +236,7 @@ inline void from_node(const BasicNodeType& n, typename BasicNodeType::string_typ
     {
         throw exception("The target node value type is not string type.");
     }
-    s = n.to_string();
+    s = n.template get_value_ref<const typename BasicNodeType::string_type&>();
 }
 
 /**

--- a/include/fkYAML/detail/input/deserializer.hpp
+++ b/include/fkYAML/detail/input/deserializer.hpp
@@ -155,7 +155,8 @@ public:
                     }
 
                     // for the second or later mapping items in a sequence node.
-                    m_node_stack.back()->template get_value_ref<sequence_type&>().emplace_back(BasicNodeType::mapping());
+                    m_node_stack.back()->template get_value_ref<sequence_type&>().emplace_back(
+                        BasicNodeType::mapping());
                     m_current_node = &(m_node_stack.back()->template get_value_ref<sequence_type&>().back());
                     set_yaml_version(*m_current_node);
                     break;

--- a/include/fkYAML/detail/input/deserializer.hpp
+++ b/include/fkYAML/detail/input/deserializer.hpp
@@ -102,12 +102,12 @@ public:
                 {
                     // make sequence node to mapping node.
                     // TODO: This is just a workaround. Need to be refactored to fix this way.
-                    string_type tmp_str = m_current_node->operator[](0).to_string();
+                    string_type tmp_str = m_current_node->operator[](0).template get_value<string_type>();
                     m_current_node->operator[](0) = BasicNodeType::mapping();
                     m_node_stack.emplace_back(m_current_node);
                     m_current_node = &(m_current_node->operator[](0));
                     set_yaml_version(*m_current_node);
-                    m_current_node->to_mapping().emplace(tmp_str, BasicNodeType());
+                    m_current_node->template get_value_ref<mapping_type&>().emplace(tmp_str, BasicNodeType());
                     m_node_stack.emplace_back(m_current_node);
                     m_current_node = &(m_current_node->operator[](tmp_str));
                     set_yaml_version(*m_current_node);
@@ -155,8 +155,8 @@ public:
                     }
 
                     // for the second or later mapping items in a sequence node.
-                    m_node_stack.back()->to_sequence().emplace_back(BasicNodeType::mapping());
-                    m_current_node = &(m_node_stack.back()->to_sequence().back());
+                    m_node_stack.back()->template get_value_ref<sequence_type&>().emplace_back(BasicNodeType::mapping());
+                    m_current_node = &(m_node_stack.back()->template get_value_ref<sequence_type&>().back());
                     set_yaml_version(*m_current_node);
                     break;
                 }
@@ -275,9 +275,9 @@ private:
             m_indent_stack.push_back(indent);
         }
 
-        m_current_node->to_mapping().emplace(key, BasicNodeType());
+        m_current_node->template get_value_ref<mapping_type&>().emplace(key, BasicNodeType());
         m_node_stack.push_back(m_current_node);
-        m_current_node = &(m_current_node->to_mapping().at(key));
+        m_current_node = &(m_current_node->template get_value_ref<mapping_type&>().at(key));
     }
 
     /**
@@ -289,12 +289,12 @@ private:
     {
         if (m_current_node->is_sequence())
         {
-            m_current_node->to_sequence().emplace_back(std::move(node_value));
-            set_yaml_version(m_current_node->to_sequence().back());
+            m_current_node->template get_value_ref<sequence_type&>().emplace_back(std::move(node_value));
+            set_yaml_version(m_current_node->template get_value_ref<sequence_type&>().back());
             if (m_needs_anchor_impl)
             {
-                m_current_node->to_sequence().back().add_anchor_name(m_anchor_name);
-                m_anchor_table[m_anchor_name] = m_current_node->to_sequence().back();
+                m_current_node->template get_value_ref<sequence_type&>().back().add_anchor_name(m_anchor_name);
+                m_anchor_table[m_anchor_name] = m_current_node->template get_value_ref<sequence_type&>().back();
                 m_needs_anchor_impl = false;
                 m_anchor_name.clear();
             }

--- a/include/fkYAML/detail/meta/stl_supplement.hpp
+++ b/include/fkYAML/detail/meta/stl_supplement.hpp
@@ -42,6 +42,16 @@ namespace detail
 #ifndef FK_YAML_HAS_CXX_14
 
 /**
+ * @brief An alias template for std::add_pointer::type with C++11.
+ * @note std::add_pointer_t is available since C++14.
+ * @sa https://en.cppreference.com/w/cpp/types/add_pointer
+ *
+ * @tparam T A type to be added a pointer.
+ */
+template <typename T>
+using add_pointer_t = typename std::add_pointer<T>::type;
+
+/**
  * @brief An alias template for std::enable_if::type with C++11.
  * @note std::enable_if_t is available since C++14.
  * @sa https://en.cppreference.com/w/cpp/types/enable_if
@@ -72,11 +82,23 @@ using remove_cv_t = typename std::remove_cv<T>::type;
 template <typename T>
 using remove_pointer_t = typename std::remove_pointer<T>::type;
 
+/**
+ * @brief An alias template for std::remove_reference::type with C++11.
+ * @note std::remove_reference_t is available since C++14.
+ * @sa https://en.cppreference.com/w/cpp/types/remove_reference
+ *
+ * @tparam T A type from which a reference is removed.
+ */
+template <typename T>
+using remove_reference_t = typename std::remove_reference<T>::type;
+
 #else
 
+using std::add_pointer_t;
 using std::enable_if_t;
 using std::remove_cv_t;
 using std::remove_pointer_t;
+using std::remove_reference_t;
 
 #endif
 

--- a/include/fkYAML/detail/output/serializer.hpp
+++ b/include/fkYAML/detail/output/serializer.hpp
@@ -116,20 +116,19 @@ private:
             str += m_tmp_str_buff;
             break;
         case node_t::BOOLEAN:
-            to_string(m_tmp_str_buff, node.to_boolean());
+            to_string(m_tmp_str_buff, node.template get_value<typename BasicNodeType::boolean_type>());
             str += m_tmp_str_buff;
             break;
         case node_t::INTEGER:
-            to_string(m_tmp_str_buff, node.to_integer());
+            to_string(m_tmp_str_buff, node.template get_value<typename BasicNodeType::integer_type>());
             str += m_tmp_str_buff;
             break;
-        case node_t::FLOAT_NUMBER: {
-            to_string(m_tmp_str_buff, node.to_float_number());
+        case node_t::FLOAT_NUMBER:
+            to_string(m_tmp_str_buff, node.template get_value<typename BasicNodeType::float_number_type>());
             str += m_tmp_str_buff;
             break;
-        }
         case node_t::STRING:
-            str += node.to_string();
+            str += node.template get_value_ref<const typename BasicNodeType::string_type&>();
             break;
         default:                                                     // LCOV_EXCL_LINE
             throw fkyaml::exception("Unsupported node type found."); // LCOV_EXCL_LINE

--- a/include/fkYAML/node.hpp
+++ b/include/fkYAML/node.hpp
@@ -1101,24 +1101,6 @@ inline void swap(
 /// @sa https://fktn-k.github.io/fkYAML/api/basic_node/node/
 using node = basic_node<>;
 
-/// @brief A default type for sequence node values.
-using node_sequence_type = typename node::sequence_type;
-
-/// @brief A default type for mapping node values.
-using node_mapping_type = typename node::mapping_type;
-
-/// @brief A default type for boolean node values.
-using node_boolean_type = typename node::boolean_type;
-
-/// @brief A default type for integer node values.
-using node_integer_type = typename node::integer_type;
-
-/// @brief A default type for float number node values.
-using node_float_number_type = typename node::float_number_type;
-
-/// @brief A default type for string node values.
-using node_string_type = typename node::string_type;
-
 FK_YAML_NAMESPACE_END
 
 #endif /* FK_YAML_NODE_HPP_ */

--- a/include/fkYAML/node.hpp
+++ b/include/fkYAML/node.hpp
@@ -823,166 +823,21 @@ public:
         return ret;
     }
 
-    /// @brief Returns reference to sequence basic_node value from a non-const basic_node object. Throws exception if
-    /// the basic_node value is not of sequence type.
-    /// @sa https://fktn-k.github.io/fkYAML/api/basic_node/to_sequence/
-    sequence_type& to_sequence() // NOLINT(readability-make-member-function-const)
+    template <typename ReferenceType, detail::enable_if_t<std::is_reference<ReferenceType>::value, int> = 0>
+    ReferenceType get_value_ref()
     {
-        if (!is_sequence())
-        {
-            throw fkyaml::exception("The target node is not of a sequence type.");
-        }
-
-        FK_YAML_ASSERT(m_node_value.p_sequence != nullptr);
-        return *(m_node_value.p_sequence);
+        return get_value_ref_impl(static_cast<detail::add_pointer_t<ReferenceType>>(nullptr));
     }
 
-    /// @brief Returns reference to sequence basic_node value from a const basic_node object.  Throws exception if the
-    /// basic_node value is not of sequence type.
-    /// @sa https://fktn-k.github.io/fkYAML/api/basic_node/to_sequence/
-    const sequence_type& to_sequence() const
+    template <
+        typename ReferenceType,
+        detail::enable_if_t<
+            detail::conjunction<
+                std::is_reference<ReferenceType>, std::is_const<detail::remove_reference_t<ReferenceType>>>::value,
+            int> = 0>
+    ReferenceType get_value_ref() const
     {
-        if (!is_sequence())
-        {
-            throw fkyaml::exception("The target node is not of a sequence type.");
-        }
-
-        FK_YAML_ASSERT(m_node_value.p_sequence != nullptr);
-        return *(m_node_value.p_sequence);
-    }
-
-    /// @brief Returns reference to mapping basic_node value from a non-const basic_node object. Throws exception if the
-    /// basic_node value is not of mapping type.
-    /// @sa https://fktn-k.github.io/fkYAML/api/basic_node/to_mapping/
-    mapping_type& to_mapping() // NOLINT(readability-make-member-function-const)
-    {
-        if (!is_mapping())
-        {
-            throw fkyaml::exception("The target node is not of a mapping type.");
-        }
-
-        FK_YAML_ASSERT(m_node_value.p_mapping != nullptr);
-        return *(m_node_value.p_mapping);
-    }
-
-    /// @brief Returns reference to mapping basic_node value from a const basic_node object.  Throws exception if the
-    /// basic_node value is not of mapping type.
-    /// @sa https://fktn-k.github.io/fkYAML/api/basic_node/to_mapping/
-    const mapping_type& to_mapping() const
-    {
-        if (!is_mapping())
-        {
-            throw fkyaml::exception("The target node is not of a mapping type.");
-        }
-
-        FK_YAML_ASSERT(m_node_value.p_mapping != nullptr);
-        return *(m_node_value.p_mapping);
-    }
-
-    /// @brief Returns reference to boolean basic_node value from a non-const basic_node object. Throws exception if the
-    /// basic_node value is not of boolean type.
-    /// @sa https://fktn-k.github.io/fkYAML/api/basic_node/to_boolean/
-    boolean_type& to_boolean()
-    {
-        if (!is_boolean())
-        {
-            throw fkyaml::exception("The target node is not of a boolean type.");
-        }
-
-        return m_node_value.boolean;
-    }
-
-    /// @brief Returns reference to boolean basic_node value from a const basic_node object.  Throws exception if the
-    /// basic_node value is not of boolean type.
-    /// @sa https://fktn-k.github.io/fkYAML/api/basic_node/to_boolean
-    const boolean_type& to_boolean() const
-    {
-        if (!is_boolean())
-        {
-            throw fkyaml::exception("The target node is not of a boolean type.");
-        }
-
-        return m_node_value.boolean;
-    }
-
-    /// @brief Returns reference to  integer basic_node value from a non-const basic_node object. Throws exception if
-    /// the basic_node value is not of  integer type.
-    /// @sa https://fktn-k.github.io/fkYAML/api/basic_node/to_integer/
-    integer_type& to_integer()
-    {
-        if (!is_integer())
-        {
-            throw fkyaml::exception("The target node is not of integer type.");
-        }
-
-        return m_node_value.integer;
-    }
-
-    /// @brief Returns reference to  integer basic_node value from a const basic_node object. Throws exception if the
-    /// basic_node value is not of  integer type.
-    /// @sa https://fktn-k.github.io/fkYAML/api/basic_node/to_integer/
-    const integer_type& to_integer() const
-    {
-        if (!is_integer())
-        {
-            throw fkyaml::exception("The target node is not of integer type.");
-        }
-
-        return m_node_value.integer;
-    }
-
-    /// @brief Returns reference to float number basic_node value from a non-const basic_node object. Throws exception
-    /// if the basic_node value is not of float number type.
-    /// @sa https://fktn-k.github.io/fkYAML/api/basic_node/to_float_number/
-    float_number_type& to_float_number()
-    {
-        if (!is_float_number())
-        {
-            throw fkyaml::exception("The target node is not of a float number type.");
-        }
-
-        return m_node_value.float_val;
-    }
-
-    /// @brief Returns reference to float number basic_node value from a const basic_node object. Throws exception if
-    /// the basic_node value is not of float number type.
-    /// @sa https://fktn-k.github.io/fkYAML/api/basic_node/to_float_number/
-    const float_number_type& to_float_number() const
-    {
-        if (!is_float_number())
-        {
-            throw fkyaml::exception("The target node is not of a float number type.");
-        }
-
-        return m_node_value.float_val;
-    }
-
-    /// @brief Returns reference to string basic_node value from a non-const basic_node object. Throws exception if the
-    /// basic_node value is not of string type.
-    /// @sa https://fktn-k.github.io/fkYAML/api/basic_node/to_string/
-    string_type& to_string() // NOLINT(readability-make-member-function-const)
-    {
-        if (!is_string())
-        {
-            throw fkyaml::exception("The target node is not of a string type.");
-        }
-
-        FK_YAML_ASSERT(m_node_value.p_string != nullptr);
-        return *(m_node_value.p_string);
-    }
-
-    /// @brief Returns reference to string basic_node value from a const basic_node object. Throws exception if the
-    /// basic_node value is not of string type.
-    /// @sa https://fktn-k.github.io/fkYAML/api/basic_node/to_string/
-    const string_type& to_string() const
-    {
-        if (!is_string())
-        {
-            throw fkyaml::exception("The target node is not of a string type.");
-        }
-
-        FK_YAML_ASSERT(m_node_value.p_string != nullptr);
-        return *(m_node_value.p_string);
+        return get_value_ref_impl(static_cast<detail::add_pointer_t<ReferenceType>>(nullptr));
     }
 
     /// @brief Swaps data with the specified basic_node object.
@@ -1074,6 +929,150 @@ public:
     }
 
 private:
+    /// @brief Returns reference to the sequence node value.
+    /// @throw fkyaml::exception The node value is not a sequence.
+    /// @return Reference to the sequence node value.
+    sequence_type& get_value_ref_impl(sequence_type* /*unused*/)
+    {
+        if (!is_sequence())
+        {
+            throw fkyaml::exception("The node value is not a sequence.");
+        }
+        return *(m_node_value.p_sequence);
+    }
+
+    /// @brief Returns constant reference to the sequence node value.
+    /// @throw fkyaml::exception The node value is not a sequence.
+    /// @return Constant reference to the sequence node value.
+    constexpr const sequence_type& get_value_ref_impl(const sequence_type* /*unused*/) const
+    {
+        if (!is_sequence())
+        {
+            throw fkyaml::exception("The node value is not a sequence.");
+        }
+        return *(m_node_value.p_sequence);
+    }
+
+    /// @brief Returns reference to the mapping node value.
+    /// @throw fkyaml::exception The node value is not a mapping.
+    /// @return Reference to the mapping node value.
+    mapping_type& get_value_ref_impl(mapping_type* /*unused*/)
+    {
+        if (!is_mapping())
+        {
+            throw fkyaml::exception("The node value is not a mapping.");
+        }
+        return *(m_node_value.p_mapping);
+    }
+
+    /// @brief Returns constant reference to the mapping node value.
+    /// @throw fkyaml::exception The node value is not a mapping.
+    /// @return Constant reference to the mapping node value.
+    constexpr const mapping_type& get_value_ref_impl(const mapping_type* /*unused*/) const
+    {
+        if (!is_mapping())
+        {
+            throw fkyaml::exception("The node value is not a mapping.");
+        }
+        return *(m_node_value.p_mapping);
+    }
+
+    /// @brief Returns reference to the boolean node value.
+    /// @throw fkyaml::exception The node value is not a boolean.
+    /// @return Reference to the boolean node value.
+    boolean_type& get_value_ref_impl(boolean_type* /*unused*/)
+    {
+        if (!is_boolean())
+        {
+            throw fkyaml::exception("The node value is not a boolean.");
+        }
+        return m_node_value.boolean;
+    }
+
+    /// @brief Returns reference to the boolean node value.
+    /// @throw fkyaml::exception The node value is not a boolean.
+    /// @return Reference to the boolean node value.
+    constexpr const boolean_type& get_value_ref_impl(const boolean_type* /*unused*/) const
+    {
+        if (!is_boolean())
+        {
+            throw fkyaml::exception("The node value is not a boolean.");
+        }
+        return m_node_value.boolean;
+    }
+
+    /// @brief Returns reference to the integer node value.
+    /// @throw fkyaml::exception The node value is not an integer.
+    /// @return Reference to the integer node value.
+    integer_type& get_value_ref_impl(integer_type* /*unused*/)
+    {
+        if (!is_integer())
+        {
+            throw fkyaml::exception("The node value is not an integer.");
+        }
+        return m_node_value.integer;
+    }
+
+    /// @brief Returns reference to the integer node value.
+    /// @throw fkyaml::exception The node value is not an integer.
+    /// @return Reference to the integer node value.
+    constexpr const integer_type& get_value_ref_impl(const integer_type* /*unused*/) const
+    {
+        if (!is_integer())
+        {
+            throw fkyaml::exception("The node value is not an integer.");
+        }
+        return m_node_value.integer;
+    }
+
+    /// @brief Returns reference to the floating point number node value.
+    /// @throw fkyaml::exception The node value is not a floating point number.
+    /// @return Reference to the floating point number node value.
+    float_number_type& get_value_ref_impl(float_number_type* /*unused*/)
+    {
+        if (!is_float_number())
+        {
+            throw fkyaml::exception("The node value is not a floating point number.");
+        }
+        return m_node_value.float_val;
+    }
+
+    /// @brief Returns reference to the floating point number node value.
+    /// @throw fkyaml::exception The node value is not a floating point number.
+    /// @return Reference to the floating point number node value.
+    constexpr const float_number_type& get_value_ref_impl(const float_number_type* /*unused*/) const
+    {
+        if (!is_float_number())
+        {
+            throw fkyaml::exception("The node value is not a floating point number.");
+        }
+        return m_node_value.float_val;
+    }
+
+    /// @brief Returns reference to the string node value.
+    /// @throw fkyaml::exception The node value is not a string.
+    /// @return Reference to the string node value.
+    string_type& get_value_ref_impl(string_type* /*unused*/)
+    {
+        if (!is_string())
+        {
+            throw fkyaml::exception("The node value is not a string.");
+        }
+        return *(m_node_value.p_string);
+    }
+
+    /// @brief Returns reference to the string node value.
+    /// @throw fkyaml::exception The node value is not a string.
+    /// @return Reference to the string node value.
+    constexpr const string_type& get_value_ref_impl(const string_type* /*unused*/) const
+    {
+        if (!is_string())
+        {
+            throw fkyaml::exception("The node value is not a string.");
+        }
+        return *(m_node_value.p_string);
+    }
+
     /// The current node value type.
     node_t m_node_type {node_t::NULL_OBJECT};
     /// The YAML version specification.

--- a/test/unit_test/test_deserializer_class.cpp
+++ b/test/unit_test/test_deserializer_class.cpp
@@ -79,7 +79,7 @@ TEST_CASE("DeserializerClassTest_DeserializeNumericKey", "[DeserializerClassTest
     REQUIRE(root.is_mapping());
     REQUIRE(root.size() == 1);
     REQUIRE(root.contains(str_val_pair.second));
-    REQUIRE(root[str_val_pair.second].to_string() == "foo");
+    REQUIRE(root[str_val_pair.second].get_value_ref<fkyaml::node::string_type&>() == "foo");
 }
 
 TEST_CASE("DeserializerClassTest_DeserializeInvalidIndentation", "[DeserializerClassTest]")
@@ -116,16 +116,16 @@ TEST_CASE("DeserializerClassTest_DeserializeBlockSequenceTest", "[DeserializerCl
         REQUIRE(test_0_node.is_string());
         REQUIRE_NOTHROW(test_0_node.size());
         REQUIRE(test_0_node.size() == 3);
-        REQUIRE_NOTHROW(test_0_node.to_string());
-        REQUIRE(test_0_node.to_string().compare("foo") == 0);
+        REQUIRE_NOTHROW(test_0_node.get_value_ref<fkyaml::node::string_type&>());
+        REQUIRE(test_0_node.get_value_ref<fkyaml::node::string_type&>().compare("foo") == 0);
 
         REQUIRE_NOTHROW(test_node[1]);
         fkyaml::node& test_1_node = test_node[1];
         REQUIRE(test_1_node.is_string());
         REQUIRE_NOTHROW(test_1_node.size());
         REQUIRE(test_1_node.size() == 3);
-        REQUIRE_NOTHROW(test_1_node.to_string());
-        REQUIRE(test_1_node.to_string().compare("bar") == 0);
+        REQUIRE_NOTHROW(test_1_node.get_value_ref<fkyaml::node::string_type&>());
+        REQUIRE(test_1_node.get_value_ref<fkyaml::node::string_type&>().compare("bar") == 0);
     }
 
     SECTION("Input source No.2.")
@@ -153,14 +153,14 @@ TEST_CASE("DeserializerClassTest_DeserializeBlockSequenceTest", "[DeserializerCl
         REQUIRE_NOTHROW(test_0_node["foo"]);
         fkyaml::node& test_0_foo_node = test_0_node["foo"];
         REQUIRE(test_0_foo_node.is_boolean());
-        REQUIRE_NOTHROW(test_0_foo_node.to_boolean());
-        REQUIRE(test_0_foo_node.to_boolean() == true);
+        REQUIRE_NOTHROW(test_0_foo_node.get_value<fkyaml::node::boolean_type>());
+        REQUIRE(test_0_foo_node.get_value<fkyaml::node::boolean_type>() == true);
 
         REQUIRE_NOTHROW(test_0_node["bar"]);
         fkyaml::node& test_0_bar_node = test_0_node["bar"];
         REQUIRE(test_0_bar_node.is_string());
-        REQUIRE_NOTHROW(test_0_bar_node.to_string());
-        REQUIRE(test_0_bar_node.to_string().compare("one") == 0);
+        REQUIRE_NOTHROW(test_0_bar_node.get_value_ref<fkyaml::node::string_type&>());
+        REQUIRE(test_0_bar_node.get_value_ref<fkyaml::node::string_type&>().compare("one") == 0);
 
         REQUIRE_NOTHROW(test_node[1]);
         fkyaml::node& test_1_node = test_node[1];
@@ -171,14 +171,14 @@ TEST_CASE("DeserializerClassTest_DeserializeBlockSequenceTest", "[DeserializerCl
         REQUIRE_NOTHROW(test_1_node["foo"]);
         fkyaml::node& test_1_foo_node = test_1_node["foo"];
         REQUIRE(test_1_foo_node.is_boolean());
-        REQUIRE_NOTHROW(test_1_foo_node.to_boolean());
-        REQUIRE(test_1_foo_node.to_boolean() == false);
+        REQUIRE_NOTHROW(test_1_foo_node.get_value<fkyaml::node::boolean_type>());
+        REQUIRE(test_1_foo_node.get_value<fkyaml::node::boolean_type>() == false);
 
         REQUIRE_NOTHROW(test_1_node["bar"]);
         fkyaml::node& test_1_bar_node = test_1_node["bar"];
         REQUIRE(test_1_bar_node.is_string());
-        REQUIRE_NOTHROW(test_1_bar_node.to_string());
-        REQUIRE(test_1_bar_node.to_string().compare("two") == 0);
+        REQUIRE_NOTHROW(test_1_bar_node.get_value_ref<fkyaml::node::string_type&>());
+        REQUIRE(test_1_bar_node.get_value_ref<fkyaml::node::string_type&>().compare("two") == 0);
     }
 
     SECTION("Input source No.3.")
@@ -201,14 +201,14 @@ TEST_CASE("DeserializerClassTest_DeserializeBlockSequenceTest", "[DeserializerCl
         REQUIRE(test_0_node.has_anchor_name());
         REQUIRE(test_0_node.get_anchor_name().compare("anchor") == 0);
         REQUIRE(test_0_node.is_boolean());
-        REQUIRE_NOTHROW(test_0_node.to_boolean());
-        REQUIRE(test_0_node.to_boolean() == true);
+        REQUIRE_NOTHROW(test_0_node.get_value<fkyaml::node::boolean_type>());
+        REQUIRE(test_0_node.get_value<fkyaml::node::boolean_type>() == true);
 
         REQUIRE_NOTHROW(test_node[1]);
         fkyaml::node& test_1_node = test_node[1];
         REQUIRE(test_1_node.is_boolean());
-        REQUIRE_NOTHROW(test_1_node.to_boolean());
-        REQUIRE(test_1_node.to_boolean() == test_0_node.to_boolean());
+        REQUIRE_NOTHROW(test_1_node.get_value<fkyaml::node::boolean_type>());
+        REQUIRE(test_1_node.get_value<fkyaml::node::boolean_type>() == test_0_node.get_value<fkyaml::node::boolean_type>());
     }
 
     SECTION("Input source No.4.")
@@ -231,14 +231,14 @@ TEST_CASE("DeserializerClassTest_DeserializeBlockSequenceTest", "[DeserializerCl
         REQUIRE(test_0_node.has_anchor_name());
         REQUIRE(test_0_node.get_anchor_name().compare("anchor") == 0);
         REQUIRE(test_0_node.is_integer());
-        REQUIRE_NOTHROW(test_0_node.to_integer());
-        REQUIRE(test_0_node.to_integer() == -123);
+        REQUIRE_NOTHROW(test_0_node.get_value<fkyaml::node::integer_type>());
+        REQUIRE(test_0_node.get_value<fkyaml::node::integer_type>() == -123);
 
         REQUIRE_NOTHROW(test_node[1]);
         fkyaml::node& test_1_node = test_node[1];
         REQUIRE(test_1_node.is_integer());
-        REQUIRE_NOTHROW(test_1_node.to_integer());
-        REQUIRE(test_1_node.to_integer() == test_0_node.to_integer());
+        REQUIRE_NOTHROW(test_1_node.get_value<fkyaml::node::integer_type>());
+        REQUIRE(test_1_node.get_value<fkyaml::node::integer_type>() == test_0_node.get_value<fkyaml::node::integer_type>());
     }
 
     SECTION("Input source No.5.")
@@ -261,14 +261,14 @@ TEST_CASE("DeserializerClassTest_DeserializeBlockSequenceTest", "[DeserializerCl
         REQUIRE(test_0_node.has_anchor_name());
         REQUIRE(test_0_node.get_anchor_name().compare("anchor") == 0);
         REQUIRE(test_0_node.is_integer());
-        REQUIRE_NOTHROW(test_0_node.to_integer());
-        REQUIRE(test_0_node.to_integer() == 567);
+        REQUIRE_NOTHROW(test_0_node.get_value<fkyaml::node::integer_type>());
+        REQUIRE(test_0_node.get_value<fkyaml::node::integer_type>() == 567);
 
         REQUIRE_NOTHROW(test_node[1]);
         fkyaml::node& test_1_node = test_node[1];
         REQUIRE(test_1_node.is_integer());
-        REQUIRE_NOTHROW(test_1_node.to_integer());
-        REQUIRE(test_1_node.to_integer() == test_0_node.to_integer());
+        REQUIRE_NOTHROW(test_1_node.get_value<fkyaml::node::integer_type>());
+        REQUIRE(test_1_node.get_value<fkyaml::node::integer_type>() == test_0_node.get_value<fkyaml::node::integer_type>());
     }
 
     SECTION("Input source No.6.")
@@ -291,14 +291,14 @@ TEST_CASE("DeserializerClassTest_DeserializeBlockSequenceTest", "[DeserializerCl
         REQUIRE(test_0_node.has_anchor_name());
         REQUIRE(test_0_node.get_anchor_name().compare("anchor") == 0);
         REQUIRE(test_0_node.is_float_number());
-        REQUIRE_NOTHROW(test_0_node.to_float_number());
-        REQUIRE(test_0_node.to_float_number() == 3.14);
+        REQUIRE_NOTHROW(test_0_node.get_value<fkyaml::node::float_number_type>());
+        REQUIRE(test_0_node.get_value<fkyaml::node::float_number_type>() == 3.14);
 
         REQUIRE_NOTHROW(test_node[1]);
         fkyaml::node& test_1_node = test_node[1];
         REQUIRE(test_1_node.is_float_number());
-        REQUIRE_NOTHROW(test_1_node.to_float_number());
-        REQUIRE(test_1_node.to_float_number() == test_0_node.to_float_number());
+        REQUIRE_NOTHROW(test_1_node.get_value<fkyaml::node::float_number_type>());
+        REQUIRE(test_1_node.get_value<fkyaml::node::float_number_type>() == test_0_node.get_value<fkyaml::node::float_number_type>());
     }
 
     SECTION("Input source No.7.")
@@ -323,16 +323,16 @@ TEST_CASE("DeserializerClassTest_DeserializeBlockSequenceTest", "[DeserializerCl
         REQUIRE(test_0_node.is_string());
         REQUIRE_NOTHROW(test_0_node.size());
         REQUIRE(test_0_node.size() == 3);
-        REQUIRE_NOTHROW(test_0_node.to_string());
-        REQUIRE(test_0_node.to_string().compare("foo") == 0);
+        REQUIRE_NOTHROW(test_0_node.get_value_ref<fkyaml::node::string_type&>());
+        REQUIRE(test_0_node.get_value_ref<fkyaml::node::string_type&>().compare("foo") == 0);
 
         REQUIRE_NOTHROW(test_node[1]);
         fkyaml::node& test_1_node = test_node[1];
         REQUIRE(test_1_node.is_string());
         REQUIRE_NOTHROW(test_1_node.size());
         REQUIRE(test_1_node.size() == 3);
-        REQUIRE_NOTHROW(test_1_node.to_string());
-        REQUIRE(test_1_node.to_string().compare("foo") == 0);
+        REQUIRE_NOTHROW(test_1_node.get_value_ref<fkyaml::node::string_type&>());
+        REQUIRE(test_1_node.get_value_ref<fkyaml::node::string_type&>().compare("foo") == 0);
     }
 }
 
@@ -352,20 +352,20 @@ TEST_CASE("DeserializerClassTest_DeserializeBlockMappingTest", "[DeserializerCla
         REQUIRE_NOTHROW(root["foo"]);
         fkyaml::node& foo_node = root["foo"];
         REQUIRE(foo_node.is_string());
-        REQUIRE_NOTHROW(foo_node.to_string());
-        REQUIRE(foo_node.to_string().compare("one") == 0);
+        REQUIRE_NOTHROW(foo_node.get_value_ref<fkyaml::node::string_type&>());
+        REQUIRE(foo_node.get_value_ref<fkyaml::node::string_type&>().compare("one") == 0);
 
         REQUIRE_NOTHROW(root["bar"]);
         fkyaml::node& bar_node = root["bar"];
         REQUIRE(bar_node.is_boolean());
-        REQUIRE_NOTHROW(bar_node.to_boolean());
-        REQUIRE(bar_node.to_boolean() == true);
+        REQUIRE_NOTHROW(bar_node.get_value<fkyaml::node::boolean_type>());
+        REQUIRE(bar_node.get_value<fkyaml::node::boolean_type>() == true);
 
         REQUIRE_NOTHROW(root["pi"]);
         fkyaml::node& pi_node = root["pi"];
         REQUIRE(pi_node.is_float_number());
-        REQUIRE_NOTHROW(pi_node.to_float_number());
-        REQUIRE(pi_node.to_float_number() == 3.14);
+        REQUIRE_NOTHROW(pi_node.get_value<fkyaml::node::float_number_type>());
+        REQUIRE(pi_node.get_value<fkyaml::node::float_number_type>() == 3.14);
     }
 
     SECTION("Input source No.2.")
@@ -387,20 +387,20 @@ TEST_CASE("DeserializerClassTest_DeserializeBlockMappingTest", "[DeserializerCla
         REQUIRE_NOTHROW(test_node["bool"]);
         fkyaml::node& test_bool_node = test_node["bool"];
         REQUIRE(test_bool_node.is_boolean());
-        REQUIRE_NOTHROW(test_bool_node.to_boolean());
-        REQUIRE(test_bool_node.to_boolean() == true);
+        REQUIRE_NOTHROW(test_bool_node.get_value<fkyaml::node::boolean_type>());
+        REQUIRE(test_bool_node.get_value<fkyaml::node::boolean_type>() == true);
 
         REQUIRE_NOTHROW(test_node["foo"]);
         fkyaml::node& test_foo_node = test_node["foo"];
         REQUIRE(test_foo_node.is_string());
-        REQUIRE_NOTHROW(test_foo_node.to_string());
-        REQUIRE(test_foo_node.to_string().compare("bar") == 0);
+        REQUIRE_NOTHROW(test_foo_node.get_value_ref<fkyaml::node::string_type&>());
+        REQUIRE(test_foo_node.get_value_ref<fkyaml::node::string_type&>().compare("bar") == 0);
 
         REQUIRE_NOTHROW(test_node["pi"]);
         fkyaml::node& test_pi_node = test_node["pi"];
         REQUIRE(test_pi_node.is_float_number());
-        REQUIRE_NOTHROW(test_pi_node.to_float_number());
-        REQUIRE(test_pi_node.to_float_number() == 3.14);
+        REQUIRE_NOTHROW(test_pi_node.get_value<fkyaml::node::float_number_type>());
+        REQUIRE(test_pi_node.get_value<fkyaml::node::float_number_type>() == 3.14);
     }
 
     SECTION("Input source No.3.")
@@ -416,14 +416,14 @@ TEST_CASE("DeserializerClassTest_DeserializeBlockMappingTest", "[DeserializerCla
         REQUIRE(foo_node.has_anchor_name());
         REQUIRE(foo_node.get_anchor_name().compare("anchor") == 0);
         REQUIRE(foo_node.is_boolean());
-        REQUIRE_NOTHROW(foo_node.to_boolean());
-        REQUIRE(foo_node.to_boolean() == true);
+        REQUIRE_NOTHROW(foo_node.get_value<fkyaml::node::boolean_type>());
+        REQUIRE(foo_node.get_value<fkyaml::node::boolean_type>() == true);
 
         REQUIRE_NOTHROW(root["bar"]);
         fkyaml::node& bar_node = root["bar"];
         REQUIRE(bar_node.is_boolean());
-        REQUIRE_NOTHROW(bar_node.to_boolean());
-        REQUIRE(bar_node.to_boolean() == foo_node.to_boolean());
+        REQUIRE_NOTHROW(bar_node.get_value<fkyaml::node::boolean_type>());
+        REQUIRE(bar_node.get_value<fkyaml::node::boolean_type>() == foo_node.get_value<fkyaml::node::boolean_type>());
     }
 
     SECTION("Input source No.4.")
@@ -439,14 +439,14 @@ TEST_CASE("DeserializerClassTest_DeserializeBlockMappingTest", "[DeserializerCla
         REQUIRE(foo_node.has_anchor_name());
         REQUIRE(foo_node.get_anchor_name().compare("anchor") == 0);
         REQUIRE(foo_node.is_integer());
-        REQUIRE_NOTHROW(foo_node.to_integer());
-        REQUIRE(foo_node.to_integer() == -123);
+        REQUIRE_NOTHROW(foo_node.get_value<fkyaml::node::integer_type>());
+        REQUIRE(foo_node.get_value<fkyaml::node::integer_type>() == -123);
 
         REQUIRE_NOTHROW(root["bar"]);
         fkyaml::node& bar_node = root["bar"];
         REQUIRE(bar_node.is_integer());
-        REQUIRE_NOTHROW(bar_node.to_integer());
-        REQUIRE(bar_node.to_integer() == foo_node.to_integer());
+        REQUIRE_NOTHROW(bar_node.get_value<fkyaml::node::integer_type>());
+        REQUIRE(bar_node.get_value<fkyaml::node::integer_type>() == foo_node.get_value<fkyaml::node::integer_type>());
     }
 
     SECTION("Input source No.5.")
@@ -462,14 +462,14 @@ TEST_CASE("DeserializerClassTest_DeserializeBlockMappingTest", "[DeserializerCla
         REQUIRE(foo_node.has_anchor_name());
         REQUIRE(foo_node.get_anchor_name().compare("anchor") == 0);
         REQUIRE(foo_node.is_integer());
-        REQUIRE_NOTHROW(foo_node.to_integer());
-        REQUIRE(foo_node.to_integer() == 567);
+        REQUIRE_NOTHROW(foo_node.get_value<fkyaml::node::integer_type>());
+        REQUIRE(foo_node.get_value<fkyaml::node::integer_type>() == 567);
 
         REQUIRE_NOTHROW(root["bar"]);
         fkyaml::node& bar_node = root["bar"];
         REQUIRE(bar_node.is_integer());
-        REQUIRE_NOTHROW(bar_node.to_integer());
-        REQUIRE(bar_node.to_integer() == foo_node.to_integer());
+        REQUIRE_NOTHROW(bar_node.get_value<fkyaml::node::integer_type>());
+        REQUIRE(bar_node.get_value<fkyaml::node::integer_type>() == foo_node.get_value<fkyaml::node::integer_type>());
     }
 
     SECTION("Input source No.6.")
@@ -485,14 +485,14 @@ TEST_CASE("DeserializerClassTest_DeserializeBlockMappingTest", "[DeserializerCla
         REQUIRE(foo_node.has_anchor_name());
         REQUIRE(foo_node.get_anchor_name().compare("anchor") == 0);
         REQUIRE(foo_node.is_float_number());
-        REQUIRE_NOTHROW(foo_node.to_float_number());
-        REQUIRE(foo_node.to_float_number() == 3.14);
+        REQUIRE_NOTHROW(foo_node.get_value<fkyaml::node::float_number_type>());
+        REQUIRE(foo_node.get_value<fkyaml::node::float_number_type>() == 3.14);
 
         REQUIRE_NOTHROW(root["bar"]);
         fkyaml::node& bar_node = root["bar"];
         REQUIRE(bar_node.is_float_number());
-        REQUIRE_NOTHROW(bar_node.to_float_number());
-        REQUIRE(bar_node.to_float_number() == foo_node.to_float_number());
+        REQUIRE_NOTHROW(bar_node.get_value<fkyaml::node::float_number_type>());
+        REQUIRE(bar_node.get_value<fkyaml::node::float_number_type>() == foo_node.get_value<fkyaml::node::float_number_type>());
     }
 
     SECTION("Input source No.7.")
@@ -508,14 +508,14 @@ TEST_CASE("DeserializerClassTest_DeserializeBlockMappingTest", "[DeserializerCla
         REQUIRE(foo_node.has_anchor_name());
         REQUIRE(foo_node.get_anchor_name().compare("anchor") == 0);
         REQUIRE(foo_node.is_string());
-        REQUIRE_NOTHROW(foo_node.to_string());
-        REQUIRE(foo_node.to_string().compare("one") == 0);
+        REQUIRE_NOTHROW(foo_node.get_value_ref<fkyaml::node::string_type&>());
+        REQUIRE(foo_node.get_value_ref<fkyaml::node::string_type&>().compare("one") == 0);
 
         REQUIRE_NOTHROW(root["bar"]);
         fkyaml::node& bar_node = root["bar"];
         REQUIRE(bar_node.is_string());
-        REQUIRE_NOTHROW(bar_node.to_string());
-        REQUIRE(bar_node.to_string() == foo_node.to_string());
+        REQUIRE_NOTHROW(bar_node.get_value_ref<fkyaml::node::string_type&>());
+        REQUIRE(bar_node.get_value_ref<fkyaml::node::string_type&>() == foo_node.get_value_ref<fkyaml::node::string_type&>());
     }
 
     SECTION("Input source No.8.")
@@ -532,18 +532,18 @@ TEST_CASE("DeserializerClassTest_DeserializeBlockMappingTest", "[DeserializerCla
         REQUIRE(root["foo"].size() == 1);
         REQUIRE(root["foo"].contains("bar"));
         REQUIRE(root["foo"]["bar"].is_string());
-        REQUIRE(root["foo"]["bar"].to_string() == "baz");
+        REQUIRE(root["foo"]["bar"].get_value_ref<fkyaml::node::string_type&>() == "baz");
 
         REQUIRE(root.contains("qux"));
         REQUIRE(root["qux"].is_integer());
-        REQUIRE(root["qux"].to_integer() == 123);
+        REQUIRE(root["qux"].get_value<fkyaml::node::integer_type>() == 123);
 
         REQUIRE(root.contains("quux"));
         REQUIRE(root["quux"].is_mapping());
         REQUIRE(root["quux"].size() == 1);
         REQUIRE(root["quux"].contains("corge"));
         REQUIRE(root["quux"]["corge"].is_string());
-        REQUIRE(root["quux"]["corge"].to_string() == "grault");
+        REQUIRE(root["quux"]["corge"].get_value_ref<fkyaml::node::string_type&>() == "grault");
     }
 
     SECTION("Input source No.9.")
@@ -564,11 +564,11 @@ TEST_CASE("DeserializerClassTest_DeserializeBlockMappingTest", "[DeserializerCla
 
         REQUIRE(root["foo"]["bar"].contains("baz"));
         REQUIRE(root["foo"]["bar"]["baz"].is_integer());
-        REQUIRE(root["foo"]["bar"]["baz"].to_integer() == 123);
+        REQUIRE(root["foo"]["bar"]["baz"].get_value<fkyaml::node::integer_type>() == 123);
 
         REQUIRE(root.contains("qux"));
         REQUIRE(root["qux"].is_boolean());
-        REQUIRE(root["qux"].to_boolean() == true);
+        REQUIRE(root["qux"].get_value<fkyaml::node::boolean_type>() == true);
     }
 }
 
@@ -594,14 +594,14 @@ TEST_CASE("DeserializerClassTest_DeserializeFlowSequenceTest", "[DeserializerCla
         REQUIRE_NOTHROW(test_node[0]);
         fkyaml::node& test_0_node = test_node[0];
         REQUIRE(test_0_node.is_string());
-        REQUIRE_NOTHROW(test_0_node.to_string());
-        REQUIRE(test_0_node.to_string().compare("foo") == 0);
+        REQUIRE_NOTHROW(test_0_node.get_value_ref<fkyaml::node::string_type&>());
+        REQUIRE(test_0_node.get_value_ref<fkyaml::node::string_type&>().compare("foo") == 0);
 
         REQUIRE_NOTHROW(test_node[1]);
         fkyaml::node& test_1_node = test_node[1];
         REQUIRE(test_1_node.is_string());
-        REQUIRE_NOTHROW(test_1_node.to_string());
-        REQUIRE(test_1_node.to_string().compare("bar") == 0);
+        REQUIRE_NOTHROW(test_1_node.get_value_ref<fkyaml::node::string_type&>());
+        REQUIRE(test_1_node.get_value_ref<fkyaml::node::string_type&>().compare("bar") == 0);
     }
 }
 
@@ -628,20 +628,20 @@ TEST_CASE("DeserializerClassTest_DeserializeFlowMappingTest", "[DeserializerClas
         REQUIRE_NOTHROW(test_node["bool"]);
         fkyaml::node& test_bool_node = test_node["bool"];
         REQUIRE(test_bool_node.is_boolean());
-        REQUIRE_NOTHROW(test_bool_node.to_boolean());
-        REQUIRE(test_bool_node.to_boolean() == true);
+        REQUIRE_NOTHROW(test_bool_node.get_value<fkyaml::node::boolean_type>());
+        REQUIRE(test_bool_node.get_value<fkyaml::node::boolean_type>() == true);
 
         REQUIRE_NOTHROW(test_node["foo"]);
         fkyaml::node& test_foo_node = test_node["foo"];
         REQUIRE(test_foo_node.is_string());
-        REQUIRE_NOTHROW(test_foo_node.to_string());
-        REQUIRE(test_foo_node.to_string().compare("bar") == 0);
+        REQUIRE_NOTHROW(test_foo_node.get_value_ref<fkyaml::node::string_type&>());
+        REQUIRE(test_foo_node.get_value_ref<fkyaml::node::string_type&>().compare("bar") == 0);
 
         REQUIRE_NOTHROW(test_node["pi"]);
         fkyaml::node& test_pi_node = test_node["pi"];
         REQUIRE(test_pi_node.is_float_number());
-        REQUIRE_NOTHROW(test_pi_node.to_float_number());
-        REQUIRE(test_pi_node.to_float_number() == 3.14);
+        REQUIRE_NOTHROW(test_pi_node.get_value<fkyaml::node::float_number_type>());
+        REQUIRE(test_pi_node.get_value<fkyaml::node::float_number_type>() == 3.14);
     }
 
     SECTION("Input source No.2. (invalid)")
@@ -664,20 +664,20 @@ TEST_CASE("DeserializerClassTest_DeserializeInputWithCommentTest", "[Deserialize
     REQUIRE_NOTHROW(root["foo"]);
     fkyaml::node& foo_node = root["foo"];
     REQUIRE(foo_node.is_string());
-    REQUIRE_NOTHROW(foo_node.to_string());
-    REQUIRE(foo_node.to_string().compare("one") == 0);
+    REQUIRE_NOTHROW(foo_node.get_value_ref<fkyaml::node::string_type&>());
+    REQUIRE(foo_node.get_value_ref<fkyaml::node::string_type&>().compare("one") == 0);
 
     REQUIRE_NOTHROW(root["bar"]);
     fkyaml::node& bar_node = root["bar"];
     REQUIRE(bar_node.is_boolean());
-    REQUIRE_NOTHROW(bar_node.to_boolean());
-    REQUIRE(bar_node.to_boolean() == true);
+    REQUIRE_NOTHROW(bar_node.get_value<fkyaml::node::boolean_type>());
+    REQUIRE(bar_node.get_value<fkyaml::node::boolean_type>() == true);
 
     REQUIRE_NOTHROW(root["pi"]);
     fkyaml::node& pi_node = root["pi"];
     REQUIRE(pi_node.is_float_number());
-    REQUIRE_NOTHROW(pi_node.to_float_number());
-    REQUIRE(pi_node.to_float_number() == 3.14);
+    REQUIRE_NOTHROW(pi_node.get_value<fkyaml::node::float_number_type>());
+    REQUIRE(pi_node.get_value<fkyaml::node::float_number_type>() == 3.14);
 }
 
 TEST_CASE("DeserializerClassTest_DeserializeYAMLVerDirectiveTest", "[DeserializerClassTest]")
@@ -697,8 +697,8 @@ TEST_CASE("DeserializerClassTest_DeserializeYAMLVerDirectiveTest", "[Deserialize
         fkyaml::node& foo_node = root["foo"];
         REQUIRE(root.get_yaml_version() == fkyaml::node::yaml_version_t::VER_1_1);
         REQUIRE(foo_node.is_string());
-        REQUIRE_NOTHROW(foo_node.to_string());
-        REQUIRE(foo_node.to_string().compare("one") == 0);
+        REQUIRE_NOTHROW(foo_node.get_value_ref<fkyaml::node::string_type&>());
+        REQUIRE(foo_node.get_value_ref<fkyaml::node::string_type&>().compare("one") == 0);
     }
 
     SECTION("YAML 1.2")
@@ -713,8 +713,8 @@ TEST_CASE("DeserializerClassTest_DeserializeYAMLVerDirectiveTest", "[Deserialize
         fkyaml::node& foo_node = root["foo"];
         REQUIRE(root.get_yaml_version() == fkyaml::node::yaml_version_t::VER_1_2);
         REQUIRE(foo_node.is_string());
-        REQUIRE_NOTHROW(foo_node.to_string());
-        REQUIRE(foo_node.to_string().compare("one") == 0);
+        REQUIRE_NOTHROW(foo_node.get_value_ref<fkyaml::node::string_type&>());
+        REQUIRE(foo_node.get_value_ref<fkyaml::node::string_type&>().compare("one") == 0);
     }
 }
 

--- a/test/unit_test/test_deserializer_class.cpp
+++ b/test/unit_test/test_deserializer_class.cpp
@@ -208,7 +208,8 @@ TEST_CASE("DeserializerClassTest_DeserializeBlockSequenceTest", "[DeserializerCl
         fkyaml::node& test_1_node = test_node[1];
         REQUIRE(test_1_node.is_boolean());
         REQUIRE_NOTHROW(test_1_node.get_value<fkyaml::node::boolean_type>());
-        REQUIRE(test_1_node.get_value<fkyaml::node::boolean_type>() == test_0_node.get_value<fkyaml::node::boolean_type>());
+        REQUIRE(
+            test_1_node.get_value<fkyaml::node::boolean_type>() == test_0_node.get_value<fkyaml::node::boolean_type>());
     }
 
     SECTION("Input source No.4.")
@@ -238,7 +239,8 @@ TEST_CASE("DeserializerClassTest_DeserializeBlockSequenceTest", "[DeserializerCl
         fkyaml::node& test_1_node = test_node[1];
         REQUIRE(test_1_node.is_integer());
         REQUIRE_NOTHROW(test_1_node.get_value<fkyaml::node::integer_type>());
-        REQUIRE(test_1_node.get_value<fkyaml::node::integer_type>() == test_0_node.get_value<fkyaml::node::integer_type>());
+        REQUIRE(
+            test_1_node.get_value<fkyaml::node::integer_type>() == test_0_node.get_value<fkyaml::node::integer_type>());
     }
 
     SECTION("Input source No.5.")
@@ -268,7 +270,8 @@ TEST_CASE("DeserializerClassTest_DeserializeBlockSequenceTest", "[DeserializerCl
         fkyaml::node& test_1_node = test_node[1];
         REQUIRE(test_1_node.is_integer());
         REQUIRE_NOTHROW(test_1_node.get_value<fkyaml::node::integer_type>());
-        REQUIRE(test_1_node.get_value<fkyaml::node::integer_type>() == test_0_node.get_value<fkyaml::node::integer_type>());
+        REQUIRE(
+            test_1_node.get_value<fkyaml::node::integer_type>() == test_0_node.get_value<fkyaml::node::integer_type>());
     }
 
     SECTION("Input source No.6.")
@@ -298,7 +301,9 @@ TEST_CASE("DeserializerClassTest_DeserializeBlockSequenceTest", "[DeserializerCl
         fkyaml::node& test_1_node = test_node[1];
         REQUIRE(test_1_node.is_float_number());
         REQUIRE_NOTHROW(test_1_node.get_value<fkyaml::node::float_number_type>());
-        REQUIRE(test_1_node.get_value<fkyaml::node::float_number_type>() == test_0_node.get_value<fkyaml::node::float_number_type>());
+        REQUIRE(
+            test_1_node.get_value<fkyaml::node::float_number_type>() ==
+            test_0_node.get_value<fkyaml::node::float_number_type>());
     }
 
     SECTION("Input source No.7.")
@@ -492,7 +497,9 @@ TEST_CASE("DeserializerClassTest_DeserializeBlockMappingTest", "[DeserializerCla
         fkyaml::node& bar_node = root["bar"];
         REQUIRE(bar_node.is_float_number());
         REQUIRE_NOTHROW(bar_node.get_value<fkyaml::node::float_number_type>());
-        REQUIRE(bar_node.get_value<fkyaml::node::float_number_type>() == foo_node.get_value<fkyaml::node::float_number_type>());
+        REQUIRE(
+            bar_node.get_value<fkyaml::node::float_number_type>() ==
+            foo_node.get_value<fkyaml::node::float_number_type>());
     }
 
     SECTION("Input source No.7.")
@@ -515,7 +522,9 @@ TEST_CASE("DeserializerClassTest_DeserializeBlockMappingTest", "[DeserializerCla
         fkyaml::node& bar_node = root["bar"];
         REQUIRE(bar_node.is_string());
         REQUIRE_NOTHROW(bar_node.get_value_ref<fkyaml::node::string_type&>());
-        REQUIRE(bar_node.get_value_ref<fkyaml::node::string_type&>() == foo_node.get_value_ref<fkyaml::node::string_type&>());
+        REQUIRE(
+            bar_node.get_value_ref<fkyaml::node::string_type&>() ==
+            foo_node.get_value_ref<fkyaml::node::string_type&>());
     }
 
     SECTION("Input source No.8.")

--- a/test/unit_test/test_iterator_class.cpp
+++ b/test/unit_test/test_iterator_class.cpp
@@ -15,7 +15,7 @@ TEST_CASE("IteratorClassTest_SequenceCtorTest", "[IteratorClassTest]")
 {
     fkyaml::node sequence = fkyaml::node::sequence();
     fkyaml::detail::iterator<fkyaml::node> iterator(
-        fkyaml::detail::sequence_iterator_tag {}, sequence.to_sequence().begin());
+        fkyaml::detail::sequence_iterator_tag {}, sequence.get_value_ref<fkyaml::node::sequence_type&>().begin());
     REQUIRE(iterator.type() == fkyaml::detail::iterator_t::SEQUENCE);
 }
 
@@ -23,7 +23,7 @@ TEST_CASE("IteratorClassTest_MappingCtorTest", "[IteratorClassTest]")
 {
     fkyaml::node mapping = fkyaml::node::mapping();
     fkyaml::detail::iterator<fkyaml::node> iterator(
-        fkyaml::detail::mapping_iterator_tag {}, mapping.to_mapping().begin());
+        fkyaml::detail::mapping_iterator_tag {}, mapping.get_value_ref<fkyaml::node::mapping_type&>().begin());
     REQUIRE(iterator.type() == fkyaml::detail::iterator_t::MAPPING);
 }
 
@@ -31,7 +31,7 @@ TEST_CASE("IteratorClassTest_SequenceCopyCtorTest", "[IteratorClassTest]")
 {
     fkyaml::node sequence = fkyaml::node::sequence({fkyaml::node()});
     fkyaml::detail::iterator<fkyaml::node> copied(
-        fkyaml::detail::sequence_iterator_tag {}, sequence.to_sequence().begin());
+        fkyaml::detail::sequence_iterator_tag {}, sequence.get_value_ref<fkyaml::node::sequence_type&>().begin());
     fkyaml::detail::iterator<fkyaml::node> iterator(copied);
     REQUIRE(iterator.type() == fkyaml::detail::iterator_t::SEQUENCE);
     REQUIRE(iterator->is_null());
@@ -41,7 +41,7 @@ TEST_CASE("IteratorClassTest_MappingCopyCtorTest", "[IteratorClassTest]")
 {
     fkyaml::node mapping = fkyaml::node::mapping({{"test", fkyaml::node()}});
     fkyaml::detail::iterator<fkyaml::node> copied(
-        fkyaml::detail::mapping_iterator_tag {}, mapping.to_mapping().begin());
+        fkyaml::detail::mapping_iterator_tag {}, mapping.get_value_ref<fkyaml::node::mapping_type&>().begin());
     fkyaml::detail::iterator<fkyaml::node> iterator(copied);
     REQUIRE(iterator.type() == fkyaml::detail::iterator_t::MAPPING);
     REQUIRE(iterator.key().compare("test") == 0);
@@ -52,17 +52,17 @@ TEST_CASE("IteratorClassTest_SequenceMoveCtorTest", "[IteratorClassTest]")
 {
     fkyaml::node sequence = {std::string("test")};
     fkyaml::detail::iterator<fkyaml::node> moved(
-        fkyaml::detail::sequence_iterator_tag {}, sequence.to_sequence().begin());
+        fkyaml::detail::sequence_iterator_tag {}, sequence.get_value_ref<fkyaml::node::sequence_type&>().begin());
     fkyaml::detail::iterator<fkyaml::node> iterator(std::move(moved));
     REQUIRE(iterator.type() == fkyaml::detail::iterator_t::SEQUENCE);
     REQUIRE(iterator->is_string());
-    REQUIRE(iterator->to_string().compare("test") == 0);
+    REQUIRE(iterator->get_value_ref<fkyaml::node::string_type&>().compare("test") == 0);
 }
 
 TEST_CASE("IteratorClassTest_MappingMoveCtorTest", "[IteratorClassTest]")
 {
     fkyaml::node mapping = fkyaml::node::mapping({{"test", fkyaml::node()}});
-    fkyaml::detail::iterator<fkyaml::node> moved(fkyaml::detail::mapping_iterator_tag {}, mapping.to_mapping().begin());
+    fkyaml::detail::iterator<fkyaml::node> moved(fkyaml::detail::mapping_iterator_tag {}, mapping.get_value_ref<fkyaml::node::mapping_type&>().begin());
     fkyaml::detail::iterator<fkyaml::node> iterator(std::move(moved));
     REQUIRE(iterator.type() == fkyaml::detail::iterator_t::MAPPING);
     REQUIRE(iterator.key().compare("test") == 0);
@@ -75,7 +75,7 @@ TEST_CASE("IteratorClassTest_AssignmentOperatorTest", "[IteratorClassTest]")
     {
         fkyaml::node sequence = fkyaml::node::sequence({fkyaml::node()});
         fkyaml::detail::iterator<fkyaml::node> iterator(
-            fkyaml::detail::sequence_iterator_tag {}, sequence.to_sequence().begin());
+            fkyaml::detail::sequence_iterator_tag {}, sequence.get_value_ref<fkyaml::node::sequence_type&>().begin());
 
         SECTION("Test lvalue iterator.")
         {
@@ -96,17 +96,17 @@ TEST_CASE("IteratorClassTest_AssignmentOperatorTest", "[IteratorClassTest]")
     {
         fkyaml::node copied_seq = {std::string("test")};
         fkyaml::detail::iterator<fkyaml::node> copied_itr(
-            fkyaml::detail::sequence_iterator_tag {}, copied_seq.to_sequence().begin());
+            fkyaml::detail::sequence_iterator_tag {}, copied_seq.get_value_ref<fkyaml::node::sequence_type&>().begin());
         fkyaml::node sequence = {false};
         fkyaml::detail::iterator<fkyaml::node> iterator(
-            fkyaml::detail::sequence_iterator_tag {}, sequence.to_sequence().begin());
+            fkyaml::detail::sequence_iterator_tag {}, sequence.get_value_ref<fkyaml::node::sequence_type&>().begin());
 
         SECTION("Test lvalue iterator.")
         {
             iterator = copied_itr;
             REQUIRE(iterator.type() == fkyaml::detail::iterator_t::SEQUENCE);
             REQUIRE(iterator->is_string());
-            REQUIRE(iterator->to_string().compare("test") == 0);
+            REQUIRE(iterator->get_value_ref<fkyaml::node::string_type&>().compare("test") == 0);
         }
 
         SECTION("Test rvalue iterator.")
@@ -114,7 +114,7 @@ TEST_CASE("IteratorClassTest_AssignmentOperatorTest", "[IteratorClassTest]")
             iterator = std::move(copied_itr);
             REQUIRE(iterator.type() == fkyaml::detail::iterator_t::SEQUENCE);
             REQUIRE(iterator->is_string());
-            REQUIRE(iterator->to_string().compare("test") == 0);
+            REQUIRE(iterator->get_value_ref<fkyaml::node::string_type&>().compare("test") == 0);
         }
     }
 
@@ -122,10 +122,10 @@ TEST_CASE("IteratorClassTest_AssignmentOperatorTest", "[IteratorClassTest]")
     {
         fkyaml::node copied_map = {{std::string("key"), std::string("test")}};
         fkyaml::detail::iterator<fkyaml::node> copied_itr(
-            fkyaml::detail::mapping_iterator_tag {}, copied_map.to_mapping().begin());
+            fkyaml::detail::mapping_iterator_tag {}, copied_map.get_value_ref<fkyaml::node::mapping_type&>().begin());
         fkyaml::node map = {{std::string("foo"), false}};
         fkyaml::detail::iterator<fkyaml::node> iterator(
-            fkyaml::detail::mapping_iterator_tag {}, map.to_mapping().begin());
+            fkyaml::detail::mapping_iterator_tag {}, map.get_value_ref<fkyaml::node::mapping_type&>().begin());
 
         SECTION("Test lvalue iterator.")
         {
@@ -133,7 +133,7 @@ TEST_CASE("IteratorClassTest_AssignmentOperatorTest", "[IteratorClassTest]")
             REQUIRE(iterator.type() == fkyaml::detail::iterator_t::MAPPING);
             REQUIRE(iterator.key().compare("key") == 0);
             REQUIRE(iterator.value().is_string());
-            REQUIRE(iterator.value().to_string().compare("test") == 0);
+            REQUIRE(iterator.value().get_value_ref<fkyaml::node::string_type&>().compare("test") == 0);
         }
 
         SECTION("Test rvalue iterator.")
@@ -142,7 +142,7 @@ TEST_CASE("IteratorClassTest_AssignmentOperatorTest", "[IteratorClassTest]")
             REQUIRE(iterator.type() == fkyaml::detail::iterator_t::MAPPING);
             REQUIRE(iterator.key().compare("key") == 0);
             REQUIRE(iterator.value().is_string());
-            REQUIRE(iterator.value().to_string().compare("test") == 0);
+            REQUIRE(iterator.value().get_value_ref<fkyaml::node::string_type&>().compare("test") == 0);
         }
     }
 }
@@ -153,16 +153,16 @@ TEST_CASE("IteratorClassTest_ArrowOperatorTest", "[IteratorClassTest]")
     {
         fkyaml::node seq = {std::string("test")};
         fkyaml::detail::iterator<fkyaml::node> iterator(
-            fkyaml::detail::sequence_iterator_tag {}, seq.to_sequence().begin());
-        REQUIRE(iterator.operator->() == &(seq.to_sequence().operator[](0)));
+            fkyaml::detail::sequence_iterator_tag {}, seq.get_value_ref<fkyaml::node::sequence_type&>().begin());
+        REQUIRE(iterator.operator->() == &(seq.get_value_ref<fkyaml::node::sequence_type&>().operator[](0)));
     }
 
     SECTION("Test mapping iterator.")
     {
         fkyaml::node map = {{std::string("key"), std::string("test")}};
         fkyaml::detail::iterator<fkyaml::node> iterator(
-            fkyaml::detail::mapping_iterator_tag {}, map.to_mapping().begin());
-        REQUIRE(iterator.operator->() == &(map.to_mapping().operator[]("key")));
+            fkyaml::detail::mapping_iterator_tag {}, map.get_value_ref<fkyaml::node::mapping_type&>().begin());
+        REQUIRE(iterator.operator->() == &(map.get_value_ref<fkyaml::node::mapping_type&>().operator[]("key")));
     }
 }
 
@@ -172,16 +172,16 @@ TEST_CASE("IteratorClassTest_DereferenceOperatorTest", "[IteratorClassTest]")
     {
         fkyaml::node seq = {std::string("test")};
         fkyaml::detail::iterator<fkyaml::node> iterator(
-            fkyaml::detail::sequence_iterator_tag {}, seq.to_sequence().begin());
-        REQUIRE(&(iterator.operator*()) == &(seq.to_sequence().operator[](0)));
+            fkyaml::detail::sequence_iterator_tag {}, seq.get_value_ref<fkyaml::node::sequence_type&>().begin());
+        REQUIRE(&(iterator.operator*()) == &(seq.get_value_ref<fkyaml::node::sequence_type&>().operator[](0)));
     }
 
     SECTION("Test mapping iterator.")
     {
         fkyaml::node map = fkyaml::node::mapping({{"key", std::string("test")}});
         fkyaml::detail::iterator<fkyaml::node> iterator(
-            fkyaml::detail::mapping_iterator_tag {}, map.to_mapping().begin());
-        REQUIRE(&(iterator.operator*()) == &(map.to_mapping().operator[]("key")));
+            fkyaml::detail::mapping_iterator_tag {}, map.get_value_ref<fkyaml::node::mapping_type&>().begin());
+        REQUIRE(&(iterator.operator*()) == &(map.get_value_ref<fkyaml::node::mapping_type&>().operator[]("key")));
     }
 }
 
@@ -191,21 +191,21 @@ TEST_CASE("IteratorClassTest_CompoundAssignmentOperatorBySumTest", "[IteratorCla
     {
         fkyaml::node sequence = {false, true};
         fkyaml::detail::iterator<fkyaml::node> iterator(
-            fkyaml::detail::sequence_iterator_tag {}, sequence.to_sequence().begin());
+            fkyaml::detail::sequence_iterator_tag {}, sequence.get_value_ref<fkyaml::node::sequence_type&>().begin());
         iterator += 1;
         REQUIRE(iterator->is_boolean());
-        REQUIRE(iterator->to_boolean() == true);
+        REQUIRE(iterator->get_value<fkyaml::node::boolean_type>() == true);
     }
 
     SECTION("Test mapping iterator.")
     {
         fkyaml::node mapping = {{std::string("test0"), false}, {std::string("test1"), true}};
         fkyaml::detail::iterator<fkyaml::node> iterator(
-            fkyaml::detail::mapping_iterator_tag {}, mapping.to_mapping().begin());
+            fkyaml::detail::mapping_iterator_tag {}, mapping.get_value_ref<fkyaml::node::mapping_type&>().begin());
         iterator += 1;
         REQUIRE(iterator.key().compare("test1") == 0);
         REQUIRE(iterator.value().is_boolean());
-        REQUIRE(iterator.value().to_boolean() == true);
+        REQUIRE(iterator.value().get_value<fkyaml::node::boolean_type>() == true);
     }
 }
 
@@ -215,21 +215,21 @@ TEST_CASE("IteratorClassTest_PlusOperatorTest", "[IteratorClassTest]")
     {
         fkyaml::node sequence = {false, true};
         fkyaml::detail::iterator<fkyaml::node> iterator(
-            fkyaml::detail::sequence_iterator_tag {}, sequence.to_sequence().begin());
+            fkyaml::detail::sequence_iterator_tag {}, sequence.get_value_ref<fkyaml::node::sequence_type&>().begin());
         fkyaml::detail::iterator<fkyaml::node> after_plus_itr = iterator + 1;
         REQUIRE(after_plus_itr->is_boolean());
-        REQUIRE(after_plus_itr->to_boolean() == true);
+        REQUIRE(after_plus_itr->get_value<fkyaml::node::boolean_type>() == true);
     }
 
     SECTION("Test mapping iterator.")
     {
         fkyaml::node mapping = {{std::string("test0"), false}, {std::string("test1"), true}};
         fkyaml::detail::iterator<fkyaml::node> iterator(
-            fkyaml::detail::mapping_iterator_tag {}, mapping.to_mapping().begin());
+            fkyaml::detail::mapping_iterator_tag {}, mapping.get_value_ref<fkyaml::node::mapping_type&>().begin());
         fkyaml::detail::iterator<fkyaml::node> after_plus_itr = iterator + 1;
         REQUIRE(after_plus_itr.key().compare("test1") == 0);
         REQUIRE(after_plus_itr.value().is_boolean());
-        REQUIRE(after_plus_itr.value().to_boolean() == true);
+        REQUIRE(after_plus_itr.value().get_value<fkyaml::node::boolean_type>() == true);
     }
 }
 
@@ -239,21 +239,21 @@ TEST_CASE("IteratorClassTest_PreIncrementOperatorTest", "[IteratorClassTest]")
     {
         fkyaml::node sequence = {false, true};
         fkyaml::detail::iterator<fkyaml::node> iterator(
-            fkyaml::detail::sequence_iterator_tag {}, sequence.to_sequence().begin());
+            fkyaml::detail::sequence_iterator_tag {}, sequence.get_value_ref<fkyaml::node::sequence_type&>().begin());
         ++iterator;
         REQUIRE(iterator->is_boolean());
-        REQUIRE(iterator->to_boolean() == true);
+        REQUIRE(iterator->get_value<fkyaml::node::boolean_type>() == true);
     }
 
     SECTION("Test mapping iterator.")
     {
         fkyaml::node mapping = {{std::string("test0"), false}, {std::string("test1"), true}};
         fkyaml::detail::iterator<fkyaml::node> iterator(
-            fkyaml::detail::mapping_iterator_tag {}, mapping.to_mapping().begin());
+            fkyaml::detail::mapping_iterator_tag {}, mapping.get_value_ref<fkyaml::node::mapping_type&>().begin());
         ++iterator;
         REQUIRE(iterator.key().compare("test1") == 0);
         REQUIRE(iterator.value().is_boolean());
-        REQUIRE(iterator.value().to_boolean() == true);
+        REQUIRE(iterator.value().get_value<fkyaml::node::boolean_type>() == true);
     }
 }
 
@@ -263,21 +263,21 @@ TEST_CASE("IteratorClassTest_PostIncrementOperatorTest", "[IteratorClassTest]")
     {
         fkyaml::node sequence = {false, true};
         fkyaml::detail::iterator<fkyaml::node> iterator(
-            fkyaml::detail::sequence_iterator_tag {}, sequence.to_sequence().begin());
+            fkyaml::detail::sequence_iterator_tag {}, sequence.get_value_ref<fkyaml::node::sequence_type&>().begin());
         iterator++;
         REQUIRE(iterator->is_boolean());
-        REQUIRE(iterator->to_boolean() == true);
+        REQUIRE(iterator->get_value<fkyaml::node::boolean_type>() == true);
     }
 
     SECTION("Test mapping iterator.")
     {
         fkyaml::node mapping = {{std::string("test0"), false}, {std::string("test1"), true}};
         fkyaml::detail::iterator<fkyaml::node> iterator(
-            fkyaml::detail::mapping_iterator_tag {}, mapping.to_mapping().begin());
+            fkyaml::detail::mapping_iterator_tag {}, mapping.get_value_ref<fkyaml::node::mapping_type&>().begin());
         iterator++;
         REQUIRE(iterator.key().compare("test1") == 0);
         REQUIRE(iterator.value().is_boolean());
-        REQUIRE(iterator.value().to_boolean() == true);
+        REQUIRE(iterator.value().get_value<fkyaml::node::boolean_type>() == true);
     }
 }
 
@@ -287,21 +287,21 @@ TEST_CASE("IteratorClassTest_CompoundAssignmentOperatorByDifferenceTest", "[Iter
     {
         fkyaml::node sequence = {false, true};
         fkyaml::detail::iterator<fkyaml::node> iterator(
-            fkyaml::detail::sequence_iterator_tag {}, sequence.to_sequence().end());
+            fkyaml::detail::sequence_iterator_tag {}, sequence.get_value_ref<fkyaml::node::sequence_type&>().end());
         iterator -= 1;
         REQUIRE(iterator->is_boolean());
-        REQUIRE(iterator->to_boolean() == true);
+        REQUIRE(iterator->get_value<fkyaml::node::boolean_type>() == true);
     }
 
     SECTION("Test mapping iterator.")
     {
         fkyaml::node mapping = {{std::string("test0"), false}, {std::string("test1"), true}};
         fkyaml::detail::iterator<fkyaml::node> iterator(
-            fkyaml::detail::mapping_iterator_tag {}, mapping.to_mapping().end());
+            fkyaml::detail::mapping_iterator_tag {}, mapping.get_value_ref<fkyaml::node::mapping_type&>().end());
         iterator -= 1;
         REQUIRE(iterator.key().compare("test1") == 0);
         REQUIRE(iterator.value().is_boolean());
-        REQUIRE(iterator.value().to_boolean() == true);
+        REQUIRE(iterator.value().get_value<fkyaml::node::boolean_type>() == true);
     }
 }
 
@@ -311,21 +311,21 @@ TEST_CASE("IteratorClassTest_MinusOperatorTest", "[IteratorClassTest]")
     {
         fkyaml::node sequence = {false, true};
         fkyaml::detail::iterator<fkyaml::node> iterator(
-            fkyaml::detail::sequence_iterator_tag {}, sequence.to_sequence().end());
+            fkyaml::detail::sequence_iterator_tag {}, sequence.get_value_ref<fkyaml::node::sequence_type&>().end());
         fkyaml::detail::iterator<fkyaml::node> after_minus_itr = iterator - 1;
         REQUIRE(after_minus_itr->is_boolean());
-        REQUIRE(after_minus_itr->to_boolean() == true);
+        REQUIRE(after_minus_itr->get_value<fkyaml::node::boolean_type>() == true);
     }
 
     SECTION("Test mapping iterator.")
     {
         fkyaml::node mapping = {{std::string("test0"), false}, {std::string("test1"), true}};
         fkyaml::detail::iterator<fkyaml::node> iterator(
-            fkyaml::detail::mapping_iterator_tag {}, mapping.to_mapping().end());
+            fkyaml::detail::mapping_iterator_tag {}, mapping.get_value_ref<fkyaml::node::mapping_type&>().end());
         fkyaml::detail::iterator<fkyaml::node> after_minus_itr = iterator - 1;
         REQUIRE(after_minus_itr.key().compare("test1") == 0);
         REQUIRE(after_minus_itr.value().is_boolean());
-        REQUIRE(after_minus_itr.value().to_boolean() == true);
+        REQUIRE(after_minus_itr.value().get_value<fkyaml::node::boolean_type>() == true);
     }
 }
 
@@ -335,21 +335,21 @@ TEST_CASE("IteratorClassTest_PreDecrementOperatorTest", "[IteratorClassTest]")
     {
         fkyaml::node sequence = {false, true};
         fkyaml::detail::iterator<fkyaml::node> iterator(
-            fkyaml::detail::sequence_iterator_tag {}, sequence.to_sequence().end());
+            fkyaml::detail::sequence_iterator_tag {}, sequence.get_value_ref<fkyaml::node::sequence_type&>().end());
         --iterator;
         REQUIRE(iterator->is_boolean());
-        REQUIRE(iterator->to_boolean() == true);
+        REQUIRE(iterator->get_value<fkyaml::node::boolean_type>() == true);
     }
 
     SECTION("Test mapping iterator.")
     {
         fkyaml::node mapping = {{std::string("test0"), false}, {std::string("test1"), true}};
         fkyaml::detail::iterator<fkyaml::node> iterator(
-            fkyaml::detail::mapping_iterator_tag {}, mapping.to_mapping().end());
+            fkyaml::detail::mapping_iterator_tag {}, mapping.get_value_ref<fkyaml::node::mapping_type&>().end());
         --iterator;
         REQUIRE(iterator.key().compare("test1") == 0);
         REQUIRE(iterator.value().is_boolean());
-        REQUIRE(iterator.value().to_boolean() == true);
+        REQUIRE(iterator.value().get_value<fkyaml::node::boolean_type>() == true);
     }
 }
 
@@ -359,21 +359,21 @@ TEST_CASE("IteratorClassTest_PostDecrementOperatorTest", "[IteratorClassTest]")
     {
         fkyaml::node sequence = {false, true};
         fkyaml::detail::iterator<fkyaml::node> iterator(
-            fkyaml::detail::sequence_iterator_tag {}, sequence.to_sequence().end());
+            fkyaml::detail::sequence_iterator_tag {}, sequence.get_value_ref<fkyaml::node::sequence_type&>().end());
         iterator--;
         REQUIRE(iterator->is_boolean());
-        REQUIRE(iterator->to_boolean() == true);
+        REQUIRE(iterator->get_value<fkyaml::node::boolean_type>() == true);
     }
 
     SECTION("Test mapping iterator.")
     {
         fkyaml::node mapping = {{std::string("test0"), false}, {std::string("test1"), true}};
         fkyaml::detail::iterator<fkyaml::node> iterator(
-            fkyaml::detail::mapping_iterator_tag {}, mapping.to_mapping().end());
+            fkyaml::detail::mapping_iterator_tag {}, mapping.get_value_ref<fkyaml::node::mapping_type&>().end());
         iterator--;
         REQUIRE(iterator.key().compare("test1") == 0);
         REQUIRE(iterator.value().is_boolean());
-        REQUIRE(iterator.value().to_boolean() == true);
+        REQUIRE(iterator.value().get_value<fkyaml::node::boolean_type>() == true);
     }
 }
 
@@ -383,9 +383,9 @@ TEST_CASE("IteratorClassTest_EqualToOperatorTest", "[IteratorClassTest]")
     {
         fkyaml::node sequence = {false, true};
         fkyaml::detail::iterator<fkyaml::node> lhs(
-            fkyaml::detail::sequence_iterator_tag {}, sequence.to_sequence().begin());
+            fkyaml::detail::sequence_iterator_tag {}, sequence.get_value_ref<fkyaml::node::sequence_type&>().begin());
         fkyaml::detail::iterator<fkyaml::node> rhs(
-            fkyaml::detail::sequence_iterator_tag {}, sequence.to_sequence().begin());
+            fkyaml::detail::sequence_iterator_tag {}, sequence.get_value_ref<fkyaml::node::sequence_type&>().begin());
         REQUIRE(lhs == rhs);
     }
 
@@ -393,9 +393,9 @@ TEST_CASE("IteratorClassTest_EqualToOperatorTest", "[IteratorClassTest]")
     {
         fkyaml::node mapping = {{std::string("test0"), false}, {std::string("test1"), true}};
         fkyaml::detail::iterator<fkyaml::node> lhs(
-            fkyaml::detail::mapping_iterator_tag {}, mapping.to_mapping().begin());
+            fkyaml::detail::mapping_iterator_tag {}, mapping.get_value_ref<fkyaml::node::mapping_type&>().begin());
         fkyaml::detail::iterator<fkyaml::node> rhs(
-            fkyaml::detail::mapping_iterator_tag {}, mapping.to_mapping().begin());
+            fkyaml::detail::mapping_iterator_tag {}, mapping.get_value_ref<fkyaml::node::mapping_type&>().begin());
         REQUIRE(lhs == rhs);
     }
 
@@ -403,10 +403,10 @@ TEST_CASE("IteratorClassTest_EqualToOperatorTest", "[IteratorClassTest]")
     {
         fkyaml::node sequence = {false, true};
         fkyaml::detail::iterator<fkyaml::node> lhs(
-            fkyaml::detail::sequence_iterator_tag {}, sequence.to_sequence().begin());
+            fkyaml::detail::sequence_iterator_tag {}, sequence.get_value_ref<fkyaml::node::sequence_type&>().begin());
         fkyaml::node mapping = {{std::string("test0"), false}, {std::string("test1"), true}};
         fkyaml::detail::iterator<fkyaml::node> rhs(
-            fkyaml::detail::mapping_iterator_tag {}, mapping.to_mapping().begin());
+            fkyaml::detail::mapping_iterator_tag {}, mapping.get_value_ref<fkyaml::node::mapping_type&>().begin());
         REQUIRE_THROWS_AS(lhs == rhs, fkyaml::exception);
     }
 }
@@ -417,9 +417,9 @@ TEST_CASE("IteratorClassTest_NotEqualToOperatorTest", "[IteratorClassTest]")
     {
         fkyaml::node sequence = {false, true};
         fkyaml::detail::iterator<fkyaml::node> lhs(
-            fkyaml::detail::sequence_iterator_tag {}, sequence.to_sequence().begin());
+            fkyaml::detail::sequence_iterator_tag {}, sequence.get_value_ref<fkyaml::node::sequence_type&>().begin());
         fkyaml::detail::iterator<fkyaml::node> rhs(
-            fkyaml::detail::sequence_iterator_tag {}, sequence.to_sequence().begin());
+            fkyaml::detail::sequence_iterator_tag {}, sequence.get_value_ref<fkyaml::node::sequence_type&>().begin());
         ++rhs;
         REQUIRE(lhs != rhs);
     }
@@ -428,9 +428,9 @@ TEST_CASE("IteratorClassTest_NotEqualToOperatorTest", "[IteratorClassTest]")
     {
         fkyaml::node mapping = {{std::string("test0"), false}, {std::string("test1"), true}};
         fkyaml::detail::iterator<fkyaml::node> lhs(
-            fkyaml::detail::mapping_iterator_tag {}, mapping.to_mapping().begin());
+            fkyaml::detail::mapping_iterator_tag {}, mapping.get_value_ref<fkyaml::node::mapping_type&>().begin());
         fkyaml::detail::iterator<fkyaml::node> rhs(
-            fkyaml::detail::mapping_iterator_tag {}, mapping.to_mapping().begin());
+            fkyaml::detail::mapping_iterator_tag {}, mapping.get_value_ref<fkyaml::node::mapping_type&>().begin());
         ++rhs;
         REQUIRE(lhs != rhs);
     }
@@ -439,10 +439,10 @@ TEST_CASE("IteratorClassTest_NotEqualToOperatorTest", "[IteratorClassTest]")
     {
         fkyaml::node sequence = {false, true};
         fkyaml::detail::iterator<fkyaml::node> lhs(
-            fkyaml::detail::sequence_iterator_tag {}, sequence.to_sequence().begin());
+            fkyaml::detail::sequence_iterator_tag {}, sequence.get_value_ref<fkyaml::node::sequence_type&>().begin());
         fkyaml::node mapping = {{std::string("test0"), false}, {std::string("test1"), true}};
         fkyaml::detail::iterator<fkyaml::node> rhs(
-            fkyaml::detail::mapping_iterator_tag {}, mapping.to_mapping().begin());
+            fkyaml::detail::mapping_iterator_tag {}, mapping.get_value_ref<fkyaml::node::mapping_type&>().begin());
         REQUIRE_THROWS_AS(lhs == rhs, fkyaml::exception);
     }
 }
@@ -453,9 +453,9 @@ TEST_CASE("IteratorClassTest_LessThanOperatorTest", "[IteratorClassTest]")
     {
         fkyaml::node sequence = {false, true};
         fkyaml::detail::iterator<fkyaml::node> lhs(
-            fkyaml::detail::sequence_iterator_tag {}, sequence.to_sequence().begin());
+            fkyaml::detail::sequence_iterator_tag {}, sequence.get_value_ref<fkyaml::node::sequence_type&>().begin());
         fkyaml::detail::iterator<fkyaml::node> rhs(
-            fkyaml::detail::sequence_iterator_tag {}, sequence.to_sequence().begin());
+            fkyaml::detail::sequence_iterator_tag {}, sequence.get_value_ref<fkyaml::node::sequence_type&>().begin());
         REQUIRE_FALSE(lhs < rhs);
         ++rhs;
         REQUIRE(lhs < rhs);
@@ -465,9 +465,9 @@ TEST_CASE("IteratorClassTest_LessThanOperatorTest", "[IteratorClassTest]")
     {
         fkyaml::node mapping = {{std::string("test0"), false}, {std::string("test1"), true}};
         fkyaml::detail::iterator<fkyaml::node> lhs(
-            fkyaml::detail::mapping_iterator_tag {}, mapping.to_mapping().begin());
+            fkyaml::detail::mapping_iterator_tag {}, mapping.get_value_ref<fkyaml::node::mapping_type&>().begin());
         fkyaml::detail::iterator<fkyaml::node> rhs(
-            fkyaml::detail::mapping_iterator_tag {}, mapping.to_mapping().begin());
+            fkyaml::detail::mapping_iterator_tag {}, mapping.get_value_ref<fkyaml::node::mapping_type&>().begin());
         REQUIRE_THROWS_AS(lhs < rhs, fkyaml::exception);
     }
 
@@ -475,10 +475,10 @@ TEST_CASE("IteratorClassTest_LessThanOperatorTest", "[IteratorClassTest]")
     {
         fkyaml::node sequence = {false, true};
         fkyaml::detail::iterator<fkyaml::node> lhs(
-            fkyaml::detail::sequence_iterator_tag {}, sequence.to_sequence().begin());
+            fkyaml::detail::sequence_iterator_tag {}, sequence.get_value_ref<fkyaml::node::sequence_type&>().begin());
         fkyaml::node mapping = {{std::string("test0"), false}, {std::string("test1"), true}};
         fkyaml::detail::iterator<fkyaml::node> rhs(
-            fkyaml::detail::mapping_iterator_tag {}, mapping.to_mapping().begin());
+            fkyaml::detail::mapping_iterator_tag {}, mapping.get_value_ref<fkyaml::node::mapping_type&>().begin());
         REQUIRE_THROWS_AS(lhs < rhs, fkyaml::exception);
     }
 }
@@ -489,9 +489,9 @@ TEST_CASE("IteratorClassTest_LessThanOrEqualToOperatorTest", "[IteratorClassTest
     {
         fkyaml::node sequence = {false, true};
         fkyaml::detail::iterator<fkyaml::node> lhs(
-            fkyaml::detail::sequence_iterator_tag {}, sequence.to_sequence().begin());
+            fkyaml::detail::sequence_iterator_tag {}, sequence.get_value_ref<fkyaml::node::sequence_type&>().begin());
         fkyaml::detail::iterator<fkyaml::node> rhs(
-            fkyaml::detail::sequence_iterator_tag {}, sequence.to_sequence().begin());
+            fkyaml::detail::sequence_iterator_tag {}, sequence.get_value_ref<fkyaml::node::sequence_type&>().begin());
         ++lhs;
         REQUIRE_FALSE(lhs <= rhs);
         --lhs;
@@ -504,9 +504,9 @@ TEST_CASE("IteratorClassTest_LessThanOrEqualToOperatorTest", "[IteratorClassTest
     {
         fkyaml::node mapping = {{std::string("test0"), false}, {std::string("test1"), true}};
         fkyaml::detail::iterator<fkyaml::node> lhs(
-            fkyaml::detail::mapping_iterator_tag {}, mapping.to_mapping().begin());
+            fkyaml::detail::mapping_iterator_tag {}, mapping.get_value_ref<fkyaml::node::mapping_type&>().begin());
         fkyaml::detail::iterator<fkyaml::node> rhs(
-            fkyaml::detail::mapping_iterator_tag {}, mapping.to_mapping().begin());
+            fkyaml::detail::mapping_iterator_tag {}, mapping.get_value_ref<fkyaml::node::mapping_type&>().begin());
         REQUIRE_THROWS_AS(lhs <= rhs, fkyaml::exception);
     }
 
@@ -514,10 +514,10 @@ TEST_CASE("IteratorClassTest_LessThanOrEqualToOperatorTest", "[IteratorClassTest
     {
         fkyaml::node sequence = {false, true};
         fkyaml::detail::iterator<fkyaml::node> lhs(
-            fkyaml::detail::sequence_iterator_tag {}, sequence.to_sequence().begin());
+            fkyaml::detail::sequence_iterator_tag {}, sequence.get_value_ref<fkyaml::node::sequence_type&>().begin());
         fkyaml::node mapping = {{std::string("test0"), false}, {std::string("test1"), true}};
         fkyaml::detail::iterator<fkyaml::node> rhs(
-            fkyaml::detail::mapping_iterator_tag {}, mapping.to_mapping().begin());
+            fkyaml::detail::mapping_iterator_tag {}, mapping.get_value_ref<fkyaml::node::mapping_type&>().begin());
         REQUIRE_THROWS_AS(lhs <= rhs, fkyaml::exception);
     }
 }
@@ -528,9 +528,9 @@ TEST_CASE("IteratorClassTest_GreaterThanOperatorTest", "[IteratorClassTest]")
     {
         fkyaml::node sequence = {false, true};
         fkyaml::detail::iterator<fkyaml::node> lhs(
-            fkyaml::detail::sequence_iterator_tag {}, sequence.to_sequence().begin());
+            fkyaml::detail::sequence_iterator_tag {}, sequence.get_value_ref<fkyaml::node::sequence_type&>().begin());
         fkyaml::detail::iterator<fkyaml::node> rhs(
-            fkyaml::detail::sequence_iterator_tag {}, sequence.to_sequence().begin());
+            fkyaml::detail::sequence_iterator_tag {}, sequence.get_value_ref<fkyaml::node::sequence_type&>().begin());
         REQUIRE_FALSE(lhs > rhs);
         ++lhs;
         REQUIRE(lhs > rhs);
@@ -540,9 +540,9 @@ TEST_CASE("IteratorClassTest_GreaterThanOperatorTest", "[IteratorClassTest]")
     {
         fkyaml::node mapping = {{std::string("test0"), false}, {std::string("test1"), true}};
         fkyaml::detail::iterator<fkyaml::node> lhs(
-            fkyaml::detail::mapping_iterator_tag {}, mapping.to_mapping().begin());
+            fkyaml::detail::mapping_iterator_tag {}, mapping.get_value_ref<fkyaml::node::mapping_type&>().begin());
         fkyaml::detail::iterator<fkyaml::node> rhs(
-            fkyaml::detail::mapping_iterator_tag {}, mapping.to_mapping().begin());
+            fkyaml::detail::mapping_iterator_tag {}, mapping.get_value_ref<fkyaml::node::mapping_type&>().begin());
         REQUIRE_THROWS_AS(lhs > rhs, fkyaml::exception);
     }
 
@@ -550,10 +550,10 @@ TEST_CASE("IteratorClassTest_GreaterThanOperatorTest", "[IteratorClassTest]")
     {
         fkyaml::node sequence = {false, true};
         fkyaml::detail::iterator<fkyaml::node> lhs(
-            fkyaml::detail::sequence_iterator_tag {}, sequence.to_sequence().begin());
+            fkyaml::detail::sequence_iterator_tag {}, sequence.get_value_ref<fkyaml::node::sequence_type&>().begin());
         fkyaml::node mapping = {{std::string("test0"), false}, {std::string("test1"), true}};
         fkyaml::detail::iterator<fkyaml::node> rhs(
-            fkyaml::detail::mapping_iterator_tag {}, mapping.to_mapping().begin());
+            fkyaml::detail::mapping_iterator_tag {}, mapping.get_value_ref<fkyaml::node::mapping_type&>().begin());
         REQUIRE_THROWS_AS(lhs > rhs, fkyaml::exception);
     }
 }
@@ -564,9 +564,9 @@ TEST_CASE("IteratorClassTest_GreaterThanOrEqualToOperatorTest", "[IteratorClassT
     {
         fkyaml::node sequence = {false, true};
         fkyaml::detail::iterator<fkyaml::node> lhs(
-            fkyaml::detail::sequence_iterator_tag {}, sequence.to_sequence().begin());
+            fkyaml::detail::sequence_iterator_tag {}, sequence.get_value_ref<fkyaml::node::sequence_type&>().begin());
         fkyaml::detail::iterator<fkyaml::node> rhs(
-            fkyaml::detail::sequence_iterator_tag {}, sequence.to_sequence().begin());
+            fkyaml::detail::sequence_iterator_tag {}, sequence.get_value_ref<fkyaml::node::sequence_type&>().begin());
         ++rhs;
         REQUIRE_FALSE(lhs >= rhs);
         --rhs;
@@ -579,9 +579,9 @@ TEST_CASE("IteratorClassTest_GreaterThanOrEqualToOperatorTest", "[IteratorClassT
     {
         fkyaml::node mapping = {{std::string("test0"), false}, {std::string("test1"), true}};
         fkyaml::detail::iterator<fkyaml::node> lhs(
-            fkyaml::detail::mapping_iterator_tag {}, mapping.to_mapping().begin());
+            fkyaml::detail::mapping_iterator_tag {}, mapping.get_value_ref<fkyaml::node::mapping_type&>().begin());
         fkyaml::detail::iterator<fkyaml::node> rhs(
-            fkyaml::detail::mapping_iterator_tag {}, mapping.to_mapping().begin());
+            fkyaml::detail::mapping_iterator_tag {}, mapping.get_value_ref<fkyaml::node::mapping_type&>().begin());
         REQUIRE_THROWS_AS(lhs >= rhs, fkyaml::exception);
     }
 
@@ -589,10 +589,10 @@ TEST_CASE("IteratorClassTest_GreaterThanOrEqualToOperatorTest", "[IteratorClassT
     {
         fkyaml::node sequence = {false, true};
         fkyaml::detail::iterator<fkyaml::node> lhs(
-            fkyaml::detail::sequence_iterator_tag {}, sequence.to_sequence().begin());
+            fkyaml::detail::sequence_iterator_tag {}, sequence.get_value_ref<fkyaml::node::sequence_type&>().begin());
         fkyaml::node mapping = {{std::string("test0"), false}, {std::string("test1"), true}};
         fkyaml::detail::iterator<fkyaml::node> rhs(
-            fkyaml::detail::mapping_iterator_tag {}, mapping.to_mapping().begin());
+            fkyaml::detail::mapping_iterator_tag {}, mapping.get_value_ref<fkyaml::node::mapping_type&>().begin());
         REQUIRE_THROWS_AS(lhs >= rhs, fkyaml::exception);
     }
 }
@@ -603,7 +603,7 @@ TEST_CASE("IteratorClassTest_TypeGetterTest", "[IteratorClassTest]")
     {
         fkyaml::node sequence = {false, true};
         fkyaml::detail::iterator<fkyaml::node> iterator(
-            fkyaml::detail::sequence_iterator_tag {}, sequence.to_sequence().begin());
+            fkyaml::detail::sequence_iterator_tag {}, sequence.get_value_ref<fkyaml::node::sequence_type&>().begin());
         REQUIRE(iterator.type() == fkyaml::detail::iterator_t::SEQUENCE);
     }
 
@@ -611,7 +611,7 @@ TEST_CASE("IteratorClassTest_TypeGetterTest", "[IteratorClassTest]")
     {
         fkyaml::node mapping = {{std::string("test0"), false}, {std::string("test1"), true}};
         fkyaml::detail::iterator<fkyaml::node> iterator(
-            fkyaml::detail::mapping_iterator_tag {}, mapping.to_mapping().begin());
+            fkyaml::detail::mapping_iterator_tag {}, mapping.get_value_ref<fkyaml::node::mapping_type&>().begin());
         REQUIRE(iterator.type() == fkyaml::detail::iterator_t::MAPPING);
     }
 }
@@ -622,7 +622,7 @@ TEST_CASE("IteratorClassTest_KeyGetterTest", "[IteratorClassTest]")
     {
         fkyaml::node sequence = {false, true};
         fkyaml::detail::iterator<fkyaml::node> iterator(
-            fkyaml::detail::sequence_iterator_tag {}, sequence.to_sequence().begin());
+            fkyaml::detail::sequence_iterator_tag {}, sequence.get_value_ref<fkyaml::node::sequence_type&>().begin());
         REQUIRE_THROWS_AS(iterator.key(), fkyaml::exception);
     }
 
@@ -630,7 +630,7 @@ TEST_CASE("IteratorClassTest_KeyGetterTest", "[IteratorClassTest]")
     {
         fkyaml::node mapping = {{std::string("test0"), false}, {std::string("test1"), true}};
         fkyaml::detail::iterator<fkyaml::node> iterator(
-            fkyaml::detail::mapping_iterator_tag {}, mapping.to_mapping().begin());
+            fkyaml::detail::mapping_iterator_tag {}, mapping.get_value_ref<fkyaml::node::mapping_type&>().begin());
         REQUIRE_NOTHROW(iterator.key());
         REQUIRE(iterator.key().compare("test0") == 0);
     }
@@ -642,17 +642,17 @@ TEST_CASE("IteratorClassTest_ValueGetterTest", "[IteratorClassTest]")
     {
         fkyaml::node sequence = {false, true};
         fkyaml::detail::iterator<fkyaml::node> iterator(
-            fkyaml::detail::sequence_iterator_tag {}, sequence.to_sequence().begin());
+            fkyaml::detail::sequence_iterator_tag {}, sequence.get_value_ref<fkyaml::node::sequence_type&>().begin());
         REQUIRE(iterator.value().is_boolean());
-        REQUIRE(iterator.value().to_boolean() == false);
+        REQUIRE(iterator.value().get_value<fkyaml::node::boolean_type>() == false);
     }
 
     SECTION("Test mapping iterator.")
     {
         fkyaml::node mapping = {{std::string("test0"), false}, {std::string("test1"), true}};
         fkyaml::detail::iterator<fkyaml::node> iterator(
-            fkyaml::detail::mapping_iterator_tag {}, mapping.to_mapping().begin());
+            fkyaml::detail::mapping_iterator_tag {}, mapping.get_value_ref<fkyaml::node::mapping_type&>().begin());
         REQUIRE(iterator.value().is_boolean());
-        REQUIRE(iterator.value().to_boolean() == false);
+        REQUIRE(iterator.value().get_value<fkyaml::node::boolean_type>() == false);
     }
 }

--- a/test/unit_test/test_iterator_class.cpp
+++ b/test/unit_test/test_iterator_class.cpp
@@ -62,7 +62,8 @@ TEST_CASE("IteratorClassTest_SequenceMoveCtorTest", "[IteratorClassTest]")
 TEST_CASE("IteratorClassTest_MappingMoveCtorTest", "[IteratorClassTest]")
 {
     fkyaml::node mapping = fkyaml::node::mapping({{"test", fkyaml::node()}});
-    fkyaml::detail::iterator<fkyaml::node> moved(fkyaml::detail::mapping_iterator_tag {}, mapping.get_value_ref<fkyaml::node::mapping_type&>().begin());
+    fkyaml::detail::iterator<fkyaml::node> moved(
+        fkyaml::detail::mapping_iterator_tag {}, mapping.get_value_ref<fkyaml::node::mapping_type&>().begin());
     fkyaml::detail::iterator<fkyaml::node> iterator(std::move(moved));
     REQUIRE(iterator.type() == fkyaml::detail::iterator_t::MAPPING);
     REQUIRE(iterator.key().compare("test") == 0);

--- a/test/unit_test/test_lexical_analyzer_class.cpp
+++ b/test/unit_test/test_lexical_analyzer_class.cpp
@@ -238,7 +238,7 @@ TEST_CASE("LexicalAnalyzerClassTest_ScanIntegerTokenTest", "[LexicalAnalyzerClas
 
     SECTION("Test nothrow expected tokens.")
     {
-        using value_pair_t = std::pair<std::string, fkyaml::node_integer_type>;
+        using value_pair_t = std::pair<std::string, fkyaml::node::integer_type>;
         auto value_pair = GENERATE(
             value_pair_t(std::string("-1234"), -1234),
             value_pair_t(std::string("-853255"), -853255),
@@ -265,7 +265,7 @@ TEST_CASE("LexicalAnalyzerClassTest_ScanIntegerTokenTest", "[LexicalAnalyzerClas
 
 TEST_CASE("LexicalAnalyzerClassTest_ScanOctalNumberTokenTest", "[LexicalAnalyzerClassTest]")
 {
-    using value_pair_t = std::pair<std::string, fkyaml::node_integer_type>;
+    using value_pair_t = std::pair<std::string, fkyaml::node::integer_type>;
     auto value_pair = GENERATE(
         value_pair_t(std::string("0o27"), 027),
         value_pair_t(std::string("0o5"), 05),
@@ -283,7 +283,7 @@ TEST_CASE("LexicalAnalyzerClassTest_ScanOctalNumberTokenTest", "[LexicalAnalyzer
 
 TEST_CASE("LexicalAnalyzerClassTest_ScanHexadecimalNumberTokenTest", "[LexicalAnalyzerClassTest]")
 {
-    using value_pair_t = std::pair<std::string, fkyaml::node_integer_type>;
+    using value_pair_t = std::pair<std::string, fkyaml::node::integer_type>;
     auto value_pair = GENERATE(
         value_pair_t(std::string("0xA04F"), 0xA04F),
         value_pair_t(std::string("0xa7F3"), 0xa7F3),
@@ -304,7 +304,7 @@ TEST_CASE("LexicalAnalyzerClassTest_ScanFloatNumberTokenTest", "[LexicalAnalyzer
 
     SECTION("Test nothrow expected tokens.")
     {
-        using value_pair_t = std::pair<std::string, fkyaml::node_float_number_type>;
+        using value_pair_t = std::pair<std::string, fkyaml::node::float_number_type>;
         auto value_pair = GENERATE(
             value_pair_t(std::string("-1.234"), -1.234),
             value_pair_t(std::string("567.8"), 567.8),
@@ -387,43 +387,43 @@ TEST_CASE("LexicalAnalyzerClassTest_ScanInvalidNumberTokenTest", "[LexicalAnalyz
 
 TEST_CASE("LexicalAnalyzerClassTest_ScanStringTokenTest", "[LexicalAnalyzerClassTest]")
 {
-    using value_pair_t = std::pair<std::string, fkyaml::node_string_type>;
+    using value_pair_t = std::pair<std::string, fkyaml::node::string_type>;
     auto value_pair = GENERATE(
-        value_pair_t(std::string("\"\""), fkyaml::node_string_type("")),
-        value_pair_t(std::string("\'\'"), fkyaml::node_string_type("")),
-        value_pair_t(std::string("test"), fkyaml::node_string_type("test")),
-        value_pair_t(std::string("nop"), fkyaml::node_string_type("nop")),
-        value_pair_t(std::string("none"), fkyaml::node_string_type("none")),
-        value_pair_t(std::string(".NET"), fkyaml::node_string_type(".NET")),
-        value_pair_t(std::string(".on"), fkyaml::node_string_type(".on")),
-        value_pair_t(std::string("foo]"), fkyaml::node_string_type("foo")),
-        value_pair_t(std::string("foo:bar"), fkyaml::node_string_type("foo:bar")),
-        value_pair_t(std::string("\"foo bar\""), fkyaml::node_string_type("foo bar")),
-        value_pair_t(std::string("\"foo:bar\""), fkyaml::node_string_type("foo:bar")),
-        value_pair_t(std::string("\"foo,bar\""), fkyaml::node_string_type("foo,bar")),
-        value_pair_t(std::string("\"foo]bar\""), fkyaml::node_string_type("foo]bar")),
-        value_pair_t(std::string("\"foo}bar\""), fkyaml::node_string_type("foo}bar")),
-        value_pair_t(std::string("\"foo\\abar\""), fkyaml::node_string_type("foo\abar")),
-        value_pair_t(std::string("\"foo\\bbar\""), fkyaml::node_string_type("foo\bbar")),
-        value_pair_t(std::string("\"foo\\tbar\""), fkyaml::node_string_type("foo\tbar")),
-        value_pair_t(std::string("\"foo\tbar\""), fkyaml::node_string_type("foo\tbar")),
-        value_pair_t(std::string("\"foo\\nbar\""), fkyaml::node_string_type("foo\nbar")),
-        value_pair_t(std::string("\"foo\\vbar\""), fkyaml::node_string_type("foo\vbar")),
-        value_pair_t(std::string("\"foo\\fbar\""), fkyaml::node_string_type("foo\fbar")),
-        value_pair_t(std::string("\"foo\\rbar\""), fkyaml::node_string_type("foo\rbar")),
-        value_pair_t(std::string("\"foo\\ebar\""), fkyaml::node_string_type("foo\u001Bbar")),
-        value_pair_t(std::string("\"foo\\ bar\""), fkyaml::node_string_type("foo bar")),
-        value_pair_t(std::string("\"foo\\\"bar\""), fkyaml::node_string_type("foo\"bar")),
-        value_pair_t(std::string("\"foo\\/bar\""), fkyaml::node_string_type("foo/bar")),
-        value_pair_t(std::string("\"foo\\\\bar\""), fkyaml::node_string_type("foo\\bar")),
-        value_pair_t(std::string("\"\\x30\\x2B\\x6d\""), fkyaml::node_string_type("0+m")),
-        value_pair_t(std::string("\'foo bar\'"), fkyaml::node_string_type("foo bar")),
-        value_pair_t(std::string("\'foo\'\'bar\'"), fkyaml::node_string_type("foo\'bar")),
-        value_pair_t(std::string("\'foo,bar\'"), fkyaml::node_string_type("foo,bar")),
-        value_pair_t(std::string("\'foo]bar\'"), fkyaml::node_string_type("foo]bar")),
-        value_pair_t(std::string("\'foo}bar\'"), fkyaml::node_string_type("foo}bar")),
-        value_pair_t(std::string("\'foo\"bar\'"), fkyaml::node_string_type("foo\"bar")),
-        value_pair_t(std::string("\'foo:bar\'"), fkyaml::node_string_type("foo:bar")));
+        value_pair_t(std::string("\"\""), fkyaml::node::string_type("")),
+        value_pair_t(std::string("\'\'"), fkyaml::node::string_type("")),
+        value_pair_t(std::string("test"), fkyaml::node::string_type("test")),
+        value_pair_t(std::string("nop"), fkyaml::node::string_type("nop")),
+        value_pair_t(std::string("none"), fkyaml::node::string_type("none")),
+        value_pair_t(std::string(".NET"), fkyaml::node::string_type(".NET")),
+        value_pair_t(std::string(".on"), fkyaml::node::string_type(".on")),
+        value_pair_t(std::string("foo]"), fkyaml::node::string_type("foo")),
+        value_pair_t(std::string("foo:bar"), fkyaml::node::string_type("foo:bar")),
+        value_pair_t(std::string("\"foo bar\""), fkyaml::node::string_type("foo bar")),
+        value_pair_t(std::string("\"foo:bar\""), fkyaml::node::string_type("foo:bar")),
+        value_pair_t(std::string("\"foo,bar\""), fkyaml::node::string_type("foo,bar")),
+        value_pair_t(std::string("\"foo]bar\""), fkyaml::node::string_type("foo]bar")),
+        value_pair_t(std::string("\"foo}bar\""), fkyaml::node::string_type("foo}bar")),
+        value_pair_t(std::string("\"foo\\abar\""), fkyaml::node::string_type("foo\abar")),
+        value_pair_t(std::string("\"foo\\bbar\""), fkyaml::node::string_type("foo\bbar")),
+        value_pair_t(std::string("\"foo\\tbar\""), fkyaml::node::string_type("foo\tbar")),
+        value_pair_t(std::string("\"foo\tbar\""), fkyaml::node::string_type("foo\tbar")),
+        value_pair_t(std::string("\"foo\\nbar\""), fkyaml::node::string_type("foo\nbar")),
+        value_pair_t(std::string("\"foo\\vbar\""), fkyaml::node::string_type("foo\vbar")),
+        value_pair_t(std::string("\"foo\\fbar\""), fkyaml::node::string_type("foo\fbar")),
+        value_pair_t(std::string("\"foo\\rbar\""), fkyaml::node::string_type("foo\rbar")),
+        value_pair_t(std::string("\"foo\\ebar\""), fkyaml::node::string_type("foo\u001Bbar")),
+        value_pair_t(std::string("\"foo\\ bar\""), fkyaml::node::string_type("foo bar")),
+        value_pair_t(std::string("\"foo\\\"bar\""), fkyaml::node::string_type("foo\"bar")),
+        value_pair_t(std::string("\"foo\\/bar\""), fkyaml::node::string_type("foo/bar")),
+        value_pair_t(std::string("\"foo\\\\bar\""), fkyaml::node::string_type("foo\\bar")),
+        value_pair_t(std::string("\"\\x30\\x2B\\x6d\""), fkyaml::node::string_type("0+m")),
+        value_pair_t(std::string("\'foo bar\'"), fkyaml::node::string_type("foo bar")),
+        value_pair_t(std::string("\'foo\'\'bar\'"), fkyaml::node::string_type("foo\'bar")),
+        value_pair_t(std::string("\'foo,bar\'"), fkyaml::node::string_type("foo,bar")),
+        value_pair_t(std::string("\'foo]bar\'"), fkyaml::node::string_type("foo]bar")),
+        value_pair_t(std::string("\'foo}bar\'"), fkyaml::node::string_type("foo}bar")),
+        value_pair_t(std::string("\'foo\"bar\'"), fkyaml::node::string_type("foo\"bar")),
+        value_pair_t(std::string("\'foo:bar\'"), fkyaml::node::string_type("foo:bar")));
 
     str_lexer_t lexer(fkyaml::detail::input_adapter(value_pair.first));
     fkyaml::detail::lexical_token_t token;

--- a/test/unit_test/test_node_class.cpp
+++ b/test/unit_test/test_node_class.cpp
@@ -49,21 +49,21 @@ TEST_CASE("NodeClassTest_BooleanTypeCtorTest", "[NodeClassTest]")
 {
     fkyaml::node node(fkyaml::node::node_t::BOOLEAN);
     REQUIRE(node.is_boolean());
-    REQUIRE(node.to_boolean() == false);
+    REQUIRE(node.get_value_ref<fkyaml::node::boolean_type&>() == false);
 }
 
 TEST_CASE("NodeClassTest_IntegerTypeCtorTest", "[NodeClassTest]")
 {
     fkyaml::node node(fkyaml::node::node_t::INTEGER);
     REQUIRE(node.is_integer());
-    REQUIRE(node.to_integer() == 0);
+    REQUIRE(node.get_value_ref<fkyaml::node::integer_type&>() == 0);
 }
 
 TEST_CASE("NodeClassTest_FloatNumberTypeCtorTest", "[NodeClassTest]")
 {
     fkyaml::node node(fkyaml::node::node_t::FLOAT_NUMBER);
     REQUIRE(node.is_float_number());
-    REQUIRE(node.to_float_number() == 0.0);
+    REQUIRE(node.get_value_ref<fkyaml::node::float_number_type&>() == 0.0);
 }
 
 TEST_CASE("NodeClassTest_StringTypeCtorTest", "[NodeClassTest]")
@@ -94,9 +94,9 @@ TEST_CASE("NodeClassTest_SequenceCtorTest", "[NodeClassTest]")
     REQUIRE(node.is_sequence());
     REQUIRE(node.size() == 2);
     REQUIRE(node[0].is_boolean());
-    REQUIRE(node[0].to_boolean() == true);
+    REQUIRE(node[0].get_value_ref<fkyaml::node::boolean_type&>() == true);
     REQUIRE(node[1].is_boolean());
-    REQUIRE(node[1].to_boolean() == false);
+    REQUIRE(node[1].get_value_ref<fkyaml::node::boolean_type&>() == false);
 }
 
 TEST_CASE("NodeClassTest_MappingCtorTest", "[NodeClassTest]")
@@ -107,7 +107,7 @@ TEST_CASE("NodeClassTest_MappingCtorTest", "[NodeClassTest]")
     REQUIRE(node.size() == 1);
     REQUIRE(node.contains("test"));
     REQUIRE(node["test"].is_boolean());
-    REQUIRE(node["test"].to_boolean() == true);
+    REQUIRE(node["test"].get_value_ref<fkyaml::node::boolean_type&>() == true);
 }
 
 TEST_CASE("NodeClassTest_NullCtorTest", "[NodeClassTest]")
@@ -122,7 +122,7 @@ TEST_CASE("NodeClassTest_BooleanCtorTest", "[NodeClassTest]")
     fkyaml::node node(true);
     REQUIRE(node.type() == fkyaml::node::node_t::BOOLEAN);
     REQUIRE(node.is_boolean());
-    REQUIRE(node.to_boolean() == true);
+    REQUIRE(node.get_value_ref<fkyaml::node::boolean_type&>() == true);
 }
 
 TEST_CASE("NodeClassTest_IntegerCtorTest", "[NodeClassTest]")
@@ -130,7 +130,7 @@ TEST_CASE("NodeClassTest_IntegerCtorTest", "[NodeClassTest]")
     fkyaml::node node(23467);
     REQUIRE(node.type() == fkyaml::node::node_t::INTEGER);
     REQUIRE(node.is_integer());
-    REQUIRE(node.to_integer() == 23467);
+    REQUIRE(node.get_value_ref<fkyaml::node::integer_type&>() == 23467);
 }
 
 TEST_CASE("NodeClassTest_FloatNumberCtorTest", "[NodeClassTest]")
@@ -138,7 +138,7 @@ TEST_CASE("NodeClassTest_FloatNumberCtorTest", "[NodeClassTest]")
     fkyaml::node node(3.14);
     REQUIRE(node.type() == fkyaml::node::node_t::FLOAT_NUMBER);
     REQUIRE(node.is_float_number());
-    REQUIRE(node.to_float_number() == 3.14);
+    REQUIRE(node.get_value_ref<fkyaml::node::float_number_type&>() == 3.14);
 }
 
 TEST_CASE("NodeClassTest_StringCtorTest", "[NodeClassTest]")
@@ -147,7 +147,7 @@ TEST_CASE("NodeClassTest_StringCtorTest", "[NodeClassTest]")
     REQUIRE(node.type() == fkyaml::node::node_t::STRING);
     REQUIRE(node.is_string());
     REQUIRE(node.size() == 4);
-    REQUIRE(node.to_string() == "test");
+    REQUIRE(node.get_value_ref<fkyaml::node::string_type&>() == "test");
 }
 
 TEST_CASE("NodeClassTest_SequenceCopyCtorTest", "[NodeClassTest]")
@@ -159,14 +159,14 @@ TEST_CASE("NodeClassTest_SequenceCopyCtorTest", "[NodeClassTest]")
     REQUIRE(node.size() == 2);
     REQUIRE_NOTHROW(node[0]);
     REQUIRE(node[0].is_boolean());
-    REQUIRE_NOTHROW(node[0].to_boolean());
-    REQUIRE(node[0].to_boolean() == true);
+    REQUIRE_NOTHROW(node[0].get_value_ref<fkyaml::node::boolean_type&>());
+    REQUIRE(node[0].get_value_ref<fkyaml::node::boolean_type&>() == true);
     REQUIRE_NOTHROW(node[1]);
     REQUIRE(node[1].is_string());
-    REQUIRE_NOTHROW(node[1].to_string());
-    REQUIRE_NOTHROW(node[1].to_string().size());
-    REQUIRE(node[1].to_string().size() == 4);
-    REQUIRE(node[1].to_string().compare("test") == 0);
+    REQUIRE_NOTHROW(node[1].get_value_ref<fkyaml::node::string_type&>());
+    REQUIRE_NOTHROW(node[1].get_value_ref<fkyaml::node::string_type&>().size());
+    REQUIRE(node[1].get_value_ref<fkyaml::node::string_type&>().size() == 4);
+    REQUIRE(node[1].get_value_ref<fkyaml::node::string_type&>().compare("test") == 0);
 }
 
 TEST_CASE("NodeClassTest_MappingCopyCtorTest", "[NodeClassTest]")
@@ -178,12 +178,12 @@ TEST_CASE("NodeClassTest_MappingCopyCtorTest", "[NodeClassTest]")
     REQUIRE(node.size() == 2);
     REQUIRE_NOTHROW(node["test0"]);
     REQUIRE(node["test0"].is_integer());
-    REQUIRE_NOTHROW(node["test0"].to_integer());
-    REQUIRE(node["test0"].to_integer() == 123);
+    REQUIRE_NOTHROW(node["test0"].get_value_ref<fkyaml::node::integer_type&>());
+    REQUIRE(node["test0"].get_value_ref<fkyaml::node::integer_type&>() == 123);
     REQUIRE_NOTHROW(node["test1"]);
     REQUIRE(node["test1"].is_float_number());
-    REQUIRE_NOTHROW(node["test1"].to_float_number());
-    REQUIRE(node["test1"].to_float_number() == 3.14);
+    REQUIRE_NOTHROW(node["test1"].get_value_ref<fkyaml::node::float_number_type&>());
+    REQUIRE(node["test1"].get_value_ref<fkyaml::node::float_number_type&>() == 3.14);
 }
 
 TEST_CASE("NodeClassTest_NullCopyCtorTest", "[NodeClassTest]")
@@ -198,8 +198,8 @@ TEST_CASE("NodeClassTest_BooleanCopyCtorTest", "[NodeClassTest]")
     fkyaml::node copied = true;
     fkyaml::node node(copied);
     REQUIRE(node.is_boolean());
-    REQUIRE_NOTHROW(node.to_boolean());
-    REQUIRE(node.to_boolean() == true);
+    REQUIRE_NOTHROW(node.get_value_ref<fkyaml::node::boolean_type&>());
+    REQUIRE(node.get_value_ref<fkyaml::node::boolean_type&>() == true);
 }
 
 TEST_CASE("NodeClassTest_IntegerCopyCtorTest", "[NodeClassTest]")
@@ -207,8 +207,8 @@ TEST_CASE("NodeClassTest_IntegerCopyCtorTest", "[NodeClassTest]")
     fkyaml::node copied = 123;
     fkyaml::node node(copied);
     REQUIRE(node.is_integer());
-    REQUIRE_NOTHROW(node.to_integer());
-    REQUIRE(node.to_integer() == 123);
+    REQUIRE_NOTHROW(node.get_value_ref<fkyaml::node::integer_type&>());
+    REQUIRE(node.get_value_ref<fkyaml::node::integer_type&>() == 123);
 }
 
 TEST_CASE("NodeClassTest_FloatNumberCopyCtorTest", "[NodeClassTest]")
@@ -216,8 +216,8 @@ TEST_CASE("NodeClassTest_FloatNumberCopyCtorTest", "[NodeClassTest]")
     fkyaml::node copied = 3.14;
     fkyaml::node node(copied);
     REQUIRE(node.is_float_number());
-    REQUIRE_NOTHROW(node.to_float_number());
-    REQUIRE(node.to_float_number() == 3.14);
+    REQUIRE_NOTHROW(node.get_value_ref<fkyaml::node::float_number_type&>());
+    REQUIRE(node.get_value_ref<fkyaml::node::float_number_type&>() == 3.14);
 }
 
 TEST_CASE("NodeClassTest_StringCopyCtorTest", "[NodeClassTest]")
@@ -227,8 +227,8 @@ TEST_CASE("NodeClassTest_StringCopyCtorTest", "[NodeClassTest]")
     REQUIRE(node.is_string());
     REQUIRE_NOTHROW(node.size());
     REQUIRE(node.size() == 4);
-    REQUIRE_NOTHROW(node.to_string());
-    REQUIRE(node.to_string().compare("test") == 0);
+    REQUIRE_NOTHROW(node.get_value_ref<fkyaml::node::string_type&>());
+    REQUIRE(node.get_value_ref<fkyaml::node::string_type&>().compare("test") == 0);
 }
 
 TEST_CASE("NodeClassTest_AliasCopyCtorTest", "[NodeClassTest]")
@@ -238,8 +238,8 @@ TEST_CASE("NodeClassTest_AliasCopyCtorTest", "[NodeClassTest]")
     fkyaml::node tmp_alias = fkyaml::node::alias_of(tmp);
     fkyaml::node alias(tmp_alias);
     REQUIRE(alias.is_boolean());
-    REQUIRE_NOTHROW(alias.to_boolean());
-    REQUIRE(alias.to_boolean() == true);
+    REQUIRE_NOTHROW(alias.get_value_ref<fkyaml::node::boolean_type&>());
+    REQUIRE(alias.get_value_ref<fkyaml::node::boolean_type&>() == true);
 }
 
 TEST_CASE("NodeClassTest_SequenceMoveCtorTest", "[NodeClassTest]")
@@ -251,14 +251,14 @@ TEST_CASE("NodeClassTest_SequenceMoveCtorTest", "[NodeClassTest]")
     REQUIRE(node.size() == 2);
     REQUIRE_NOTHROW(node[0]);
     REQUIRE(node[0].is_boolean());
-    REQUIRE_NOTHROW(node[0].to_boolean());
-    REQUIRE(node[0].to_boolean() == true);
+    REQUIRE_NOTHROW(node[0].get_value_ref<fkyaml::node::boolean_type&>());
+    REQUIRE(node[0].get_value_ref<fkyaml::node::boolean_type&>() == true);
     REQUIRE_NOTHROW(node[1]);
     REQUIRE(node[1].is_string());
-    REQUIRE_NOTHROW(node[1].to_string());
-    REQUIRE_NOTHROW(node[1].to_string().size());
-    REQUIRE(node[1].to_string().size() == 4);
-    REQUIRE(node[1].to_string().compare("test") == 0);
+    REQUIRE_NOTHROW(node[1].get_value_ref<fkyaml::node::string_type&>());
+    REQUIRE_NOTHROW(node[1].get_value_ref<fkyaml::node::string_type&>().size());
+    REQUIRE(node[1].get_value_ref<fkyaml::node::string_type&>().size() == 4);
+    REQUIRE(node[1].get_value_ref<fkyaml::node::string_type&>().compare("test") == 0);
 }
 
 TEST_CASE("NodeClassTest_MappingMoveCtorTest", "[NodeClassTest]")
@@ -270,12 +270,12 @@ TEST_CASE("NodeClassTest_MappingMoveCtorTest", "[NodeClassTest]")
     REQUIRE(node.size() == 2);
     REQUIRE_NOTHROW(node["test0"]);
     REQUIRE(node["test0"].is_integer());
-    REQUIRE_NOTHROW(node["test0"].to_integer());
-    REQUIRE(node["test0"].to_integer() == 123);
+    REQUIRE_NOTHROW(node["test0"].get_value_ref<fkyaml::node::integer_type&>());
+    REQUIRE(node["test0"].get_value_ref<fkyaml::node::integer_type&>() == 123);
     REQUIRE_NOTHROW(node["test1"]);
     REQUIRE(node["test1"].is_float_number());
-    REQUIRE_NOTHROW(node["test1"].to_float_number());
-    REQUIRE(node["test1"].to_float_number() == 3.14);
+    REQUIRE_NOTHROW(node["test1"].get_value_ref<fkyaml::node::float_number_type&>());
+    REQUIRE(node["test1"].get_value_ref<fkyaml::node::float_number_type&>() == 3.14);
 }
 
 TEST_CASE("NodeClassTest_NullMoveCtorTest", "[NodeClassTest]")
@@ -290,8 +290,8 @@ TEST_CASE("NodeClassTest_BooleanMoveCtorTest", "[NodeClassTest]")
     fkyaml::node moved = true;
     fkyaml::node node(std::move(moved));
     REQUIRE(node.is_boolean());
-    REQUIRE_NOTHROW(node.to_boolean());
-    REQUIRE(node.to_boolean() == true);
+    REQUIRE_NOTHROW(node.get_value_ref<fkyaml::node::boolean_type&>());
+    REQUIRE(node.get_value_ref<fkyaml::node::boolean_type&>() == true);
 }
 
 TEST_CASE("NodeClassTest_IntegerMoveCtorTest", "[NodeClassTest]")
@@ -299,8 +299,8 @@ TEST_CASE("NodeClassTest_IntegerMoveCtorTest", "[NodeClassTest]")
     fkyaml::node moved = 123;
     fkyaml::node node(std::move(moved));
     REQUIRE(node.is_integer());
-    REQUIRE_NOTHROW(node.to_integer());
-    REQUIRE(node.to_integer() == 123);
+    REQUIRE_NOTHROW(node.get_value_ref<fkyaml::node::integer_type&>());
+    REQUIRE(node.get_value_ref<fkyaml::node::integer_type&>() == 123);
 }
 
 TEST_CASE("NodeClassTest_FloatNumberMoveCtorTest", "[NodeClassTest]")
@@ -308,8 +308,8 @@ TEST_CASE("NodeClassTest_FloatNumberMoveCtorTest", "[NodeClassTest]")
     fkyaml::node moved = 3.14;
     fkyaml::node node(std::move(moved));
     REQUIRE(node.is_float_number());
-    REQUIRE_NOTHROW(node.to_float_number());
-    REQUIRE(node.to_float_number() == 3.14);
+    REQUIRE_NOTHROW(node.get_value_ref<fkyaml::node::float_number_type&>());
+    REQUIRE(node.get_value_ref<fkyaml::node::float_number_type&>() == 3.14);
 }
 
 TEST_CASE("NodeClassTest_StringMoveCtorTest", "[NodeClassTest]")
@@ -319,8 +319,8 @@ TEST_CASE("NodeClassTest_StringMoveCtorTest", "[NodeClassTest]")
     REQUIRE(node.is_string());
     REQUIRE_NOTHROW(node.size());
     REQUIRE(node.size() == 4);
-    REQUIRE_NOTHROW(node.to_string());
-    REQUIRE(node.to_string().compare("test") == 0);
+    REQUIRE_NOTHROW(node.get_value_ref<fkyaml::node::string_type&>());
+    REQUIRE(node.get_value_ref<fkyaml::node::string_type&>().compare("test") == 0);
 }
 
 TEST_CASE("NodeClassTest_AliasMoveCtorTest", "[NodeClassTest]")
@@ -330,8 +330,8 @@ TEST_CASE("NodeClassTest_AliasMoveCtorTest", "[NodeClassTest]")
     fkyaml::node tmp_alias = fkyaml::node::alias_of(tmp);
     fkyaml::node alias(std::move(tmp_alias));
     REQUIRE(alias.is_boolean());
-    REQUIRE_NOTHROW(alias.to_boolean());
-    REQUIRE(alias.to_boolean() == true);
+    REQUIRE_NOTHROW(alias.get_value_ref<fkyaml::node::boolean_type&>());
+    REQUIRE(alias.get_value_ref<fkyaml::node::boolean_type&>() == true);
 }
 
 TEST_CASE("NodeClassTest_InitializerListCtorTest", "[NodeClassTest]")
@@ -345,19 +345,20 @@ TEST_CASE("NodeClassTest_InitializerListCtorTest", "[NodeClassTest]")
 
     REQUIRE(node.contains("foo"));
     REQUIRE(node["foo"].is_float_number());
-    REQUIRE(node["foo"].to_float_number() == 3.14);
+    REQUIRE(node["foo"].get_value_ref<fkyaml::node::float_number_type&>() == 3.14);
 
     REQUIRE(node.contains("bar"));
     REQUIRE(node["bar"].is_integer());
-    REQUIRE(node["bar"].to_integer() == 123);
+    REQUIRE(node["bar"].get_value_ref<fkyaml::node::integer_type&>() == 123);
 
     REQUIRE(node.contains("baz"));
     REQUIRE(node["baz"].is_sequence());
     REQUIRE(node["baz"].size() == 2);
-    REQUIRE(node["baz"].to_sequence()[0].is_boolean());
-    REQUIRE(node["baz"].to_sequence()[0].to_boolean() == true);
-    REQUIRE(node["baz"].to_sequence()[1].is_boolean());
-    REQUIRE(node["baz"].to_sequence()[1].to_boolean() == false);
+    auto& baz_seq = node["baz"].get_value_ref<fkyaml::node::sequence_type&>();
+    REQUIRE(baz_seq[0].is_boolean());
+    REQUIRE(baz_seq[0].get_value_ref<fkyaml::node::boolean_type&>() == true);
+    REQUIRE(baz_seq[1].is_boolean());
+    REQUIRE(baz_seq[1].get_value_ref<fkyaml::node::boolean_type&>() == false);
 
     REQUIRE(node.contains("qux"));
     REQUIRE(node["qux"].is_null());
@@ -453,7 +454,7 @@ TEST_CASE("NodeClassTest_MappingNodeFactoryTest", "[NodeClassTest]")
             REQUIRE(node.is_mapping());
             REQUIRE(node.size() == 1);
             REQUIRE(node["test"].is_boolean());
-            REQUIRE(node["test"].to_boolean() == true);
+            REQUIRE(node["test"].get_value_ref<fkyaml::node::boolean_type&>() == true);
         }
 
         SECTION("Test rvalue mapping node factory method.")
@@ -462,7 +463,7 @@ TEST_CASE("NodeClassTest_MappingNodeFactoryTest", "[NodeClassTest]")
             REQUIRE(node.is_mapping());
             REQUIRE(node.size() == 1);
             REQUIRE(node["test"].is_boolean());
-            REQUIRE(node["test"].to_boolean() == true);
+            REQUIRE(node["test"].get_value_ref<fkyaml::node::boolean_type&>() == true);
         }
     }
 }
@@ -472,7 +473,7 @@ TEST_CASE("NodeClassTest_BooleanNodeFactoryTest", "[NodeClassTest]")
     auto boolean = GENERATE(true, false);
     fkyaml::node node = boolean;
     REQUIRE(node.is_boolean());
-    REQUIRE(node.to_boolean() == boolean);
+    REQUIRE(node.get_value_ref<fkyaml::node::boolean_type&>() == boolean);
 }
 
 TEST_CASE("NodeClassTest_IntegerNodeFactoryTest", "[NodeClassTest]")
@@ -483,7 +484,7 @@ TEST_CASE("NodeClassTest_IntegerNodeFactoryTest", "[NodeClassTest]")
         std::numeric_limits<fkyaml::node_integer_type>::max());
     fkyaml::node node = integer;
     REQUIRE(node.is_integer());
-    REQUIRE(node.to_integer() == integer);
+    REQUIRE(node.get_value_ref<fkyaml::node::integer_type&>() == integer);
 }
 
 TEST_CASE("NodeClassTest_FloatNumberNodeFactoryTest", "[NodeClassTest]")
@@ -494,7 +495,7 @@ TEST_CASE("NodeClassTest_FloatNumberNodeFactoryTest", "[NodeClassTest]")
         std::numeric_limits<fkyaml::node_float_number_type>::max());
     fkyaml::node node = float_val;
     REQUIRE(node.is_float_number());
-    REQUIRE(node.to_float_number() == float_val);
+    REQUIRE(node.get_value_ref<fkyaml::node::float_number_type&>() == float_val);
 }
 
 TEST_CASE("NodeClassTest_StringNodeFactoryTest", "[NodeClassTest]")
@@ -512,7 +513,7 @@ TEST_CASE("NodeClassTest_StringNodeFactoryTest", "[NodeClassTest]")
         fkyaml::node node = std::string(str);
         REQUIRE(node.is_string());
         REQUIRE(node.size() == str.size());
-        REQUIRE(node.to_string() == str);
+        REQUIRE(node.get_value_ref<fkyaml::node::string_type&>() == str);
     }
 
     SECTION("Test rvalue string node factory method.")
@@ -520,7 +521,7 @@ TEST_CASE("NodeClassTest_StringNodeFactoryTest", "[NodeClassTest]")
         fkyaml::node node = std::string("test");
         REQUIRE(node.is_string());
         REQUIRE(node.size() == 4);
-        REQUIRE(node.to_string().compare("test") == 0);
+        REQUIRE(node.get_value_ref<fkyaml::node::string_type&>().compare("test") == 0);
     }
 }
 
@@ -545,7 +546,7 @@ TEST_CASE("NodeClassTest_AliasNodeFactoryTest", "[NodeClassTest]")
         REQUIRE_NOTHROW(fkyaml::node::alias_of(anchor));
         fkyaml::node alias = fkyaml::node::alias_of(anchor);
         REQUIRE(alias.is_string());
-        REQUIRE(alias.to_string().compare("alias_test") == 0);
+        REQUIRE(alias.get_value_ref<fkyaml::node::string_type&>().compare("alias_test") == 0);
     }
 }
 
@@ -655,7 +656,7 @@ TEST_CASE("NodeClassTest_IntegerSubscriptOperatorTest", "[NodeClassTest]")
     SECTION("Test nothrow expected integer subscript operators.")
     {
         fkyaml::node node = fkyaml::node::sequence();
-        node.to_sequence().emplace_back();
+        node.get_value_ref<fkyaml::node::sequence_type&>().emplace_back();
 
         SECTION("Test non-const non-alias integer subscript operators")
         {
@@ -1421,7 +1422,7 @@ TEST_CASE("NodeClassTest_GetValueTest", "[NodeClassTest]")
 
         SECTION("test for sequence value.")
         {
-            auto seq = node.get_value<fkyaml::node_sequence_type>();
+            auto& seq = node.get_value_ref<fkyaml::node::sequence_type&>();
             REQUIRE(seq.size() == 2);
             REQUIRE(seq[0].is_boolean());
             REQUIRE(seq[0].get_value<bool>() == true);
@@ -1443,11 +1444,11 @@ TEST_CASE("NodeClassTest_GetValueTest", "[NodeClassTest]")
     SECTION("test mapping node value.")
     {
         fkyaml::node node(
-            fkyaml::node_mapping_type {{"test", fkyaml::node(3.14)}, {"foo", fkyaml::node(std::string("bar"))}});
+            fkyaml::node::mapping_type {{"test", fkyaml::node(3.14)}, {"foo", fkyaml::node(std::string("bar"))}});
 
         SECTION("test for mapping value.")
         {
-            auto map = node.get_value<fkyaml::node_mapping_type>();
+            auto& map = node.get_value_ref<fkyaml::node::mapping_type&>();
             REQUIRE(map.size() == 2);
             REQUIRE(map.find("test") != map.end());
             REQUIRE(map.at("test").is_float_number());
@@ -1600,7 +1601,7 @@ TEST_CASE("NodeClassTest_GetValueTest", "[NodeClassTest]")
 
         SECTION("test for string value.")
         {
-            auto str = node.get_value<std::string>();
+            auto& str = node.get_value_ref<fkyaml::node::string_type&>();
             REQUIRE(str.size() == 4);
             REQUIRE(str == "test");
         }
@@ -1630,22 +1631,22 @@ TEST_CASE("NodeClassTest_ToSequenceTest", "[NodeClassTest]")
 
         SECTION("Test non-alias sequence node.")
         {
-            REQUIRE_NOTHROW(node.to_sequence());
-            REQUIRE(node.to_sequence().size() == 3);
+            REQUIRE_NOTHROW(node.get_value_ref<fkyaml::node::sequence_type&>());
+            REQUIRE(node.get_value_ref<fkyaml::node::sequence_type&>().size() == 3);
             for (int i = 0; i < 3; ++i)
             {
-                REQUIRE(node.to_sequence()[i].is_null());
+                REQUIRE(node.get_value_ref<fkyaml::node::sequence_type&>()[i].is_null());
             }
         }
 
         SECTION("Test const non-alias sequence node.")
         {
             const fkyaml::node const_node = node;
-            REQUIRE_NOTHROW(const_node.to_sequence());
-            REQUIRE(const_node.to_sequence().size() == 3);
+            REQUIRE_NOTHROW(const_node.get_value_ref<const fkyaml::node::sequence_type&>());
+            REQUIRE(const_node.get_value_ref<const fkyaml::node::sequence_type&>().size() == 3);
             for (int i = 0; i < 3; ++i)
             {
-                REQUIRE(node.to_sequence()[i].is_null());
+                REQUIRE(node.get_value_ref<const fkyaml::node::sequence_type&>()[i].is_null());
             }
         }
 
@@ -1653,11 +1654,11 @@ TEST_CASE("NodeClassTest_ToSequenceTest", "[NodeClassTest]")
         {
             node.add_anchor_name("anchor_name");
             fkyaml::node alias = fkyaml::node::alias_of(node);
-            REQUIRE_NOTHROW(alias.to_sequence());
-            REQUIRE(alias.to_sequence().size() == 3);
+            REQUIRE_NOTHROW(alias.get_value_ref<fkyaml::node::sequence_type&>());
+            REQUIRE(alias.get_value_ref<fkyaml::node::sequence_type&>().size() == 3);
             for (int i = 0; i < 3; ++i)
             {
-                REQUIRE(alias.to_sequence()[i].is_null());
+                REQUIRE(alias.get_value_ref<fkyaml::node::sequence_type&>()[i].is_null());
             }
         }
 
@@ -1665,11 +1666,11 @@ TEST_CASE("NodeClassTest_ToSequenceTest", "[NodeClassTest]")
         {
             node.add_anchor_name("anchor_name");
             const fkyaml::node alias = fkyaml::node::alias_of(node);
-            REQUIRE_NOTHROW(alias.to_sequence());
-            REQUIRE(alias.to_sequence().size() == 3);
+            REQUIRE_NOTHROW(alias.get_value_ref<const fkyaml::node::sequence_type&>());
+            REQUIRE(alias.get_value_ref<const fkyaml::node::sequence_type&>().size() == 3);
             for (int i = 0; i < 3; ++i)
             {
-                REQUIRE(alias.to_sequence()[i].is_null());
+                REQUIRE(alias.get_value_ref<const fkyaml::node::sequence_type&>()[i].is_null());
             }
         }
     }
@@ -1686,27 +1687,27 @@ TEST_CASE("NodeClassTest_ToSequenceTest", "[NodeClassTest]")
 
         SECTION("Test non-alias non-sequence nodes.")
         {
-            REQUIRE_THROWS_AS(node.to_sequence(), fkyaml::exception);
+            REQUIRE_THROWS_AS(node.get_value_ref<fkyaml::node::sequence_type&>(), fkyaml::exception);
         }
 
         SECTION("Test const non-alias non-sequence nodes.")
         {
             const fkyaml::node const_node = node;
-            REQUIRE_THROWS_AS(const_node.to_sequence(), fkyaml::exception);
+            REQUIRE_THROWS_AS(const_node.get_value_ref<const fkyaml::node::sequence_type&>(), fkyaml::exception);
         }
 
         SECTION("Test alias non-sequence nodes.")
         {
             node.add_anchor_name("anchor_name");
             fkyaml::node alias = fkyaml::node::alias_of(node);
-            REQUIRE_THROWS_AS(alias.to_sequence(), fkyaml::exception);
+            REQUIRE_THROWS_AS(alias.get_value_ref<fkyaml::node::sequence_type&>(), fkyaml::exception);
         }
 
         SECTION("Test const alias non-sequence nodes.")
         {
             node.add_anchor_name("anchor_name");
             const fkyaml::node alias = fkyaml::node::alias_of(node);
-            REQUIRE_THROWS_AS(alias.to_sequence(), fkyaml::exception);
+            REQUIRE_THROWS_AS(alias.get_value_ref<const fkyaml::node::sequence_type&>(), fkyaml::exception);
         }
     }
 }
@@ -1720,8 +1721,8 @@ TEST_CASE("NodeClassTest_ToMappingTest", "[NodeClassTest]")
 
         SECTION("Test non-alias mapping node.")
         {
-            REQUIRE_NOTHROW(node.to_mapping());
-            REQUIRE(node.to_mapping().size() == 3);
+            REQUIRE_NOTHROW(node.get_value_ref<fkyaml::node::mapping_type&>());
+            REQUIRE(node.get_value_ref<fkyaml::node::mapping_type&>().size() == 3);
             REQUIRE(node["test0"].is_null());
             REQUIRE(node["test1"].is_null());
             REQUIRE(node["test2"].is_null());
@@ -1730,8 +1731,8 @@ TEST_CASE("NodeClassTest_ToMappingTest", "[NodeClassTest]")
         SECTION("Test const non-alias mapping node.")
         {
             const fkyaml::node const_node = node;
-            REQUIRE_NOTHROW(const_node.to_mapping());
-            REQUIRE(const_node.to_mapping().size() == 3);
+            REQUIRE_NOTHROW(const_node.get_value_ref<const fkyaml::node::mapping_type&>());
+            REQUIRE(const_node.get_value_ref<const fkyaml::node::mapping_type&>().size() == 3);
             REQUIRE(const_node["test0"].is_null());
             REQUIRE(const_node["test1"].is_null());
             REQUIRE(const_node["test2"].is_null());
@@ -1741,8 +1742,8 @@ TEST_CASE("NodeClassTest_ToMappingTest", "[NodeClassTest]")
         {
             node.add_anchor_name("anchor_name");
             fkyaml::node alias = fkyaml::node::alias_of(node);
-            REQUIRE_NOTHROW(alias.to_mapping());
-            REQUIRE(alias.to_mapping().size() == 3);
+            REQUIRE_NOTHROW(alias.get_value_ref<fkyaml::node::mapping_type&>());
+            REQUIRE(alias.get_value_ref<fkyaml::node::mapping_type&>().size() == 3);
             REQUIRE(alias["test0"].is_null());
             REQUIRE(alias["test1"].is_null());
             REQUIRE(alias["test2"].is_null());
@@ -1752,7 +1753,7 @@ TEST_CASE("NodeClassTest_ToMappingTest", "[NodeClassTest]")
         {
             node.add_anchor_name("anchor_name");
             const fkyaml::node alias = fkyaml::node::alias_of(node);
-            REQUIRE_NOTHROW(alias.to_mapping());
+            REQUIRE_NOTHROW(alias.get_value_ref<const fkyaml::node::mapping_type&>());
             REQUIRE(alias["test0"].is_null());
             REQUIRE(alias["test1"].is_null());
             REQUIRE(alias["test2"].is_null());
@@ -1771,27 +1772,27 @@ TEST_CASE("NodeClassTest_ToMappingTest", "[NodeClassTest]")
 
         SECTION("Test non-alias non-mapping nodes.")
         {
-            REQUIRE_THROWS_AS(node.to_mapping(), fkyaml::exception);
+            REQUIRE_THROWS_AS(node.get_value_ref<fkyaml::node::mapping_type&>(), fkyaml::exception);
         }
 
         SECTION("Test const non-alias non-mapping nodes.")
         {
             const fkyaml::node const_node = node;
-            REQUIRE_THROWS_AS(const_node.to_mapping(), fkyaml::exception);
+            REQUIRE_THROWS_AS(const_node.get_value_ref<const fkyaml::node::mapping_type&>(), fkyaml::exception);
         }
 
         SECTION("Test alias non-mapping nodes.")
         {
             node.add_anchor_name("anchor_name");
             fkyaml::node alias = fkyaml::node::alias_of(node);
-            REQUIRE_THROWS_AS(alias.to_mapping(), fkyaml::exception);
+            REQUIRE_THROWS_AS(alias.get_value_ref<fkyaml::node::mapping_type&>(), fkyaml::exception);
         }
 
         SECTION("Test const alias non-mapping nodes.")
         {
             node.add_anchor_name("anchor_name");
             const fkyaml::node alias = fkyaml::node::alias_of(node);
-            REQUIRE_THROWS_AS(alias.to_mapping(), fkyaml::exception);
+            REQUIRE_THROWS_AS(alias.get_value_ref<const fkyaml::node::mapping_type&>(), fkyaml::exception);
         }
     }
 }
@@ -1804,31 +1805,31 @@ TEST_CASE("NodeClassTest_ToBooleanTest", "[NodeClassTest]")
 
         SECTION("Test non-alias boolean node.")
         {
-            REQUIRE_NOTHROW(node.to_boolean());
-            REQUIRE(node.to_boolean() == true);
+            REQUIRE_NOTHROW(node.get_value_ref<fkyaml::node::boolean_type&>());
+            REQUIRE(node.get_value_ref<fkyaml::node::boolean_type&>() == true);
         }
 
         SECTION("Test const non-alias boolean node.")
         {
             const fkyaml::node const_node = node;
-            REQUIRE_NOTHROW(const_node.to_boolean());
-            REQUIRE(const_node.to_boolean() == true);
+            REQUIRE_NOTHROW(const_node.get_value_ref<const fkyaml::node::boolean_type&>());
+            REQUIRE(const_node.get_value_ref<const fkyaml::node::boolean_type&>() == true);
         }
 
         SECTION("Test alias boolean node.")
         {
             node.add_anchor_name("anchor_name");
             fkyaml::node alias = fkyaml::node::alias_of(node);
-            REQUIRE_NOTHROW(alias.to_boolean());
-            REQUIRE(alias.to_boolean() == true);
+            REQUIRE_NOTHROW(alias.get_value_ref<fkyaml::node::boolean_type&>());
+            REQUIRE(alias.get_value_ref<fkyaml::node::boolean_type&>() == true);
         }
 
         SECTION("Test const alias boolean node.")
         {
             node.add_anchor_name("anchor_name");
             const fkyaml::node alias = fkyaml::node::alias_of(node);
-            REQUIRE_NOTHROW(alias.to_boolean());
-            REQUIRE(alias.to_boolean() == true);
+            REQUIRE_NOTHROW(alias.get_value_ref<const fkyaml::node::boolean_type&>());
+            REQUIRE(alias.get_value_ref<const fkyaml::node::boolean_type&>() == true);
         }
     }
 
@@ -1844,27 +1845,27 @@ TEST_CASE("NodeClassTest_ToBooleanTest", "[NodeClassTest]")
 
         SECTION("Test non-alias non-boolean nodes.")
         {
-            REQUIRE_THROWS_AS(node.to_boolean(), fkyaml::exception);
+            REQUIRE_THROWS_AS(node.get_value_ref<fkyaml::node::boolean_type&>(), fkyaml::exception);
         }
 
         SECTION("Test const non-alias non-boolean nodes.")
         {
             const fkyaml::node const_node = node;
-            REQUIRE_THROWS_AS(const_node.to_boolean(), fkyaml::exception);
+            REQUIRE_THROWS_AS(const_node.get_value_ref<const fkyaml::node::boolean_type&>(), fkyaml::exception);
         }
 
         SECTION("Test alias non-boolean nodes.")
         {
             node.add_anchor_name("anchor_name");
             fkyaml::node alias = fkyaml::node::alias_of(node);
-            REQUIRE_THROWS_AS(alias.to_boolean(), fkyaml::exception);
+            REQUIRE_THROWS_AS(alias.get_value_ref<fkyaml::node::boolean_type&>(), fkyaml::exception);
         }
 
         SECTION("Test const alias non-boolean nodes.")
         {
             node.add_anchor_name("anchor_name");
             const fkyaml::node alias = fkyaml::node::alias_of(node);
-            REQUIRE_THROWS_AS(alias.to_boolean(), fkyaml::exception);
+            REQUIRE_THROWS_AS(alias.get_value_ref<const fkyaml::node::boolean_type&>(), fkyaml::exception);
         }
     }
 }
@@ -1878,31 +1879,31 @@ TEST_CASE("NodeClassTest_ToIntegerTest", "[NodeClassTest]")
 
         SECTION("Test non-alias  integer node.")
         {
-            REQUIRE_NOTHROW(node.to_integer());
-            REQUIRE(node.to_integer() == integer);
+            REQUIRE_NOTHROW(node.get_value_ref<fkyaml::node::integer_type&>());
+            REQUIRE(node.get_value_ref<fkyaml::node::integer_type&>() == integer);
         }
 
         SECTION("Test const non-alias  integer node.")
         {
             const fkyaml::node const_node = node;
-            REQUIRE_NOTHROW(const_node.to_integer());
-            REQUIRE(const_node.to_integer() == integer);
+            REQUIRE_NOTHROW(const_node.get_value_ref<const fkyaml::node::integer_type&>());
+            REQUIRE(const_node.get_value_ref<const fkyaml::node::integer_type&>() == integer);
         }
 
         SECTION("Test alias  integer node.")
         {
             node.add_anchor_name("anchor_name");
             fkyaml::node alias = fkyaml::node::alias_of(node);
-            REQUIRE_NOTHROW(alias.to_integer());
-            REQUIRE(alias.to_integer() == integer);
+            REQUIRE_NOTHROW(alias.get_value_ref<fkyaml::node::integer_type&>());
+            REQUIRE(alias.get_value_ref<fkyaml::node::integer_type&>() == integer);
         }
 
         SECTION("Test const alias  integer node.")
         {
             node.add_anchor_name("anchor_name");
             const fkyaml::node alias = fkyaml::node::alias_of(node);
-            REQUIRE_NOTHROW(alias.to_integer());
-            REQUIRE(alias.to_integer() == integer);
+            REQUIRE_NOTHROW(alias.get_value_ref<const fkyaml::node::integer_type&>());
+            REQUIRE(alias.get_value_ref<const fkyaml::node::integer_type&>() == integer);
         }
     }
 
@@ -1918,27 +1919,27 @@ TEST_CASE("NodeClassTest_ToIntegerTest", "[NodeClassTest]")
 
         SECTION("Test non-alias non-integer nodes.")
         {
-            REQUIRE_THROWS_AS(node.to_integer(), fkyaml::exception);
+            REQUIRE_THROWS_AS(node.get_value_ref<fkyaml::node::integer_type&>(), fkyaml::exception);
         }
 
         SECTION("Test const non-alias non-integer nodes.")
         {
             const fkyaml::node const_node = node;
-            REQUIRE_THROWS_AS(const_node.to_integer(), fkyaml::exception);
+            REQUIRE_THROWS_AS(const_node.get_value_ref<const fkyaml::node::integer_type&>(), fkyaml::exception);
         }
 
         SECTION("Test alias non-integer nodes.")
         {
             node.add_anchor_name("anchor_name");
             fkyaml::node alias = fkyaml::node::alias_of(node);
-            REQUIRE_THROWS_AS(alias.to_integer(), fkyaml::exception);
+            REQUIRE_THROWS_AS(alias.get_value_ref<fkyaml::node::integer_type&>(), fkyaml::exception);
         }
 
         SECTION("Test const alias non-integer nodes.")
         {
             node.add_anchor_name("anchor_name");
             const fkyaml::node alias = fkyaml::node::alias_of(node);
-            REQUIRE_THROWS_AS(alias.to_integer(), fkyaml::exception);
+            REQUIRE_THROWS_AS(alias.get_value_ref<const fkyaml::node::integer_type&>(), fkyaml::exception);
         }
     }
 }
@@ -1952,31 +1953,31 @@ TEST_CASE("NodeClassTest_ToFloatNumberTest", "[NodeClassTest]")
 
         SECTION("Test non-alias float number node.")
         {
-            REQUIRE_NOTHROW(node.to_float_number());
-            REQUIRE(node.to_float_number() == float_val);
+            REQUIRE_NOTHROW(node.get_value_ref<fkyaml::node::float_number_type&>());
+            REQUIRE(node.get_value_ref<fkyaml::node::float_number_type&>() == float_val);
         }
 
         SECTION("Test const non-alias float number node.")
         {
             const fkyaml::node const_node = node;
-            REQUIRE_NOTHROW(const_node.to_float_number());
-            REQUIRE(const_node.to_float_number() == float_val);
+            REQUIRE_NOTHROW(const_node.get_value_ref<const fkyaml::node::float_number_type&>());
+            REQUIRE(const_node.get_value_ref<const fkyaml::node::float_number_type&>() == float_val);
         }
 
         SECTION("Test alias float number node.")
         {
             node.add_anchor_name("anchor_name");
             fkyaml::node alias = fkyaml::node::alias_of(node);
-            REQUIRE_NOTHROW(alias.to_float_number());
-            REQUIRE(alias.to_float_number() == float_val);
+            REQUIRE_NOTHROW(alias.get_value_ref<fkyaml::node::float_number_type&>());
+            REQUIRE(alias.get_value_ref<fkyaml::node::float_number_type&>() == float_val);
         }
 
         SECTION("Test const alias float number node.")
         {
             node.add_anchor_name("anchor_name");
             const fkyaml::node alias = fkyaml::node::alias_of(node);
-            REQUIRE_NOTHROW(alias.to_float_number());
-            REQUIRE(alias.to_float_number() == float_val);
+            REQUIRE_NOTHROW(alias.get_value_ref<const fkyaml::node::float_number_type&>());
+            REQUIRE(alias.get_value_ref<const fkyaml::node::float_number_type&>() == float_val);
         }
     }
 
@@ -1992,27 +1993,27 @@ TEST_CASE("NodeClassTest_ToFloatNumberTest", "[NodeClassTest]")
 
         SECTION("Test non-alias non-float-number nodes.")
         {
-            REQUIRE_THROWS_AS(node.to_float_number(), fkyaml::exception);
+            REQUIRE_THROWS_AS(node.get_value_ref<fkyaml::node::float_number_type&>(), fkyaml::exception);
         }
 
         SECTION("Test const non-alias non-float-number nodes.")
         {
             const fkyaml::node const_node = node;
-            REQUIRE_THROWS_AS(const_node.to_float_number(), fkyaml::exception);
+            REQUIRE_THROWS_AS(const_node.get_value_ref<const fkyaml::node::float_number_type&>(), fkyaml::exception);
         }
 
         SECTION("Test alias non-float-number nodes.")
         {
             node.add_anchor_name("anchor_name");
             fkyaml::node alias = fkyaml::node::alias_of(node);
-            REQUIRE_THROWS_AS(alias.to_float_number(), fkyaml::exception);
+            REQUIRE_THROWS_AS(alias.get_value_ref<fkyaml::node::float_number_type&>(), fkyaml::exception);
         }
 
         SECTION("Test const alias non-float-number nodes.")
         {
             node.add_anchor_name("anchor_name");
             const fkyaml::node alias = fkyaml::node::alias_of(node);
-            REQUIRE_THROWS_AS(alias.to_float_number(), fkyaml::exception);
+            REQUIRE_THROWS_AS(alias.get_value_ref<const fkyaml::node::float_number_type&>(), fkyaml::exception);
         }
     }
 }
@@ -2026,31 +2027,31 @@ TEST_CASE("NodeClassTest_ToStringTest", "[NodeClassTest]")
 
         SECTION("Test non-alias string node.")
         {
-            REQUIRE_NOTHROW(node.to_string());
-            REQUIRE(node.to_string() == str);
+            REQUIRE_NOTHROW(node.get_value_ref<fkyaml::node::string_type&>());
+            REQUIRE(node.get_value_ref<fkyaml::node::string_type&>() == str);
         }
 
         SECTION("Test const non-alias string node.")
         {
             const fkyaml::node const_node = node;
-            REQUIRE_NOTHROW(const_node.to_string());
-            REQUIRE(const_node.to_string() == str);
+            REQUIRE_NOTHROW(const_node.get_value_ref<const fkyaml::node::string_type&>());
+            REQUIRE(const_node.get_value_ref<const fkyaml::node::string_type&>() == str);
         }
 
         SECTION("Test alias string node.")
         {
             node.add_anchor_name("anchor_name");
             fkyaml::node alias = fkyaml::node::alias_of(node);
-            REQUIRE_NOTHROW(alias.to_string());
-            REQUIRE(alias.to_string() == str);
+            REQUIRE_NOTHROW(alias.get_value_ref<fkyaml::node::string_type&>());
+            REQUIRE(alias.get_value_ref<fkyaml::node::string_type&>() == str);
         }
 
         SECTION("Test const alias string node.")
         {
             node.add_anchor_name("anchor_name");
             const fkyaml::node alias = fkyaml::node::alias_of(node);
-            REQUIRE_NOTHROW(alias.to_string());
-            REQUIRE(alias.to_string() == str);
+            REQUIRE_NOTHROW(alias.get_value_ref<const fkyaml::node::string_type&>());
+            REQUIRE(alias.get_value_ref<const fkyaml::node::string_type&>() == str);
         }
     }
 
@@ -2066,27 +2067,27 @@ TEST_CASE("NodeClassTest_ToStringTest", "[NodeClassTest]")
 
         SECTION("Test non-alias non-string nodes.")
         {
-            REQUIRE_THROWS_AS(node.to_string(), fkyaml::exception);
+            REQUIRE_THROWS_AS(node.get_value_ref<fkyaml::node::string_type&>(), fkyaml::exception);
         }
 
         SECTION("Test const non-alias non-string nodes.")
         {
             const fkyaml::node const_node = node;
-            REQUIRE_THROWS_AS(const_node.to_string(), fkyaml::exception);
+            REQUIRE_THROWS_AS(const_node.get_value_ref<const fkyaml::node::string_type&>(), fkyaml::exception);
         }
 
         SECTION("Test alias non-string nodes.")
         {
             node.add_anchor_name("anchor_name");
             fkyaml::node alias = fkyaml::node::alias_of(node);
-            REQUIRE_THROWS_AS(alias.to_string(), fkyaml::exception);
+            REQUIRE_THROWS_AS(alias.get_value_ref<fkyaml::node::string_type&>(), fkyaml::exception);
         }
 
         SECTION("Test const alias non-string nodes.")
         {
             node.add_anchor_name("anchor_name");
             const fkyaml::node alias = fkyaml::node::alias_of(node);
-            REQUIRE_THROWS_AS(alias.to_string(), fkyaml::exception);
+            REQUIRE_THROWS_AS(alias.get_value_ref<const fkyaml::node::string_type&>(), fkyaml::exception);
         }
     }
 }
@@ -2227,9 +2228,9 @@ TEST_CASE("NodeClassTest_SwapTest", "[NodeClassTest]")
     fkyaml::node rhs_node = 123;
     lhs_node.swap(rhs_node);
     REQUIRE(lhs_node.is_integer());
-    REQUIRE(lhs_node.to_integer() == 123);
+    REQUIRE(lhs_node.get_value_ref<fkyaml::node::integer_type&>() == 123);
     REQUIRE(rhs_node.is_boolean());
-    REQUIRE(rhs_node.to_boolean() == true);
+    REQUIRE(rhs_node.get_value_ref<fkyaml::node::boolean_type&>() == true);
 }
 
 TEST_CASE("NodeClassTest_ADLSwapTest", "[NodeClassTest]")
@@ -2241,7 +2242,7 @@ TEST_CASE("NodeClassTest_ADLSwapTest", "[NodeClassTest]")
     swap(lhs_node, rhs_node);
 
     REQUIRE(lhs_node.is_integer());
-    REQUIRE(lhs_node.to_integer() == 123);
+    REQUIRE(lhs_node.get_value_ref<fkyaml::node::integer_type&>() == 123);
     REQUIRE(rhs_node.is_boolean());
-    REQUIRE(rhs_node.to_boolean() == true);
+    REQUIRE(rhs_node.get_value_ref<fkyaml::node::boolean_type&>() == true);
 }

--- a/test/unit_test/test_node_class.cpp
+++ b/test/unit_test/test_node_class.cpp
@@ -736,7 +736,7 @@ TEST_CASE("NodeClassTest_TypeGetterTest", "[NodeClassTest]")
     }
 }
 
-TEST_CASE("NodeClassTest_is_sequenceTest", "[NodeClassTest]")
+TEST_CASE("NodeClassTest_IsSequenceTest", "[NodeClassTest]")
 {
     SECTION("Test sequence node type.")
     {
@@ -779,7 +779,7 @@ TEST_CASE("NodeClassTest_is_sequenceTest", "[NodeClassTest]")
     }
 }
 
-TEST_CASE("NodeClassTest_is_mappingTest", "[NodeClassTest]")
+TEST_CASE("NodeClassTest_IsMappingTest", "[NodeClassTest]")
 {
     SECTION("Test mapping node type.")
     {
@@ -822,7 +822,7 @@ TEST_CASE("NodeClassTest_is_mappingTest", "[NodeClassTest]")
     }
 }
 
-TEST_CASE("NodeClassTest_is_nullTest", "[NodeClassTest]")
+TEST_CASE("NodeClassTest_IsNullTest", "[NodeClassTest]")
 {
     SECTION("Test null node type.")
     {
@@ -865,7 +865,7 @@ TEST_CASE("NodeClassTest_is_nullTest", "[NodeClassTest]")
     }
 }
 
-TEST_CASE("NodeClassTest_is_booleanTest", "[NodeClassTest]")
+TEST_CASE("NodeClassTest_IsBooleanTest", "[NodeClassTest]")
 {
     SECTION("Test boolean node type.")
     {
@@ -908,7 +908,7 @@ TEST_CASE("NodeClassTest_is_booleanTest", "[NodeClassTest]")
     }
 }
 
-TEST_CASE("NodeClassTest_is_integerTest", "[NodeClassTest]")
+TEST_CASE("NodeClassTest_IsIntegerTest", "[NodeClassTest]")
 {
     SECTION("Test integer node type.")
     {
@@ -1037,7 +1037,7 @@ TEST_CASE("NodeClassTest_IsStringTest", "[NodeClassTest]")
     }
 }
 
-TEST_CASE("NodeClassTest_is_scalarTest", "[NodeClassTest]")
+TEST_CASE("NodeClassTest_IsScalarTest", "[NodeClassTest]")
 {
     SECTION("Test scalar node types.")
     {
@@ -1097,7 +1097,7 @@ TEST_CASE("NodeClassTest_IsAliasTest", "[NodeClassTest]")
 // test cases for emptiness checker
 //
 
-TEST_CASE("NodeClassTest_emptyTest", "[NodeClassTest]")
+TEST_CASE("NodeClassTest_EmptyTest", "[NodeClassTest]")
 {
     SECTION("Test nothrow expected node emptiness.")
     {
@@ -1251,7 +1251,7 @@ TEST_CASE("NodeClassTest_ContainsTest", "[NodeClassTest]")
 // test cases for container size getter
 //
 
-TEST_CASE("NodeClassTest_sizeGetterTest", "[NodeClassTest]")
+TEST_CASE("NodeClassTest_SizeGetterTest", "[NodeClassTest]")
 {
     SECTION("Test nothrow expected node size.")
     {
@@ -1422,7 +1422,7 @@ TEST_CASE("NodeClassTest_GetValueTest", "[NodeClassTest]")
 
         SECTION("test for sequence value.")
         {
-            auto& seq = node.get_value_ref<fkyaml::node::sequence_type&>();
+            auto seq = node.get_value<fkyaml::node::sequence_type>();
             REQUIRE(seq.size() == 2);
             REQUIRE(seq[0].is_boolean());
             REQUIRE(seq[0].get_value<bool>() == true);
@@ -1448,7 +1448,7 @@ TEST_CASE("NodeClassTest_GetValueTest", "[NodeClassTest]")
 
         SECTION("test for mapping value.")
         {
-            auto& map = node.get_value_ref<fkyaml::node::mapping_type&>();
+            auto map = node.get_value<fkyaml::node::mapping_type>();
             REQUIRE(map.size() == 2);
             REQUIRE(map.find("test") != map.end());
             REQUIRE(map.at("test").is_float_number());
@@ -1622,7 +1622,7 @@ TEST_CASE("NodeClassTest_GetValueTest", "[NodeClassTest]")
 // test cases for value reference getters
 //
 
-TEST_CASE("NodeClassTest_ToSequenceTest", "[NodeClassTest]")
+TEST_CASE("NodeClassTest_GetValueRefForSequenceTest", "[NodeClassTest]")
 {
     SECTION("Test nothrow expected nodes.")
     {
@@ -1712,7 +1712,7 @@ TEST_CASE("NodeClassTest_ToSequenceTest", "[NodeClassTest]")
     }
 }
 
-TEST_CASE("NodeClassTest_ToMappingTest", "[NodeClassTest]")
+TEST_CASE("NodeClassTest_GetValueRefForMappingTest", "[NodeClassTest]")
 {
     SECTION("Test nothrow expected nodes.")
     {
@@ -1797,7 +1797,7 @@ TEST_CASE("NodeClassTest_ToMappingTest", "[NodeClassTest]")
     }
 }
 
-TEST_CASE("NodeClassTest_ToBooleanTest", "[NodeClassTest]")
+TEST_CASE("NodeClassTest_GetValueRefForBooleanTest", "[NodeClassTest]")
 {
     SECTION("Test nothrow expected nodes.")
     {
@@ -1870,7 +1870,7 @@ TEST_CASE("NodeClassTest_ToBooleanTest", "[NodeClassTest]")
     }
 }
 
-TEST_CASE("NodeClassTest_ToIntegerTest", "[NodeClassTest]")
+TEST_CASE("NodeClassTest_GetValueRefForIntegerTest", "[NodeClassTest]")
 {
     SECTION("Test nothrow expected nodes.")
     {
@@ -1944,7 +1944,7 @@ TEST_CASE("NodeClassTest_ToIntegerTest", "[NodeClassTest]")
     }
 }
 
-TEST_CASE("NodeClassTest_ToFloatNumberTest", "[NodeClassTest]")
+TEST_CASE("NodeClassTest_GetValueRefForFloatNumberTest", "[NodeClassTest]")
 {
     SECTION("Test nothrow expected nodes.")
     {
@@ -2018,7 +2018,7 @@ TEST_CASE("NodeClassTest_ToFloatNumberTest", "[NodeClassTest]")
     }
 }
 
-TEST_CASE("NodeClassTest_ToStringTest", "[NodeClassTest]")
+TEST_CASE("NodeClassTest_GetValueRefForStringTest", "[NodeClassTest]")
 {
     SECTION("Test nothrow expected nodes.")
     {

--- a/test/unit_test/test_node_class.cpp
+++ b/test/unit_test/test_node_class.cpp
@@ -89,7 +89,7 @@ TEST_CASE("NodeClassTest_ThrowingSpecializationTypeCtorTest", "[NodeClassTest]")
 
 TEST_CASE("NodeClassTest_SequenceCtorTest", "[NodeClassTest]")
 {
-    fkyaml::node node(fkyaml::node_sequence_type {fkyaml::node(true), fkyaml::node(false)});
+    fkyaml::node node(fkyaml::node::sequence_type {fkyaml::node(true), fkyaml::node(false)});
     REQUIRE(node.type() == fkyaml::node::node_t::SEQUENCE);
     REQUIRE(node.is_sequence());
     REQUIRE(node.size() == 2);
@@ -101,7 +101,7 @@ TEST_CASE("NodeClassTest_SequenceCtorTest", "[NodeClassTest]")
 
 TEST_CASE("NodeClassTest_MappingCtorTest", "[NodeClassTest]")
 {
-    fkyaml::node node(fkyaml::node_mapping_type {{"test", fkyaml::node(true)}});
+    fkyaml::node node(fkyaml::node::mapping_type {{"test", fkyaml::node(true)}});
     REQUIRE(node.type() == fkyaml::node::node_t::MAPPING);
     REQUIRE(node.is_mapping());
     REQUIRE(node.size() == 1);
@@ -143,7 +143,7 @@ TEST_CASE("NodeClassTest_FloatNumberCtorTest", "[NodeClassTest]")
 
 TEST_CASE("NodeClassTest_StringCtorTest", "[NodeClassTest]")
 {
-    auto node = GENERATE(fkyaml::node(fkyaml::node_string_type("test")));
+    auto node = GENERATE(fkyaml::node(fkyaml::node::string_type("test")));
     REQUIRE(node.type() == fkyaml::node::node_t::STRING);
     REQUIRE(node.is_string());
     REQUIRE(node.size() == 4);
@@ -409,7 +409,7 @@ TEST_CASE("NodeClassTest_SequenceNodeFactoryTest", "[NodeClassTest]")
 
     SECTION("Test non-empty sequence node factory methods.")
     {
-        fkyaml::node_sequence_type seq(3);
+        fkyaml::node::sequence_type seq(3);
 
         SECTION("Test lvalue sequence node factory method.")
         {
@@ -446,7 +446,7 @@ TEST_CASE("NodeClassTest_MappingNodeFactoryTest", "[NodeClassTest]")
 
     SECTION("Test non-empty mapping node factory methods.")
     {
-        fkyaml::node_mapping_type map {{std::string("test"), true}};
+        fkyaml::node::mapping_type map {{std::string("test"), true}};
 
         SECTION("Test lvalue mapping node factory method.")
         {
@@ -479,9 +479,9 @@ TEST_CASE("NodeClassTest_BooleanNodeFactoryTest", "[NodeClassTest]")
 TEST_CASE("NodeClassTest_IntegerNodeFactoryTest", "[NodeClassTest]")
 {
     auto integer = GENERATE(
-        std::numeric_limits<fkyaml::node_integer_type>::min(),
+        std::numeric_limits<fkyaml::node::integer_type>::min(),
         0,
-        std::numeric_limits<fkyaml::node_integer_type>::max());
+        std::numeric_limits<fkyaml::node::integer_type>::max());
     fkyaml::node node = integer;
     REQUIRE(node.is_integer());
     REQUIRE(node.get_value_ref<fkyaml::node::integer_type&>() == integer);
@@ -490,9 +490,9 @@ TEST_CASE("NodeClassTest_IntegerNodeFactoryTest", "[NodeClassTest]")
 TEST_CASE("NodeClassTest_FloatNumberNodeFactoryTest", "[NodeClassTest]")
 {
     auto float_val = GENERATE(
-        std::numeric_limits<fkyaml::node_float_number_type>::min(),
+        std::numeric_limits<fkyaml::node::float_number_type>::min(),
         3.141592,
-        std::numeric_limits<fkyaml::node_float_number_type>::max());
+        std::numeric_limits<fkyaml::node::float_number_type>::max());
     fkyaml::node node = float_val;
     REQUIRE(node.is_float_number());
     REQUIRE(node.get_value_ref<fkyaml::node::float_number_type&>() == float_val);
@@ -509,7 +509,7 @@ TEST_CASE("NodeClassTest_StringNodeFactoryTest", "[NodeClassTest]")
 
     SECTION("Test lvalue string node factory method.")
     {
-        fkyaml::node_string_type str("test");
+        fkyaml::node::string_type str("test");
         fkyaml::node node = std::string(str);
         REQUIRE(node.is_string());
         REQUIRE(node.size() == str.size());
@@ -558,7 +558,7 @@ TEST_CASE("NodeClassTest_StringSubscriptOperatorTest", "[NodeClassTest]")
 {
     SECTION("Test nothrow expected string subscript operators.")
     {
-        fkyaml::node_mapping_type map {{"test", fkyaml::node()}};
+        fkyaml::node::mapping_type map {{"test", fkyaml::node()}};
 
         SECTION("Test the non-const string subscript operators.")
         {
@@ -1123,8 +1123,8 @@ TEST_CASE("NodeClassTest_emptyTest", "[NodeClassTest]")
         SECTION("Test non-empty container node emptiness.")
         {
             auto node = GENERATE(
-                fkyaml::node::sequence(fkyaml::node_sequence_type(3)),
-                fkyaml::node::mapping(fkyaml::node_mapping_type {{"test", fkyaml::node()}}),
+                fkyaml::node::sequence(fkyaml::node::sequence_type(3)),
+                fkyaml::node::mapping(fkyaml::node::mapping_type {{"test", fkyaml::node()}}),
                 fkyaml::node(std::string("test")));
 
             SECTION("Test non-empty non-alias container node emptiness.")
@@ -1418,7 +1418,7 @@ TEST_CASE("NodeClassTest_GetValueTest", "[NodeClassTest]")
 {
     SECTION("test sequence node value.")
     {
-        fkyaml::node node(fkyaml::node_sequence_type {fkyaml::node(true), fkyaml::node(false)});
+        fkyaml::node node(fkyaml::node::sequence_type {fkyaml::node(true), fkyaml::node(false)});
 
         SECTION("test for sequence value.")
         {
@@ -1432,12 +1432,12 @@ TEST_CASE("NodeClassTest_GetValueTest", "[NodeClassTest]")
 
         SECTION("test for non-sequence value.")
         {
-            REQUIRE_THROWS_AS(node.get_value<fkyaml::node_mapping_type>(), fkyaml::exception);
+            REQUIRE_THROWS_AS(node.get_value<fkyaml::node::mapping_type>(), fkyaml::exception);
             REQUIRE_THROWS_AS(node.get_value<std::nullptr_t>(), fkyaml::exception);
-            REQUIRE_THROWS_AS(node.get_value<fkyaml::node_boolean_type>(), fkyaml::exception);
-            REQUIRE_THROWS_AS(node.get_value<fkyaml::node_integer_type>(), fkyaml::exception);
-            REQUIRE_THROWS_AS(node.get_value<fkyaml::node_float_number_type>(), fkyaml::exception);
-            REQUIRE_THROWS_AS(node.get_value<fkyaml::node_string_type>(), fkyaml::exception);
+            REQUIRE_THROWS_AS(node.get_value<fkyaml::node::boolean_type>(), fkyaml::exception);
+            REQUIRE_THROWS_AS(node.get_value<fkyaml::node::integer_type>(), fkyaml::exception);
+            REQUIRE_THROWS_AS(node.get_value<fkyaml::node::float_number_type>(), fkyaml::exception);
+            REQUIRE_THROWS_AS(node.get_value<fkyaml::node::string_type>(), fkyaml::exception);
         }
     }
 
@@ -1460,12 +1460,12 @@ TEST_CASE("NodeClassTest_GetValueTest", "[NodeClassTest]")
 
         SECTION("test for non-mapping values.")
         {
-            REQUIRE_THROWS_AS(node.get_value<fkyaml::node_sequence_type>(), fkyaml::exception);
+            REQUIRE_THROWS_AS(node.get_value<fkyaml::node::sequence_type>(), fkyaml::exception);
             REQUIRE_THROWS_AS(node.get_value<std::nullptr_t>(), fkyaml::exception);
-            REQUIRE_THROWS_AS(node.get_value<fkyaml::node_boolean_type>(), fkyaml::exception);
-            REQUIRE_THROWS_AS(node.get_value<fkyaml::node_integer_type>(), fkyaml::exception);
-            REQUIRE_THROWS_AS(node.get_value<fkyaml::node_float_number_type>(), fkyaml::exception);
-            REQUIRE_THROWS_AS(node.get_value<fkyaml::node_string_type>(), fkyaml::exception);
+            REQUIRE_THROWS_AS(node.get_value<fkyaml::node::boolean_type>(), fkyaml::exception);
+            REQUIRE_THROWS_AS(node.get_value<fkyaml::node::integer_type>(), fkyaml::exception);
+            REQUIRE_THROWS_AS(node.get_value<fkyaml::node::float_number_type>(), fkyaml::exception);
+            REQUIRE_THROWS_AS(node.get_value<fkyaml::node::string_type>(), fkyaml::exception);
         }
     }
 
@@ -1481,12 +1481,12 @@ TEST_CASE("NodeClassTest_GetValueTest", "[NodeClassTest]")
 
         SECTION("test for non-null values.")
         {
-            REQUIRE_THROWS_AS(node.get_value<fkyaml::node_sequence_type>(), fkyaml::exception);
-            REQUIRE_THROWS_AS(node.get_value<fkyaml::node_mapping_type>(), fkyaml::exception);
-            REQUIRE_THROWS_AS(node.get_value<fkyaml::node_boolean_type>(), fkyaml::exception);
-            REQUIRE_THROWS_AS(node.get_value<fkyaml::node_integer_type>(), fkyaml::exception);
-            REQUIRE_THROWS_AS(node.get_value<fkyaml::node_float_number_type>(), fkyaml::exception);
-            REQUIRE_THROWS_AS(node.get_value<fkyaml::node_string_type>(), fkyaml::exception);
+            REQUIRE_THROWS_AS(node.get_value<fkyaml::node::sequence_type>(), fkyaml::exception);
+            REQUIRE_THROWS_AS(node.get_value<fkyaml::node::mapping_type>(), fkyaml::exception);
+            REQUIRE_THROWS_AS(node.get_value<fkyaml::node::boolean_type>(), fkyaml::exception);
+            REQUIRE_THROWS_AS(node.get_value<fkyaml::node::integer_type>(), fkyaml::exception);
+            REQUIRE_THROWS_AS(node.get_value<fkyaml::node::float_number_type>(), fkyaml::exception);
+            REQUIRE_THROWS_AS(node.get_value<fkyaml::node::string_type>(), fkyaml::exception);
         }
     }
 
@@ -1501,12 +1501,12 @@ TEST_CASE("NodeClassTest_GetValueTest", "[NodeClassTest]")
 
         SECTION("test for non-boolean values.")
         {
-            REQUIRE_THROWS_AS(node.get_value<fkyaml::node_sequence_type>(), fkyaml::exception);
-            REQUIRE_THROWS_AS(node.get_value<fkyaml::node_mapping_type>(), fkyaml::exception);
+            REQUIRE_THROWS_AS(node.get_value<fkyaml::node::sequence_type>(), fkyaml::exception);
+            REQUIRE_THROWS_AS(node.get_value<fkyaml::node::mapping_type>(), fkyaml::exception);
             REQUIRE_THROWS_AS(node.get_value<std::nullptr_t>(), fkyaml::exception);
-            REQUIRE_THROWS_AS(node.get_value<fkyaml::node_integer_type>(), fkyaml::exception);
-            REQUIRE_THROWS_AS(node.get_value<fkyaml::node_float_number_type>(), fkyaml::exception);
-            REQUIRE_THROWS_AS(node.get_value<fkyaml::node_string_type>(), fkyaml::exception);
+            REQUIRE_THROWS_AS(node.get_value<fkyaml::node::integer_type>(), fkyaml::exception);
+            REQUIRE_THROWS_AS(node.get_value<fkyaml::node::float_number_type>(), fkyaml::exception);
+            REQUIRE_THROWS_AS(node.get_value<fkyaml::node::string_type>(), fkyaml::exception);
         }
     }
 
@@ -1528,12 +1528,12 @@ TEST_CASE("NodeClassTest_GetValueTest", "[NodeClassTest]")
 
         SECTION("test for non-integer values.")
         {
-            REQUIRE_THROWS_AS(node.get_value<fkyaml::node_sequence_type>(), fkyaml::exception);
-            REQUIRE_THROWS_AS(node.get_value<fkyaml::node_mapping_type>(), fkyaml::exception);
+            REQUIRE_THROWS_AS(node.get_value<fkyaml::node::sequence_type>(), fkyaml::exception);
+            REQUIRE_THROWS_AS(node.get_value<fkyaml::node::mapping_type>(), fkyaml::exception);
             REQUIRE_THROWS_AS(node.get_value<std::nullptr_t>(), fkyaml::exception);
-            REQUIRE_THROWS_AS(node.get_value<fkyaml::node_boolean_type>(), fkyaml::exception);
-            REQUIRE_THROWS_AS(node.get_value<fkyaml::node_float_number_type>(), fkyaml::exception);
-            REQUIRE_THROWS_AS(node.get_value<fkyaml::node_string_type>(), fkyaml::exception);
+            REQUIRE_THROWS_AS(node.get_value<fkyaml::node::boolean_type>(), fkyaml::exception);
+            REQUIRE_THROWS_AS(node.get_value<fkyaml::node::float_number_type>(), fkyaml::exception);
+            REQUIRE_THROWS_AS(node.get_value<fkyaml::node::string_type>(), fkyaml::exception);
         }
 
         SECTION("test for non-integer node value.")
@@ -1544,13 +1544,13 @@ TEST_CASE("NodeClassTest_GetValueTest", "[NodeClassTest]")
 
         SECTION("test underflowable integer type.")
         {
-            fkyaml::node negative_int_node(std::numeric_limits<fkyaml::node_integer_type>::min());
+            fkyaml::node negative_int_node(std::numeric_limits<fkyaml::node::integer_type>::min());
             REQUIRE_THROWS_AS(negative_int_node.get_value<int8_t>(), fkyaml::exception);
         }
 
         SECTION("test overflowable integer type.")
         {
-            fkyaml::node large_int_node(std::numeric_limits<fkyaml::node_integer_type>::max());
+            fkyaml::node large_int_node(std::numeric_limits<fkyaml::node::integer_type>::max());
             REQUIRE_THROWS_AS(large_int_node.get_value<int8_t>(), fkyaml::exception);
         }
     }
@@ -1568,12 +1568,12 @@ TEST_CASE("NodeClassTest_GetValueTest", "[NodeClassTest]")
 
         SECTION("test for non-float-number values.")
         {
-            REQUIRE_THROWS_AS(node.get_value<fkyaml::node_sequence_type>(), fkyaml::exception);
-            REQUIRE_THROWS_AS(node.get_value<fkyaml::node_mapping_type>(), fkyaml::exception);
+            REQUIRE_THROWS_AS(node.get_value<fkyaml::node::sequence_type>(), fkyaml::exception);
+            REQUIRE_THROWS_AS(node.get_value<fkyaml::node::mapping_type>(), fkyaml::exception);
             REQUIRE_THROWS_AS(node.get_value<std::nullptr_t>(), fkyaml::exception);
-            REQUIRE_THROWS_AS(node.get_value<fkyaml::node_boolean_type>(), fkyaml::exception);
-            REQUIRE_THROWS_AS(node.get_value<fkyaml::node_integer_type>(), fkyaml::exception);
-            REQUIRE_THROWS_AS(node.get_value<fkyaml::node_string_type>(), fkyaml::exception);
+            REQUIRE_THROWS_AS(node.get_value<fkyaml::node::boolean_type>(), fkyaml::exception);
+            REQUIRE_THROWS_AS(node.get_value<fkyaml::node::integer_type>(), fkyaml::exception);
+            REQUIRE_THROWS_AS(node.get_value<fkyaml::node::string_type>(), fkyaml::exception);
         }
 
         SECTION("test for non-float-number node value.")
@@ -1584,13 +1584,13 @@ TEST_CASE("NodeClassTest_GetValueTest", "[NodeClassTest]")
 
         SECTION("test underflowable float number type.")
         {
-            fkyaml::node negative_float_node(std::numeric_limits<fkyaml::node_float_number_type>::min());
+            fkyaml::node negative_float_node(std::numeric_limits<fkyaml::node::float_number_type>::min());
             REQUIRE_THROWS_AS(negative_float_node.get_value<float>(), fkyaml::exception);
         }
 
         SECTION("test overflowable float number type.")
         {
-            fkyaml::node large_float_node(std::numeric_limits<fkyaml::node_float_number_type>::max());
+            fkyaml::node large_float_node(std::numeric_limits<fkyaml::node::float_number_type>::max());
             REQUIRE_THROWS_AS(large_float_node.get_value<float>(), fkyaml::exception);
         }
     }
@@ -1608,12 +1608,12 @@ TEST_CASE("NodeClassTest_GetValueTest", "[NodeClassTest]")
 
         SECTION("test for non-string values.")
         {
-            REQUIRE_THROWS_AS(node.get_value<fkyaml::node_sequence_type>(), fkyaml::exception);
-            REQUIRE_THROWS_AS(node.get_value<fkyaml::node_mapping_type>(), fkyaml::exception);
+            REQUIRE_THROWS_AS(node.get_value<fkyaml::node::sequence_type>(), fkyaml::exception);
+            REQUIRE_THROWS_AS(node.get_value<fkyaml::node::mapping_type>(), fkyaml::exception);
             REQUIRE_THROWS_AS(node.get_value<std::nullptr_t>(), fkyaml::exception);
-            REQUIRE_THROWS_AS(node.get_value<fkyaml::node_boolean_type>(), fkyaml::exception);
-            REQUIRE_THROWS_AS(node.get_value<fkyaml::node_integer_type>(), fkyaml::exception);
-            REQUIRE_THROWS_AS(node.get_value<fkyaml::node_float_number_type>(), fkyaml::exception);
+            REQUIRE_THROWS_AS(node.get_value<fkyaml::node::boolean_type>(), fkyaml::exception);
+            REQUIRE_THROWS_AS(node.get_value<fkyaml::node::integer_type>(), fkyaml::exception);
+            REQUIRE_THROWS_AS(node.get_value<fkyaml::node::float_number_type>(), fkyaml::exception);
         }
     }
 }
@@ -1627,7 +1627,7 @@ TEST_CASE("NodeClassTest_ToSequenceTest", "[NodeClassTest]")
     SECTION("Test nothrow expected nodes.")
     {
         fkyaml::node node =
-            fkyaml::node::sequence(fkyaml::node_sequence_type {fkyaml::node(), fkyaml::node(), fkyaml::node()});
+            fkyaml::node::sequence(fkyaml::node::sequence_type {fkyaml::node(), fkyaml::node(), fkyaml::node()});
 
         SECTION("Test non-alias sequence node.")
         {
@@ -1716,7 +1716,7 @@ TEST_CASE("NodeClassTest_ToMappingTest", "[NodeClassTest]")
 {
     SECTION("Test nothrow expected nodes.")
     {
-        fkyaml::node node = fkyaml::node::mapping(fkyaml::node_mapping_type {
+        fkyaml::node node = fkyaml::node::mapping(fkyaml::node::mapping_type {
             {"test0", fkyaml::node()}, {"test1", fkyaml::node()}, {"test2", fkyaml::node()}});
 
         SECTION("Test non-alias mapping node.")
@@ -1874,7 +1874,7 @@ TEST_CASE("NodeClassTest_ToIntegerTest", "[NodeClassTest]")
 {
     SECTION("Test nothrow expected nodes.")
     {
-        fkyaml::node_integer_type integer = -123;
+        fkyaml::node::integer_type integer = -123;
         fkyaml::node node = integer;
 
         SECTION("Test non-alias  integer node.")
@@ -1948,7 +1948,7 @@ TEST_CASE("NodeClassTest_ToFloatNumberTest", "[NodeClassTest]")
 {
     SECTION("Test nothrow expected nodes.")
     {
-        fkyaml::node_float_number_type float_val = 123.45;
+        fkyaml::node::float_number_type float_val = 123.45;
         fkyaml::node node = float_val;
 
         SECTION("Test non-alias float number node.")
@@ -2022,7 +2022,7 @@ TEST_CASE("NodeClassTest_ToStringTest", "[NodeClassTest]")
 {
     SECTION("Test nothrow expected nodes.")
     {
-        fkyaml::node_string_type str = "test";
+        fkyaml::node::string_type str = "test";
         fkyaml::node node = str;
 
         SECTION("Test non-alias string node.")

--- a/test/unit_test/test_node_ref_storage_class.cpp
+++ b/test/unit_test/test_node_ref_storage_class.cpp
@@ -21,7 +21,7 @@ TEST_CASE("NodeRefStorageTest_CtorWithLvalueNodeTest", "[NodeRefStorageTest]")
 
     fkyaml::node retrieved_node = storage.release();
     REQUIRE(retrieved_node.is_boolean());
-    REQUIRE(retrieved_node.to_boolean() == true);
+    REQUIRE(retrieved_node.get_value<fkyaml::node::boolean_type>() == true);
 }
 
 TEST_CASE("NodeRefStorageTest_CtorWithRvalueNodeTest", "[NodeRefStorageTest]")
@@ -32,7 +32,7 @@ TEST_CASE("NodeRefStorageTest_CtorWithRvalueNodeTest", "[NodeRefStorageTest]")
 
     fkyaml::node retrieved_node = storage.release();
     REQUIRE(retrieved_node.is_float_number());
-    REQUIRE(retrieved_node.to_float_number() == 3.14);
+    REQUIRE(retrieved_node.get_value<fkyaml::node::float_number_type>() == 3.14);
 }
 
 TEST_CASE("NodeRefStorageTest_ArrowOperatorTest", "[NodeRefStorageTest]")
@@ -41,7 +41,7 @@ TEST_CASE("NodeRefStorageTest_ArrowOperatorTest", "[NodeRefStorageTest]")
     fkyaml::detail::node_ref_storage<fkyaml::node> storage(node);
     REQUIRE(storage.operator->() == &node);
     REQUIRE(storage->is_integer());
-    REQUIRE(storage->to_integer() == 123);
+    REQUIRE(storage->get_value<fkyaml::node::integer_type>() == 123);
 
     fkyaml::node node2 = {true, false};
     fkyaml::detail::node_ref_storage<fkyaml::node> storage2(std::move(node2));
@@ -56,7 +56,7 @@ TEST_CASE("NodeRefStorageTest_ReleaseTest", "[NodeRefStorageTest]")
     fkyaml::node released_node = storage.release();
     REQUIRE(&released_node != &node);
     REQUIRE(released_node.is_integer());
-    REQUIRE(released_node.to_integer() == 123);
+    REQUIRE(released_node.get_value<fkyaml::node::integer_type>() == 123);
 
     fkyaml::node node2 = {true, false};
     fkyaml::detail::node_ref_storage<fkyaml::node> storage2(std::move(node2));

--- a/test/unit_test/test_serializer_class.cpp
+++ b/test/unit_test/test_serializer_class.cpp
@@ -62,8 +62,8 @@ TEST_CASE("SerializeClassTest_SerializeFloatNumberNode", "[SerializeClassTest]")
     auto node_str_pair = GENERATE(
         NodeStrPair(fkyaml::node(3.14), "3.14"),
         NodeStrPair(fkyaml::node(-53.97), "-53.97"),
-        NodeStrPair(fkyaml::node(std::numeric_limits<fkyaml::node_float_number_type>::infinity()), ".inf"),
-        NodeStrPair(fkyaml::node(-1 * std::numeric_limits<fkyaml::node_float_number_type>::infinity()), "-.inf"),
+        NodeStrPair(fkyaml::node(std::numeric_limits<fkyaml::node::float_number_type>::infinity()), ".inf"),
+        NodeStrPair(fkyaml::node(-1 * std::numeric_limits<fkyaml::node::float_number_type>::infinity()), "-.inf"),
         NodeStrPair(fkyaml::node(std::nan("")), ".nan"));
     fkyaml::detail::basic_serializer<fkyaml::node> serializer;
     REQUIRE(serializer.serialize(node_str_pair.first) == node_str_pair.second);


### PR DESCRIPTION
To minimize the public API variation, existing getter APIs for node value references (e.g., to_sequence, to_string, etc.) have been integrated into the newly implemented get_value_ref API, which executes the same operations as the APIs mentioned above.  
Furthermore, type aliases only for fkyaml::node class have been deleted because they are too one-sided to make the fkYAML APIs generalized for various use cases.  
