### PR TITLE
#187 support compatible strings as an argument in basic_node ctors

### DIFF
--- a/README.md
+++ b/README.md
@@ -181,7 +181,7 @@ assert(root["bar"].get_value_ref<double&>() == 3.14);
 assert(root["baz"].get_value_ref<bool&>() == true);
 
 // You can get values of YAML node like the followings:
-assert(root["foo"].get_value<std::string>() == "test");
+assert(root["foo"].get_value_ref<std::string&>() == "test");
 assert(root["bar"].get_value<double>() == 3.14);
 assert(root["baz"].get_value<bool>() == true);
 ```
@@ -202,9 +202,9 @@ The `Serializer` class provides an API for serializing YAML node values into a s
 // ...
 
 fkyaml::node root = {
-    { std::string("foo"), std::string("test") },
-    { std::string("bar"), { 3.14, std::nan("") } },
-    { std::string("baz"), true }
+    { "foo", "test" },
+    { "bar", { 3.14, std::nan("") } },
+    { "baz", true }
 };
 
 std::string str = fkyaml::node::serialize(root);
@@ -233,7 +233,7 @@ The `node` class provides APIs for building YAML nodes programatically.
 fkyaml::node root = fkyaml::node::mapping();
 
 // Add a string scalar node.
-root["foo"] = std::string("test");
+root["foo"] = "test";
 
 // Add a sequence node containing floating number scalar nodes.
 root["bar"] = { 3.14, std::nan("") };
@@ -243,9 +243,9 @@ root["baz"] = true;
 
 // Instead, you can build YAML nodes all at once.
 fkyaml::node another_root = {
-    { std::string("foo"), std::string("test") },
-    { std::string("bar"), { 3.14, std::nan("") } },
-    { std::string("baz"), true }
+    { "foo", "test" },
+    { "bar", { 3.14, std::nan("") } },
+    { "baz", true }
 };
 ```
 

--- a/include/fkYAML/detail/conversions/to_node.hpp
+++ b/include/fkYAML/detail/conversions/to_node.hpp
@@ -195,6 +195,20 @@ struct external_node_constructor<node_t::STRING>
         n.m_node_value.p_string =
             BasicNodeType::template create_object<typename BasicNodeType::string_type>(std::move(s));
     }
+
+    template <
+        typename BasicNodeType, typename CompatibleStringType,
+        enable_if_t<
+            conjunction<
+                is_basic_node<BasicNodeType>,
+                negation<std::is_same<typename BasicNodeType::string_type, CompatibleStringType>>>::value,
+            int> = 0>
+    static void construct(BasicNodeType& n, const CompatibleStringType& s) noexcept
+    {
+        n.m_node_value.destroy(n.m_node_type);
+        n.m_node_type = node_t::STRING;
+        n.m_node_value.p_string = BasicNodeType::template create_object<typename BasicNodeType::string_type>(s);
+    }
 };
 
 /////////////////
@@ -307,15 +321,37 @@ inline void to_node(BasicNodeType& n, T f) noexcept
     external_node_constructor<node_t::FLOAT_NUMBER>::construct(n, f);
 }
 
+/**
+ * @brief to_node function for compatible strings.
+ *
+ * @tparam BasicNodeType A basic_node template instance type.
+ * @tparam T A compatible string type.
+ * @param n A basic_node object.
+ * @param s A compatible string object.
+ */
 template <
     typename BasicNodeType, typename T,
     enable_if_t<
         conjunction<
-            is_basic_node<BasicNodeType>, std::is_same<typename BasicNodeType::string_type, remove_cvref_t<T>>>::value,
+            is_basic_node<BasicNodeType>, negation<is_null_pointer<T>>,
+            std::is_constructible<typename BasicNodeType::string_type, const T&>>::value,
         int> = 0>
-inline void to_node(BasicNodeType& n, T&& s) noexcept
+inline void to_node(BasicNodeType& n, const T& s)
 {
-    external_node_constructor<node_t::STRING>::construct(n, std::forward<T>(s));
+    external_node_constructor<node_t::STRING>::construct(n, s);
+}
+
+/**
+ * @brief to_node function for rvalue string node values
+ *
+ * @tparam BasicNodeType A basic_node template instance type
+ * @param n A basic_node object.
+ * @param s An rvalue string node value.
+ */
+template <typename BasicNodeType, enable_if_t<is_basic_node<BasicNodeType>::value, int> = 0>
+inline void to_node(BasicNodeType& n, typename BasicNodeType::string_type&& s) noexcept
+{
+    external_node_constructor<node_t::STRING>::construct(n, std::move(s));
 }
 
 /**

--- a/include/fkYAML/detail/meta/stl_supplement.hpp
+++ b/include/fkYAML/detail/meta/stl_supplement.hpp
@@ -13,6 +13,7 @@
 #ifndef FK_YAML_DETAIL_META_STL_SUPPLEMENT_HPP_
 #define FK_YAML_DETAIL_META_STL_SUPPLEMENT_HPP_
 
+#include <cstddef>
 #include <type_traits>
 
 #include <fkYAML/detail/macros/version_macros.hpp>
@@ -63,6 +64,18 @@ template <bool Condition, typename T = void>
 using enable_if_t = typename std::enable_if<Condition, T>::type;
 
 /**
+ * @brief A simple implementation to use std::is_null_pointer with C++11.
+ * @note std::is_null_pointer is available since C++14.
+ * @sa https://en.cppreference.com/w/cpp/types/is_null_pointer
+ *
+ * @tparam T The type to be checked if it's equal to std::nullptr_t.
+ */
+template <typename T>
+struct is_null_pointer : std::is_same<std::nullptr_t, typename std::remove_cv<T>::type>
+{
+};
+
+/**
  * @brief An alias template for std::remove_cv::type with C++11.
  * @note std::remove_cv_t is available since C++14.
  * @sa https://en.cppreference.com/w/cpp/types/remove_cv
@@ -96,6 +109,7 @@ using remove_reference_t = typename std::remove_reference<T>::type;
 
 using std::add_pointer_t;
 using std::enable_if_t;
+using std::is_null_pointer;
 using std::remove_cv_t;
 using std::remove_pointer_t;
 using std::remove_reference_t;

--- a/include/fkYAML/detail/node_ref_storage.hpp
+++ b/include/fkYAML/detail/node_ref_storage.hpp
@@ -53,7 +53,7 @@ public:
      *
      * @param n An rvalue basic_node object.
      */
-    explicit node_ref_storage(node_type&& n)
+    node_ref_storage(node_type&& n)
         : owned_value(std::move(n))
     {
     }
@@ -63,7 +63,7 @@ public:
      *
      * @param n An lvalue basic_node object.
      */
-    explicit node_ref_storage(const node_type& n)
+    node_ref_storage(const node_type& n)
         : value_ref(&n)
     {
     }
@@ -84,12 +84,7 @@ public:
      * @tparam Args Types of arguments to construct a basic_node object.
      * @param args Arguments to construct a basic_node object.
      */
-    template <
-        typename... Args, enable_if_t<
-                              conjunction<
-                                  negation<std::is_lvalue_reference<head_type<Args...>>>,
-                                  std::is_constructible<node_type, Args...>>::value,
-                              int> = 0>
+    template <typename... Args, enable_if_t<std::is_constructible<node_type, Args...>::value, int> = 0>
     node_ref_storage(Args&&... args)
         : owned_value(std::forward<Args>(args)...)
     {

--- a/test/unit_test/test_iterator_class.cpp
+++ b/test/unit_test/test_iterator_class.cpp
@@ -50,7 +50,7 @@ TEST_CASE("IteratorClassTest_MappingCopyCtorTest", "[IteratorClassTest]")
 
 TEST_CASE("IteratorClassTest_SequenceMoveCtorTest", "[IteratorClassTest]")
 {
-    fkyaml::node sequence = {std::string("test")};
+    fkyaml::node sequence = {"test"};
     fkyaml::detail::iterator<fkyaml::node> moved(
         fkyaml::detail::sequence_iterator_tag {}, sequence.get_value_ref<fkyaml::node::sequence_type&>().begin());
     fkyaml::detail::iterator<fkyaml::node> iterator(std::move(moved));
@@ -95,7 +95,7 @@ TEST_CASE("IteratorClassTest_AssignmentOperatorTest", "[IteratorClassTest]")
 
     SECTION("Test sequence iterators.")
     {
-        fkyaml::node copied_seq = {std::string("test")};
+        fkyaml::node copied_seq = {"test"};
         fkyaml::detail::iterator<fkyaml::node> copied_itr(
             fkyaml::detail::sequence_iterator_tag {}, copied_seq.get_value_ref<fkyaml::node::sequence_type&>().begin());
         fkyaml::node sequence = {false};
@@ -121,10 +121,10 @@ TEST_CASE("IteratorClassTest_AssignmentOperatorTest", "[IteratorClassTest]")
 
     SECTION("Test mapping iterators.")
     {
-        fkyaml::node copied_map = {{std::string("key"), std::string("test")}};
+        fkyaml::node copied_map = {{"key", "test"}};
         fkyaml::detail::iterator<fkyaml::node> copied_itr(
             fkyaml::detail::mapping_iterator_tag {}, copied_map.get_value_ref<fkyaml::node::mapping_type&>().begin());
-        fkyaml::node map = {{std::string("foo"), false}};
+        fkyaml::node map = {{"foo", false}};
         fkyaml::detail::iterator<fkyaml::node> iterator(
             fkyaml::detail::mapping_iterator_tag {}, map.get_value_ref<fkyaml::node::mapping_type&>().begin());
 
@@ -152,7 +152,7 @@ TEST_CASE("IteratorClassTest_ArrowOperatorTest", "[IteratorClassTest]")
 {
     SECTION("Test sequence iterator.")
     {
-        fkyaml::node seq = {std::string("test")};
+        fkyaml::node seq = {"test"};
         fkyaml::detail::iterator<fkyaml::node> iterator(
             fkyaml::detail::sequence_iterator_tag {}, seq.get_value_ref<fkyaml::node::sequence_type&>().begin());
         REQUIRE(iterator.operator->() == &(seq.get_value_ref<fkyaml::node::sequence_type&>().operator[](0)));
@@ -160,7 +160,7 @@ TEST_CASE("IteratorClassTest_ArrowOperatorTest", "[IteratorClassTest]")
 
     SECTION("Test mapping iterator.")
     {
-        fkyaml::node map = {{std::string("key"), std::string("test")}};
+        fkyaml::node map = {{"key", "test"}};
         fkyaml::detail::iterator<fkyaml::node> iterator(
             fkyaml::detail::mapping_iterator_tag {}, map.get_value_ref<fkyaml::node::mapping_type&>().begin());
         REQUIRE(iterator.operator->() == &(map.get_value_ref<fkyaml::node::mapping_type&>().operator[]("key")));
@@ -171,7 +171,7 @@ TEST_CASE("IteratorClassTest_DereferenceOperatorTest", "[IteratorClassTest]")
 {
     SECTION("Test sequence iterator.")
     {
-        fkyaml::node seq = {std::string("test")};
+        fkyaml::node seq = {"test"};
         fkyaml::detail::iterator<fkyaml::node> iterator(
             fkyaml::detail::sequence_iterator_tag {}, seq.get_value_ref<fkyaml::node::sequence_type&>().begin());
         REQUIRE(&(iterator.operator*()) == &(seq.get_value_ref<fkyaml::node::sequence_type&>().operator[](0)));
@@ -179,7 +179,7 @@ TEST_CASE("IteratorClassTest_DereferenceOperatorTest", "[IteratorClassTest]")
 
     SECTION("Test mapping iterator.")
     {
-        fkyaml::node map = fkyaml::node::mapping({{"key", std::string("test")}});
+        fkyaml::node map = fkyaml::node::mapping({{"key", "test"}});
         fkyaml::detail::iterator<fkyaml::node> iterator(
             fkyaml::detail::mapping_iterator_tag {}, map.get_value_ref<fkyaml::node::mapping_type&>().begin());
         REQUIRE(&(iterator.operator*()) == &(map.get_value_ref<fkyaml::node::mapping_type&>().operator[]("key")));
@@ -200,7 +200,7 @@ TEST_CASE("IteratorClassTest_CompoundAssignmentOperatorBySumTest", "[IteratorCla
 
     SECTION("Test mapping iterator.")
     {
-        fkyaml::node mapping = {{std::string("test0"), false}, {std::string("test1"), true}};
+        fkyaml::node mapping = {{"test0", false}, {"test1", true}};
         fkyaml::detail::iterator<fkyaml::node> iterator(
             fkyaml::detail::mapping_iterator_tag {}, mapping.get_value_ref<fkyaml::node::mapping_type&>().begin());
         iterator += 1;
@@ -224,7 +224,7 @@ TEST_CASE("IteratorClassTest_PlusOperatorTest", "[IteratorClassTest]")
 
     SECTION("Test mapping iterator.")
     {
-        fkyaml::node mapping = {{std::string("test0"), false}, {std::string("test1"), true}};
+        fkyaml::node mapping = {{"test0", false}, {"test1", true}};
         fkyaml::detail::iterator<fkyaml::node> iterator(
             fkyaml::detail::mapping_iterator_tag {}, mapping.get_value_ref<fkyaml::node::mapping_type&>().begin());
         fkyaml::detail::iterator<fkyaml::node> after_plus_itr = iterator + 1;
@@ -248,7 +248,7 @@ TEST_CASE("IteratorClassTest_PreIncrementOperatorTest", "[IteratorClassTest]")
 
     SECTION("Test mapping iterator.")
     {
-        fkyaml::node mapping = {{std::string("test0"), false}, {std::string("test1"), true}};
+        fkyaml::node mapping = {{"test0", false}, {"test1", true}};
         fkyaml::detail::iterator<fkyaml::node> iterator(
             fkyaml::detail::mapping_iterator_tag {}, mapping.get_value_ref<fkyaml::node::mapping_type&>().begin());
         ++iterator;
@@ -272,7 +272,7 @@ TEST_CASE("IteratorClassTest_PostIncrementOperatorTest", "[IteratorClassTest]")
 
     SECTION("Test mapping iterator.")
     {
-        fkyaml::node mapping = {{std::string("test0"), false}, {std::string("test1"), true}};
+        fkyaml::node mapping = {{"test0", false}, {"test1", true}};
         fkyaml::detail::iterator<fkyaml::node> iterator(
             fkyaml::detail::mapping_iterator_tag {}, mapping.get_value_ref<fkyaml::node::mapping_type&>().begin());
         iterator++;
@@ -296,7 +296,7 @@ TEST_CASE("IteratorClassTest_CompoundAssignmentOperatorByDifferenceTest", "[Iter
 
     SECTION("Test mapping iterator.")
     {
-        fkyaml::node mapping = {{std::string("test0"), false}, {std::string("test1"), true}};
+        fkyaml::node mapping = {{"test0", false}, {"test1", true}};
         fkyaml::detail::iterator<fkyaml::node> iterator(
             fkyaml::detail::mapping_iterator_tag {}, mapping.get_value_ref<fkyaml::node::mapping_type&>().end());
         iterator -= 1;
@@ -320,7 +320,7 @@ TEST_CASE("IteratorClassTest_MinusOperatorTest", "[IteratorClassTest]")
 
     SECTION("Test mapping iterator.")
     {
-        fkyaml::node mapping = {{std::string("test0"), false}, {std::string("test1"), true}};
+        fkyaml::node mapping = {{"test0", false}, {"test1", true}};
         fkyaml::detail::iterator<fkyaml::node> iterator(
             fkyaml::detail::mapping_iterator_tag {}, mapping.get_value_ref<fkyaml::node::mapping_type&>().end());
         fkyaml::detail::iterator<fkyaml::node> after_minus_itr = iterator - 1;
@@ -344,7 +344,7 @@ TEST_CASE("IteratorClassTest_PreDecrementOperatorTest", "[IteratorClassTest]")
 
     SECTION("Test mapping iterator.")
     {
-        fkyaml::node mapping = {{std::string("test0"), false}, {std::string("test1"), true}};
+        fkyaml::node mapping = {{"test0", false}, {"test1", true}};
         fkyaml::detail::iterator<fkyaml::node> iterator(
             fkyaml::detail::mapping_iterator_tag {}, mapping.get_value_ref<fkyaml::node::mapping_type&>().end());
         --iterator;
@@ -368,7 +368,7 @@ TEST_CASE("IteratorClassTest_PostDecrementOperatorTest", "[IteratorClassTest]")
 
     SECTION("Test mapping iterator.")
     {
-        fkyaml::node mapping = {{std::string("test0"), false}, {std::string("test1"), true}};
+        fkyaml::node mapping = {{"test0", false}, {"test1", true}};
         fkyaml::detail::iterator<fkyaml::node> iterator(
             fkyaml::detail::mapping_iterator_tag {}, mapping.get_value_ref<fkyaml::node::mapping_type&>().end());
         iterator--;
@@ -392,7 +392,7 @@ TEST_CASE("IteratorClassTest_EqualToOperatorTest", "[IteratorClassTest]")
 
     SECTION("Test mapping iterator.")
     {
-        fkyaml::node mapping = {{std::string("test0"), false}, {std::string("test1"), true}};
+        fkyaml::node mapping = {{"test0", false}, {"test1", true}};
         fkyaml::detail::iterator<fkyaml::node> lhs(
             fkyaml::detail::mapping_iterator_tag {}, mapping.get_value_ref<fkyaml::node::mapping_type&>().begin());
         fkyaml::detail::iterator<fkyaml::node> rhs(
@@ -405,7 +405,7 @@ TEST_CASE("IteratorClassTest_EqualToOperatorTest", "[IteratorClassTest]")
         fkyaml::node sequence = {false, true};
         fkyaml::detail::iterator<fkyaml::node> lhs(
             fkyaml::detail::sequence_iterator_tag {}, sequence.get_value_ref<fkyaml::node::sequence_type&>().begin());
-        fkyaml::node mapping = {{std::string("test0"), false}, {std::string("test1"), true}};
+        fkyaml::node mapping = {{"test0", false}, {"test1", true}};
         fkyaml::detail::iterator<fkyaml::node> rhs(
             fkyaml::detail::mapping_iterator_tag {}, mapping.get_value_ref<fkyaml::node::mapping_type&>().begin());
         REQUIRE_THROWS_AS(lhs == rhs, fkyaml::exception);
@@ -427,7 +427,7 @@ TEST_CASE("IteratorClassTest_NotEqualToOperatorTest", "[IteratorClassTest]")
 
     SECTION("Test mapping iterator.")
     {
-        fkyaml::node mapping = {{std::string("test0"), false}, {std::string("test1"), true}};
+        fkyaml::node mapping = {{"test0", false}, {"test1", true}};
         fkyaml::detail::iterator<fkyaml::node> lhs(
             fkyaml::detail::mapping_iterator_tag {}, mapping.get_value_ref<fkyaml::node::mapping_type&>().begin());
         fkyaml::detail::iterator<fkyaml::node> rhs(
@@ -441,7 +441,7 @@ TEST_CASE("IteratorClassTest_NotEqualToOperatorTest", "[IteratorClassTest]")
         fkyaml::node sequence = {false, true};
         fkyaml::detail::iterator<fkyaml::node> lhs(
             fkyaml::detail::sequence_iterator_tag {}, sequence.get_value_ref<fkyaml::node::sequence_type&>().begin());
-        fkyaml::node mapping = {{std::string("test0"), false}, {std::string("test1"), true}};
+        fkyaml::node mapping = {{"test0", false}, {"test1", true}};
         fkyaml::detail::iterator<fkyaml::node> rhs(
             fkyaml::detail::mapping_iterator_tag {}, mapping.get_value_ref<fkyaml::node::mapping_type&>().begin());
         REQUIRE_THROWS_AS(lhs == rhs, fkyaml::exception);
@@ -464,7 +464,7 @@ TEST_CASE("IteratorClassTest_LessThanOperatorTest", "[IteratorClassTest]")
 
     SECTION("Test mapping iterator.")
     {
-        fkyaml::node mapping = {{std::string("test0"), false}, {std::string("test1"), true}};
+        fkyaml::node mapping = {{"test0", false}, {"test1", true}};
         fkyaml::detail::iterator<fkyaml::node> lhs(
             fkyaml::detail::mapping_iterator_tag {}, mapping.get_value_ref<fkyaml::node::mapping_type&>().begin());
         fkyaml::detail::iterator<fkyaml::node> rhs(
@@ -477,7 +477,7 @@ TEST_CASE("IteratorClassTest_LessThanOperatorTest", "[IteratorClassTest]")
         fkyaml::node sequence = {false, true};
         fkyaml::detail::iterator<fkyaml::node> lhs(
             fkyaml::detail::sequence_iterator_tag {}, sequence.get_value_ref<fkyaml::node::sequence_type&>().begin());
-        fkyaml::node mapping = {{std::string("test0"), false}, {std::string("test1"), true}};
+        fkyaml::node mapping = {{"test0", false}, {"test1", true}};
         fkyaml::detail::iterator<fkyaml::node> rhs(
             fkyaml::detail::mapping_iterator_tag {}, mapping.get_value_ref<fkyaml::node::mapping_type&>().begin());
         REQUIRE_THROWS_AS(lhs < rhs, fkyaml::exception);
@@ -503,7 +503,7 @@ TEST_CASE("IteratorClassTest_LessThanOrEqualToOperatorTest", "[IteratorClassTest
 
     SECTION("Test mapping iterator.")
     {
-        fkyaml::node mapping = {{std::string("test0"), false}, {std::string("test1"), true}};
+        fkyaml::node mapping = {{"test0", false}, {"test1", true}};
         fkyaml::detail::iterator<fkyaml::node> lhs(
             fkyaml::detail::mapping_iterator_tag {}, mapping.get_value_ref<fkyaml::node::mapping_type&>().begin());
         fkyaml::detail::iterator<fkyaml::node> rhs(
@@ -516,7 +516,7 @@ TEST_CASE("IteratorClassTest_LessThanOrEqualToOperatorTest", "[IteratorClassTest
         fkyaml::node sequence = {false, true};
         fkyaml::detail::iterator<fkyaml::node> lhs(
             fkyaml::detail::sequence_iterator_tag {}, sequence.get_value_ref<fkyaml::node::sequence_type&>().begin());
-        fkyaml::node mapping = {{std::string("test0"), false}, {std::string("test1"), true}};
+        fkyaml::node mapping = {{"test0", false}, {"test1", true}};
         fkyaml::detail::iterator<fkyaml::node> rhs(
             fkyaml::detail::mapping_iterator_tag {}, mapping.get_value_ref<fkyaml::node::mapping_type&>().begin());
         REQUIRE_THROWS_AS(lhs <= rhs, fkyaml::exception);
@@ -539,7 +539,7 @@ TEST_CASE("IteratorClassTest_GreaterThanOperatorTest", "[IteratorClassTest]")
 
     SECTION("Test mapping iterator.")
     {
-        fkyaml::node mapping = {{std::string("test0"), false}, {std::string("test1"), true}};
+        fkyaml::node mapping = {{"test0", false}, {"test1", true}};
         fkyaml::detail::iterator<fkyaml::node> lhs(
             fkyaml::detail::mapping_iterator_tag {}, mapping.get_value_ref<fkyaml::node::mapping_type&>().begin());
         fkyaml::detail::iterator<fkyaml::node> rhs(
@@ -552,7 +552,7 @@ TEST_CASE("IteratorClassTest_GreaterThanOperatorTest", "[IteratorClassTest]")
         fkyaml::node sequence = {false, true};
         fkyaml::detail::iterator<fkyaml::node> lhs(
             fkyaml::detail::sequence_iterator_tag {}, sequence.get_value_ref<fkyaml::node::sequence_type&>().begin());
-        fkyaml::node mapping = {{std::string("test0"), false}, {std::string("test1"), true}};
+        fkyaml::node mapping = {{"test0", false}, {"test1", true}};
         fkyaml::detail::iterator<fkyaml::node> rhs(
             fkyaml::detail::mapping_iterator_tag {}, mapping.get_value_ref<fkyaml::node::mapping_type&>().begin());
         REQUIRE_THROWS_AS(lhs > rhs, fkyaml::exception);
@@ -578,7 +578,7 @@ TEST_CASE("IteratorClassTest_GreaterThanOrEqualToOperatorTest", "[IteratorClassT
 
     SECTION("Test mapping iterator.")
     {
-        fkyaml::node mapping = {{std::string("test0"), false}, {std::string("test1"), true}};
+        fkyaml::node mapping = {{"test0", false}, {"test1", true}};
         fkyaml::detail::iterator<fkyaml::node> lhs(
             fkyaml::detail::mapping_iterator_tag {}, mapping.get_value_ref<fkyaml::node::mapping_type&>().begin());
         fkyaml::detail::iterator<fkyaml::node> rhs(
@@ -591,7 +591,7 @@ TEST_CASE("IteratorClassTest_GreaterThanOrEqualToOperatorTest", "[IteratorClassT
         fkyaml::node sequence = {false, true};
         fkyaml::detail::iterator<fkyaml::node> lhs(
             fkyaml::detail::sequence_iterator_tag {}, sequence.get_value_ref<fkyaml::node::sequence_type&>().begin());
-        fkyaml::node mapping = {{std::string("test0"), false}, {std::string("test1"), true}};
+        fkyaml::node mapping = {{"test0", false}, {"test1", true}};
         fkyaml::detail::iterator<fkyaml::node> rhs(
             fkyaml::detail::mapping_iterator_tag {}, mapping.get_value_ref<fkyaml::node::mapping_type&>().begin());
         REQUIRE_THROWS_AS(lhs >= rhs, fkyaml::exception);
@@ -610,7 +610,7 @@ TEST_CASE("IteratorClassTest_TypeGetterTest", "[IteratorClassTest]")
 
     SECTION("Test mapping iterator.")
     {
-        fkyaml::node mapping = {{std::string("test0"), false}, {std::string("test1"), true}};
+        fkyaml::node mapping = {{"test0", false}, {"test1", true}};
         fkyaml::detail::iterator<fkyaml::node> iterator(
             fkyaml::detail::mapping_iterator_tag {}, mapping.get_value_ref<fkyaml::node::mapping_type&>().begin());
         REQUIRE(iterator.type() == fkyaml::detail::iterator_t::MAPPING);
@@ -629,7 +629,7 @@ TEST_CASE("IteratorClassTest_KeyGetterTest", "[IteratorClassTest]")
 
     SECTION("Test mapping iterator.")
     {
-        fkyaml::node mapping = {{std::string("test0"), false}, {std::string("test1"), true}};
+        fkyaml::node mapping = {{"test0", false}, {"test1", true}};
         fkyaml::detail::iterator<fkyaml::node> iterator(
             fkyaml::detail::mapping_iterator_tag {}, mapping.get_value_ref<fkyaml::node::mapping_type&>().begin());
         REQUIRE_NOTHROW(iterator.key());
@@ -650,7 +650,7 @@ TEST_CASE("IteratorClassTest_ValueGetterTest", "[IteratorClassTest]")
 
     SECTION("Test mapping iterator.")
     {
-        fkyaml::node mapping = {{std::string("test0"), false}, {std::string("test1"), true}};
+        fkyaml::node mapping = {{"test0", false}, {"test1", true}};
         fkyaml::detail::iterator<fkyaml::node> iterator(
             fkyaml::detail::mapping_iterator_tag {}, mapping.get_value_ref<fkyaml::node::mapping_type&>().begin());
         REQUIRE(iterator.value().is_boolean());

--- a/test/unit_test/test_node_class.cpp
+++ b/test/unit_test/test_node_class.cpp
@@ -143,7 +143,7 @@ TEST_CASE("NodeClassTest_FloatNumberCtorTest", "[NodeClassTest]")
 
 TEST_CASE("NodeClassTest_StringCtorTest", "[NodeClassTest]")
 {
-    auto node = GENERATE(fkyaml::node(fkyaml::node::string_type("test")));
+    auto node = GENERATE(fkyaml::node(std::string("test")));
     REQUIRE(node.type() == fkyaml::node::node_t::STRING);
     REQUIRE(node.is_string());
     REQUIRE(node.size() == 4);
@@ -152,7 +152,9 @@ TEST_CASE("NodeClassTest_StringCtorTest", "[NodeClassTest]")
 
 TEST_CASE("NodeClassTest_SequenceCopyCtorTest", "[NodeClassTest]")
 {
-    fkyaml::node copied = {true, std::string("test")};
+    fkyaml::node n = "test";
+
+    fkyaml::node copied = {true, "test"};
     fkyaml::node node(copied);
     REQUIRE(node.is_sequence());
     REQUIRE_NOTHROW(node.size());
@@ -171,7 +173,7 @@ TEST_CASE("NodeClassTest_SequenceCopyCtorTest", "[NodeClassTest]")
 
 TEST_CASE("NodeClassTest_MappingCopyCtorTest", "[NodeClassTest]")
 {
-    fkyaml::node copied = {{std::string("test0"), 123}, {std::string("test1"), 3.14}};
+    fkyaml::node copied = {{"test0", 123}, {"test1", 3.14}};
     fkyaml::node node(copied);
     REQUIRE(node.is_mapping());
     REQUIRE_NOTHROW(node.size());
@@ -222,7 +224,7 @@ TEST_CASE("NodeClassTest_FloatNumberCopyCtorTest", "[NodeClassTest]")
 
 TEST_CASE("NodeClassTest_StringCopyCtorTest", "[NodeClassTest]")
 {
-    fkyaml::node copied = std::string("test");
+    fkyaml::node copied = "test";
     fkyaml::node node(copied);
     REQUIRE(node.is_string());
     REQUIRE_NOTHROW(node.size());
@@ -244,7 +246,7 @@ TEST_CASE("NodeClassTest_AliasCopyCtorTest", "[NodeClassTest]")
 
 TEST_CASE("NodeClassTest_SequenceMoveCtorTest", "[NodeClassTest]")
 {
-    fkyaml::node moved = {true, std::string("test")};
+    fkyaml::node moved = {true, "test"};
     fkyaml::node node(std::move(moved));
     REQUIRE(node.is_sequence());
     REQUIRE_NOTHROW(node.size());
@@ -263,7 +265,7 @@ TEST_CASE("NodeClassTest_SequenceMoveCtorTest", "[NodeClassTest]")
 
 TEST_CASE("NodeClassTest_MappingMoveCtorTest", "[NodeClassTest]")
 {
-    fkyaml::node moved = {{std::string("test0"), 123}, {std::string("test1"), 3.14}};
+    fkyaml::node moved = {{"test0", 123}, {"test1", 3.14}};
     fkyaml::node node(std::move(moved));
     REQUIRE(node.is_mapping());
     REQUIRE_NOTHROW(node.size());
@@ -314,7 +316,7 @@ TEST_CASE("NodeClassTest_FloatNumberMoveCtorTest", "[NodeClassTest]")
 
 TEST_CASE("NodeClassTest_StringMoveCtorTest", "[NodeClassTest]")
 {
-    fkyaml::node moved = std::string("test");
+    fkyaml::node moved = "test";
     fkyaml::node node(std::move(moved));
     REQUIRE(node.is_string());
     REQUIRE_NOTHROW(node.size());
@@ -337,10 +339,10 @@ TEST_CASE("NodeClassTest_AliasMoveCtorTest", "[NodeClassTest]")
 TEST_CASE("NodeClassTest_InitializerListCtorTest", "[NodeClassTest]")
 {
     fkyaml::node node = {
-        {std::string("foo"), 3.14},
-        {std::string("bar"), 123},
-        {std::string("baz"), {true, false}},
-        {std::string("qux"), nullptr},
+        {"foo", 3.14},
+        {"bar", 123},
+        {"baz", {true, false}},
+        {"qux", nullptr},
     };
 
     REQUIRE(node.contains("foo"));
@@ -385,7 +387,7 @@ TEST_CASE("NodeClassTest_DeserializeTest", "[NodeClassTest]")
     REQUIRE(node.size() == 1);
     REQUIRE(node.contains("foo"));
     REQUIRE(node["foo"].is_string());
-    REQUIRE(node["foo"].get_value<std::string>() == "bar");
+    REQUIRE(node["foo"].get_value_ref<std::string&>() == "bar");
 }
 
 TEST_CASE("NodeClassTest_SerializeTest", "[NodeClassTest]")
@@ -446,7 +448,7 @@ TEST_CASE("NodeClassTest_MappingNodeFactoryTest", "[NodeClassTest]")
 
     SECTION("Test non-empty mapping node factory methods.")
     {
-        fkyaml::node::mapping_type map {{std::string("test"), true}};
+        fkyaml::node::mapping_type map {{"test", true}};
 
         SECTION("Test lvalue mapping node factory method.")
         {
@@ -502,7 +504,7 @@ TEST_CASE("NodeClassTest_StringNodeFactoryTest", "[NodeClassTest]")
 {
     SECTION("Test empty string node factory method.")
     {
-        fkyaml::node node = std::string();
+        fkyaml::node node = "";
         REQUIRE(node.is_string());
         REQUIRE(node.size() == 0);
     }
@@ -510,7 +512,7 @@ TEST_CASE("NodeClassTest_StringNodeFactoryTest", "[NodeClassTest]")
     SECTION("Test lvalue string node factory method.")
     {
         fkyaml::node::string_type str("test");
-        fkyaml::node node = std::string(str);
+        fkyaml::node node = str;
         REQUIRE(node.is_string());
         REQUIRE(node.size() == str.size());
         REQUIRE(node.get_value_ref<fkyaml::node::string_type&>() == str);
@@ -518,7 +520,7 @@ TEST_CASE("NodeClassTest_StringNodeFactoryTest", "[NodeClassTest]")
 
     SECTION("Test rvalue string node factory method.")
     {
-        fkyaml::node node = std::string("test");
+        fkyaml::node node = "test";
         REQUIRE(node.is_string());
         REQUIRE(node.size() == 4);
         REQUIRE(node.get_value_ref<fkyaml::node::string_type&>().compare("test") == 0);
@@ -527,7 +529,7 @@ TEST_CASE("NodeClassTest_StringNodeFactoryTest", "[NodeClassTest]")
 
 TEST_CASE("NodeClassTest_AliasNodeFactoryTest", "[NodeClassTest]")
 {
-    fkyaml::node anchor = std::string("alias_test");
+    fkyaml::node anchor = "alias_test";
 
     SECTION("Make sure BasicNode::alias_of() throws an exception without anchor name.")
     {
@@ -623,7 +625,7 @@ TEST_CASE("NodeClassTest_StringSubscriptOperatorTest", "[NodeClassTest]")
             fkyaml::node(false),
             fkyaml::node(0),
             fkyaml::node(0.0),
-            fkyaml::node(std::string()));
+            fkyaml::node(""));
 
         SECTION("Test non-const lvalue throwing invocation.")
         {
@@ -692,7 +694,7 @@ TEST_CASE("NodeClassTest_IntegerSubscriptOperatorTest", "[NodeClassTest]")
             fkyaml::node(false),
             fkyaml::node(0),
             fkyaml::node(0.0),
-            fkyaml::node(std::string()));
+            fkyaml::node(""));
 
         SECTION("Test non-const non-sequence nodes.")
         {
@@ -721,7 +723,7 @@ TEST_CASE("NodeClassTest_TypeGetterTest", "[NodeClassTest]")
         NodeTypePair(fkyaml::node(false), fkyaml::node::node_t::BOOLEAN),
         NodeTypePair(fkyaml::node(0), fkyaml::node::node_t::INTEGER),
         NodeTypePair(fkyaml::node(0.0), fkyaml::node::node_t::FLOAT_NUMBER),
-        NodeTypePair(fkyaml::node(std::string()), fkyaml::node::node_t::STRING));
+        NodeTypePair(fkyaml::node(""), fkyaml::node::node_t::STRING));
 
     SECTION("Test non-alias node types.")
     {
@@ -763,7 +765,7 @@ TEST_CASE("NodeClassTest_IsSequenceTest", "[NodeClassTest]")
             fkyaml::node(false),
             fkyaml::node(0),
             fkyaml::node(0.0),
-            fkyaml::node(std::string()));
+            fkyaml::node(""));
 
         SECTION("Test non-alias non-sequence node types")
         {
@@ -806,7 +808,7 @@ TEST_CASE("NodeClassTest_IsMappingTest", "[NodeClassTest]")
             fkyaml::node(false),
             fkyaml::node(0),
             fkyaml::node(0.0),
-            fkyaml::node(std::string()));
+            fkyaml::node(""));
 
         SECTION("Test non-alias non-mapping node types")
         {
@@ -849,7 +851,7 @@ TEST_CASE("NodeClassTest_IsNullTest", "[NodeClassTest]")
             fkyaml::node(false),
             fkyaml::node(0),
             fkyaml::node(0.0),
-            fkyaml::node(std::string()));
+            fkyaml::node(""));
 
         SECTION("Test non-alias non-null node types")
         {
@@ -892,7 +894,7 @@ TEST_CASE("NodeClassTest_IsBooleanTest", "[NodeClassTest]")
             fkyaml::node(),
             fkyaml::node(0),
             fkyaml::node(0.0),
-            fkyaml::node(std::string()));
+            fkyaml::node(""));
 
         SECTION("Test non-alias non-boolean node types")
         {
@@ -935,7 +937,7 @@ TEST_CASE("NodeClassTest_IsIntegerTest", "[NodeClassTest]")
             fkyaml::node(),
             fkyaml::node(false),
             fkyaml::node(0.0),
-            fkyaml::node(std::string()));
+            fkyaml::node(""));
 
         SECTION("Test non-alias non-integer node types")
         {
@@ -978,7 +980,7 @@ TEST_CASE("NodeClassTest_IsFloatNumberTest", "[NodeClassTest]")
             fkyaml::node(),
             fkyaml::node(false),
             fkyaml::node(0),
-            fkyaml::node(std::string()));
+            fkyaml::node(""));
 
         SECTION("Test non-alias non-float-number node types")
         {
@@ -998,7 +1000,7 @@ TEST_CASE("NodeClassTest_IsStringTest", "[NodeClassTest]")
 {
     SECTION("Test string node type.")
     {
-        fkyaml::node node = std::string();
+        fkyaml::node node = "";
 
         SECTION("Test non-alias string node type.")
         {
@@ -1041,8 +1043,7 @@ TEST_CASE("NodeClassTest_IsScalarTest", "[NodeClassTest]")
 {
     SECTION("Test scalar node types.")
     {
-        auto node = GENERATE(
-            fkyaml::node(), fkyaml::node(false), fkyaml::node(0), fkyaml::node(0.0), fkyaml::node(std::string()));
+        auto node = GENERATE(fkyaml::node(), fkyaml::node(false), fkyaml::node(0), fkyaml::node(0.0), fkyaml::node(""));
 
         SECTION("Test non-alias scalar node types.")
         {
@@ -1084,7 +1085,7 @@ TEST_CASE("NodeClassTest_IsAliasTest", "[NodeClassTest]")
         fkyaml::node(false),
         fkyaml::node(0),
         fkyaml::node(0.0),
-        fkyaml::node(std::string()));
+        fkyaml::node(""));
 
     SECTION("Test alias node types.")
     {
@@ -1103,7 +1104,7 @@ TEST_CASE("NodeClassTest_EmptyTest", "[NodeClassTest]")
     {
         SECTION("Test empty container node emptiness.")
         {
-            auto node = GENERATE(fkyaml::node::sequence(), fkyaml::node::mapping(), fkyaml::node(std::string()));
+            auto node = GENERATE(fkyaml::node::sequence(), fkyaml::node::mapping(), fkyaml::node(""));
 
             SECTION("Test empty non-alias container node emptiness.")
             {
@@ -1125,7 +1126,7 @@ TEST_CASE("NodeClassTest_EmptyTest", "[NodeClassTest]")
             auto node = GENERATE(
                 fkyaml::node::sequence(fkyaml::node::sequence_type(3)),
                 fkyaml::node::mapping(fkyaml::node::mapping_type {{"test", fkyaml::node()}}),
-                fkyaml::node(std::string("test")));
+                fkyaml::node("test"));
 
             SECTION("Test non-empty non-alias container node emptiness.")
             {
@@ -1218,7 +1219,7 @@ TEST_CASE("NodeClassTest_ContainsTest", "[NodeClassTest]")
             fkyaml::node(false),
             fkyaml::node(0),
             fkyaml::node(0.0),
-            fkyaml::node(std::string()));
+            fkyaml::node(""));
         std::string key = "test";
 
         SECTION("Test non-alias non-mapping node with lvalue key.")
@@ -1258,7 +1259,7 @@ TEST_CASE("NodeClassTest_SizeGetterTest", "[NodeClassTest]")
         auto node = GENERATE(
             fkyaml::node::sequence({fkyaml::node(), fkyaml::node(), fkyaml::node()}),
             fkyaml::node::mapping({{"test0", fkyaml::node()}, {"test1", fkyaml::node()}, {"test2", fkyaml::node()}}),
-            fkyaml::node(std::string("tmp")));
+            fkyaml::node("tmp"));
 
         SECTION("Test container node size.")
         {
@@ -1443,8 +1444,7 @@ TEST_CASE("NodeClassTest_GetValueTest", "[NodeClassTest]")
 
     SECTION("test mapping node value.")
     {
-        fkyaml::node node(
-            fkyaml::node::mapping_type {{"test", fkyaml::node(3.14)}, {"foo", fkyaml::node(std::string("bar"))}});
+        fkyaml::node node(fkyaml::node::mapping_type {{"test", fkyaml::node(3.14)}, {"foo", fkyaml::node("bar")}});
 
         SECTION("test for mapping value.")
         {
@@ -1455,7 +1455,7 @@ TEST_CASE("NodeClassTest_GetValueTest", "[NodeClassTest]")
             REQUIRE(map.at("test").get_value<double>() == 3.14);
             REQUIRE(map.find("foo") != map.end());
             REQUIRE(map.at("foo").is_string());
-            REQUIRE(map.at("foo").get_value<std::string>() == "bar");
+            REQUIRE(map.at("foo").get_value_ref<std::string&>() == "bar");
         }
 
         SECTION("test for non-mapping values.")
@@ -1597,7 +1597,7 @@ TEST_CASE("NodeClassTest_GetValueTest", "[NodeClassTest]")
 
     SECTION("test string node value.")
     {
-        fkyaml::node node(std::string("test"));
+        fkyaml::node node("test");
 
         SECTION("test for string value.")
         {
@@ -1683,7 +1683,7 @@ TEST_CASE("NodeClassTest_GetValueRefForSequenceTest", "[NodeClassTest]")
             fkyaml::node(false),
             fkyaml::node(0),
             fkyaml::node(0.0),
-            fkyaml::node(std::string()));
+            fkyaml::node(""));
 
         SECTION("Test non-alias non-sequence nodes.")
         {
@@ -1768,7 +1768,7 @@ TEST_CASE("NodeClassTest_GetValueRefForMappingTest", "[NodeClassTest]")
             fkyaml::node(false),
             fkyaml::node(0),
             fkyaml::node(0.0),
-            fkyaml::node(std::string()));
+            fkyaml::node(""));
 
         SECTION("Test non-alias non-mapping nodes.")
         {
@@ -1841,7 +1841,7 @@ TEST_CASE("NodeClassTest_GetValueRefForBooleanTest", "[NodeClassTest]")
             fkyaml::node(),
             fkyaml::node(0),
             fkyaml::node(0.0),
-            fkyaml::node(std::string()));
+            fkyaml::node(""));
 
         SECTION("Test non-alias non-boolean nodes.")
         {
@@ -1915,7 +1915,7 @@ TEST_CASE("NodeClassTest_GetValueRefForIntegerTest", "[NodeClassTest]")
             fkyaml::node(),
             fkyaml::node(false),
             fkyaml::node(0.0),
-            fkyaml::node(std::string()));
+            fkyaml::node(""));
 
         SECTION("Test non-alias non-integer nodes.")
         {
@@ -1989,7 +1989,7 @@ TEST_CASE("NodeClassTest_GetValueRefForFloatNumberTest", "[NodeClassTest]")
             fkyaml::node(),
             fkyaml::node(false),
             fkyaml::node(0),
-            fkyaml::node(std::string()));
+            fkyaml::node(""));
 
         SECTION("Test non-alias non-float-number nodes.")
         {
@@ -2141,8 +2141,7 @@ TEST_CASE("NodeClassTest_BeginTest", "[NodeClassTest]")
 
     SECTION("Test nothrow unexpected nodes.")
     {
-        auto node = GENERATE(
-            fkyaml::node(), fkyaml::node(false), fkyaml::node(0), fkyaml::node(0.0), fkyaml::node(std::string()));
+        auto node = GENERATE(fkyaml::node(), fkyaml::node(false), fkyaml::node(0), fkyaml::node(0.0), fkyaml::node(""));
 
         SECTION("Test non-const throwing node.")
         {
@@ -2202,8 +2201,7 @@ TEST_CASE("NodeClassTest_EndTest", "[NodeClassTest]")
 
     SECTION("Test nothrow unexpected nodes.")
     {
-        auto node = GENERATE(
-            fkyaml::node(), fkyaml::node(false), fkyaml::node(0), fkyaml::node(0.0), fkyaml::node(std::string()));
+        auto node = GENERATE(fkyaml::node(), fkyaml::node(false), fkyaml::node(0), fkyaml::node(0.0), fkyaml::node(""));
 
         SECTION("Test non-const throwing node.")
         {

--- a/test/unit_test/test_node_ref_storage_class.cpp
+++ b/test/unit_test/test_node_ref_storage_class.cpp
@@ -39,7 +39,6 @@ TEST_CASE("NodeRefStorageTest_ArrowOperatorTest", "[NodeRefStorageTest]")
 {
     fkyaml::node node = 123;
     fkyaml::detail::node_ref_storage<fkyaml::node> storage(node);
-    REQUIRE(storage.operator->() == &node);
     REQUIRE(storage->is_integer());
     REQUIRE(storage->get_value<fkyaml::node::integer_type>() == 123);
 

--- a/test/unit_test/test_serializer_class.cpp
+++ b/test/unit_test/test_serializer_class.cpp
@@ -18,7 +18,7 @@ TEST_CASE("SerializerClassTest_SerializeSequenceNode", "[SerializerClassTest]")
     using NodeStrPair = std::pair<fkyaml::node, std::string>;
     auto node_str_pair = GENERATE(
         NodeStrPair({true, false}, "- true\n- false\n"),
-        NodeStrPair({{{std::string("foo"), -1234}, {std::string("bar"), nullptr}}}, "-\n  bar: null\n  foo: -1234\n"));
+        NodeStrPair({{{"foo", -1234}, {"bar", nullptr}}}, "-\n  bar: null\n  foo: -1234\n"));
     fkyaml::detail::basic_serializer<fkyaml::node> serializer;
     REQUIRE(serializer.serialize(node_str_pair.first) == node_str_pair.second);
 }
@@ -27,8 +27,8 @@ TEST_CASE("SerializerClassTest_SerializeMappingNode", "[SerializerClassTest]")
 {
     using NodeStrPair = std::pair<fkyaml::node, std::string>;
     auto node_str_pair = GENERATE(
-        NodeStrPair({{std::string("foo"), -1234}, {std::string("bar"), nullptr}}, "bar: null\nfoo: -1234\n"),
-        NodeStrPair({{std::string("foo"), {true, false}}}, "foo:\n  - true\n  - false\n"));
+        NodeStrPair({{"foo", -1234}, {"bar", nullptr}}, "bar: null\nfoo: -1234\n"),
+        NodeStrPair({{"foo", {true, false}}}, "foo:\n  - true\n  - false\n"));
     fkyaml::detail::basic_serializer<fkyaml::node> serializer;
     REQUIRE(serializer.serialize(node_str_pair.first) == node_str_pair.second);
 }
@@ -72,9 +72,8 @@ TEST_CASE("SerializeClassTest_SerializeFloatNumberNode", "[SerializeClassTest]")
 TEST_CASE("SerializerClassTest_SerializeStringNode", "[SerializerClassTest]")
 {
     using node_str_pair_t = std::pair<fkyaml::node, std::string>;
-    auto node_str_pair = GENERATE(
-        node_str_pair_t(fkyaml::node(std::string("test")), "test"),
-        node_str_pair_t(fkyaml::node(std::string("foo bar")), "foo bar"));
+    auto node_str_pair =
+        GENERATE(node_str_pair_t(fkyaml::node("test"), "test"), node_str_pair_t(fkyaml::node("foo bar"), "foo bar"));
 
     fkyaml::detail::basic_serializer<fkyaml::node> serializer;
     REQUIRE(serializer.serialize(node_str_pair.first) == node_str_pair.second);


### PR DESCRIPTION
Currently, constructing a string scalar node requires exactly the same type as basic_node::string_type as an argument type.  
This restriction had been forcing users to create a lot of boilerplate codes before this PR.  
To resolve the issue, this PR have supported compatible strings, e.g., character arrays or std::string_view (only with C++17 or later), as an argument of the basic_node constructor.  