### PR TITLE
#200 Allow a space in unquoted strings

### DIFF
--- a/docs/mkdocs/docs/tutorials/index.md
+++ b/docs/mkdocs/docs/tutorials/index.md
@@ -68,20 +68,20 @@ See [the CMake Integration section]() for the other ways and modify the implemen
 
     ```yaml
     novels:
-      - title: "Robinson Crusoe"
-        author: "Daniel Defoe"
+      - title: Robinson Crusoe
+        author: Daniel Defoe
         year: 1678
-      - title: "Frankenstein"
-        author: "Jane Austen"
+      - title: Frankenstein
+        author: Jane Austen
         year: 1818
-      - title: "Moby-Dick"
-        author: "Herman Melville"
+      - title: Moby-Dick
+        author: Herman Melville
         year: 1851
-      - title: "Brave New World"
-        author: "Aldous Huxley"
+      - title: Brave New World
+        author: Aldous Huxley
         year: 1932
-      - title: "Never Let Me Go"
-        author: "Kazuo Ishiguro"
+      - title: Never Let Me Go
+        author: Kazuo Ishiguro
         year: 2005
     ```
 === "tutorial.cpp"
@@ -133,24 +133,24 @@ If you run the tutorial executable file, you will see the output like:
 ```bash
 novels:
   -
-    title: "Robinson Crusoe"
-    author: "Daniel Defoe"
+    title: Robinson Crusoe
+    author: Daniel Defoe
     year: 1678
   -
-    title: "Frankenstein"
-    author: "Jane Austen"
+    title: Frankenstein
+    author: Jane Austen
     year: 1818
   -
-    title: "Moby-Dick"
-    author: "Herman Melville"
+    title: Moby-Dick
+    author: Herman Melville
     year: 1851
   -
-    title: "Brave New World"
-    author: "Aldous Huxley"
+    title: Brave New World
+    author: Aldous Huxley
     year: 1932
   -
-    title: "Never Let Me Go"
-    author: "Kazuo Ishiguro"
+    title: Never Let Me Go
+    author: Kazuo Ishiguro
     year: 2005
 ```
 
@@ -241,20 +241,20 @@ Rebuild and run the application, and you'll see the output like:
 ```bash
 recommends:
   -
-    title: "Robinson Crusoe"
-    author: "Daniel Defoe"
+    title: Robinson Crusoe
+    author: Daniel Defoe
   -
-    title: "Frankenstein"
-    author: "Jane Austen"
+    title: Frankenstein
+    author: Jane Austen
   -
-    title: "Moby-Dick"
-    author: "Herman Melville"
+    title: Moby-Dick
+    author: Herman Melville
   -
-    title: "Brave New World"
-    author: "Aldous Huxley"
+    title: Brave New World
+    author: Aldous Huxley
   -
-    title: "Never Let Me Go"
-    author: "Kazuo Ishiguro"
+    title: Never Let Me Go
+    author: Kazuo Ishiguro
 ```
 
 ### :pill: Integrate with user-defined types

--- a/include/fkYAML/detail/input/lexical_analyzer.hpp
+++ b/include/fkYAML/detail/input/lexical_analyzer.hpp
@@ -222,7 +222,7 @@ public:
         case 'F':
         case 'f': {
             // YAML specifies that only these words represent the boolean value `false`.
-            // See "10.3.2. Tag Resolution" section in https://yaml.org/spec/1.2.2/
+            // See "10.3.2 Tag Resolution" section in https://yaml.org/spec/1.2.2/
             char_int_type ret = m_input_handler.get_range(5, m_value_buffer);
             if (ret == end_of_input)
             {
@@ -247,7 +247,7 @@ public:
         case 'n': {
             // YAML specifies that these words and a tilde represent a null value.
             // Tildes are already checked above, so no check is needed here.
-            // See "10.3.2. Tag Resolution" section in https://yaml.org/spec/1.2.2/
+            // See "10.3.2 Tag Resolution" section in https://yaml.org/spec/1.2.2/
             char_int_type ret = m_input_handler.get_range(4, m_value_buffer);
             if (ret == end_of_input)
             {
@@ -271,7 +271,7 @@ public:
         case 'T':
         case 't': {
             // YAML specifies that only these words represent the boolean value `true`.
-            // See "10.3.2. Tag Resolution" section in https://yaml.org/spec/1.2.2/
+            // See "10.3.2 Tag Resolution" section in https://yaml.org/spec/1.2.2/
             char_int_type ret = m_input_handler.get_range(4, m_value_buffer);
             if (ret == end_of_input)
             {
@@ -636,7 +636,7 @@ private:
         case 'o':
             // Do not store 'o' since std::strtoull does not support "0o" but "0" as the prefix for octal numbers.
             // YAML specifies octal values start with the prefix "0o".
-            // See "10.3.2. Tag Resolution" section in https://yaml.org/spec/1.2.2/
+            // See "10.3.2 Tag Resolution" section in https://yaml.org/spec/1.2.2/
             return scan_octal_number();
         case 'x':
             m_value_buffer.push_back(char_traits_type::to_char_type(next));
@@ -813,7 +813,26 @@ private:
             {
                 if (!needs_last_double_quote && !needs_last_single_quote)
                 {
-                    return lexical_token_t::STRING_VALUE;
+                    // Allow a space in an unquoted string only if the space is surrounded by non-space characters.
+                    // See "7.3.3 Plain Style" section in https://yaml.org/spec/1.2.2/
+                    current = m_input_handler.get_next();
+                    switch (current)
+                    {
+                    case ' ':
+                    case '\r':
+                    case '\n':
+                    case '{':
+                    case '}':
+                    case '[':
+                    case ']':
+                    case ',':
+                    case ':':
+                    case '#':
+                    case '\\':
+                        return lexical_token_t::STRING_VALUE;
+                    }
+                    m_input_handler.unget();
+                    current = m_input_handler.get_current();
                 }
                 m_value_buffer.push_back(char_traits_type::to_char_type(current));
                 continue;
@@ -932,7 +951,7 @@ private:
             }
 
             // Handle escaped characters.
-            // See "5.7. Escaped Characters" section in https://yaml.org/spec/1.2.2/
+            // See "5.7 Escaped Characters" section in https://yaml.org/spec/1.2.2/
             if (current == '\\')
             {
                 if (!needs_last_double_quote)

--- a/test/unit_test/test_lexical_analyzer_class.cpp
+++ b/test/unit_test/test_lexical_analyzer_class.cpp
@@ -398,6 +398,7 @@ TEST_CASE("LexicalAnalyzerClassTest_ScanStringTokenTest", "[LexicalAnalyzerClass
         value_pair_t(std::string(".on"), fkyaml::node::string_type(".on")),
         value_pair_t(std::string("foo]"), fkyaml::node::string_type("foo")),
         value_pair_t(std::string("foo:bar"), fkyaml::node::string_type("foo:bar")),
+        value_pair_t(std::string("foo bar"), fkyaml::node::string_type("foo bar")),
         value_pair_t(std::string("\"foo bar\""), fkyaml::node::string_type("foo bar")),
         value_pair_t(std::string("\"foo:bar\""), fkyaml::node::string_type("foo:bar")),
         value_pair_t(std::string("\"foo,bar\""), fkyaml::node::string_type("foo,bar")),


### PR DESCRIPTION
As described [here](https://yaml.org/spec/1.2.2/#plain-style) in the YAML specification, plain (unquoted) string scalars can contain a space character within the character sequence if a space character is surrounded by non-space characters, for instance:

```yaml
test: This should be allowed but fkYAML throws an exception
```

fkYAML, however, did not support the exceptional case before this PR.  
So, this PR has fixed the deserialization procedure and supported the above case when the precondition is met with the YAML specification.