### PR TITLE
#190 Support specialization of deserialization for a vector of user-defined type objects

### DIFF
--- a/docs/mkdocs/docs/tutorials/index.md
+++ b/docs/mkdocs/docs/tutorials/index.md
@@ -138,7 +138,7 @@ novels:
     year: 1678
   -
     title: Frankenstein
-    author: Jane Austen
+    author: Mary Shelly
     year: 1818
   -
     title: Moby-Dick
@@ -245,7 +245,7 @@ recommends:
     author: Daniel Defoe
   -
     title: Frankenstein
-    author: Jane Austen
+    author: Mary Shelly
   -
     title: Moby-Dick
     author: Herman Melville
@@ -259,12 +259,12 @@ recommends:
 
 ### :pill: Integrate with user-defined types
 
-As described in the API Reference pages for [`from_node()`](../api/node_value_converter/from_node.md) and [`to_node()`](../api/node_value_converter/to_node.md) functions, you can specialize deserialization for user-defined types.  
+As described in the API Reference pages for [`from_node()`](../api/node_value_converter/from_node.md) and [`to_node()`](../api/node_value_converter/to_node.md) functions, you can specialize serialization and deserialization for user-defined types.  
 Note that you don't need to implement specializations for STL types (such as std::vector or std::string) because the fkYAML library has already implemented them.  
 
 The updated code snippet down below shows how the specializations for user-defined types can reduce boilerplate code.  
 
-```cpp title="tutorial.cpp" hl_lines="6-38 55-60"
+```cpp title="tutorial.cpp" hl_lines="6-39 53-54 56-57 59-61"
 #include <fstream>
 #include <iostream>
 #include <utility>
@@ -292,6 +292,7 @@ void from_node(const fkyaml::node& node, novel& novel)
 {
     novel.title = node["title"].get_value_ref<const std::string&>();
     novel.author = node["author"].get_value_ref<const std::string&>();
+    novel.year = node["year"].get_value<int>();
 }
 
 void to_node(fkyaml::node& node, const recommend& recommend)
@@ -316,12 +317,12 @@ int main()
     fkyaml::node response = { "recommends", fkyaml::node::sequence() };
     auto& recommends = response["recommends"].get_value_ref<fkyaml::node::sequence_type&>();
 
-    // generate recommendations by extracting "title" & "author" values.
-    for (auto& novel_node : root["novels"])
-    {
-        // get novel directly from the node.
-        ns::novel novel = novel_node.get_value<ns::novel>();
+    // get novels directly from the node.
+    auto novels = root["novels"].get_value<std::vector<ns::novel>>();
 
+    // generate recommendations by extracting "title" & "author" values.
+    for (auto& novel : novels)
+    {
         // create a recommendation node directly with a recommend object.
         ns::recommend recommend = { std::move(novel.title), std::move(novel.author) };
         recommends.emplace_back(recommend);

--- a/test/unit_test/CMakeLists.txt
+++ b/test/unit_test/CMakeLists.txt
@@ -150,6 +150,7 @@ set(TEST_TARGET "fkYAMLUnitTest")
 
 add_executable(
   ${TEST_TARGET}
+  test_custom_from_node.cpp
   test_deserializer_class.cpp
   test_exception_class.cpp
   test_from_string.cpp

--- a/test/unit_test/test_custom_from_node.cpp
+++ b/test/unit_test/test_custom_from_node.cpp
@@ -1,0 +1,66 @@
+//  _______   __ __   __  _____   __  __  __
+// |   __| |_/  |  \_/  |/  _  \ /  \/  \|  |     fkYAML: A C++ header-only YAML library (supporting code)
+// |   __|  _  < \_   _/|  ___  |    _   |  |___  version 0.2.0
+// |__|  |_| \__|  |_|  |_|   |_|___||___|______| https://github.com/fktn-k/fkYAML
+//
+// SPDX-FileCopyrightText: 2023 Kensuke Fukutani <fktn.dev@gmail.com>
+// SPDX-License-Identifier: MIT
+
+#include <string>
+#include <vector>
+
+#include <catch2/catch.hpp>
+
+#include <fkYAML/node.hpp>
+
+namespace test
+{
+
+struct novel
+{
+    std::string title;
+    std::string author;
+    int year;
+};
+
+void from_node(const fkyaml::node& node, novel& novel)
+{
+    novel.title = node["title"].get_value_ref<const std::string&>();
+    novel.author = node["author"].get_value_ref<const std::string&>();
+    novel.year = node["year"].get_value<int>();
+}
+
+} // namespace test
+
+TEST_CASE("FromNodeTest_UserDefinedTypeTest", "[FromNodeTest]")
+{
+    std::string input = "title: Robinson Crusoe\n"
+                        "author: Daniel Defoe\n"
+                        "year: 1678";
+    fkyaml::node node = fkyaml::node::deserialize(input);
+
+    auto novel = node.get_value<test::novel>();
+    REQUIRE(novel.title == "Robinson Crusoe");
+    REQUIRE(novel.author == "Daniel Defoe");
+    REQUIRE(novel.year == 1678);
+}
+
+TEST_CASE("FromNodeTest_UserDefinedTypeVectorTest", "[FromNodeTest]")
+{
+    std::string input = "novels:\n"
+                        "  - title: Robinson Crusoe\n"
+                        "    author: Daniel Defoe\n"
+                        "    year: 1678\n"
+                        "  - title: Frankenstein\n"
+                        "    author: Mary Shelly\n"
+                        "    year: 1818\n";
+    fkyaml::node node = fkyaml::node::deserialize(input);
+
+    auto novels = node["novels"].get_value<std::vector<test::novel>>();
+    REQUIRE(novels[0].title == "Robinson Crusoe");
+    REQUIRE(novels[0].author == "Daniel Defoe");
+    REQUIRE(novels[0].year == 1678);
+    REQUIRE(novels[1].title == "Frankenstein");
+    REQUIRE(novels[1].author == "Mary Shelly");
+    REQUIRE(novels[1].year == 1818);
+}

--- a/test/unit_test/test_custom_from_node.cpp
+++ b/test/unit_test/test_custom_from_node.cpp
@@ -64,3 +64,16 @@ TEST_CASE("FromNodeTest_UserDefinedTypeVectorTest", "[FromNodeTest]")
     REQUIRE(novels[1].author == "Mary Shelly");
     REQUIRE(novels[1].year == 1818);
 }
+
+TEST_CASE("FromNodeTest_UserDefinedTypeVectorErrorTest", "[FromNodeTest]")
+{
+    std::string input = "novels:\n"
+                        "  - title: Robinson Crusoe\n"
+                        "    author: Daniel Defoe\n"
+                        "    year: 1678\n"
+                        "  - title: Frankenstein\n"
+                        "    author: Mary Shelly\n"
+                        "    year: 1818\n";
+    fkyaml::node node = fkyaml::node::deserialize(input);
+    REQUIRE_THROWS_AS(node.get_value<std::vector<test::novel>>(), fkyaml::exception);
+}


### PR DESCRIPTION
Currently, deserializing YAML sequence nodes only supports the `fkyaml::basic_node<...>::sequence_type` type.  
When attempting specialization for a vector of user-defined type objects, a user must call the specialization within a for-loop, which can be avoided by implementing partial specialization in fkYAML.  
So, this PR have resolved the issue described above.  