### PR TITLE
#179 Migrate API docs with MkDocs

### DIFF
--- a/docs/mkdocs/docs/api/basic_node/add_anchor_name.md
+++ b/docs/mkdocs/docs/api/basic_node/add_anchor_name.md
@@ -1,0 +1,49 @@
+<small>Defined in header [`<fkYAML/node.hpp>`](https://github.com/fktn-k/fkYAML/blob/develop/include/fkYAML/node.hpp)</small>
+
+# <small>fkyaml::basic_node::</small>add_anchor_name
+
+```cpp
+void add_anchor_name(const std::string& anchor_name);
+void add_anchor_name(std::string&& anchor_name);
+```
+
+Adds an anchor name to the YAML node.  
+If the basic_node has already had any anchor name, the new anchor name overwrites the old one.
+
+## **Parameters**
+
+***anchor_name***
+:   An anchor name. This should not be empty.
+
+???+ Example
+
+    ```cpp
+    #include <iostream>
+    #include <fkYAML/node.hpp>
+
+    int main()
+    {
+        // create a YAML node.
+        fkyaml::node n = 123;
+
+        // add an anchor name to the node.
+        n.add_anchor_name("anchor");
+        std::cout << n.get_anchor_name() << std::endl;
+
+        // overwrite it with a new one.
+        n.add_anchor_name("anchor2");
+        std::cout << n.get_anchor_name() << std::endl;
+
+        return 0;
+    }
+    ```
+
+    ```bash
+    anchor
+    anchor2
+    ```
+
+## **See Also**
+
+* [basic_node](index.md)
+* [get_anchor_name](get_anchor_name.md)

--- a/docs/mkdocs/docs/api/basic_node/alias_of.md
+++ b/docs/mkdocs/docs/api/basic_node/alias_of.md
@@ -3,5 +3,55 @@
 # <small>fkyaml::basic_node::</small>alias_of
 
 ```cpp
-yaml_version_t alias_of(const basic_node& anchor) const noexcept;
+static basic_node alias_of(const basic_node& anchor);
 ```
+
+Creates an alias YAML node from an anchor node.  
+
+## **Parameters**
+
+***anchor*** [in]
+:   A basic_node object with an anchor name.  
+    This node must have some anchor name.  
+
+## **Return Value**
+
+An alias YAML node which is created from the given anchor node.  
+If the given anchor node does not have any non-empty anchor name, an [`fkyaml::exception`](../exception/index.md) will be thrown.  
+
+!!! Note
+
+    If this API throws an exception, the internally stored YAML node value in the given anchor node stays intact.
+
+???+ Example
+
+    ```cpp
+    #include <iostream>
+    #include <fkYAML/node.hpp>
+
+    int main()
+    {
+        // create a YAML node.
+        fkyaml::node anchor_node = "test";
+
+        // add an anchor name to the node.
+        anchor_node.add_anchor_name("anchor");
+
+        // create an alias YAML node.
+        fkyaml::node alias_node = fkyaml::node::alias_of(anchor_node);
+
+        // print the value in the alias node.
+        std::cout<< alias_node.get_value_ref<fkyaml::node::string_type> << std::endl;
+
+        return 0;
+    }
+    ```
+
+    ```bash
+    test
+    ```
+
+## **See Also**
+
+* [basic_node](index.md)
+* [add_anchor_name](add_anchor_name.md)

--- a/docs/mkdocs/docs/api/basic_node/begin.md
+++ b/docs/mkdocs/docs/api/basic_node/begin.md
@@ -16,7 +16,7 @@ Throws a [`fkyaml::exception`](../exception/index.md) if a basic_node does not h
 
 An iterator to the first element of a container node value (either sequence or mapping).
 
-??? Example
+???+ Example
 
     ```cpp
     #include <iostream>

--- a/docs/mkdocs/docs/api/basic_node/begin.md
+++ b/docs/mkdocs/docs/api/basic_node/begin.md
@@ -25,7 +25,7 @@ An iterator to the first element of a container node value (either sequence or m
     int main()
     {
         // create a sequence node.
-        fkyaml::node n = {std::string("foo"), std::string("bar")};
+        fkyaml::node n = {"foo", "bar"};
         // get an iterator to the first element.
         fkyaml::node::iterator it = n.begin();
         std::cout << fkyaml::node::serialize(*it) << std::endl;

--- a/docs/mkdocs/docs/api/basic_node/boolean_type.md
+++ b/docs/mkdocs/docs/api/basic_node/boolean_type.md
@@ -16,7 +16,7 @@ To store boolean objects in [`basic_node`](index.md) class, the type is defined 
 If not explicitly specified, the default type `bool` will be chosen.  
 With the decided type, boolean objects are stored directly inside a [`basic_node`](index.md).  
 
-??? Example
+???+ Example
 
     ```cpp
     #include <iomanip>

--- a/docs/mkdocs/docs/api/basic_node/const_iterator.md
+++ b/docs/mkdocs/docs/api/basic_node/const_iterator.md
@@ -9,7 +9,7 @@ using const_iterator = detail::iterator<const basic_node>;
 The type for constant iterators of [`basic_node`](index.md) containers.  
 This iterator type is commonly used for sequence and mapping container values.  
 
-??? Example
+???+ Example
 
     ```cpp
     #include <iomanip>

--- a/docs/mkdocs/docs/api/basic_node/constructor.md
+++ b/docs/mkdocs/docs/api/basic_node/constructor.md
@@ -39,7 +39,7 @@ basic_node() = default;
 Default constructor. Constructs a basic_node with a null value.  
 The resulting basic_node has the [`node_t::NULL_OBJECT`](node_t.md) type.  
 
-??? example
+???+ Example
 
     ```cpp
     #include <iostream>
@@ -69,9 +69,9 @@ The resulting basic_node has a default value for the given type.
 ### **Parameters**
 
 ***`type`*** [in]
-:   A YAML node value.
+:   A YAML node type.
 
-??? example
+???+ Example
 
     ```cpp
     #include <iostream>
@@ -101,9 +101,9 @@ The resulting basic_node has the same type and value as `rhs`.
 ### **Parameters**
 
 ***`rhs`*** [in]
-:   A basic node to be copied with.
+:   A basic_node object to be copied with.
 
-??? example
+???+ Example
 
     ```cpp
     #include <iostream>
@@ -135,9 +135,9 @@ The value of the argument `rhs` after calling this move constructor, will be the
 ### **Parameters**
 
 ***`rhs`*** [in]
-:   A basic node to be moved from.
+:   A basic_node object to be moved from.
 
-??? example
+???+ Example
 
     ```cpp
     #include <iostream>
@@ -185,7 +185,7 @@ The resulting basic_node has the value of `val` and the type which is associated
 ***`val`*** [in]
 :   The value of a compatible type.
 
-??? example
+???+ Example
 
     ```cpp
     #include <iostream>
@@ -232,7 +232,7 @@ The resulting basic_node has the value of the referenced basic_node by `node_ref
 ***`node_ref_storage`*** [in]
 :   A node_ref_storage template class object.
 
-??? example
+???+ Example
 
     ```cpp
     #include <iostream>
@@ -279,7 +279,7 @@ If `init` contains a sequence of basic_node objects in which the number of basic
 ***`init`*** [in]
 :   A initializer list of basic_node objects.
 
-??? example
+???+ Example
 
     ```cpp
     #include <iostream>

--- a/docs/mkdocs/docs/api/basic_node/constructor.md
+++ b/docs/mkdocs/docs/api/basic_node/constructor.md
@@ -194,7 +194,7 @@ The resulting basic_node has the value of `val` and the type which is associated
     int main()
     {
         double pi = 3.141592;
-        fkyaml::node n(pi);
+        fkyaml::node n = pi;
         std::cout << fkyaml::node::serialize(n) << std::endl;
         return 0;
     }
@@ -262,18 +262,6 @@ The resulting basic_node has the value of a container (sequence or mapping) whic
 Basically, the basic_node objects in `init` are considered as a sequence node.
 If `init` contains a sequence of basic_node objects in which the number of basic_node objects is 2 and the first has the type of `node_t::STRING`, however, such a sequence is reinterpreted as a mapping node.  
 
-!!! Note
-
-    To avoid ambiguity between a sequence of `char` and a `std::string`, c-style char arrays are intentionally unsupported in this constructor.  
-    To contain a string in a `initializer_list_t` object, you must explicitly pass a `std::string` object as follows:  
-    ```cpp
-    // this is not supported.
-    fkyaml::node n = {"foo", "bar"};
-
-    // you must do this instead.
-    fkyaml::node n2 = {std::string("foo"), std::string("bar")};
-    ```
-
 ### **Parameters**
 
 ***`init`*** [in]
@@ -290,7 +278,7 @@ If `init` contains a sequence of basic_node objects in which the number of basic
         fkyaml::node n = {true, false};
         std::cout << fkyaml::node::serialize(n) << std::endl;
 
-        fkyaml::node n2 = {std::string("foo"), 1024};
+        fkyaml::node n2 = {"foo", 1024};
         std::cout << fkyaml::node::serialize(n2) << std::endl;
         return 0;
     }

--- a/docs/mkdocs/docs/api/basic_node/contains.md
+++ b/docs/mkdocs/docs/api/basic_node/contains.md
@@ -10,3 +10,59 @@ template <
                             int> = 0>
 bool contains(KeyType&& key) const;
 ```
+
+Checks if the YAML node has the given key.  
+If the node value is not a mapping, this API will throw an [`fkyaml::exception`](../exception/index.md).  
+
+## **Template Parameters**
+
+***KeyType***
+:   A type compatible with the key type of mapping node values.
+
+## **Parameters**
+
+***key*** [in]
+:   A key to the target value in the YAML mapping node value.
+
+## **Return Value**
+
+`true` if the YAML node is a mapping and has the given key, `false` otherwise.  
+
+???+ Example
+
+    ```cpp
+    #include <iomanip>
+    #include <iostream>
+    #include <fkYAML/node.hpp>
+
+    int main()
+    {
+        // create a YAML mapping node.
+        fkyaml::node n = {{"foo", true}, {"bar", 123}};
+
+        // check if the node has the following keys.
+        std::cout << std::boolalpha;
+        std::cout << n.contains("foo") << std::endl;
+        std::cout << n.contains("baz") << std::endl;
+
+        // create a YAML node. (not mapping)
+        fkyaml::node n2 = "qux";
+
+        // check if the node has the following key.
+        std::cout << std::boolalpha << n2.contains("qux") << std::endl;
+
+        return 0;
+    }
+    ```
+
+    output:
+    ```bash
+    true
+    false
+    false
+    ```
+
+## **See Also**
+
+* [basic_node](index.md)
+* [mapping_type](mapping_type.md)

--- a/docs/mkdocs/docs/api/basic_node/deserialize.md
+++ b/docs/mkdocs/docs/api/basic_node/deserialize.md
@@ -40,7 +40,7 @@ static basic_node deserialize(InputType&& input);
 ***`input`*** [in]
 :   An input source in the YAML format.
 
-### **Return Values**
+### **Return Value**
 
 The resulting `basic_node` object deserialized from the input source.  
 
@@ -67,13 +67,13 @@ static basic_node deserialize(ItrType&& begin, ItrType&& end);
 ***`end`*** [in]
 :   An iterator to the past-the-last element of an input sequence
 
-### **Return Values**
+### **Return Value**
 
 The resulting `basic_node` object deserialized from the pair of iterators.
 
 ## Examples
 
-??? Example "Example (a character array)"
+???+ Example "Example (a character array)"
 
     ```cpp
     #include <cstdint>
@@ -106,7 +106,7 @@ The resulting `basic_node` object deserialized from the pair of iterators.
     3.14
     ```
 
-??? Example "Example (a std::string object)"
+???+ Example "Example (a std::string object)"
 
     ```cpp
     #include <cstdint>
@@ -140,7 +140,7 @@ The resulting `basic_node` object deserialized from the pair of iterators.
     3.14
     ```
 
-??? Example "Example (a FILE pointer)"
+???+ Example "Example (a FILE pointer)"
 
     ```yaml title="input.yaml"
     foo: true
@@ -181,7 +181,7 @@ The resulting `basic_node` object deserialized from the pair of iterators.
     3.14
     ```
 
-??? Example "Example (a pair of iterators)"
+???+ Example "Example (a pair of iterators)"
 
     ```cpp
     #include <cstdint>

--- a/docs/mkdocs/docs/api/basic_node/empty.md
+++ b/docs/mkdocs/docs/api/basic_node/empty.md
@@ -11,9 +11,9 @@ Throws a [`fkyaml::exception`](../exception/index.md) if a basic_node does not h
 
 ### **Return Value**
 
-Returns `true` if the node value is empty, `false` otherwise.
+`true` if the node value is empty, `false` otherwise.
 
-??? Example
+???+ Example
 
     ```cpp
     #include <iomanip>

--- a/docs/mkdocs/docs/api/basic_node/empty.md
+++ b/docs/mkdocs/docs/api/basic_node/empty.md
@@ -26,12 +26,12 @@ Throws a [`fkyaml::exception`](../exception/index.md) if a basic_node does not h
         std::vector<fkyaml::node> nodes =
         {
             {1, 2, 3},
-            {{std::string("foo"), true}, {std::string("bar"), false}},
+            {{"foo", true}, {"bar", false}},
             fkyaml::node(),
             true,
             256,
             3.14,
-            std::string("Hello, world!")
+            "Hello, world!"
         };
 
         for (const auto& n : nodes)

--- a/docs/mkdocs/docs/api/basic_node/end.md
+++ b/docs/mkdocs/docs/api/basic_node/end.md
@@ -16,7 +16,7 @@ Throws a [`fkyaml::exception`](../exception/index.md) if a basic_node does not h
 
 An iterator to the past-the-last element of a container node value (either sequence or mapping).
 
-??? Example
+???+ Example
 
     ```cpp
     #include <iostream>

--- a/docs/mkdocs/docs/api/basic_node/end.md
+++ b/docs/mkdocs/docs/api/basic_node/end.md
@@ -25,7 +25,7 @@ An iterator to the past-the-last element of a container node value (either seque
     int main()
     {
         // create a sequence node.
-        fkyaml::node n = {std::string("foo"), std::string("bar")};
+        fkyaml::node n = {"foo", "bar"};
         // get an iterator to the past-the-last element.
         fkyaml::node::iterator it = n.end();
         // decrement the iterator to point to the last element.

--- a/docs/mkdocs/docs/api/basic_node/float_number_type.md
+++ b/docs/mkdocs/docs/api/basic_node/float_number_type.md
@@ -16,7 +16,7 @@ To store floating point number objects in [`basic_node`](index.md) class, the ty
 If not explicitly specified, the default type `double` will be chosen.  
 With the decided type, floating point number objects are stored directly inside a [`basic_node`](index.md).  
 
-??? Example
+???+ Example
 
     ```cpp
     #include <iomanip>

--- a/docs/mkdocs/docs/api/basic_node/get_anchor_name.md
+++ b/docs/mkdocs/docs/api/basic_node/get_anchor_name.md
@@ -1,0 +1,56 @@
+<small>Defined in header [`<fkYAML/node.hpp>`](https://github.com/fktn-k/fkYAML/blob/develop/include/fkYAML/node.hpp)</small>
+
+# <small>fkyaml::basic_node::</small>get_anchor_name
+
+```cpp
+const std::string& get_anchor_name() const;
+```
+
+Gets the anchor name associated to the YAML node.  
+Some anchor name must be set before calling this API.  
+Calling [`has_anchor_name`](has_anchor_name.md) to see if the node has any anchor name beforehand.
+
+## **Return Value**
+
+The anchor name associated to the node.  
+If no anchor name has been set, an [`fkyaml::exception`](../exception/index.md) will be thrown.
+
+???+ Example
+
+    ```cpp
+    #include <iostream>
+    #include <fkYAML/node.hpp>
+
+    int main()
+    {
+        // create a YAML node.
+        fkyaml::node n = 123;
+
+        // try to get an anchor name before any anchor name has been set.
+        try
+        {
+            std::cout << n.get_anchor_name() << std::endl;
+        }
+        catch (const fkyaml::exception& e)
+        {
+            std::cout << e.what() << std::endl;
+        }
+
+        // add an anchor name to the node.
+        n.add_anchor_name("anchor");
+        std::cout << n.get_anchor_name() << std::endl;
+
+        return 0;
+    }
+    ```
+
+    output:
+    ```bash
+    No anchor name has been set.
+    anchor
+    ```
+
+## **See Also**
+
+* [basic_node](index.md)
+* [set_anchor_name](get_anchor_name.md)

--- a/docs/mkdocs/docs/api/basic_node/get_value.md
+++ b/docs/mkdocs/docs/api/basic_node/get_value.md
@@ -12,3 +12,21 @@ template <
 T get_value() const noexcept(
     noexcept(ConverterType<ValueType>::from_node(std::declval<const basic_node&>(), std::declval<ValueType&>())));
 ```
+
+Explicit type conversion between the internally stored YAML node value and a compatible value which is [copy-constructible](https://en.cppreference.com/w/cpp/named_req/CopyConstructible) and [default-constructible](https://en.cppreference.com/w/cpp/named_req/DefaultConstructible).  
+The conversion relies on the [`node_value_converter`](../node_value_converter/index.md)::[`from_node`](../node_value_converter/from_node.md).  
+This API makes a copy of the value.  
+If the copying costs a lot, or if you need an address of the original value, then it might be more suitable to call [`get_value_ref`](get_value_ref.md) instead.  
+
+## **Template Parameters**
+
+***T***
+:   A compatible value type which might be cv-qualified or a reference type.  
+
+***ValueType***
+:   A compatible value type.  
+    This is, by default, a result of [std::remove_cvref_t<T>](https://en.cppreference.com/w/cpp/types/remove_cvref).  
+
+## **Return Value**
+
+A compatible native data value converted from the basic_node object.

--- a/docs/mkdocs/docs/api/basic_node/get_value_ref.md
+++ b/docs/mkdocs/docs/api/basic_node/get_value_ref.md
@@ -1,0 +1,80 @@
+<small>Defined in header [`<fkYAML/node.hpp>`](https://github.com/fktn-k/fkYAML/blob/develop/include/fkYAML/node.hpp)</small>
+
+# <small>fkyaml::basic_node::</small>get_value_ref
+
+```cpp
+template <typename ReferenceType, detail::enable_if_t<std::is_reference<ReferenceType>::value, int> = 0>
+ReferenceType get_value_ref() const noexcept(
+    noexcept(ConverterType<ValueType>::from_node(std::declval<const basic_node&>(), std::declval<ValueType&>())));
+
+template <
+    typename ReferenceType,
+    detail::enable_if_t<
+        detail::conjunction<
+            std::is_reference<ReferenceType>, std::is_const<detail::remove_reference_t<ReferenceType>>>::value,
+        int> = 0>
+ReferenceType get_value_ref() const;
+```
+
+Explicit reference access to the internally stored YAML node value.  
+This API makes no copies.  
+
+## **Template Parameters**
+
+***ReferenceType***
+:   reference type to the target YAML node value.  
+    This must be a reference to [`sequence_type`](sequence_type.md), [`mapping_type`](mapping_type.md), [`boolean_type`](boolean_type.md), [`integer_type`](integer_type.md), [`float_number_type`](float_number_type.md) or [`string_type`](string_type.md).  
+    The above restriction is enforced by a static assertion.
+
+## **Return Value**
+
+Reference to the internally stored YAML node value if the requested reference type fits to the YAML node value.  
+A [`fkyaml::exception`](../exception/index.md) would be thrown otherwise.  
+
+!!! Note
+
+    If this API throws an exception, the internally stored YAML node value stays intact.
+
+???+ Example
+
+    ```cpp
+    #include <iostream>
+    #include <fkYAML/node.hpp>
+
+    int main()
+    {
+        // create a YAML node.
+        fkyaml::node n = 123;
+
+        // get references to the value.
+        auto ref = n.get_value_ref<fkyaml::node::integer_type&>();
+        auto cref = n.get_value_ref<const fkyaml::node::integer_type&>();
+
+        // print the referenced values
+        std::cout << ref << std::endl;
+        std::cout << cref << std::endl;
+
+        // specifying incompatible reference type throws an exception
+        try
+        {
+            auto iref = value.get_value_ref<fkyaml::node::mapping_type&>();
+        }
+        catch (const fkyaml::exception& e)
+        {
+            std::cout << e.what() << std::endl;
+        }
+
+        return 0;
+    }
+    ```
+
+    output:
+    ```bash
+    123
+    123
+    The node value is not a mapping.
+    ```
+
+## **See Also**
+
+* [basic_node](index.md)

--- a/docs/mkdocs/docs/api/basic_node/get_yaml_version.md
+++ b/docs/mkdocs/docs/api/basic_node/get_yaml_version.md
@@ -8,14 +8,16 @@ yaml_version_t get_yaml_version() const noexcept;
 
 Returns the version of the YAML format applied for the `basic_node` object.  
 
-### **Return Values**
+### **Return Value**
+
+The version of the YAML format applied to the basic_node object.
 
 | YAML version | Return Value            |
 | ------------ | ----------------------- |
 | 1.1          | yaml_version_t::VER_1_1 |
 | 1.2          | yaml_version_t::VER_1_2 |
 
-??? Example
+???+ Example
 
     ```cpp
     #include <iomanip>

--- a/docs/mkdocs/docs/api/basic_node/has_anchor_name.md
+++ b/docs/mkdocs/docs/api/basic_node/has_anchor_name.md
@@ -1,0 +1,49 @@
+<small>Defined in header [`<fkYAML/node.hpp>`](https://github.com/fktn-k/fkYAML/blob/develop/include/fkYAML/node.hpp)</small>
+
+# <small>fkyaml::basic_node::</small>has_anchor_name
+
+```cpp
+bool has_anchor_name() const noexcept;
+```
+
+Check if the YAML node has an anchor name.  
+
+## **Return Value**
+
+`true` if the YAML node has an anchor name, `false` otherwise.  
+
+???+ Example
+
+    ```cpp
+    #include <iostream>
+    #include <fkYAML/node.hpp>
+
+    int main()
+    {
+        // create a YAML node.
+        fkyaml::node n = {{"foo", true}};
+
+        // check if the node has an anchor name.
+        std::cout << std::boolalpha << n.has_anchor_name() << std::endl;
+
+        // set an anchor name.
+        n.add_anchor_name("anchor");
+
+        // check if the node has an anchor name again.
+        std::cout << std::boolalpha << n.has_anchor_name() << std::endl;
+
+        return 0;
+    }
+    ```
+
+    output:
+    ```bash
+    false
+    true
+    false
+    ```
+
+## **See Also**
+
+* [basic_node](index.md)
+* [add_anchor_name](add_anchor_name.md)

--- a/docs/mkdocs/docs/api/basic_node/index.md
+++ b/docs/mkdocs/docs/api/basic_node/index.md
@@ -74,17 +74,12 @@ This class provides features to handle YAML nodes.
 | [is_string](is_string.md)             | checks if a basic_node has a string node value.       |
 
 ### Conversions
-| Name                                  | Description                                             |
-| ------------------------------------- | ------------------------------------------------------- |
-| [deserialize](deserialize.md)         | deserializes a YAML formatted string into a basic_node. |
-| [serialize](serialize.md)             | serializes a basic_node into a YAML formatted string.   |
-| [get_value](get_value.md)             | converts a basic_node into a target native data type.   |
-| [to_sequence](to_sequence.md)         | gets reference to the sequence node value.              |
-| [to_mapping](to_mapping.md)           | gets reference to the mapping node value.               |
-| [to_boolean](to_boolean.md)           | gets reference to the boolean node value.               |
-| [to_integer](to_integer.md)           | gets reference to the integer node value.               |
-| [to_float_number](to_float_number.md) | gets reference to the floating point number node value. |
-| [to_string](to_string.md)             | gets reference to the string node value.                |
+| Name                              |          | Description                                                        |
+| --------------------------------- | -------- | ------------------------------------------------------------------ |
+| [deserialize](deserialize.md)     | (static) | deserializes a YAML formatted string into a basic_node.            |
+| [serialize](serialize.md)         | (static) | serializes a basic_node into a YAML formatted string.              |
+| [get_value](get_value.md)         |          | converts a basic_node into a target native data type.              |
+| [get_value_ref](get_value_ref.md) |          | converts a basic_node into reference to a target native data type. |
 
 ### Iterators
 | Name              | Description                                              |
@@ -105,7 +100,14 @@ This class provides features to handle YAML nodes.
 | [operator[]](operator[].md) | accesses an item specified by the key/index |
 
 ### Aliasing Nodes
-| Name                                  | Description                                      |
-| ------------------------------------- | ------------------------------------------------ |
-| [add_anchor_name](add_anchor_name.md) | registers an anchor name to a basic_node object. |
-| [has_anchor_name](has_anchor_name.md) | checks if a basic_node has any anchor name.      |
+| Name                                  | Description                                              |
+| ------------------------------------- | -------------------------------------------------------- |
+| [add_anchor_name](add_anchor_name.md) | registers an anchor name to a basic_node object.         |
+| [get_anchor_name](get_anchor_name.md) | gets an anchor name associated with a basic_node object. |
+| [has_anchor_name](has_anchor_name.md) | checks if a basic_node has any anchor name.              |
+
+### Modifiers
+
+| Name            | Description                      |
+| --------------- | -------------------------------- |
+| [swap](swap.md) | swaps the internally stored data |

--- a/docs/mkdocs/docs/api/basic_node/integer_type.md
+++ b/docs/mkdocs/docs/api/basic_node/integer_type.md
@@ -12,7 +12,7 @@ To store integer objects in [`basic_node`](index.md) class, the type is defined 
 If not explicitly specified, the default type `std::int64_t` will be chosen.  
 With the decided type, integer objects are stored directly inside a [`basic_node`](index.md).  
 
-??? Example
+???+ Example
 
     ```cpp
     #include <cstdint>

--- a/docs/mkdocs/docs/api/basic_node/is_boolean.md
+++ b/docs/mkdocs/docs/api/basic_node/is_boolean.md
@@ -12,7 +12,7 @@ Tests whether the node value type is [`node_t::BOOLEAN`](node_t.md).
 
 `true` if the type is [`node_t::BOOLEAN`](node_t.md), `false` otherwise.  
 
-??? Example
+???+ Example
 
     ```cpp
     #include <iomanip>

--- a/docs/mkdocs/docs/api/basic_node/is_float_number.md
+++ b/docs/mkdocs/docs/api/basic_node/is_float_number.md
@@ -12,7 +12,7 @@ Tests whether the node value type is [`node_t::FLOAT_NUMBER`](node_t.md).
 
 `true` if the type is [`node_t::FLOAT_NUMBER`](node_t.md), `false` otherwise.  
 
-??? Example
+???+ Example
 
     ```cpp
     #include <iomanip>

--- a/docs/mkdocs/docs/api/basic_node/is_integer.md
+++ b/docs/mkdocs/docs/api/basic_node/is_integer.md
@@ -12,7 +12,7 @@ Tests whether the node value type is [`node_t::INTEGER`](node_t.md).
 
 `true` if the type is [`node_t::INTEGER`](node_t.md), `false` otherwise.  
 
-??? Example
+???+ Example
 
     ```cpp
     #include <iomanip>

--- a/docs/mkdocs/docs/api/basic_node/is_mapping.md
+++ b/docs/mkdocs/docs/api/basic_node/is_mapping.md
@@ -12,7 +12,7 @@ Tests whether the node value type is [`node_t::MAPPING`](node_t.md).
 
 `true` if the type is [`node_t::MAPPING`](node_t.md), `false` otherwise.  
 
-??? Example
+???+ Example
 
     ```cpp
     #include <iomanip>

--- a/docs/mkdocs/docs/api/basic_node/is_mapping.md
+++ b/docs/mkdocs/docs/api/basic_node/is_mapping.md
@@ -21,7 +21,7 @@ Tests whether the node value type is [`node_t::MAPPING`](node_t.md).
 
     int main()
     {
-        fkyaml::node n = {{std::string("foo"), true}};
+        fkyaml::node n = {{"foo", true}};
         std::cout << std::boolalpha << n.is_mapping() << std::endl;
         return 0;
     }

--- a/docs/mkdocs/docs/api/basic_node/is_null.md
+++ b/docs/mkdocs/docs/api/basic_node/is_null.md
@@ -12,7 +12,7 @@ Tests whether the node value type is [`node_t::NULL_OBJECT`](node_t.md).
 
 `true` if the type is [`node_t::NULL_OBJECT`](node_t.md), `false` otherwise.  
 
-??? Example
+???+ Example
 
     ```cpp
     #include <iomanip>

--- a/docs/mkdocs/docs/api/basic_node/is_scalar.md
+++ b/docs/mkdocs/docs/api/basic_node/is_scalar.md
@@ -31,7 +31,7 @@ Tests whether the node value type is one of the followings:
         fkyaml::node boolean_node = true;
         fkyaml::node integer_node = 256;
         fkyaml::node float_node = 3.14;
-        fkyaml::node string_node = std::string("Hello, world!");
+        fkyaml::node string_node = "Hello, world!";
 
         // call type()
         std::cout << std::boolalpha;

--- a/docs/mkdocs/docs/api/basic_node/is_scalar.md
+++ b/docs/mkdocs/docs/api/basic_node/is_scalar.md
@@ -17,7 +17,7 @@ Tests whether the node value type is one of the followings:
 
 `true` if the type is a scalar type, `false` otherwise.  
 
-??? Example
+???+ Example
 
     ```cpp
     #include <iomanip>

--- a/docs/mkdocs/docs/api/basic_node/is_sequence.md
+++ b/docs/mkdocs/docs/api/basic_node/is_sequence.md
@@ -12,7 +12,7 @@ Tests whether the node value type is [`node_t::SEQUENCE`](node_t.md).
 
 `true` if the type is [`node_t::SEQUENCE`](node_t.md), `false` otherwise.  
 
-??? Example
+???+ Example
 
     ```cpp
     #include <iomanip>

--- a/docs/mkdocs/docs/api/basic_node/is_string.md
+++ b/docs/mkdocs/docs/api/basic_node/is_string.md
@@ -21,7 +21,7 @@ Tests whether the node value type is [`node_t::STRING`](node_t.md).
 
     int main()
     {
-        fkyaml::node n = std::string("foo");
+        fkyaml::node n = "foo";
         std::cout << std::boolalpha << n.is_string() << std::endl;
         return 0;
     }

--- a/docs/mkdocs/docs/api/basic_node/is_string.md
+++ b/docs/mkdocs/docs/api/basic_node/is_string.md
@@ -12,7 +12,7 @@ Tests whether the node value type is [`node_t::STRING`](node_t.md).
 
 `true` if the type is [`node_t::STRING`](node_t.md), `false` otherwise.  
 
-??? Example
+???+ Example
 
     ```cpp
     #include <iomanip>

--- a/docs/mkdocs/docs/api/basic_node/iterator.md
+++ b/docs/mkdocs/docs/api/basic_node/iterator.md
@@ -9,7 +9,7 @@ using iterator = detail::iterator<basic_node>;
 The type for iterators of [`basic_node`](index.md) containers.  
 This iterator type is commonly used for sequence and mapping container values.  
 
-??? Example
+???+ Example
 
     ```cpp
     #include <iomanip>

--- a/docs/mkdocs/docs/api/basic_node/mapping.md
+++ b/docs/mkdocs/docs/api/basic_node/mapping.md
@@ -21,8 +21,8 @@ The resulting basic_node has the [`node_t::MAPPING`](node_t.md) type.
     int main()
     {
         fkyaml::node::mapping_type m = {
-            {fkyaml::node(std::string("foo")), fkyaml::node(false)},
-            {fkyaml::node(std::string("bar")), fkyaml::node(3.14)}
+            {"foo", false},
+            {"bar", 3.14}
         };
         fkyaml::node n = fkyaml::node::mapping(m);
         std::cout << fkyaml::node::serialize(n) << std::endl;

--- a/docs/mkdocs/docs/api/basic_node/mapping.md
+++ b/docs/mkdocs/docs/api/basic_node/mapping.md
@@ -12,7 +12,7 @@ The factory method which constructs a basic_node with the [`node_t::MAPPING`](no
 Calling this API with no arguments will constructs a basic_node with an empty mapping node value.  
 The resulting basic_node has the [`node_t::MAPPING`](node_t.md) type.  
 
-??? example
+???+ Example
 
     ```cpp
     #include <iostream>

--- a/docs/mkdocs/docs/api/basic_node/mapping_type.md
+++ b/docs/mkdocs/docs/api/basic_node/mapping_type.md
@@ -33,7 +33,7 @@ Note that mapping objects are stored as pointers in a [`basic_node`](index.md) s
 `StringType`
 :   The type of keys and string scalar values. Defaults to `std::string`.
 
-??? Example
+???+ Example
 
     ```cpp
     #include <cstdint>

--- a/docs/mkdocs/docs/api/basic_node/node.md
+++ b/docs/mkdocs/docs/api/basic_node/node.md
@@ -8,7 +8,7 @@ using node = basic_node<>;
 
 This type is the default specialization of the [basic_node](index.md) class which uses the standard template types.  
 
-??? Example
+???+ Example
 
     ```cpp
     #include <iostream>

--- a/docs/mkdocs/docs/api/basic_node/node.md
+++ b/docs/mkdocs/docs/api/basic_node/node.md
@@ -19,16 +19,16 @@ This type is the default specialization of the [basic_node](index.md) class whic
         // create a YAML node.
         fkyaml::node n =
         {
-            {std::string("foo"), 3.14},
-            {std::string("bar"), true},
-            {std::string("baz"), nullptr},
-            {std::string("qux"), {
-                {std::string("corge"), {1, 2, 3}}
+            {"foo", 3.14},
+            {"bar", true},
+            {"baz", nullptr},
+            {"qux", {
+                {"corge", {1, 2, 3}}
             }}
         };
 
         // add a new value.
-        n["qux"]["key"] = {std::string("another"), std::string("value")};
+        n["qux"]["key"] = {"another", "value"};
 
         // output a YAML formatted string.
         std::cout << fkyaml::node::serialize(n) << std::endl;

--- a/docs/mkdocs/docs/api/basic_node/node_t.md
+++ b/docs/mkdocs/docs/api/basic_node/node_t.md
@@ -26,7 +26,7 @@ This enumeration collects the different YAML value types. They are internally us
     * [`float_number_type`](float_number_type.md) for float number scalar values
     * [`string_type`](string_type.md) for string scalar values
 
-??? Example
+???+ Example
 
     ```cpp
     #include <iomanip>

--- a/docs/mkdocs/docs/api/basic_node/node_t.md
+++ b/docs/mkdocs/docs/api/basic_node/node_t.md
@@ -37,12 +37,12 @@ This enumeration collects the different YAML value types. They are internally us
     {
         // create YAML nodes.
         fkyaml::node sequence_node = {1, 2, 3};
-        fkyaml::node mapping_node = {{std::string("foo"), true}, {std::string("bar"), false}};
+        fkyaml::node mapping_node = {{"foo", true}, {"bar", false}};
         fkyaml::node null_node;
         fkyaml::node boolean_node = true;
         fkyaml::node integer_node = 256;
         fkyaml::node float_node = 3.14;
-        fkyaml::node string_node = std::string("Hello, world!");
+        fkyaml::node string_node = "Hello, world!";
 
         // call type()
         std::cout << std::boolalpha;

--- a/docs/mkdocs/docs/api/basic_node/operator=.md
+++ b/docs/mkdocs/docs/api/basic_node/operator=.md
@@ -20,7 +20,16 @@ basic_node& operator=(const basic_node& rhs) noexcept;
 Copy assignment operator.  
 Copies a YAML node value via the "copy and swap" strategy to enhance exception safety.  
 
-??? Example
+### **Parameters**
+
+***`rhs`*** [in]
+:   A lvalue basic_node object to be copied with.
+
+### **Return Value**
+
+Reference to this basic_node object.
+
+???+ Example
 
     ```cpp
     #include <iostream>
@@ -31,6 +40,49 @@ Copies a YAML node value via the "copy and swap" strategy to enhance exception s
         fkyaml::node n = true;
         fkyaml::node n2 = 123;
         n = n2;
+
+        std::cout << std::boolalpha << n.is_integer() << std::endl;
+        std::cout << n.get_value<std::int64_t>() << std::endl;
+
+        return 0;
+    }
+    ```
+
+    output:
+    ```bash
+    true
+    123
+    ```
+
+## Overload (2)
+
+```cpp
+basic_node& operator=(basic_node&& rhs) noexcept;
+```
+
+Move assignment operator.  
+Moves a YAML node value from the given node.  
+
+### **Parameters**
+
+***`rhs`*** [in]
+:   A rvalue basic_node object to be moved from.
+
+### **Return Value**
+
+Reference to this basic_node object.
+
+???+ Example
+
+    ```cpp
+    #include <iostream>
+    #include <fkYAML/node.hpp>
+
+    int main()
+    {
+        fkyaml::node n = true;
+        fkyaml::node n2 = 123;
+        n = std::move(n2);
 
         std::cout << std::boolalpha << n.is_integer() << std::endl;
         std::cout << n.get_value<std::int64_t>() << std::endl;

--- a/docs/mkdocs/docs/api/basic_node/operator[].md
+++ b/docs/mkdocs/docs/api/basic_node/operator[].md
@@ -3,21 +3,135 @@
 # <small>fkyaml::basic_node::</small>operator[]
 
 ```cpp
-basic_node& operator[](std::size_t index);
+basic_node& operator[](std::size_t index); // (1)
 
-const basic_node& operator[](std::size_t index) const;
-
-template <
-    typename KeyType, detail::enable_if_t<
-                            detail::is_usable_as_key_type<
-                                typename mapping_type::key_compare, typename mapping_type::key_type, KeyType>::value,
-                            int> = 0>
-basic_node& operator[](KeyType&& key);
+const basic_node& operator[](std::size_t index) const; // (2)
 
 template <
     typename KeyType, detail::enable_if_t<
                             detail::is_usable_as_key_type<
                                 typename mapping_type::key_compare, typename mapping_type::key_type, KeyType>::value,
                             int> = 0>
-const basic_node& operator[](KeyType&& key) const;
+basic_node& operator[](KeyType&& key); // (3)
+
+template <
+    typename KeyType, detail::enable_if_t<
+                            detail::is_usable_as_key_type<
+                                typename mapping_type::key_compare, typename mapping_type::key_type, KeyType>::value,
+                            int> = 0>
+const basic_node& operator[](KeyType&& key) const; // (4)
 ```
+
+Access to a YAML node element with either a key or an index.  
+If the node is neither a mapping nor a sequence, a [`fkyaml::exception`](../exception/index.md) will be thrown.  
+
+## Overload (1), (2)  
+
+```cpp
+basic_node& operator[](std::size_t index); // (1)
+const basic_node& operator[](std::size_t index) const; // (2)
+```
+
+Accesses to an element in the YAML sequence node with the given index.  
+If the node is not a sequence, a [`fkyaml::exception`](../exception/index.md) will be thrown.  
+
+!!! Danger
+
+    This API does not check the size of a sequence node before accessing the element.  
+    To avoid undefined behaviors, please make sure the argument `index` is smaller than the actual sequence size with a return value of [`size()`](size.md).  
+
+### **Parameters**
+
+***`index`*** [in]
+:   An index for an element in the YAML sequence node.  
+
+### **Return Value**
+
+Reference, or constant reference, to the YAML node at the given index.  
+
+???+ Example
+
+    ```cpp
+    #include <iostream>
+    #include <fkYAML/node.hpp>
+
+    int main()
+    {
+        // create a YAML sequence node.
+        fkyaml::node n = {123, 234, 345, 456};
+
+        // print YAML nodes at the following indexes.
+        std::cout << fkyaml::node::serialize(n[0]) << std::endl;
+        std::cout << fkyaml::node::serialize(n[1]) << std::endl;
+        std::cout << fkyaml::node::serialize(n[2]) << std::endl;
+        std::cout << fkyaml::node::serialize(n[3]) << std::endl;
+        return 0;
+    }
+    ```
+
+## Overload (3), (4)
+
+```cpp
+template <
+    typename KeyType, detail::enable_if_t<
+                            detail::is_usable_as_key_type<
+                                typename mapping_type::key_compare, typename mapping_type::key_type, KeyType>::value,
+                            int> = 0>
+basic_node& operator[](KeyType&& key); // (3)
+
+template <
+    typename KeyType, detail::enable_if_t<
+                            detail::is_usable_as_key_type<
+                                typename mapping_type::key_compare, typename mapping_type::key_type, KeyType>::value,
+                            int> = 0>
+const basic_node& operator[](KeyType&& key) const; // (4)
+```
+
+Accesses to an element in the YAML mapping node with the given key.  
+The given key must be of a compatible type with [`fkyaml::string_type`](string_type.md), i.e., a [`fkyaml::string_type`](string_type.md) object can be constructible with the given key.  
+If the node is not a mapping, a [`fkyaml::exception`](../exception/index.md) will be thrown.  
+
+!!! Warning
+
+    This API does not check the existence of the given key in the YAML mapping node.  
+    If the given key does not exist, a default [basic_node](index.md) object will be created.  
+    Please make sure that the node has the given key beforehand by calling the [`contains`](contains.md) API.  
+
+### **Template Parameters**
+
+***KeyType***
+:   A type compatible with the key type of mapping node values.
+
+### **Parameters**
+
+***key*** [in]
+:   A key to the target value in the YAML mapping node.
+
+### **Return Value**
+
+Reference, or constant reference, to the YAML node associated with the given key.  
+
+???+ Example
+
+    ```cpp
+    #include <iostream>
+    #include <fkYAML/node.hpp>
+
+    int main()
+    {
+        // create a YAML node.
+        fkyaml::node n = {{"foo", true}, {"bar", 123}};
+
+        // print YAML nodes associated with the following keys.
+        std::cout << std::boolalpha << fkyaml::node::serialize(n["foo"]) << std::endl;
+        std::cout << fkyaml::node::serialize(n["bar"]) << std::endl;
+
+        return 0;
+    }
+    ```
+
+## **See Also**
+
+* [basic_node](index.md)
+* [size](size.md)
+* [contains](contains.md)

--- a/docs/mkdocs/docs/api/basic_node/sequence.md
+++ b/docs/mkdocs/docs/api/basic_node/sequence.md
@@ -12,7 +12,7 @@ The factory method which constructs a basic_node with the [`node_t::SEQUENCE`](n
 Calling this API with no arguments will constructs a basic_node with an empty sequence node value.  
 The resulting basic_node has the [`node_t::SEQUENCE`](node_t.md) type.  
 
-??? example
+???+ Example
 
     ```cpp
     #include <iostream>

--- a/docs/mkdocs/docs/api/basic_node/sequence_type.md
+++ b/docs/mkdocs/docs/api/basic_node/sequence_type.md
@@ -12,7 +12,7 @@ To store sequence objects in [`basic_node`](index.md) class, the type is defined
 If not explicitly specified, the default type `std::vector` will be chosen.  
 Note that sequence objects are stored as pointers to the decided type in a [`basic_node`](index.md) so that the internal storage size will at most be 8 bytes.  
 
-??? Example
+???+ Example
 
     ```cpp
     #include <iomanip>

--- a/docs/mkdocs/docs/api/basic_node/serialize.md
+++ b/docs/mkdocs/docs/api/basic_node/serialize.md
@@ -15,11 +15,11 @@ That means that, even if a deserialized source input is written in flow styles, 
 ***node*** [in]
 :   A `basic_node` object to be serialized.
 
-### **Return Values**
+### **Return Value**
 
 The resulting string object from the serialization of the `node` object.
 
-??? Example
+???+ Example
 
     ```cpp
     #include <iostream>

--- a/docs/mkdocs/docs/api/basic_node/serialize.md
+++ b/docs/mkdocs/docs/api/basic_node/serialize.md
@@ -29,11 +29,11 @@ The resulting string object from the serialization of the `node` object.
     {
         // create a basic_node object.
         fkyaml::node n = {
-            {std::string("foo"), true},
-            {std::string("bar"), {1, 2, 3}},
-            {std::string("baz"), {
-                {std::string("qux"), 3.14},
-                {std::string("corge"), nullptr}
+            {"foo", true},
+            {"bar", {1, 2, 3}},
+            {"baz", {
+                {"qux", 3.14},
+                {"corge", nullptr}
             }}
         };
 

--- a/docs/mkdocs/docs/api/basic_node/set_yaml_version.md
+++ b/docs/mkdocs/docs/api/basic_node/set_yaml_version.md
@@ -13,14 +13,7 @@ Sets the version of the YAML format to the `basic_node` object.
 ***version*** [in]
 :   A version of the YAML format.
 
-### **Return Values**
-
-| YAML version | Return Value            |
-| ------------ | ----------------------- |
-| 1.1          | yaml_version_t::VER_1_1 |
-| 1.2          | yaml_version_t::VER_1_2 |
-
-??? Example
+???+ Example
 
     ```cpp
     #include <iomanip>

--- a/docs/mkdocs/docs/api/basic_node/size.md
+++ b/docs/mkdocs/docs/api/basic_node/size.md
@@ -26,12 +26,12 @@ The size of a node value.
         std::vector<fkyaml::node> nodes =
         {
             {1, 2, 3},
-            {{std::string("foo"), true}, {std::string("bar"), false}. {std::string("baz"), true}},
+            {{"foo", true}, {"bar", false}. {"baz", true}},
             fkyaml::node(),
             true,
             256,
             3.14,
-            std::string("foo")
+            "foo"
         };
 
         for (const auto& n : nodes)

--- a/docs/mkdocs/docs/api/basic_node/size.md
+++ b/docs/mkdocs/docs/api/basic_node/size.md
@@ -11,9 +11,9 @@ Throws a [`fkyaml::exception`](../exception/index.md) if a basic_node does not h
 
 ### **Return Value**
 
-Returns the size of a node value.
+The size of a node value.
 
-??? Example
+???+ Example
 
     ```cpp
     #include <iomanip>

--- a/docs/mkdocs/docs/api/basic_node/string_type.md
+++ b/docs/mkdocs/docs/api/basic_node/string_type.md
@@ -12,7 +12,7 @@ To store string objects in [`basic_node`](index.md) class, the type is defined b
 If not explicitly specified, the default type `std::string` will be chosen.  
 Note that string objects are stored as pointers to the decided type in a [`basic_node`](index.md) so that the internal storage size will at most be 8 bytes.  
 
-??? Example
+???+ Example
 
     ```cpp
     #include <iomanip>

--- a/docs/mkdocs/docs/api/basic_node/swap.md
+++ b/docs/mkdocs/docs/api/basic_node/swap.md
@@ -1,0 +1,111 @@
+<small>Defined in header [`<fkYAML/node.hpp>`](https://github.com/fktn-k/fkYAML/blob/develop/include/fkYAML/node.hpp)</small>
+
+# <small>fkyaml::basic_node::</small>swap
+
+```cpp
+void swap(basic_node& rhs) noexcept; // (1)
+
+template <
+    template <typename, typename...> class SequenceType, template <typename, typename, typename...> class MappingType,
+    typename BooleanType, typename IntegerType, typename FloatNumberType, typename StringType,
+    template <typename, typename = void> class ConverterType>
+inline void swap(
+    basic_node<SequenceType, MappingType, BooleanType, IntegerType, FloatNumberType, StringType, ConverterType>& lhs,
+    basic_node<SequenceType, MappingType, BooleanType, IntegerType, FloatNumberType, StringType, ConverterType>& rhs) noexcept(noexcept(lhs.swap(rhs))); // (2)
+```
+
+Swaps the internally stored data with the given basic_node object.
+
+## Overload (1)
+
+```cpp
+void swap(basic_node& rhs) noexcept; // (1)
+```
+
+### **Parameters**
+
+***`rhs`*** [in]
+:   A basic_node object to be swapped with.
+
+???+ Example
+
+    ```cpp
+    #include <iostream>
+    #include <fkYAML/node.hpp>
+
+    int main()
+    {
+        // create YAML nodes.
+        fkyaml::node n1 = 123;
+        fkyaml::node n2 = "foo";
+
+        // swap the internally stored data between n1 & n2.
+        n1.swap(n2);
+
+        // print the swapped values.
+        std::cout << n1.get_value_ref<std::string&>() << std::endl;
+        std::cout << n2.get_value<std::int64_t>() << std::endl;
+        return 0;
+    }
+    ```
+
+    output:
+    ```bash
+    foo
+    123
+    ```
+
+## Overload (2)
+
+```cpp
+template <
+    template <typename, typename...> class SequenceType, template <typename, typename, typename...> class MappingType,
+    typename BooleanType, typename IntegerType, typename FloatNumberType, typename StringType,
+    template <typename, typename = void> class ConverterType>
+inline void swap(
+    basic_node<SequenceType, MappingType, BooleanType, IntegerType, FloatNumberType, StringType, ConverterType>& lhs,
+    basic_node<SequenceType, MappingType, BooleanType, IntegerType, FloatNumberType, StringType, ConverterType>& rhs) noexcept(noexcept(lhs.swap(rhs))); // (2)
+```
+
+### **Parameters**
+
+***`lhs`*** [in]
+:   A left-hand-side basic_node object to be swapped with.
+
+***`rhs`***
+:   A right-hand-side basic_node object to be swapped with.
+
+???+ Example
+
+    ```cpp
+    #include <iostream>
+    #include <fkYAML/node.hpp>
+
+    int main()
+    {
+        // create YAML nodes.
+        fkyaml::node n1 = 123;
+        fkyaml::node n2 = "foo";
+
+        // swap the internally stored data between n1 & n2.
+        using std::swap;
+        swap(n1, n2);
+
+        // print the swapped values.
+        std::cout << n1.get_value_ref<std::string&>() << std::endl;
+        std::cout << n2.get_value<std::int64_t>() << std::endl;
+        return 0;
+    }
+    ```
+
+    output:
+    ```bash
+    foo
+    123
+    ```
+
+## **See Also**
+
+* [basic_node](index.md)
+* [get_value](get_value.md)
+* [get_value_ref](get_value_ref.md)

--- a/docs/mkdocs/docs/api/basic_node/to_boolean.md
+++ b/docs/mkdocs/docs/api/basic_node/to_boolean.md
@@ -1,9 +1,0 @@
-<small>Defined in header [`<fkYAML/node.hpp>`](https://github.com/fktn-k/fkYAML/blob/develop/include/fkYAML/node.hpp)</small>
-
-# <small>fkyaml::basic_node::</small>to_boolean
-
-```cpp
-boolean_type& to_boolean();
-
-const boolean_type& to_boolean() const;
-```

--- a/docs/mkdocs/docs/api/basic_node/to_float_number.md
+++ b/docs/mkdocs/docs/api/basic_node/to_float_number.md
@@ -1,9 +1,0 @@
-<small>Defined in header [`<fkYAML/node.hpp>`](https://github.com/fktn-k/fkYAML/blob/develop/include/fkYAML/node.hpp)</small>
-
-# <small>fkyaml::basic_node::</small>to_float_number
-
-```cpp
-float_number_type& to_float_number();
-
-const float_number_type& to_float_number() const;
-```

--- a/docs/mkdocs/docs/api/basic_node/to_integer.md
+++ b/docs/mkdocs/docs/api/basic_node/to_integer.md
@@ -1,9 +1,0 @@
-<small>Defined in header [`<fkYAML/node.hpp>`](https://github.com/fktn-k/fkYAML/blob/develop/include/fkYAML/node.hpp)</small>
-
-# <small>fkyaml::basic_node::</small>to_integer
-
-```cpp
-integer_type& to_integer();
-
-const integer_type& to_integer() const;
-```

--- a/docs/mkdocs/docs/api/basic_node/to_mapping.md
+++ b/docs/mkdocs/docs/api/basic_node/to_mapping.md
@@ -1,9 +1,0 @@
-<small>Defined in header [`<fkYAML/node.hpp>`](https://github.com/fktn-k/fkYAML/blob/develop/include/fkYAML/node.hpp)</small>
-
-# <small>fkyaml::basic_node::</small>to_mapping
-
-```cpp
-mapping_type& to_mapping();
-
-const mapping_type& to_mapping() const;
-```

--- a/docs/mkdocs/docs/api/basic_node/to_sequence.md
+++ b/docs/mkdocs/docs/api/basic_node/to_sequence.md
@@ -1,9 +1,0 @@
-<small>Defined in header [`<fkYAML/node.hpp>`](https://github.com/fktn-k/fkYAML/blob/develop/include/fkYAML/node.hpp)</small>
-
-# <small>fkyaml::basic_node::</small>to_sequence
-
-```cpp
-sequence_type& to_sequence();
-
-const sequence_type& to_sequence() const;
-```

--- a/docs/mkdocs/docs/api/basic_node/to_string.md
+++ b/docs/mkdocs/docs/api/basic_node/to_string.md
@@ -1,9 +1,0 @@
-<small>Defined in header [`<fkYAML/node.hpp>`](https://github.com/fktn-k/fkYAML/blob/develop/include/fkYAML/node.hpp)</small>
-
-# <small>fkyaml::basic_node::</small>to_string
-
-```cpp
-string_type& to_string();
-
-const string_type& to_string() const;
-```

--- a/docs/mkdocs/docs/api/basic_node/type.md
+++ b/docs/mkdocs/docs/api/basic_node/type.md
@@ -33,12 +33,12 @@ The type of the YAML node value.
     {
         // create YAML nodes.
         fkyaml::node sequence_node = {1, 2, 3};
-        fkyaml::node mapping_node = {{std::string("foo"), true}, {std::string("bar"), false}};
+        fkyaml::node mapping_node = {{"foo", true}, {"bar", false}};
         fkyaml::node null_node;
         fkyaml::node boolean_node = true;
         fkyaml::node integer_node = 256;
         fkyaml::node float_node = 3.14;
-        fkyaml::node string_node = std::string("Hello, world!");
+        fkyaml::node string_node = "Hello, world!";
 
         // call type()
         std::cout << std::boolalpha;

--- a/docs/mkdocs/docs/api/basic_node/type.md
+++ b/docs/mkdocs/docs/api/basic_node/type.md
@@ -22,7 +22,7 @@ The type of the YAML node value.
 | floating point number | node_t::FLOAT_NUMBER |
 | string                | node_t::STRING       |
 
-??? Example
+???+ Example
 
     ```cpp
     #include <iomanip>

--- a/docs/mkdocs/docs/api/basic_node/value_converter_type.md
+++ b/docs/mkdocs/docs/api/basic_node/value_converter_type.md
@@ -21,7 +21,7 @@ If you want to convert some type from/to `basic_node`, however, it is recommende
 ***SFINAE***
 : Type to add compile type checks via SFINAE. Usually `void` is given.
 
-??? Example
+???+ Example
 
     ```cpp
     #include <iomanip>

--- a/docs/mkdocs/docs/api/basic_node/yaml_version_t.md
+++ b/docs/mkdocs/docs/api/basic_node/yaml_version_t.md
@@ -12,7 +12,7 @@ enum class yaml_version_t
 
 This enumeration collects the used versions of YAML specification. It is used as meta data of a basic_node and the functions [`get_yaml_version`](get_yaml_version.md) and [`set_yaml_version`](set_yaml_version.md) rely on it.  
 
-??? Example
+???+ Example
 
     ```cpp
     #include <iomanip>

--- a/docs/mkdocs/docs/api/exception/constructor.md
+++ b/docs/mkdocs/docs/api/exception/constructor.md
@@ -9,7 +9,7 @@ exception() = default;
 Constructs an exception without an error message.  
 You can specify an error message on constructing an exception with an overloaded constructor.  
 
-??? example
+???+ Example
 
     ```cpp
     #include <iostream>
@@ -48,7 +48,7 @@ The given error message can be retrieved by calling [`exception::what()`](what.m
 ***`msg`*** [in]
 :   An error message for the exception. If `nullptr` is given, the resulting error message will be empty.
 
-??? example
+???+ Example
 
     ```cpp
     #include <iostream>

--- a/docs/mkdocs/docs/api/exception/constructor.md
+++ b/docs/mkdocs/docs/api/exception/constructor.md
@@ -3,11 +3,21 @@
 # <small>fkyaml::exception::</small>(constructor)
 
 ```cpp
-exception() = default;
+exception() = default; // (1)
+
+explicit exception(const char* msg); // (2)
 ```
 
-Constructs an exception without an error message.  
+Constructs an exception object.   
 You can specify an error message on constructing an exception with an overloaded constructor.  
+
+## Overload (1)
+
+```cpp
+exception() = default; // (1)
+```
+
+Constructs an exception object without an error message.
 
 ???+ Example
 
@@ -34,10 +44,10 @@ You can specify an error message on constructing an exception with an overloaded
 
     ```
 
-## Overloads
+## Overloads (2)
 
 ```cpp
-explicit exception(const char* msg);
+explicit exception(const char* msg); // (2)
 ```
 
 Constructs an exception with a given error message.  
@@ -72,3 +82,8 @@ The given error message can be retrieved by calling [`exception::what()`](what.m
     ```bash
     An error message.
     ```
+
+## **See Also**
+
+* [exception](index.md)
+* [what](what.md)

--- a/docs/mkdocs/docs/api/exception/destructor.md
+++ b/docs/mkdocs/docs/api/exception/destructor.md
@@ -7,3 +7,7 @@
 ```
 
 Destroy an exception.
+
+## **See Also**
+
+* [exception](index.md)

--- a/docs/mkdocs/docs/api/exception/what.md
+++ b/docs/mkdocs/docs/api/exception/what.md
@@ -8,6 +8,32 @@ const char* what();
 
 Returns an error message for an exception. If nothing, a non-null, empty string will be returned.  
 
+???+ Example
+
+    ```cpp
+    #include <iostream>
+    #include <fkYAML/exception.hpp>
+
+    int main()
+    {
+        try
+        {
+            throw fkyaml::exception("An error message.");
+        }
+        catch (const fkyaml::exception& e)
+        {
+            std::cout << e.what() << std::endl;
+        }
+
+        return 0;
+    }
+    ```
+
+    output:
+    ```bash
+    An error message.
+    ```
+
 ### **See Also**
 
 * [(constructor)](constructor.md)

--- a/docs/mkdocs/docs/api/macros.md
+++ b/docs/mkdocs/docs/api/macros.md
@@ -1,0 +1,98 @@
+# Macros
+
+Some aspects of the fkYAML library can be configured by defining preprocessor macros **BEFORE** including the header files of the library.  
+The following preprocessor macros are currently available.  
+
+## Library Version
+
+The fkYAML library defines the following preprocessor macros for the library version numbers according to [Semantic Versioning 2.0.0](https://semver.org/spec/v2.0.0.html).  
+These macros are available for client applications as the metadata of this library.
+
+| Name                  | Description                             |
+| --------------------- | --------------------------------------- |
+| FK_YAML_MAJOR_VERSION | the major version of the fkYAML library |
+| FK_YAML_MINOR_VERSION | the minor version of the fkYAML library |
+| FK_YAML_PATCH_VERSION | the patch version of the fkYAML library |
+
+??? Example annotate "Example: print the library version"
+
+    ```cpp
+    #include <iostream>
+    #include <fkYAML/node.hpp>
+
+    int main()
+    {
+        std::cout << "fkYAML version "
+                  << FK_YAML_MAJOR_VERSION << "."
+                  << FK_YAML_MINOR_VERSION << "."
+                  << FK_YAML_PATCH_VERSION << std::endl
+        return 0;
+    }
+    ```
+
+    output:
+    ```bash
+    fkYAML version 0.1.3
+    ```
+
+## Library Namespaces
+
+| Name                    | Description                                   |
+| ----------------------- | --------------------------------------------- |
+| FK_YAML_NAMESPACE_BEGIN | the beginning of the fkYAML library namespace |
+| FK_YAML_NAMESPACE_END   | the end of the fkYAML library namespace       |
+
+## Runtime Assertions
+
+The fkYAML library calls [`assert()`](https://en.cppreference.com/w/cpp/error/assert) for runtime assertions by default.  
+Thus, the runtime assertions can be disabled just by defining `NDEBUG`.  
+You can also override the implementation by defining the following preprocessor macro.  
+
+| Name              | Description                              |
+| ----------------- | ---------------------------------------- |
+| FK_YAML_ASSERT(x) | controls behavior of runtime assertions. |
+
+??? Example annotate "Example: disable runtime assertions"
+
+    ```cpp
+    #define NDEBUG
+    #include <fkYAML/node.hpp>
+
+    ...
+    ```
+
+??? Example annotate "Example: override the implementation of runtime assertions"
+
+    ```cpp
+    #include <cstdio>
+    #include <cstdlib>
+    #define FK_YAML_ASSERT(x) \
+        if(!(x)){std::fprintf(stderr, "assertion failed in %s", __FUNC__);std::abort();}
+    #include <fkYAML/node.hpp>
+
+    ...
+    ```
+
+## Language Supports
+
+The fkYAML library targets C++11, but also supports some features introduced in later C++ standards.  
+For those new features, the library implements some preprocessor checks to determine the C++ standard based on preprocessor macros such as `__cplusplus`, `_HAS_CXX14` or `_MSVC_LANG`.  
+By defining any of the following symbols, the internal check is overridden and the provided C++ standard is unconditionally assumed.  
+This can be helpful for compilers that only implement parts of the standard and would be detected incorrectly.  
+
+| Name               | Description                               |
+| ------------------ | ----------------------------------------- |
+| FK_YAML_HAS_CXX_11 | supports C++11 features. (always enabled) |
+| FK_YAML_HAS_CXX_14 | supports C++14 features.                  |
+| FK_YAML_HAS_CXX_17 | supports C++17 features.                  |
+| FK_YAML_HAS_CXX_20 | supports C++20 features.                  |
+
+??? Example annotate "Example: force the fkYAML library to use a specific C++ standard"
+
+    ```cpp
+    // force the library to use the C++14 standard.
+    #define FK_YAML_HAS_CXX_14 1
+    #include <fkYAML/node.hpp>
+
+    ...
+    ```

--- a/docs/mkdocs/docs/api/node_value_converter/from_node.md
+++ b/docs/mkdocs/docs/api/node_value_converter/from_node.md
@@ -8,3 +8,82 @@ static auto from_node(BasicNodeType&& n, TargetType& val) noexcept(
     noexcept(::fkyaml::from_node(std::forward<BasicNodeType>(n), val)))
     -> decltype(::fkyaml::from_node(std::forward<BasicNodeType>(n), val), void())
 ```
+
+Converts a [`basic_node`](../basic_node/index.md) object to the target native data object.  
+This function is usually called by the [`get_value()`](../basic_node/get_value.md) function of the [`basic_node`](../basic_node/index.md) class.  
+Note that the `TargetType` must be default-constructible.  
+
+!!! Tips
+
+    This function can be used for user-defined types by implementing (partial) specialization for `from_node()` function which is called internally by this function.  
+    Note that the specialization **must be implemented in the same namespace as the user-defined types** so that the specialization can successfully be found by ADL (Argument Dependent Lookup).  
+    See the example below for more information.  
+
+## **Template Parameters**
+
+***BasicNodeType***
+:   A basic_node template instance type.
+
+***TargetType***
+:   A target native data type.
+
+## **Parameters**
+
+***`n`*** [in]
+:   A basic_node object used for conversion.
+
+***`val`*** [out]
+:   A native data object to which the converted value is assigned.
+
+???+ Example
+
+    ```cpp
+    #include <iostream>
+    #include <fkYAML/node.hpp>
+
+    namespace ns
+    {
+
+    struct book
+    {
+        std::string title;
+        std::string author;
+        int year;
+    };
+
+    void from_node(const fkyaml::node& n, book& b)
+    {
+        b.title  = n["title"].get_value_ref<const fkyaml::node::string_type&>();
+        b.author = n["author"].get_value_ref<const fkyaml::node::string_type&>();
+        b.year   = n["year"].get_value<int>();
+    }
+
+    } // namespace ns
+
+    int main()
+    {
+        fkyaml::node n = {
+            { "title", "Noman's Journey" },
+            { "author", "John Doe" },
+            { "year", 2023 },
+        };
+
+        auto b = n.get_value<ns::book>();
+
+        std::cout << "\"" << b.title << "\" was written by " << b.author
+                  << " in " << b.year << "." << std::endl;
+
+        return 0;
+    }
+    ```
+
+    output:
+    ```bash
+    "Noman's Journey" was written by John Doe in 2023.
+    ```
+
+## **See Also**
+
+* [node](../basic_node/node.md)
+* [basic_node::get_value](../basic_node/get_value.md)
+* [basic_node::get_value_ref](../basic_node/get_value_ref.md)

--- a/docs/mkdocs/docs/api/node_value_converter/to_node.md
+++ b/docs/mkdocs/docs/api/node_value_converter/to_node.md
@@ -8,3 +8,80 @@ static auto to_node(BasicNodeType& n, TargetType&& val) noexcept(
     noexcept(::fkyaml::to_node(n, std::forward<TargetType>(val))))
     -> decltype(::fkyaml::to_node(n, std::forward<TargetType>(val)))
 ```
+
+Converts a native data to a [`basic_node`](../basic_node/index.md) object.  
+This function is usually called by the constructors of the [`basic_node`](../basic_node/index.md) class.  
+
+!!! Tips
+
+    This function can be used for user-defined types by implementing (partial) specialization for `to_node()` function which is called internally by this function.  
+    Note that the specialization **must be implemented in the same namespace as the user-defined types** so that the specialization can successfully be found by ADL (Argument Dependent Lookup).  
+    See the example below for more information.  
+
+## **Template Parameters**
+
+***BasicNodeType***
+:   A basic_node template instance type.
+
+***TargetType***
+:   A target native data type.
+
+## **Parameters**
+
+***`n`*** [out]
+:   A basic_node object to which the converted value is assigned.
+
+***`val`*** [in]
+:   A native data object used for conversion.
+
+???+ Example
+
+    ```cpp
+    #include <iostream>
+    #include <fkYAML/node.hpp>
+
+    namespace ns
+    {
+
+    struct book
+    {
+        std::string title;
+        std::string author;
+        int year;
+    };
+
+    void to_node(fkyaml::node& n, const book& b)
+    {
+        n = fkyaml::node {
+            { "title", b.title },
+            { "author", b.author },
+            { "year", b.year }
+        };
+    }
+
+    } // namespace ns
+
+    int main()
+    {
+        ns::book b = { "Noman's Journey", "John Doe", 2023 };
+
+        fkyaml::node n = b;
+
+        std::cout << fkyaml::node::serialize(n) << std::endl;
+
+        return 0;
+    }
+    ```
+
+    output:
+    ```yaml
+    title: Noman's Journey
+    author: John Doe
+    year: 2023
+    ```
+
+## **See Also**
+
+* [node](../basic_node/node.md)
+* [basic_node::(constructor)](../basic_node/constructor.md)
+* [basic_node::serialize](../basic_node/serialize.md)

--- a/docs/mkdocs/docs/api/ordered_map/at.md
+++ b/docs/mkdocs/docs/api/ordered_map/at.md
@@ -1,0 +1,78 @@
+<small>Defined in header [`<fkYAML/node.hpp>`](https://github.com/fktn-k/fkYAML/blob/develop/include/fkYAML/ordered_map.hpp)</small>
+
+# <small>fkyaml::ordered_map::</small>at
+
+```cpp
+template <
+    typename KeyType,
+    detail::enable_if_t<detail::is_usable_as_key_type<key_compare, key_type, KeyType>::value, int> = 0>
+mapped_type& at(KeyType&& key) noexcept;
+
+template <
+    typename KeyType,
+    detail::enable_if_t<detail::is_usable_as_key_type<key_compare, key_type, KeyType>::value, int> = 0>
+const mapped_type& at(KeyType&& key) const
+```
+
+Accesses an element with the given key.  
+This API throws a [`fkyaml::exception`] if the given key does not exist in the ordered_map object.  
+
+## **Template Parameters**
+
+***KeyType***
+:   A type compatible with the key type.
+
+## **Parameters**
+
+***`key`*** [in]
+:   A key to the target value.
+
+## **Return Value**
+
+Reference, or constant reference, to a `mapped_type` object associated with the given key.  
+
+???+ Example
+
+    ```cpp
+    #include <iostream>
+    #include <fkYAML/node.hpp>
+    #include <fkYAML/ordered_map.hpp>
+
+    int main()
+    {
+        fkyaml::ordered_map<std::string, fkyaml::node> om = {
+            { "foo", 123 },
+            { "bar", "baz" }
+        };
+
+        std::cout << fkyaml::node::serialize(om.at("foo")) << std::endl;
+        std::cout << fkyaml::node::serialize(om.at("bar")) << std::endl;
+
+        // accesses with a unknown key will throw an exception.
+        try
+        {
+
+        }
+        catch (const fkyaml::exception& e)
+        {
+            std::cout << e.what() << std::endl;
+        }
+
+        return 0;
+    }
+    ```
+
+    output:
+    ```bash
+    123
+    baz
+    key not found.
+    ```
+
+## **See Also**
+
+* [ordered_map](index.md)
+* [operator[]](operator[].md)
+* [node](../basic_node/node.md)
+* [basic_node::serialize](../basic_node/serialize.md)
+* [exception::what](../exception/what.md)

--- a/docs/mkdocs/docs/api/ordered_map/constructor.md
+++ b/docs/mkdocs/docs/api/ordered_map/constructor.md
@@ -1,0 +1,91 @@
+<small>Defined in header [`<fkYAML/node.hpp>`](https://github.com/fktn-k/fkYAML/blob/develop/include/fkYAML/ordered_map.hpp)</small>
+
+# <small>fkyaml::ordered_map::</small>(constructor)
+
+```cpp
+ordered_map(); // (1)
+
+ordered_map(std::initializer_list<value_type> init); // (2)
+```
+
+Constructs a new ordered_map.  
+You can specify the initial value on constructing an ordered_map with an overloaded constructor.  
+
+## Overload (1)
+
+```cpp
+ordered_map(); // (1)
+```
+
+Constructs an ordered_map object without an initial value.  
+The content of a newly constructed ordered_map is an empty list of key-value pairs.  
+
+???+ Example
+
+    ```cpp
+    #include <iomanip>
+    #include <iostream>
+    #include <fkYAML/node.hpp>
+    #include <fkYAML/ordered_map.hpp>
+
+    int main()
+    {
+        fkyaml::ordered_map<std::string, fkyaml::node> om;
+        std::cout << std::boolalpha << om.empty() << std::endl;
+        return 0;
+    }
+    ```
+
+    output:
+    ```bash
+    true
+    ```
+
+## Overload (2)
+
+```cpp
+ordered_map(std::initializer_list<value_type> init); // (2)
+```
+
+Constructs a new ordered_map with an initializer list.  
+The resulting ordered_map object has the same list of key-value pairs as the given initializer list.  
+
+## **Parameters**
+
+***`init`*** [in]
+:   An initializer list of key-value pairs.
+
+???+ Example
+
+    ```cpp
+    #include <iostream>
+    #include <fkYAML/node.hpp>
+    #include <fkYAML/ordered_map.hpp>
+
+    int main()
+    {
+        fkyaml::ordered_map<std::string, fkyaml::node> om = {
+            { "foo", 123 },
+            { "bar", "baz" }
+        };
+
+        for (auto& pair : om)
+        {
+            std::cout << pair.first << ": " << fkyaml::node::serialize(pair.second) << std::endl;
+        }
+        return 0;
+    }
+    ```
+
+    output:
+    ```yaml
+    foo: 123
+    bar: baz
+    ```
+
+## **See Also**
+
+* [ordered_map](index.md)
+* [basic_node](../basic_node/index.md)
+* [basic_node::(constructor)](../basic_node/constructor.md)
+* [basic_node::serialize](../basic_node/serialize.md)

--- a/docs/mkdocs/docs/api/ordered_map/destructor.md
+++ b/docs/mkdocs/docs/api/ordered_map/destructor.md
@@ -1,0 +1,9 @@
+<small>Defined in header [`<fkYAML/node.hpp>`](https://github.com/fktn-k/fkYAML/blob/develop/include/fkYAML/ordered_map.hpp)</small>
+
+# <small>fkyaml::ordered_map::</small>(constructor)
+
+```cpp
+~ordered_map() = default;
+```
+
+Destroys an ordered_map object.

--- a/docs/mkdocs/docs/api/ordered_map/emplace.md
+++ b/docs/mkdocs/docs/api/ordered_map/emplace.md
@@ -1,0 +1,76 @@
+<small>Defined in header [`<fkYAML/node.hpp>`](https://github.com/fktn-k/fkYAML/blob/develop/include/fkYAML/ordered_map.hpp)</small>
+
+# <small>fkyaml::ordered_map::</small>emplace
+
+```cpp
+template <
+    typename KeyType,
+    detail::enable_if_t<detail::is_usable_as_key_type<key_compare, key_type, KeyType>::value, int> = 0>
+std::pair<iterator, bool> emplace(KeyType&& key, const mapped_type& value) noexcept;
+```
+
+Emplaces a new key-value pair if the new key does not exist in the ordered_map object.
+
+***KeyType***
+:   A type compatible with the key type.
+
+## **Parameters**
+
+***`key`*** [in]
+:   A key to the target value.
+
+***`value`*** [in]
+:   A value associated to the key.
+
+## **Return Value**
+
+A pair consisting of an iterator to the inserted element, or the already-existing element if no insertion happend, and a boolean denoting the insertion took place (`true` if insertion happened, `false` otherwise).
+
+???+ Example
+
+    ```cpp
+    #include <iomanip>
+    #include <iostream>
+    #include <fkYAML/node.hpp>
+    #include <fkYAML/ordered_map.hpp>
+
+    int main()
+    {
+        fkyaml::ordered_map<std::string, fkyaml::node> om = {
+            { "foo", 123 },
+            { "bar", "baz" }
+        };
+
+        // insert a value with a new key.
+        auto ret = om.emplace("qux", 3.14);
+        if (ret.second)
+        {
+            std::cout << "insertion took place." << std::endl;
+        }
+        std::cout << fkyaml::node::serialize(ret.first->second) << std::endl;
+
+        // insert a value with an existing key.
+        auto ret2 = om.emplace("foo", true);
+        if (!ret2.second)
+        {
+            std::cout << "insertion did not take place." << std::endl;
+        }
+        std::cout << fkyaml::node::serialize(ret2.first->second) << std::endl;
+
+        return 0;
+    }
+    ```
+
+    output:
+    ```bash
+    insertion took place.
+    3.14
+    insertion did not take place.
+    123
+    ```
+
+## **See Also**
+
+* [ordered_map](index.md)
+* [node](../basic_node/node.md)
+* [basic_node::serialize](../basic_node/serialize.md)

--- a/docs/mkdocs/docs/api/ordered_map/find.md
+++ b/docs/mkdocs/docs/api/ordered_map/find.md
@@ -1,0 +1,76 @@
+<small>Defined in header [`<fkYAML/node.hpp>`](https://github.com/fktn-k/fkYAML/blob/develop/include/fkYAML/ordered_map.hpp)</small>
+
+# <small>fkyaml::ordered_map::</small>find
+
+```cpp
+template <
+    typename KeyType,
+    detail::enable_if_t<detail::is_usable_as_key_type<key_compare, key_type, KeyType>::value, int> = 0>
+iterator find(KeyType&& key) noexcept;
+
+template <
+    typename KeyType,
+    detail::enable_if_t<detail::is_usable_as_key_type<key_compare, key_type, KeyType>::value, int> = 0>
+const_iterator find(KeyType&& key) const noexcept;
+```
+
+Find a value with the given key.  
+
+## **Template Parameters**
+
+***KeyType***
+:   A type compatible with the key type.
+
+## **Parameters**
+
+***`key`*** [in]
+:   A key to the target value.
+
+## **Return Value**
+
+An iterator to the target value if found, the result of end() otherwise.  
+
+???+ Example
+
+    ```cpp
+    #include <iomanip>
+    #include <iostream>
+    #include <fkYAML/node.hpp>
+    #include <fkYAML/ordered_map.hpp>
+
+    int main()
+    {
+        fkyaml::ordered_map<std::string, fkyaml::node> om = {
+            { "foo", 123 },
+            { "bar", "baz" }
+        };
+
+        // search for a value with an existing key.
+        auto itr = om.find("foo");
+        if (itr != om.end())
+        {
+            std::cout << fkyaml::node::serialize(*itr) << std::endl;
+        }
+
+        // search for a value with a key which does not exist.
+        auto itr2 = om.emplace("qux");
+        if (itr2 == om.end())
+        {
+            std::cout << "key does not exist." << std::endl;
+        }
+
+        return 0;
+    }
+    ```
+
+    output:
+    ```bash
+    123
+    key does not exist.
+    ```
+
+## **See Also**
+
+* [ordered_map](index.md)
+* [node](../basic_node/node.md)
+* [basic_node::serialize](../basic_node/serialize.md)

--- a/docs/mkdocs/docs/api/ordered_map/index.md
+++ b/docs/mkdocs/docs/api/ordered_map/index.md
@@ -6,10 +6,18 @@
 template<
     typename Key, typename Value, typename IgnoredCompare = std::less<Key>,
     typename Allocator = std::allocator<std::pair<const Key, Value>>>
-class ordered_map;
+class ordered_map : public std::vector<std::pair<const Key, Value>>;
 ```
 
-A minimal map-like container which preserves insertion order.
+A minimal map-like container which preserves insertion order.  
+This documentation only describes APIs which are not of the parent class [`std::vector<std::pair<const Key, Value>>`](https://en.cppreference.com/w/cpp/container/vector).  
+
+!!! Question annotate "How is this class useful?"
+
+    This class could be useful in case that **the order of insertion in YAML mapping nodes needs to be preserved**.  
+    This is because the YAML specification recommends that [a sequence of mappings should be used in such cases](https://yaml.org/spec/1.2.2/#3221-mapping-key-order), since YAML mapping nodes are defined as *unordered* sets of key-value pairs.  
+    However, the above recommendation with a sequence of key-value pair does not work so efficiently on the application layer because it cannot be a direct representation of the deserialization result and could also break the original order when the deserialized node is serialized again.  
+    The ordered_map class is thus provided to help resolve those issues.  
 
 ## Template Parameters
 
@@ -35,3 +43,28 @@ A minimal map-like container which preserves insertion order.
 | key_compare    | The type for comparison between keys.           |
 
 ## Member Functions
+
+### Construction/Destruction
+| Name                            | Description                |
+| ------------------------------- | -------------------------- |
+| [(constructor)](constructor.md) | constructs an ordered_map. |
+| [(destructor)](destructor.md)   | destroys an ordered_map.   |
+
+### Element Access
+
+| Name                        | Description                                       |
+| --------------------------- | ------------------------------------------------- |
+| [at](at.md)                 | forces to accesses an element with the given key. |
+| [operator[]](operator[].md) | accesses an element with the given key.           |
+
+### Modifiers
+
+| Name                  | Description                                                  |
+| --------------------- | ------------------------------------------------------------ |
+| [emplace](emplace.md) | emplaces a new key-value pair if the new key does not exist. |
+
+### Lookup
+
+| Name            | Description                                |
+| --------------- | ------------------------------------------ |
+| [find](find.md) | finds a value associated to the given key. |

--- a/docs/mkdocs/docs/api/ordered_map/operator[].md
+++ b/docs/mkdocs/docs/api/ordered_map/operator[].md
@@ -1,0 +1,71 @@
+<small>Defined in header [`<fkYAML/node.hpp>`](https://github.com/fktn-k/fkYAML/blob/develop/include/fkYAML/ordered_map.hpp)</small>
+
+# <small>fkyaml::ordered_map::</small>operator[]
+
+```cpp
+template <
+    typename KeyType,
+    detail::enable_if_t<detail::is_usable_as_key_type<key_compare, key_type, KeyType>::value, int> = 0>
+mapped_type& operator[](KeyType&& key) noexcept;
+```
+
+Accesses an element with the given key.  
+
+!!! Tip
+
+    This API behaves like the [`std::map`](https://en.cppreference.com/w/cpp/container/map) class does.  
+    In other words, it does not check the existence of the given key, and could return a default value if the key does not exist.  
+    To avoid such a behavior, you can use [`at()`](at.md) function which throws a [`fkyaml::exception`](../exception/index.md) if the given key does not match any keys in the ordered_map object.
+
+## **Template Parameters**
+
+***KeyType***
+:   A type compatible with the key type.
+
+## **Parameters**
+
+***`key`*** [in]
+:   A key to the target value.
+
+## **Return Value**
+
+Reference to a `mapped_type` object associated with the given key.  
+Possibly a default value of the `mapped_type` if the ordered_map does not contain the given key.  
+
+???+ Example
+
+    ```cpp
+    #include <iostream>
+    #include <fkYAML/node.hpp>
+    #include <fkYAML/ordered_map.hpp>
+
+    int main()
+    {
+        fkyaml::ordered_map<std::string, fkyaml::node> om = {
+            { "foo", 123 },
+            { "bar", "baz" }
+        };
+
+        std::cout << fkyaml::node::serialize(om["foo"]) << std::endl;
+        std::cout << fkyaml::node::serialize(om["bar"]) << std::endl;
+
+        // accesses with a unknown key will create a new key-value pair with the default value.
+        std::cout << fkyaml::node::serialize(om["qux"]) << std::endl;
+
+        return 0;
+    }
+    ```
+
+    output:
+    ```bash
+    123
+    baz
+    null
+    ```
+
+## **See Also**
+
+* [ordered_map](index.md)
+* [at](at.md)
+* [node](../basic_node/node.md)
+* [basic_node::serialize](../basic_node/serialize.md)

--- a/docs/mkdocs/mkdocs.yml
+++ b/docs/mkdocs/mkdocs.yml
@@ -149,4 +149,8 @@ nav:
           - ordered_map: api/ordered_map/index.md
           - (constructor): api/ordered_map/constructor.md
           - (destructor): api/ordered_map/destructor.md
+          - at: api/ordered_map/at.md
+          - emplace: api/ordered_map/emplace.md
+          - find: api/ordered_map/find.md
+          - operator[]: api/ordered_map/operator[].md
   - Tutorials: tutorials.md

--- a/docs/mkdocs/mkdocs.yml
+++ b/docs/mkdocs/mkdocs.yml
@@ -104,7 +104,9 @@ nav:
           - empty: api/basic_node/empty.md
           - end: api/basic_node/end.md
           - float_number_type: api/basic_node/float_number_type.md
+          - get_anchor_name: api/basic_node/get_anchor_name.md
           - get_value: api/basic_node/get_value.md
+          - get_value_ref: api/basic_node/get_value_ref.md
           - get_yaml_version: api/basic_node/get_yaml_version.md
           - has_anchor_name: api/basic_node/has_anchor_name.md
           - integer_type: api/basic_node/integer_type.md
@@ -127,12 +129,7 @@ nav:
           - set_yaml_version: api/basic_node/set_yaml_version.md
           - size: api/basic_node/size.md
           - string_type: api/basic_node/string_type.md
-          - to_boolean: api/basic_node/to_boolean.md
-          - to_float_number: api/basic_node/to_float_number.md
-          - to_integer: api/basic_node/to_integer.md
-          - to_mapping: api/basic_node/to_mapping.md
-          - to_sequence: api/basic_node/to_sequence.md
-          - to_string: api/basic_node/to_string.md
+          - swap: api/basic_node/swap.md
           - type: api/basic_node/type.md
           - value_converter_type: api/basic_node/value_converter_type.md
           - yaml_version_t: api/basic_node/yaml_version_t.md

--- a/docs/mkdocs/mkdocs.yml
+++ b/docs/mkdocs/mkdocs.yml
@@ -139,8 +139,7 @@ nav:
           - (constructor): api/exception/constructor.md
           - (destructor): api/exception/destructor.md
           - what: api/exception/what.md
-      - macros:
-          - macros: api/macros/index.md
+      - macros: api/macros.md
       - node_value_converter:
           - node_value_converter: api/node_value_converter/index.md
           - from_node: api/node_value_converter/from_node.md

--- a/include/fkYAML/exception.hpp
+++ b/include/fkYAML/exception.hpp
@@ -31,6 +31,7 @@ public:
     exception() = default;
 
     /// @brief Construct a new exception object with an error message.
+    /// @param[in] msg An error message.
     /// @sa https://fktn-k.github.io/fkYAML/api/exception/constructor/
     explicit exception(const char* msg)
     {
@@ -42,6 +43,7 @@ public:
 
 public:
     /// @brief Returns an error message internally held. If nothing, a non-null, empty string will be returned.
+    /// @return An error message internally held. The message might be empty.
     /// @sa https://fktn-k.github.io/fkYAML/api/exception/what/
     const char* what() const noexcept override
     {

--- a/include/fkYAML/node.hpp
+++ b/include/fkYAML/node.hpp
@@ -111,16 +111,16 @@ private:
 
     /// @brief The actual storage for a YAML node value of the @ref basic_node class.
     /// @details This union combines the different sotrage types for the YAML value types defined in @ref node_t.
-    /// @note Container types are stored as pointers so that the size of this union should not exceed 64 bits by
+    /// @note Container types are stored as pointers so that the size of this union will not exceed 64 bits by
     /// default.
     union node_value
     {
-        /// @brief Construct a new basic_node Value object for null types.
+        /// @brief Constructs a new basic_node Value object for null types.
         node_value() = default;
 
-        /// @brief Construct a new basic_node Value object with basic_node types. The default value for the specified
+        /// @brief Constructs a new basic_node value object with a node type. The default value for the specified
         /// type will be assigned.
-        /// @param[in] type A Node type.
+        /// @param[in] type A node type.
         explicit node_value(node_t type)
         {
             switch (type)
@@ -151,9 +151,9 @@ private:
             }
         }
 
-        /// @brief Destroy the existing Node value. This process is recursive if the specified node type is fpr
+        /// @brief Destroys the existing Node value. This process is recursive if the specified node type is for
         /// containers.
-        /// @param[in] type A Node type to determine which Node value is destroyed.
+        /// @param[in] type A Node type to determine the value to be destroyed.
         void destroy(node_t type)
         {
             if (type == node_t::SEQUENCE || type == node_t::MAPPING)
@@ -217,22 +217,22 @@ private:
             }
         }
 
-        /** A pointer to the value of sequence type. */
+        /// A pointer to the value of sequence type.
         sequence_type* p_sequence;
-        /** A pointer to the value of mapping type. This pointer is also used when node type is null. */
+        /// A pointer to the value of mapping type. This pointer is also used when node type is null.
         mapping_type* p_mapping {nullptr};
-        /** A value of boolean type. */
+        /// A value of boolean type.
         boolean_type boolean;
-        /** A value of integer type. */
+        /// A value of integer type.
         integer_type integer;
-        /** A value of float number type. */
+        /// A value of float number type.
         float_number_type float_val;
-        /** A pointer to the value of string type. */
+        /// A pointer to the value of string type.
         string_type* p_string;
     };
 
 private:
-    /// @brief Allocates and constructs an object with specified type and arguments.
+    /// @brief Allocates and constructs an object with a given type and arguments.
     /// @tparam ObjType The target object type.
     /// @tparam ArgTypes The packed argument types for constructor arguments.
     /// @param[in] args A parameter pack for constructor arguments of the target object type.
@@ -273,11 +273,12 @@ private:
     }
 
 public:
-    /// @brief Construct a new basic_node object of null type.
+    /// @brief Constructs a new basic_node object of null type.
     /// @sa https://fktn-k.github.io/fkYAML/api/basic_node/constructor/
     basic_node() = default;
 
-    /// @brief Construct a new basic_node object with a specified type.
+    /// @brief Constructs a new basic_node object with a specified type.
+    /// @param[in] type A YAML node type.
     /// @sa https://fktn-k.github.io/fkYAML/api/basic_node/constructor/
     explicit basic_node(const node_t type)
         : m_node_type(type),
@@ -286,6 +287,7 @@ public:
     }
 
     /// @brief Copy constructor of the basic_node class.
+    /// @param[in] rhs A basic_node object to be copied with.
     /// @sa https://fktn-k.github.io/fkYAML/api/basic_node/constructor/
     basic_node(const basic_node& rhs)
         : m_node_type(rhs.m_node_type),
@@ -330,6 +332,7 @@ public:
     }
 
     /// @brief Move constructor of the basic_node class.
+    /// @param[in] rhs A basic_node object to be moved from.
     /// @sa https://fktn-k.github.io/fkYAML/api/basic_node/constructor/
     basic_node(basic_node&& rhs) noexcept
         : m_node_type(rhs.m_node_type),
@@ -378,6 +381,9 @@ public:
     }
 
     /// @brief Construct a new basic_node object from a value of compatible types.
+    /// @tparam CompatibleType Type of native data which is compatible with node values.
+    /// @tparam U Type of compatible native data without cv-qualifiers and reference.
+    /// @param[in] val The value of a compatible type.
     /// @sa https://fktn-k.github.io/fkYAML/api/basic_node/constructor/
     template <
         typename CompatibleType, typename U = detail::remove_cvref_t<CompatibleType>,
@@ -393,6 +399,8 @@ public:
     }
 
     /// @brief Construct a new basic node object with a node_ref_storage object.
+    /// @tparam NodeRefStorageType Type of basic_node with reference.
+    /// @param[in] node_ref_storage A node_ref_storage template class object.
     /// @sa https://fktn-k.github.io/fkYAML/api/basic_node/constructor/
     template <
         typename NodeRefStorageType,
@@ -403,6 +411,7 @@ public:
     }
 
     /// @brief Construct a new basic node object with std::initializer_list.
+    /// @param[in] init A initializer list of basic_node objects.
     /// @sa https://fktn-k.github.io/fkYAML/api/basic_node/constructor/
     basic_node(initializer_list_t init)
     {
@@ -443,6 +452,9 @@ public:
 
 public:
     /// @brief Deserialize an input source into a basic_node object.
+    /// @tparam InputType Type of a compatible input.
+    /// @param[in] input An input source in the YAML format.
+    /// @return The resulting basic_node object deserialized from the input source.
     /// @sa https://fktn-k.github.io/fkYAML/api/basic_node/deserialize/
     template <typename InputType>
     static basic_node deserialize(InputType&& input)
@@ -451,6 +463,10 @@ public:
     }
 
     /// @brief Deserialize input iterators into a basic_node object.
+    /// @tparam ItrType Type of a compatible iterator.
+    /// @param[in] begin An iterator to the first element of an input sequence.
+    /// @param[in] end An iterator to the past-the-last element of an input sequence.
+    /// @return The resulting basic_node object deserialized from the pair of iterators.
     /// @sa https://fktn-k.github.io/fkYAML/api/basic_node/deserialize/
     template <typename ItrType>
     static basic_node deserialize(ItrType&& begin, ItrType&& end)
@@ -460,6 +476,8 @@ public:
     }
 
     /// @brief Serialize a basic_node object into a string.
+    /// @param[in] node A basic_node object to be serialized.
+    /// @return The resulting string object from the serialization of the node object.
     /// @sa https://fktn-k.github.io/fkYAML/api/basic_node/serialize/
     static std::string serialize(const basic_node& node)
     {
@@ -467,6 +485,7 @@ public:
     }
 
     /// @brief A factory method for sequence basic_node objects without sequence_type objects.
+    /// @return A YAML sequence node.
     /// @sa https://fktn-k.github.io/fkYAML/api/basic_node/sequence/
     static basic_node sequence()
     {
@@ -478,6 +497,8 @@ public:
     } // LCOV_EXCL_LINE
 
     /// @brief A factory method for sequence basic_node objects with lvalue sequence_type objects.
+    /// @param[in] seq A lvalue sequence node value.
+    /// @return A YAML sequence node.
     /// @sa https://fktn-k.github.io/fkYAML/api/basic_node/sequence/
     static basic_node sequence(const sequence_type& seq)
     {
@@ -489,6 +510,8 @@ public:
     } // LCOV_EXCL_LINE
 
     /// @brief A factory method for sequence basic_node objects with rvalue sequence_type objects.
+    /// @param[in] seq A rvalue sequence node value.
+    /// @return A YAML sequence node.
     /// @sa https://fktn-k.github.io/fkYAML/api/basic_node/sequence/
     static basic_node sequence(sequence_type&& seq)
     {
@@ -500,6 +523,7 @@ public:
     } // LCOV_EXCL_LINE
 
     /// @brief A factory method for mapping basic_node objects without mapping_type objects.
+    /// @return A YAML mapping node.
     /// @sa https://fktn-k.github.io/fkYAML/api/basic_node/mapping/
     static basic_node mapping()
     {
@@ -511,6 +535,8 @@ public:
     } // LCOV_EXCL_LINE
 
     /// @brief A factory method for mapping basic_node objects with lvalue mapping_type objects.
+    /// @param[in] map A lvalue mapping node value.
+    /// @return A YAML mapping node.
     /// @sa https://fktn-k.github.io/fkYAML/api/basic_node/mapping/
     static basic_node mapping(const mapping_type& map)
     {
@@ -522,6 +548,8 @@ public:
     } // LCOV_EXCL_LINE
 
     /// @brief A factory method for mapping basic_node objects with rvalue mapping_type objects.
+    /// @param[in] map A rvalue mapping node value.
+    /// @return A YAML mapping node.
     /// @sa https://fktn-k.github.io/fkYAML/api/basic_node/mapping/
     static basic_node mapping(mapping_type&& map)
     {
@@ -534,6 +562,8 @@ public:
 
     /// @brief A factory method for alias basic_node objects referencing the given anchor basic_node object.
     /// @note The given anchor basic_node must have a non-empty anchor name.
+    /// @param[in] anchor_node A basic_node object with an anchor name.
+    /// @return An alias YAML node created from the given anchor node.
     /// @sa https://fktn-k.github.io/fkYAML/api/basic_node/alias_of/
     static basic_node alias_of(const basic_node& anchor_node)
     {
@@ -548,6 +578,8 @@ public:
 
 public:
     /// @brief A copy assignment operator of the basic_node class.
+    /// @param[in] rhs A lvalue basic_node object to be copied with.
+    /// @return Reference to this basic_node object.
     /// @sa https://fktn-k.github.io/fkYAML/api/basic_node/operator=/
     basic_node& operator=(const basic_node& rhs) noexcept
     {
@@ -556,6 +588,8 @@ public:
     }
 
     /// @brief A move assignment operator of the basic_node class.
+    /// @param[in] rhs A rvalue basic_node object to be moved from.
+    /// @return Reference to this basic_node object.
     /// @sa https://fktn-k.github.io/fkYAML/api/basic_node/operator=/
     basic_node& operator=(basic_node&& rhs) noexcept
     {
@@ -564,6 +598,8 @@ public:
     }
 
     /// @brief A subscript operator for non-const basic_node objects.
+    /// @param[in] index An index for an element in the YAML sequence node.
+    /// @return Reference to the YAML node at the given index.
     /// @sa https://fktn-k.github.io/fkYAML/api/basic_node/operator[]/
     basic_node& operator[](std::size_t index) // NOLINT(readability-make-member-function-const)
     {
@@ -578,6 +614,8 @@ public:
     }
 
     /// @brief A subscript operator for const basic_node objects.
+    /// @param[in] index An index for an element in the YAML sequence node.
+    /// @return Constant reference to the YAML node at the given index.
     /// @sa https://fktn-k.github.io/fkYAML/api/basic_node/operator[]/
     const basic_node& operator[](std::size_t index) const
     {
@@ -592,6 +630,9 @@ public:
     }
 
     /// @brief A subscript operator for non-const basic_node objects.
+    /// @tparam KeyType A type compatible with the key type of mapping node values.
+    /// @param[in] key A key to the target value in the YAML mapping node.
+    /// @return Reference to the YAML node associated with the given key.
     /// @sa https://fktn-k.github.io/fkYAML/api/basic_node/operator[]/
     template <
         typename KeyType, detail::enable_if_t<
@@ -610,6 +651,9 @@ public:
     }
 
     /// @brief A subscript operator for const basic_node objects.
+    /// @tparam KeyType A type compatible with the key type of mapping node values.
+    /// @param[in] key A key to the target value in the YAML mapping node.
+    /// @return Constant reference to the YAML node associated with the given key.
     /// @sa https://fktn-k.github.io/fkYAML/api/basic_node/operator[]/
     template <
         typename KeyType, detail::enable_if_t<
@@ -629,6 +673,7 @@ public:
 
 public:
     /// @brief Returns the type of the current basic_node value.
+    /// @return The type of the YAML node value.
     /// @sa https://fktn-k.github.io/fkYAML/api/basic_node/type/
     node_t type() const noexcept
     {
@@ -636,6 +681,7 @@ public:
     }
 
     /// @brief Tests whether the current basic_node value is of sequence type.
+    /// @return true if the type is sequence, false otherwise.
     /// @sa https://fktn-k.github.io/fkYAML/api/basic_node/is_sequence/
     bool is_sequence() const noexcept
     {
@@ -643,6 +689,7 @@ public:
     }
 
     /// @brief Tests whether the current basic_node value is of mapping type.
+    /// @return true if the type is mapping, false otherwise.
     /// @sa https://fktn-k.github.io/fkYAML/api/basic_node/is_mapping/
     bool is_mapping() const noexcept
     {
@@ -650,6 +697,7 @@ public:
     }
 
     /// @brief Tests whether the current basic_node value is of null type.
+    /// @return true if the type is null, false otherwise.
     /// @sa https://fktn-k.github.io/fkYAML/api/basic_node/is_null/
     bool is_null() const noexcept
     {
@@ -657,6 +705,7 @@ public:
     }
 
     /// @brief Tests whether the current basic_node value is of boolean type.
+    /// @return true if the type is boolean, false otherwise
     /// @sa https://fktn-k.github.io/fkYAML/api/basic_node/is_boolean/
     bool is_boolean() const noexcept
     {
@@ -664,6 +713,7 @@ public:
     }
 
     /// @brief Tests whether the current basic_node value is of integer type.
+    /// @return true if the type is integer, false otherwise.
     /// @sa https://fktn-k.github.io/fkYAML/api/basic_node/is_integer/
     bool is_integer() const noexcept
     {
@@ -671,6 +721,7 @@ public:
     }
 
     /// @brief Tests whether the current basic_node value is of float number type.
+    /// @return true if the type is floating point number, false otherwise.
     /// @sa https://fktn-k.github.io/fkYAML/api/basic_node/is_float_number/
     bool is_float_number() const noexcept
     {
@@ -678,6 +729,7 @@ public:
     }
 
     /// @brief Tests whether the current basic_node value is of string type.
+    /// @return true if the type is string, false otherwise.
     /// @sa https://fktn-k.github.io/fkYAML/api/basic_node/is_string/
     bool is_string() const noexcept
     {
@@ -685,6 +737,7 @@ public:
     }
 
     /// @brief Tests whether the current basic_node value is of scalar types.
+    /// @return true if the type is scalar, false otherwise.
     /// @sa https://fktn-k.github.io/fkYAML/api/basic_node/is_scalar/
     bool is_scalar() const noexcept
     {
@@ -692,6 +745,7 @@ public:
     }
 
     /// @brief Tests whether the current basic_node value (sequence, mapping, string) is empty.
+    /// @return true if the node value is empty, false otherwise.
     /// @sa https://fktn-k.github.io/fkYAML/api/basic_node/empty/
     bool empty() const
     {
@@ -712,6 +766,7 @@ public:
     }
 
     /// @brief Returns the size of the current basic_node value (sequence, mapping, string).
+    /// @return The size of a node value.
     /// @sa https://fktn-k.github.io/fkYAML/api/basic_node/size/
     std::size_t size() const
     {
@@ -732,6 +787,9 @@ public:
     }
 
     /// @brief Check whether or not this basic_node object has a given key in its inner mapping Node value.
+    /// @tparam KeyType A type compatible with the key type of mapping node values.
+    /// @param[in] key A key to the target value in the YAML mapping node value.
+    /// @return true if the YAML node is a mapping and has the given key, false otherwise.
     /// @sa https://fktn-k.github.io/fkYAML/api/basic_node/contains/
     template <
         typename KeyType, detail::enable_if_t<
@@ -753,6 +811,7 @@ public:
     }
 
     /// @brief Get the YAML version specification for this basic_node object.
+    /// @return The version of the YAML format applied to the basic_node object.
     /// @sa https://fktn-k.github.io/fkYAML/api/basic_node/get_yaml_version/
     yaml_version_t get_yaml_version() const noexcept
     {
@@ -760,6 +819,7 @@ public:
     }
 
     /// @brief Set the YAML version specification for this basic_node object.
+    /// @param[in] A version of the YAML format.
     /// @sa https://fktn-k.github.io/fkYAML/api/basic_node/set_yaml_version/
     void set_yaml_version(const yaml_version_t version) noexcept
     {
@@ -767,6 +827,7 @@ public:
     }
 
     /// @brief Check whether or not this basic_node object has already had any anchor name.
+    /// @return true if ths basic_node has an anchor name, false otherwise.
     /// @sa https://fktn-k.github.io/fkYAML/api/basic_node/has_anchor_name/
     bool has_anchor_name() const noexcept
     {
@@ -776,6 +837,7 @@ public:
     /// @brief Get the anchor name associated to this basic_node object.
     /// @note Some anchor name must be set before calling this method. Call basic_node::HasAnchorName() to see if this
     /// basic_node object has any anchor name.
+    /// @return The anchor name associated to the node.
     /// @sa https://fktn-k.github.io/fkYAML/api/basic_node/get_anchor_name/
     const std::string& get_anchor_name() const
     {
@@ -798,6 +860,7 @@ public:
 
     /// @brief Add an anchor name to this basic_node object.
     /// @note If this basic_node object has already had any anchor name, the new anchor name will overwrite the old one.
+    /// @param[in] anchor_name An anchor name.This should not be empty.
     /// @sa https://fktn-k.github.io/fkYAML/api/basic_node/add_anchor_name/
     void add_anchor_name(std::string&& anchor_name)
     {
@@ -808,6 +871,9 @@ public:
 
     /// @brief Get the node value object converted into a given type.
     /// @note This function requires T objects to be default constructible.
+    /// @tparam T A compatible value type which might be cv-qualified or a reference type.
+    /// @tparam ValueType A compatible value type, without cv-qualifiers and reference by default.
+    /// @return A compatible native data value converted from the basic_node object.
     /// @sa https://fktn-k.github.io/fkYAML/api/basic_node/get_value/
     template <
         typename T, typename ValueType = detail::remove_cvref_t<T>,
@@ -823,12 +889,20 @@ public:
         return ret;
     }
 
+    /// @brief Explicit reference access to the internally stored YAML node value.
+    /// @tparam ReferenceType Reference type to the target YAML node value.
+    /// @return Reference to the internally stored YAML node value.
+    /// @sa https://fktn-k.github.io/fkYAML/api/basic_node/get_value_ref/
     template <typename ReferenceType, detail::enable_if_t<std::is_reference<ReferenceType>::value, int> = 0>
     ReferenceType get_value_ref()
     {
         return get_value_ref_impl(static_cast<detail::add_pointer_t<ReferenceType>>(nullptr));
     }
 
+    /// @brief Explicit reference access to the internally stored YAML node value.
+    /// @tparam ReferenceType Constant reference type to the target YAML node value.
+    /// @return Constant reference to the internally stored YAML node value.
+    /// @sa https://fktn-k.github.io/fkYAML/api/basic_node/get_value_ref/
     template <
         typename ReferenceType,
         detail::enable_if_t<
@@ -840,7 +914,8 @@ public:
         return get_value_ref_impl(static_cast<detail::add_pointer_t<ReferenceType>>(nullptr));
     }
 
-    /// @brief Swaps data with the specified basic_node object.
+    /// @brief Swaps the internally stored data with the specified basic_node object.
+    /// @param[in] rhs A basic_node object to be swapped with.
     /// @sa https://fktn-k.github.io/fkYAML/api/basic_node/swap/
     void swap(basic_node& rhs) noexcept
     {
@@ -858,6 +933,7 @@ public:
 
     /// @brief Returns the first iterator of basic_node values of container types (sequence or mapping) from a non-const
     /// basic_node object. Throws exception if the basic_node value is not of container types.
+    /// @return An iterator to the first element of a YAML node value (either sequence or mapping).
     /// @sa https://fktn-k.github.io/fkYAML/api/basic_node/begin/
     iterator begin()
     {
@@ -876,6 +952,7 @@ public:
 
     /// @brief Returns the first iterator of basic_node values of container types (sequence or mapping) from a const
     /// basic_node object. Throws exception if the basic_node value is not of container types.
+    /// @return A constant iterator to the first element of a YAML node value (either sequence or mapping).
     /// @sa https://fktn-k.github.io/fkYAML/api/basic_node/begin/
     const_iterator begin() const
     {
@@ -894,6 +971,7 @@ public:
 
     /// @brief Returns the last iterator of basic_node values of container types (sequence or mapping) from a non-const
     /// basic_node object. Throws exception if the basic_node value is not of container types.
+    /// @return An iterator to the past-the end element of a YAML node value (either sequence or mapping).
     /// @sa https://fktn-k.github.io/fkYAML/api/basic_node/end/
     iterator end()
     {
@@ -912,6 +990,7 @@ public:
 
     /// @brief Returns the last iterator of basic_node values of container types (sequence or mapping) from a const
     /// basic_node object. Throws exception if the basic_node value is not of container types.
+    /// @return A constant iterator to the past-the end element of a YAML node value (either sequence or mapping).
     /// @sa https://fktn-k.github.io/fkYAML/api/basic_node/end/
     const_iterator end() const
     {
@@ -1084,6 +1163,8 @@ private:
 };
 
 /// @brief Swap function for basic_node objects.
+/// @param[in] lhs A left-side-hand basic_node object to be swapped with.
+/// @param[in] rhs A right-side-hand basic_node object to be swapped with.
 /// @sa https://fktn-k.github.io/fkYAML/api/swap/
 template <
     template <typename, typename...> class SequenceType, template <typename, typename, typename...> class MappingType,

--- a/include/fkYAML/node_value_converter.hpp
+++ b/include/fkYAML/node_value_converter.hpp
@@ -21,26 +21,19 @@
 
 FK_YAML_NAMESPACE_BEGIN
 
-/**
- * @class node_value_converter
- * @brief An ADL friendly converter between basic_node objects and native data objects.
- *
- * @tparam ValueType A default target data type.
- * @tparam typename N/A
- */
+/// @brief An ADL friendly converter between basic_node objects and native data objects.
+/// @tparam ValueType A default target data type.
+/// @sa https://fktn-k.github.io/fkYAML/api/node_value_converter/
 template <typename ValueType, typename>
 class node_value_converter
 {
 public:
-    /**
-     * @brief Convert a YAML node value into compatible native data.
-     *
-     * @tparam BasicNodeType A basic_node template instance type.
-     * @tparam TargetType A native data type for conversion.
-     * @param n A basic_node object.
-     * @param val A native data object.
-     * @return decltype(::fkyaml::from_node(std::forward<BasicNodeType>(n), val), void())
-     */
+    /// @brief Convert a YAML node value into compatible native data.
+    /// @tparam BasicNodeType A basic_node template instance type.
+    /// @tparam TargetType A native data type for conversion.
+    /// @param n A basic_node object.
+    /// @param val A native data object.
+    /// @sa https://fktn-k.github.io/fkYAML/api/node_value_converter/from_node/
     template <typename BasicNodeType, typename TargetType = ValueType>
     static auto from_node(BasicNodeType&& n, TargetType& val) noexcept(
         noexcept(::fkyaml::from_node(std::forward<BasicNodeType>(n), val)))
@@ -49,15 +42,12 @@ public:
         ::fkyaml::from_node(std::forward<BasicNodeType>(n), val);
     }
 
-    /**
-     * @brief Convert compatible native data into a YAML node.
-     *
-     * @tparam BasicNodeType A basic_node template instance type.
-     * @tparam TargetType A native data type for conversion.
-     * @param n A basic_node object.
-     * @param val A native data object.
-     * @return decltype(::fkyaml::to_node(n, std::forward<TargetType>(val)))
-     */
+    /// @brief Convert compatible native data into a YAML node.
+    /// @tparam BasicNodeType A basic_node template instance type.
+    /// @tparam TargetType A native data type for conversion.
+    /// @param n A basic_node object.
+    /// @param val A native data object.
+    /// @sa https://fktn-k.github.io/fkYAML/api/node_value_converter/to_node/
     template <typename BasicNodeType, typename TargetType = ValueType>
     static auto to_node(BasicNodeType& n, TargetType&& val) noexcept(
         noexcept(::fkyaml::to_node(n, std::forward<TargetType>(val))))

--- a/include/fkYAML/ordered_map.hpp
+++ b/include/fkYAML/ordered_map.hpp
@@ -23,70 +23,60 @@
 #include <fkYAML/detail/meta/type_traits.hpp>
 #include <fkYAML/exception.hpp>
 
-/**
- * @namespace fkyaml
- * @brief namespace for fkYAML library.
- */
+/// @brief namespace for fkYAML library.
 FK_YAML_NAMESPACE_BEGIN
 
-/**
- * @brief A minimal map-like container which preserves insertion order.
- *
- * @tparam Key A type for keys.
- * @tparam Value A type for values.
- * @tparam IgnoredCompare A placeholder for key comparison. This will be ignored.
- * @tparam Allocator A class for allocators.
- */
+/// @brief A minimal map-like container which preserves insertion order.
+/// @tparam Key A type for keys.
+/// @tparam Value A type for values.
+/// @tparam IgnoredCompare A placeholder for key comparison. This will be ignored.
+/// @tparam Allocator A class for allocators.
+/// @sa https://fktn-k.github.io/fkYAML/api/ordered_map/
 template <
     typename Key, typename Value, typename IgnoredCompare = std::less<Key>,
     typename Allocator = std::allocator<std::pair<const Key, Value>>>
 class ordered_map : public std::vector<std::pair<const Key, Value>, Allocator>
 {
 public:
-    /** A type for keys. */
+    /// A type for keys.
     using key_type = Key;
-    /** A type for values. */
+    /// A type for values.
     using mapped_type = Value;
-    /** A type for internal key-value containers */
+    /// A type for internal key-value containers.
     using Container = std::vector<std::pair<const Key, Value>, Allocator>;
-    /** A type for key-value pairs */
+    /// A type for key-value pairs.
     using value_type = typename Container::value_type;
-    /** A type for non-const iterators */
+    /// A type for non-const iterators.
     using iterator = typename Container::iterator;
-    /** A type for const iterators. */
+    /// A type for const iterators.
     using const_iterator = typename Container::const_iterator;
-    /** A type for size parameters used in this class. */
+    /// A type for size parameters used in this class.
     using size_type = typename Container::size_type;
-    /** A type for comparison between keys. */
+    /// A type for comparison between keys.
     using key_compare = std::equal_to<Key>;
 
 public:
-    /**
-     * @brief Construct a new ordered_map object.
-     */
+    /// @brief Construct a new ordered_map object.
+    /// @sa https://fktn-k.github.io/fkYAML/api/ordered_map/constructor/
     ordered_map() noexcept(noexcept(Container()))
         : Container()
     {
     }
 
-    /**
-     * @brief Construct a new ordered_map object with an initializer list.
-     *
-     * @param init An initializer list to construct the inner container object.
-     */
+    /// @brief Construct a new ordered_map object with an initializer list.
+    /// @param init An initializer list to construct the inner container object.
+    /// @sa https://fktn-k.github.io/fkYAML/api/ordered_map/constructor/
     ordered_map(std::initializer_list<value_type> init)
         : Container {init}
     {
     }
 
 public:
-    /**
-     * @brief A subscript operator for ordered_map objects.
-     *
-     * @tparam KeyType A type for the input key.
-     * @param key A key to the target value.
-     * @return mapped_type& Reference to a mapped_type object associated with the given key.
-     */
+    /// @brief A subscript operator for ordered_map objects.
+    /// @tparam KeyType A type for the input key.
+    /// @param key A key to the target value.
+    /// @return mapped_type& Reference to a mapped_type object associated with the given key.
+    /// @sa https://fktn-k.github.io/fkYAML/api/ordered_map/operator[]/
     template <
         typename KeyType,
         detail::enable_if_t<detail::is_usable_as_key_type<key_compare, key_type, KeyType>::value, int> = 0>
@@ -96,13 +86,12 @@ public:
     }
 
 public:
-    /**
-     * @brief Emplace a new key-value pair if the new key does not exist.
-     *
-     * @param key A key to be emplaced to this ordered_map object.
-     * @param value A value to be emplaced to this ordered_map object.
-     * @return std::pair<iterator, bool> A result of emplacement of the new key-value pair.
-     */
+    /// @brief Emplace a new key-value pair if the new key does not exist.
+    /// @tparam KeyType A type for the input key.
+    /// @param key A key to be emplaced to this ordered_map object.
+    /// @param value A value to be emplaced to this ordered_map object.
+    /// @return std::pair<iterator, bool> A result of emplacement of the new key-value pair.
+    /// @sa https://fktn-k.github.io/fkYAML/api/ordered_map/emplace/
     template <
         typename KeyType,
         detail::enable_if_t<detail::is_usable_as_key_type<key_compare, key_type, KeyType>::value, int> = 0>
@@ -119,13 +108,11 @@ public:
         return {std::prev(this->end()), true};
     }
 
-    /**
-     * @brief Find a value associated to the given key. Throws an exception if the search fails.
-     *
-     * @tparam KeyType A type for the input key.
-     * @param key A key to find a value with.
-     * @return mapped_type& The value associated to the given key.
-     */
+    /// @brief Find a value associated to the given key. Throws an exception if the search fails.
+    /// @tparam KeyType A type for the input key.
+    /// @param key A key to find a value with.
+    /// @return mapped_type& The value associated to the given key.
+    /// @sa https://fktn-k.github.io/fkYAML/api/ordered_map/at/
     template <
         typename KeyType,
         detail::enable_if_t<detail::is_usable_as_key_type<key_compare, key_type, KeyType>::value, int> = 0>
@@ -141,13 +128,11 @@ public:
         throw fkyaml::exception("key not found.");
     }
 
-    /**
-     * @brief Find a value associated to the given key. Throws an exception if the search fails.
-     *
-     * @tparam KeyType A type for the input key.
-     * @param key A key to find a value with.
-     * @return const mapped_type& The value associated to the given key.
-     */
+    /// @brief Find a value associated to the given key. Throws an exception if the search fails.
+    /// @tparam KeyType A type for the input key.
+    /// @param key A key to find a value with.
+    /// @return const mapped_type& The value associated to the given key.
+    /// @sa https://fktn-k.github.io/fkYAML/api/ordered_map/at/
     template <
         typename KeyType,
         detail::enable_if_t<detail::is_usable_as_key_type<key_compare, key_type, KeyType>::value, int> = 0>
@@ -163,13 +148,11 @@ public:
         throw fkyaml::exception("key not found.");
     }
 
-    /**
-     * @brief Find a value with the given key.
-     *
-     * @tparam KeyType A type for the input key.
-     * @param key A key to find a value with.
-     * @return iterator The iterator for the found value, or the result of end().
-     */
+    /// @brief Find a value with the given key.
+    /// @tparam KeyType A type for the input key.
+    /// @param key A key to find a value with.
+    /// @return iterator The iterator for the found value, or the result of end().
+    /// @sa https://fktn-k.github.io/fkYAML/api/ordered_map/find/
     template <
         typename KeyType,
         detail::enable_if_t<detail::is_usable_as_key_type<key_compare, key_type, KeyType>::value, int> = 0>
@@ -185,13 +168,11 @@ public:
         return this->end();
     }
 
-    /**
-     * @brief Find a value with the given key.
-     *
-     * @tparam KeyType A type for the input key.
-     * @param key A key to find a value with.
-     * @return const_iterator The constant iterator for the found value, or the result of end().
-     */
+    /// @brief Find a value with the given key.
+    /// @tparam KeyType A type for the input key.
+    /// @param key A key to find a value with.
+    /// @return const_iterator The constant iterator for the found value, or the result of end().
+    /// @sa https://fktn-k.github.io/fkYAML/api/ordered_map/find/
     template <
         typename KeyType,
         detail::enable_if_t<detail::is_usable_as_key_type<key_compare, key_type, KeyType>::value, int> = 0>
@@ -208,7 +189,7 @@ public:
     }
 
 private:
-    /** The object for comparing keys. */
+    /// The object for comparing keys.
     key_compare m_compare {};
 };
 


### PR DESCRIPTION
API documentations have been moved to the `docs/mkdocs/api` directory to serve the documentation with MkDocs.  
For development, doxygen style comments are left in the source files.  