### PR TITLE
#179 Created tutorial pages

### DIFF
--- a/docs/mkdocs/docs/tutorials.md
+++ b/docs/mkdocs/docs/tutorials.md
@@ -1,1 +1,0 @@
-This is the top page for tutorials for the fkYAML library.  

--- a/docs/mkdocs/docs/tutorials/cmake_integration.md
+++ b/docs/mkdocs/docs/tutorials/cmake_integration.md
@@ -1,0 +1,66 @@
+# CMake Integration
+
+Since we use CMake to build fkYAML, we also provide a couple of integration points for our users.  
+You can use the `fkYAML::fkYAML` interface target in CMake.  
+This target popultes the appropriate usage requirements for `INTERFACE_INCLUDE_DIRECTORIES`(https://cmake.org/cmake/help/latest/prop_tgt/INTERFACE_INCLUDE_DIRECTORIES.html) to point to the appropriate include directories and `INTERFACE_COMPILE_FEATURES`(https://cmake.org/cmake/help/latest/prop_tgt/INTERFACE_COMPILE_FEATURES.html) for the necessary C++11 flags.  
+
+## Possible solutions
+
+The following sub-sections show some possible ways in which you can integrate an existing CMake projct with fkYAML.  
+
+### With `find_package()`
+
+To use fkYAML from a CMake project, you can locate it directly with [`find_package()`](https://cmake.org/cmake/help/latest/command/find_package.html) and use the namespaced imported target from the generated package configuration.  
+Note that this method requires a release package to be installed somewhere on your machine.  
+The package configuration file, `fkYAMLConfig.cmake`, can be used either from an install tree or directly out of the build tree.  
+
+???+ Example
+
+    ```cmake title="CMakeLists.txt"
+    cmake_minimum_required(VERSION 3.8)
+    project(ExampleProject LANGUAGES CXX)
+
+    find_package(fkYAML 0.1.3 REQUIRED)
+
+    add_executable(example example.cpp)
+    target_link_library(example PRIVATE fkYAML::fkYAML)
+    ```
+
+### With `add_subdirectory()`
+
+To embed the library directory into an existing CMake project, place the entire source tree in a subdirectory and call [`add_subdirectory()`](https://cmake.org/cmake/help/latest/command/add_subdirectory.html) in your `CMakeLists.txt` file.  
+
+???+ Example
+
+    ```cmake title="CMakeLists.txt"
+    cmake_minimum_required(VERSION 3.8)
+    project(ExampleProject LANGUAGE CXX)
+
+    add_subdirectory(./path/to/fkYAML)
+
+    add_executable(example example.cpp)
+    target_link_libraries(example PRIVATE fkYAML::fkYAML)
+    ```
+
+### With the `FetchContent` CMake module
+
+Since CMake v3.11, [`FetchContent`](https://cmake.org/cmake/help/latest/module/FetchContent.html) is available which automatically downloads a release as a dependency during configuration.  
+
+???+ Example
+
+    ```cmake title="CMakeLists.txt"
+    cmake_minimum_required(VERSION 3.11)
+    project(ExampleProject LANGUAGES CXX)
+
+    include(FetchContent)
+
+    FetchContent_Declare(
+        fkYAML
+        GIT_REPOSITORY https://github.com/fktn-k/fkYAML.git
+        GIT_TAG v0.1.3
+    )
+    FetchContent_MakeAvailable(fkYAML)
+
+    add_executable(example example.cpp)
+    target_link_library(example PRIVATE fkYAML::fkYAML)
+    ```

--- a/docs/mkdocs/docs/tutorials/index.md
+++ b/docs/mkdocs/docs/tutorials/index.md
@@ -1,0 +1,344 @@
+# The First Steps
+
+The goal of this page is to help you understand what is possible with fkYAML, and to provide some tips of how you can use it within your own project with CMake.  
+As a tutorial, we will make a very simple project which utilizes fkYAML so that your understanding can be fostered with an actual, executable example.  
+
+## :rocket: Getting fkYAML
+
+Ideally you should be using fkYAML through its [CMake](https://cmake.org/) integration.  
+Although fkYAML also provides a pkg-config file, this documentation will assume you are using CMake.  
+fkYAML provides release packages in the releases pages which contain the all the necessary header files and CMake config files.  
+Although you can just copy, paste and include the header files in your C++ project, it is highly recommended to use the library with CMake because the exported CMake target `fkYAML::fkYAML` will save you most of your work for the integration.  
+The followings are possible ways of preparing for the use of fkYAML:  
+
+### :file_folder: Download a release package
+You can [download the latest package (fkYAML.tgz for UNIX or fkYAML.zip for Windows) from here](https://github.com/fktn-k/fkYAML/releases/latest).  
+After the download gets completed, unzip and put the package in some directory on your machine.  
+The destination path can be whatever you want, and you're all set!
+
+### :inbox_tray: Install with CMake
+You can also clone the fkYAML repository and execute the following commands to install the fkYAML package on your machine.  
+Make sure the CMake executable is registered to the PATH environment variable.  
+
+```bash
+$ cd /path/to/fkYAML
+$ cmake -B build -S . [-DCMAKE_INSTALL_PREFIX=<path-to-install>]
+$ cmake --build build --target install
+```
+
+With `-DCMAKE_INSTALL_PREFIX=<path-to-install>`, you can override the default installation path.  
+The default installation path would be the followings:  
+
+| OS      | Path                      |
+| ------- | ------------------------- |
+| UNIX    | /usr/local                |
+| Windows | C:\\Program Files\\fkYAML |
+
+And you're all set! You can now `find_package()` the fkYAML package.
+
+### :pushpin: Use fkYAML as a Git submodule
+If you want to avoid system-wide installation, you can use the fkYAML library as a Git submodule in you C++ project instead.  
+The commands would be the following (Make sure the Git executable is registered to the PATH environment.):  
+
+```bash
+$ cd /path/to/your/repo
+$ git submodule add https://github.com/fktn-k/fkYAML.git [path/to/clone/fkYAML]
+```
+
+And you're all set!  
+Note that you must execute the CMake `add_subdirectory()` command for the submoduled fkYAML library in your CMakeLists.txt file as explained in the CMake integration section.  
+
+## :bulb: Use fkYAML in your C++ project
+
+### :seedling: Create a tutorial project.
+
+Let's start with a really simple example.  
+Say you have an example.yaml file and now you want to load the contents.  
+Note that the following example files assumes that you have installed the fkYAML library somewhere on your machine.  
+See [the CMake Integration section]() for the other ways and modify the implementation if necessary.  
+
+```title="Project Structure"
+.
+├── CMakeLists.txt
+├── example.yaml
+└── tutorial.cpp
+```
+
+=== "example.yaml"
+
+    ```yaml
+    novels:
+      - title: "Robinson Crusoe"
+        author: "Daniel Defoe"
+        year: 1678
+      - title: "Frankenstein"
+        author: "Jane Austen"
+        year: 1818
+      - title: "Moby-Dick"
+        author: "Herman Melville"
+        year: 1851
+      - title: "Brave New World"
+        author: "Aldous Huxley"
+        year: 1932
+      - title: "Never Let Me Go"
+        author: "Kazuo Ishiguro"
+        year: 2005
+    ```
+=== "tutorial.cpp"
+
+    ```cpp
+    #include <fstream>
+    #include <iostream>
+    #include <fkYAML/node.hpp>
+
+    int main()
+    {
+        // open a YAML file. Other streams or strings are also usable as an input.
+        std::ifstream ifs("example.yaml");
+
+        // deserialize the loaded file contents.
+        fkyaml::node root = fkyaml::node::deserialize(ifs);
+
+        // print the deserialized YAML nodes by serializing them back.
+        std::cout << fkyaml::node::serialize() << std::endl;
+        return 0;
+    }
+    ```
+=== "CMakeLists.txt"
+
+    ```cmake
+
+    cmake_minimum_required(VERSION 3.8)
+    project(tutorial LANGUAGES CXX)
+
+    find_package(fkYAML REQUIRED)
+
+    add_executable(tutorial tutorial.cpp)
+
+    # This exported CMake target sets the necessary configurations for the project.
+    target_link_library(tutorial PUBLIC fkYAML::fkYAML)
+    ```
+
+After creating a tutorial project with the above files, execute the following commands to build the project with CMake.  
+
+```bash
+$ cd /path/to/tutorial/
+$ cmake -B build -S . -DCMAKE_BUILD_TYPE=Release
+$ cmake --build build --config --config Release
+```
+
+Congratulation! You've got an application which loads a YAML file and then outputs the content on the console.  
+If you run the tutorial executable file, you will see the output like:  
+
+```bash
+novels:
+  -
+    title: "Robinson Crusoe"
+    author: "Daniel Defoe"
+    year: 1678
+  -
+    title: "Frankenstein"
+    author: "Jane Austen"
+    year: 1818
+  -
+    title: "Moby-Dick"
+    author: "Herman Melville"
+    year: 1851
+  -
+    title: "Brave New World"
+    author: "Aldous Huxley"
+    year: 1932
+  -
+    title: "Never Let Me Go"
+    author: "Kazuo Ishiguro"
+    year: 2005
+```
+
+### :mag: Access individual YAML nodes
+You can also access each YAML node with the fkYAML APIs.  
+Say you just want to care about values associated with the `title` key and ignore the others.  
+You can do it by modifying the tutorial.cpp file as follows:  
+
+```cpp title="tutorial.cpp" hl_lines="13-18"
+#include <fstream>
+#include <iostream>
+#include <fkYAML/node.hpp>
+
+int main()
+{
+    // open a YAML file. Other streams or strings are also usable as an input.
+    std::ifstream ifs("example.yaml");
+
+    // deserialize the loaded file contents.
+    fkyaml::node root = fkyaml::node::deserialize(ifs);
+
+    // print only values associated with "title" key.
+    for (auto& novel_node : root["novels"])
+    {
+        // get reference to the "title" value with `get_value_ref` function.
+        std::cout << novel_node["title"].get_value_ref<std::string&>() << std::endl;
+    }
+
+    return 0;
+}
+```
+
+Rebuild and run the application, and you'll see the output like:  
+
+```bash
+Robinson Crusoe
+Frankenstein
+Moby-Dick
+Brave New World
+Never Let Me Go
+```
+
+### :hammer: Generate YAML nodes from code
+
+When you can access the specific values, you might want to generate YAML nodes programatically, for instance, to make a response parameter.  
+The fkYAML library also provides a feature to realize such a need.  
+
+You can achieve that by changing the highlighted part of the code snippet:  
+
+```cpp title="tutorial.cpp" hl_lines="14-16 18 21-26 29-30"
+#include <fstream>
+#include <iostream>
+#include <utility>
+#include <fkYAML/node.hpp>
+
+int main()
+{
+    // open a YAML file. Other streams or strings are also usable as an input.
+    std::ifstream ifs("example.yaml");
+
+    // deserialize the loaded file contents.
+    fkyaml::node root = fkyaml::node::deserialize(ifs);
+
+    // create an empty YAML sequence node.
+    fkyaml::node response = { "recommends", fkyaml::node::sequence() };
+    auto& recommends = response["recommends"].get_value_ref<fkyaml::node::sequence_type&>();
+
+    // generate recommendations by extracting "title" & "author" values.
+    for (auto& novel_node : root["novels"])
+    {
+        // create a recommendation node with an initializer list.
+        fkyaml::node recommend = {
+            { "title", novel_node["title"] },
+            { "author", novel_node["author"] }
+        };
+        recommends.emplace_back(std::move(recommends));
+    }
+
+    // print the response YAML nodes.
+    std::cout << fkyaml::node::serialize(response) << std::endl;
+
+    return 0;
+}
+```
+
+Rebuild and run the application, and you'll see the output like:  
+
+```bash
+recommends:
+  -
+    title: "Robinson Crusoe"
+    author: "Daniel Defoe"
+  -
+    title: "Frankenstein"
+    author: "Jane Austen"
+  -
+    title: "Moby-Dick"
+    author: "Herman Melville"
+  -
+    title: "Brave New World"
+    author: "Aldous Huxley"
+  -
+    title: "Never Let Me Go"
+    author: "Kazuo Ishiguro"
+```
+
+### :pill: Integrate with user-defined types
+
+As described in the API Reference pages for [`from_node()`](../api/node_value_converter/from_node.md) and [`to_node()`](../api/node_value_converter/to_node.md) functions, you can specialize deserialization for user-defined types.  
+Note that you don't need to implement specializations for STL types (such as std::vector or std::string) because the fkYAML library has already implemented them.  
+
+The updated code snippet down below shows how the specializations for user-defined types can reduce boilerplate code.  
+
+```cpp title="tutorial.cpp" hl_lines="6-38 55-60"
+#include <fstream>
+#include <iostream>
+#include <utility>
+#include <fkYAML/node.hpp>
+
+// creating a namespace is not mandatory.
+namespace ns
+{
+
+struct novel
+{
+    std::string title;
+    std::string author;
+    int year;
+};
+
+struct recommend
+{
+    std::string title;
+    std::string author;
+};
+
+// overloads must be defined in the same namespace as user-defined types.
+void from_node(const fkyaml::node& node, novel& novel)
+{
+    novel.title = node["title"].get_value_ref<const std::string&>();
+    novel.author = node["author"].get_value_ref<const std::string&>();
+}
+
+void to_node(fkyaml::node& node, const recommend& recommend)
+{
+    node = fkyaml::node {
+        { "title", recommend.title },
+        { "author", recommend.author }
+    };
+}
+
+} // namespace ns
+
+int main()
+{
+    // open a YAML file. Other streams or strings are also usable as an input.
+    std::ifstream ifs("example.yaml");
+
+    // deserialize the loaded file contents.
+    fkyaml::node root = fkyaml::node::deserialize(ifs);
+
+    // create an empty YAML sequence node.
+    fkyaml::node response = { "recommends", fkyaml::node::sequence() };
+    auto& recommends = response["recommends"].get_value_ref<fkyaml::node::sequence_type&>();
+
+    // generate recommendations by extracting "title" & "author" values.
+    for (auto& novel_node : root["novels"])
+    {
+        // get novel directly from the node.
+        ns::novel novel = novel_node.get_value<ns::novel>();
+
+        // create a recommendation node directly with a recommend object.
+        ns::recommend recommend = { std::move(novel.title), std::move(novel.author) };
+        recommends.emplace_back(recommend);
+    }
+
+    // print the response YAML nodes.
+    std::cout << fkyaml::node::serialize(response) << std::endl;
+
+    return 0;
+}
+```
+
+The specializations highlighted above do not change the output, but they allow us to focus more on what the code is to achive.  
+Note that the specialization with user-defined types requires the types to be default-constructible.  
+
+## :tada: Next Steps
+
+This page is a brief introduction to get you up and running with fkYAML, and to show the basic features of fkYAML.  
+The features mentioned here can get you quite far, but there are many more.  
+For more information, please visit [the API Documentation section](../api/basic_node/index.md) which has a lot of descriptions for each fkYAML APIs with example code snippets.  

--- a/docs/mkdocs/mkdocs.yml
+++ b/docs/mkdocs/mkdocs.yml
@@ -88,7 +88,10 @@ nav:
       - Overview: index.md
       - License: home/license.md
       - Changelog: home/CHANGELOG.md
-  - "API Documentation":
+  - Tutorials: 
+      The First Steps: tutorials/index.md
+      CMake Integration: tutorials/cmake_integration.md
+  - API References:
       - basic_node:
           - basic_node: api/basic_node/index.md
           - (constructor): api/basic_node/constructor.md
@@ -152,4 +155,3 @@ nav:
           - emplace: api/ordered_map/emplace.md
           - find: api/ordered_map/find.md
           - operator[]: api/ordered_map/operator[].md
-  - Tutorials: tutorials.md


### PR DESCRIPTION
Tutorial pages have been created to the documentation to make it easier for users to understand what fkYAML is as well as what is possible with fkYAML through making a sample CMake project which uses fkYAML.  
