### PR TITLE
Unified doxygen comment style

### DIFF
--- a/include/fkYAML/detail/conversions/from_node.hpp
+++ b/include/fkYAML/detail/conversions/from_node.hpp
@@ -28,10 +28,7 @@
  */
 FK_YAML_NAMESPACE_BEGIN
 
-/**
- * @namespace detail
- * @brief namespace for internal implementations of fkYAML library.
- */
+/// @brief namespace for internal implementations of fkYAML library.
 namespace detail
 {
 
@@ -42,13 +39,10 @@ using fkyaml::exception;
 //   from_node   //
 ///////////////////
 
-/**
- * @brief from_node function for BasicNodeType::sequence_type objects.
- *
- * @tparam BasicNodeType A basic_node template instance type.
- * @param n A basic_node object.
- * @param s A sequence node value object.
- */
+/// @brief from_node function for BasicNodeType::sequence_type objects.
+/// @tparam BasicNodeType A basic_node template instance type.
+/// @param n A basic_node object.
+/// @param s A sequence node value object.
 template <typename BasicNodeType, enable_if_t<is_basic_node<BasicNodeType>::value, int> = 0>
 inline void from_node(const BasicNodeType& n, typename BasicNodeType::sequence_type& s)
 {
@@ -59,14 +53,11 @@ inline void from_node(const BasicNodeType& n, typename BasicNodeType::sequence_t
     s = n.template get_value_ref<const typename BasicNodeType::sequence_type&>();
 }
 
-/**
- * @brief from_node function for objects of the std::vector of compatible types.
- *
- * @tparam BasicNodeType A basic_node template instance type.
- * @tparam CompatibleValueType A compatible type for BasicNodeType.
- * @param n A basic_node object.
- * @param s A vector of compatible type objects.
- */
+/// @brief from_node function for objects of the std::vector of compatible types.
+/// @tparam BasicNodeType A basic_node template instance type.
+/// @tparam CompatibleValueType A compatible type for BasicNodeType.
+/// @param n A basic_node object.
+/// @param s A vector of compatible type objects.
 template <
     typename BasicNodeType, typename CompatibleValueType,
     enable_if_t<
@@ -90,13 +81,10 @@ inline void from_node(const BasicNodeType& n, std::vector<CompatibleValueType>& 
     }
 }
 
-/**
- * @brief from_node function for BasicNodeType::mapping_type objects.
- *
- * @tparam BasicNodeType A basic_node template instance type.
- * @param n A basic_node object.
- * @param m A mapping node value object.
- */
+/// @brief from_node function for BasicNodeType::mapping_type objects.
+/// @tparam BasicNodeType A basic_node template instance type.
+/// @param n A basic_node object.
+/// @param m A mapping node value object.
 template <typename BasicNodeType, enable_if_t<is_basic_node<BasicNodeType>::value, int> = 0>
 inline void from_node(const BasicNodeType& n, typename BasicNodeType::mapping_type& m)
 {
@@ -111,13 +99,10 @@ inline void from_node(const BasicNodeType& n, typename BasicNodeType::mapping_ty
     }
 }
 
-/**
- * @brief from_node function for null node values.
- *
- * @tparam BasicNodeType A basic_node template instance type.
- * @param n A basic_node object.
- * @param null A null node value object.
- */
+/// @brief from_node function for null node values.
+/// @tparam BasicNodeType A basic_node template instance type.
+/// @param n A basic_node object.
+/// @param null A null node value object.
 template <typename BasicNodeType, enable_if_t<is_basic_node<BasicNodeType>::value, int> = 0>
 inline void from_node(const BasicNodeType& n, std::nullptr_t& null)
 {
@@ -129,13 +114,10 @@ inline void from_node(const BasicNodeType& n, std::nullptr_t& null)
     null = nullptr;
 }
 
-/**
- * @brief from_node function for BasicNodeType::boolean_type objects.
- *
- * @tparam BasicNodeType A basic_node template instance type.
- * @param n A basic_node object.
- * @param b A boolean node value object.
- */
+/// @brief from_node function for BasicNodeType::boolean_type objects.
+/// @tparam BasicNodeType A basic_node template instance type.
+/// @param n A basic_node object.
+/// @param b A boolean node value object.
 template <typename BasicNodeType, enable_if_t<is_basic_node<BasicNodeType>::value, int> = 0>
 inline void from_node(const BasicNodeType& n, typename BasicNodeType::boolean_type& b)
 {
@@ -146,13 +128,10 @@ inline void from_node(const BasicNodeType& n, typename BasicNodeType::boolean_ty
     b = n.template get_value_ref<const typename BasicNodeType::boolean_type&>();
 }
 
-/**
- * @brief from_node function for BasicNodeType::integer_type objects.
- *
- * @tparam BasicNodeType A basic_node template instance type.
- * @param n A basic_node object.
- * @param i An integer node value object.
- */
+/// @brief from_node function for BasicNodeType::integer_type objects.
+/// @tparam BasicNodeType A basic_node template instance type.
+/// @param n A basic_node object.
+/// @param i An integer node value object.
 template <typename BasicNodeType, enable_if_t<is_basic_node<BasicNodeType>::value, int> = 0>
 inline void from_node(const BasicNodeType& n, typename BasicNodeType::integer_type& i)
 {
@@ -163,14 +142,11 @@ inline void from_node(const BasicNodeType& n, typename BasicNodeType::integer_ty
     i = n.template get_value_ref<const typename BasicNodeType::integer_type&>();
 }
 
-/**
- * @brief from_node function for other integer objects. (i.e., not BasicNodeType::integer_type)
- *
- * @tparam BasicNodeType A basic_node template instance type.
- * @tparam IntegerType An integer value type.
- * @param n A basic_node object.
- * @param i An integer node value object.
- */
+/// @brief from_node function for other integer objects. (i.e., not BasicNodeType::integer_type)
+/// @tparam BasicNodeType A basic_node template instance type.
+/// @tparam IntegerType An integer value type.
+/// @param n A basic_node object.
+/// @param i An integer node value object.
 template <
     typename BasicNodeType, typename IntegerType,
     enable_if_t<
@@ -200,13 +176,10 @@ inline void from_node(const BasicNodeType& n, IntegerType& i)
     i = static_cast<IntegerType>(tmp_int);
 }
 
-/**
- * @brief from_node function for BasicNodeType::float_number_type objects.
- *
- * @tparam BasicNodeType A basic_node template instance type.
- * @param n A basic_node object.
- * @param f A float number node value object.
- */
+/// @brief from_node function for BasicNodeType::float_number_type objects.
+/// @tparam BasicNodeType A basic_node template instance type.
+/// @param n A basic_node object.
+/// @param f A float number node value object.
 template <typename BasicNodeType, enable_if_t<is_basic_node<BasicNodeType>::value, int> = 0>
 inline void from_node(const BasicNodeType& n, typename BasicNodeType::float_number_type& f)
 {
@@ -217,14 +190,11 @@ inline void from_node(const BasicNodeType& n, typename BasicNodeType::float_numb
     f = n.template get_value_ref<const typename BasicNodeType::float_number_type&>();
 }
 
-/**
- * @brief from_node function for other float number objects. (i.e., not BasicNodeType::float_number_type)
- *
- * @tparam BasicNodeType A basic_node template instance type.
- * @tparam FloatType A float number value type.
- * @param n A basic_node object.
- * @param f A float number node value object.
- */
+/// @brief from_node function for other float number objects. (i.e., not BasicNodeType::float_number_type)
+/// @tparam BasicNodeType A basic_node template instance type.
+/// @tparam FloatType A float number value type.
+/// @param n A basic_node object.
+/// @param f A float number node value object.
 template <
     typename BasicNodeType, typename FloatType,
     enable_if_t<
@@ -252,13 +222,10 @@ inline void from_node(const BasicNodeType& n, FloatType& f)
     f = static_cast<FloatType>(tmp_float);
 }
 
-/**
- * @brief from_node function for BasicNodeType::string_type objects.
- *
- * @tparam BasicNodeType A basic_node template instance type.
- * @param n A basic_node object.
- * @param s A string node value object.
- */
+/// @brief from_node function for BasicNodeType::string_type objects.
+/// @tparam BasicNodeType A basic_node template instance type.
+/// @param n A basic_node object.
+/// @param s A string node value object.
 template <typename BasicNodeType, enable_if_t<is_basic_node<BasicNodeType>::value, int> = 0>
 inline void from_node(const BasicNodeType& n, typename BasicNodeType::string_type& s)
 {
@@ -269,21 +236,16 @@ inline void from_node(const BasicNodeType& n, typename BasicNodeType::string_typ
     s = n.template get_value_ref<const typename BasicNodeType::string_type&>();
 }
 
-/**
- * @brief A function object to call from_node functions.
- * @note User-defined specialization is available by providing implementation **OUTSIDE** fkyaml namespace.
- */
+/// @brief A function object to call from_node functions.
+/// @note User-defined specialization is available by providing implementation **OUTSIDE** fkyaml namespace.
 struct from_node_fn
 {
-    /**
-     * @brief Call from_node function suitable for the given T type.
-     *
-     * @tparam BasicNodeType A basic_node template instance type.
-     * @tparam T A target value type assigned from the basic_node object.
-     * @param n A basic_node object.
-     * @param val A target object assigned from the basic_node object.
-     * @return decltype(from_node(n, std::forward<T>(val))) void by default. User can set it to some other type.
-     */
+    /// @brief Call from_node function suitable for the given T type.
+    /// @tparam BasicNodeType A basic_node template instance type.
+    /// @tparam T A target value type assigned from the basic_node object.
+    /// @param n A basic_node object.
+    /// @param val A target object assigned from the basic_node object.
+    /// @return decltype(from_node(n, std::forward<T>(val))) void by default. User can set it to some other type.
     template <typename BasicNodeType, typename T>
     auto operator()(const BasicNodeType& n, T&& val) const noexcept(noexcept(from_node(n, std::forward<T>(val))))
         -> decltype(from_node(n, std::forward<T>(val)))
@@ -301,9 +263,7 @@ namespace // NOLINT(cert-dcl59-cpp,fuchsia-header-anon-namespaces,google-build-n
 {
 #endif
 
-/**
- * @brief A blobal object to represent ADL friendly from_node functor.
- */
+/// @brief A blobal object to represent ADL friendly from_node functor.
 // NOLINTNEXTLINE(misc-definitions-in-headers)
 FK_YAML_INLINE_VAR constexpr const auto& from_node = detail::static_const<detail::from_node_fn>::value;
 

--- a/include/fkYAML/detail/conversions/from_string.hpp
+++ b/include/fkYAML/detail/conversions/from_string.hpp
@@ -24,29 +24,20 @@
 
 FK_YAML_NAMESPACE_BEGIN
 
-/**
- * @namespace detail
- * @brief namespace for internal implementations of fkYAML library.
- */
+/// @brief namespace for internal implementations of fkYAML library.
 namespace detail
 {
 
 using fkyaml::exception;
 
-/**
- * @brief Convert a string YAML token to a ValueType object.
- *
- * @tparam ValueType A target value type.
- * @tparam CharType The type of characters in a source string.
- */
+/// @brief Convert a string YAML token to a ValueType object.
+/// @tparam ValueType A target value type.
+/// @tparam CharType The type of characters in a source string.
 template <typename ValueType, typename CharType>
 inline ValueType from_string(const std::basic_string<CharType>& s, type_tag<ValueType> /*unused*/);
 
-/**
- * @brief Specialization of from_string() for null values with std::string
- *
- * @tparam  N/A
- */
+/// @brief Specialization of from_string() for null values with std::string
+/// @tparam  N/A
 template <>
 inline std::nullptr_t from_string(const std::string& s, type_tag<std::nullptr_t> /*unused*/)
 {
@@ -58,11 +49,8 @@ inline std::nullptr_t from_string(const std::string& s, type_tag<std::nullptr_t>
     throw exception("Cannot convert a string into a null value.");
 }
 
-/**
- * @brief Specialization of from_string() for boolean values with std::string.
- *
- * @tparam  N/A
- */
+/// @brief Specialization of from_string() for boolean values with std::string.
+/// @tparam  N/A
 template <>
 inline bool from_string(const std::string& s, type_tag<bool> /*unused*/)
 {
@@ -79,11 +67,8 @@ inline bool from_string(const std::string& s, type_tag<bool> /*unused*/)
     throw exception("Cannot convert a string into a boolean value.");
 }
 
-/**
- * @brief Specialization of from_string() for int values with std::string.
- *
- * @tparam  N/A
- */
+/// @brief Specialization of from_string() for int values with std::string.
+/// @tparam  N/A
 template <>
 inline int from_string(const std::string& s, type_tag<int> /*unused*/)
 {
@@ -102,11 +87,8 @@ inline int from_string(const std::string& s, type_tag<int> /*unused*/)
     return ret;
 }
 
-/**
- * @brief Specialization of from_string() for long values with std::string.
- *
- * @tparam  N/A
- */
+/// @brief Specialization of from_string() for long values with std::string.
+/// @tparam  N/A
 template <>
 inline long from_string(const std::string& s, type_tag<long> /*unused*/)
 {
@@ -125,11 +107,8 @@ inline long from_string(const std::string& s, type_tag<long> /*unused*/)
     return ret;
 }
 
-/**
- * @brief Specialization of from_string() for long long values with std::string.
- *
- * @tparam  N/A
- */
+/// @brief Specialization of from_string() for long long values with std::string.
+/// @tparam  N/A
 template <>
 inline long long from_string(const std::string& s, type_tag<long long> /*unused*/)
 {
@@ -148,11 +127,8 @@ inline long long from_string(const std::string& s, type_tag<long long> /*unused*
     return ret;
 }
 
-/**
- * @brief Partial specialization of from_string() for other signed integer types with std::string.
- *
- * @tparam SignedIntType A signed integer type other than long long.
- */
+/// @brief Partial specialization of from_string() for other signed integer types with std::string.
+/// @tparam SignedIntType A signed integer type other than long long.
 template <typename SignedIntType>
 inline enable_if_t<
     conjunction<
@@ -170,11 +146,8 @@ from_string(const std::string& s, type_tag<SignedIntType> /*unused*/)
     return static_cast<SignedIntType>(tmp_ret);
 }
 
-/**
- * @brief Specialization of from_string() for unsigned long values with std::string.
- *
- * @tparam  N/A
- */
+/// @brief Specialization of from_string() for unsigned long values with std::string.
+/// @tparam  N/A
 template <>
 inline unsigned long from_string(const std::string& s, type_tag<unsigned long> /*unused*/)
 {
@@ -193,11 +166,8 @@ inline unsigned long from_string(const std::string& s, type_tag<unsigned long> /
     return ret;
 }
 
-/**
- * @brief Specialization of from_string() for unsigned long long values with std::string.
- *
- * @tparam  N/A
- */
+/// @brief Specialization of from_string() for unsigned long long values with std::string.
+/// @tparam  N/A
 template <>
 inline unsigned long long from_string(const std::string& s, type_tag<unsigned long long> /*unused*/)
 {
@@ -216,11 +186,8 @@ inline unsigned long long from_string(const std::string& s, type_tag<unsigned lo
     return ret;
 }
 
-/**
- * @brief Partial specialization of from_string() for other unsigned integer types with std::string.
- *
- * @tparam UnsignedIntType An unsigned integer type other than unsigned long long.
- */
+/// @brief Partial specialization of from_string() for other unsigned integer types with std::string.
+/// @tparam UnsignedIntType An unsigned integer type other than unsigned long long.
 template <typename UnsignedIntType>
 inline enable_if_t<
     conjunction<
@@ -239,11 +206,8 @@ from_string(const std::string& s, type_tag<UnsignedIntType> /*unused*/)
     return static_cast<UnsignedIntType>(tmp_ret);
 }
 
-/**
- * @brief Specialization of from_string() for float values with std::string.
- *
- * @tparam  N/A
- */
+/// @brief Specialization of from_string() for float values with std::string.
+/// @tparam  N/A
 template <>
 inline float from_string(const std::string& s, type_tag<float> /*unused*/)
 {
@@ -278,11 +242,8 @@ inline float from_string(const std::string& s, type_tag<float> /*unused*/)
     return ret;
 }
 
-/**
- * @brief Specialization of from_string() for double values with std::string.
- *
- * @tparam  N/A
- */
+/// @brief Specialization of from_string() for double values with std::string.
+/// @tparam  N/A
 template <>
 inline double from_string(const std::string& s, type_tag<double> /*unused*/)
 {

--- a/include/fkYAML/detail/conversions/to_node.hpp
+++ b/include/fkYAML/detail/conversions/to_node.hpp
@@ -19,16 +19,10 @@
 #include <fkYAML/detail/meta/type_traits.hpp>
 #include <fkYAML/detail/meta/stl_supplement.hpp>
 
-/**
- * @namespace fkyaml
- * @brief namespace for fkYAML library.
- */
+/// @brief namespace for fkYAML library.
 FK_YAML_NAMESPACE_BEGIN
 
-/**
- * @namespace detail
- * @brief namespace for internal implementations of fkYAML library.
- */
+/// @brief namespace for internal implementations of fkYAML library.
 namespace detail
 {
 
@@ -36,27 +30,23 @@ namespace detail
 //   external_node_constructor   //
 ///////////////////////////////////
 
-/**
- * @struct external_node_constructor
- * @brief The external constructor template for basic_node objects.
- * @note All the non-specialized instanciations results in compilation error since such instantiations are not
- * supported.
- * @warning All the specialization must call n.m_node_value.destroy(n.m_node_type) first in construct function to avoid
- * memory leak.
- *
- * @tparam node_t The resulting YAMK node value type.
- */
+/// @brief The external constructor template for basic_node objects.
+/// @note All the non-specialized instanciations results in compilation error since such instantiations are not
+/// supported.
+/// @warning All the specialization must call n.m_node_value.destroy(n.m_node_type) first in construct function to avoid
+/// memory leak.
+/// @tparam node_t The resulting YAMK node value type.
 template <node_t>
 struct external_node_constructor;
 
-/**
- * @brief The specialization of external_node_constructor for sequence nodes.
- *
- * @tparam N/A
- */
+/// @brief The specialization of external_node_constructor for sequence nodes.
 template <>
 struct external_node_constructor<node_t::SEQUENCE>
 {
+    /// @brief Constructs a basic_node object with const lvalue sequence.
+    /// @tparam BasicNodeType A basic_node template instance type.
+    /// @param n A basic_node object.
+    /// @param s A lvalue sequence value.
     template <typename BasicNodeType, enable_if_t<is_basic_node<BasicNodeType>::value, int> = 0>
     static void construct(BasicNodeType& n, const typename BasicNodeType::sequence_type& s) noexcept
     {
@@ -65,6 +55,10 @@ struct external_node_constructor<node_t::SEQUENCE>
         n.m_node_value.p_sequence = BasicNodeType::template create_object<typename BasicNodeType::sequence_type>(s);
     }
 
+    /// @brief Constructs a basic_node object with rvalue sequence.
+    /// @tparam BasicNodeType A basic_node template instance type.
+    /// @param n A basic_node object.
+    /// @param s A rvalue sequence value.
     template <typename BasicNodeType, enable_if_t<is_basic_node<BasicNodeType>::value, int> = 0>
     static void construct(BasicNodeType& n, typename BasicNodeType::sequence_type&& s) noexcept
     {
@@ -75,14 +69,14 @@ struct external_node_constructor<node_t::SEQUENCE>
     }
 };
 
-/**
- * @brief The specialization of external_node_constructor for mapping nodes.
- *
- * @tparam N/A
- */
+/// @brief The specialization of external_node_constructor for mapping nodes.
 template <>
 struct external_node_constructor<node_t::MAPPING>
 {
+    /// @brief Constructs a basic_node object with const lvalue mapping.
+    /// @tparam BasicNodeType A basic_node template instance type.
+    /// @param n A basic_node object.
+    /// @param m A lvalue mapping value.
     template <typename BasicNodeType, enable_if_t<is_basic_node<BasicNodeType>::value, int> = 0>
     static void construct(BasicNodeType& n, const typename BasicNodeType::mapping_type& m) noexcept
     {
@@ -91,6 +85,10 @@ struct external_node_constructor<node_t::MAPPING>
         n.m_node_value.p_mapping = BasicNodeType::template create_object<typename BasicNodeType::mapping_type>(m);
     }
 
+    /// @brief Constructs a basic_node object with rvalue mapping.
+    /// @tparam BasicNodeType A basic_node template instance type.
+    /// @param n A basic_node object.
+    /// @param m A rvalue mapping value.
     template <typename BasicNodeType, enable_if_t<is_basic_node<BasicNodeType>::value, int> = 0>
     static void construct(BasicNodeType& n, typename BasicNodeType::mapping_type&& m) noexcept
     {
@@ -101,14 +99,14 @@ struct external_node_constructor<node_t::MAPPING>
     }
 };
 
-/**
- * @brief The specialization of external_node_constructor for null nodes.
- *
- * @tparam N/A
- */
+/// @brief The specialization of external_node_constructor for null nodes.
 template <>
 struct external_node_constructor<node_t::NULL_OBJECT>
 {
+    /// @brief Constructs a basic_node object with nullptr.
+    /// @tparam BasicNodeType A basic_node template instance type.
+    /// @param n A basic_node object.
+    /// @param (unused) nullptr
     template <typename BasicNodeType, enable_if_t<is_basic_node<BasicNodeType>::value, int> = 0>
     static void construct(BasicNodeType& n, std::nullptr_t /*unused*/) noexcept
     {
@@ -118,14 +116,14 @@ struct external_node_constructor<node_t::NULL_OBJECT>
     }
 };
 
-/**
- * @brief The specialization of external_node_constructor for boolean scalar nodes.
- *
- * @tparam N/A
- */
+/// @brief The specialization of external_node_constructor for boolean scalar nodes.
 template <>
 struct external_node_constructor<node_t::BOOLEAN>
 {
+    /// @brief Constructs a basic_node object with boolean.
+    /// @tparam BasicNodeType A basic_node template instance type.
+    /// @param n A basic_node object.
+    /// @param b A boolean value.
     template <typename BasicNodeType, enable_if_t<is_basic_node<BasicNodeType>::value, int> = 0>
     static void construct(BasicNodeType& n, typename BasicNodeType::boolean_type b) noexcept
     {
@@ -135,14 +133,14 @@ struct external_node_constructor<node_t::BOOLEAN>
     }
 };
 
-/**
- * @brief The specialization of external_node_constructor for integer scalar nodes.
- *
- * @tparam N/A
- */
+/// @brief The specialization of external_node_constructor for integer scalar nodes.
 template <>
 struct external_node_constructor<node_t::INTEGER>
 {
+    /// @brief Constructs a basic_node object with integers.
+    /// @tparam BasicNodeType A basic_node template instance type.
+    /// @param n A basic_node object.
+    /// @param i An integer value.
     template <typename BasicNodeType, enable_if_t<is_basic_node<BasicNodeType>::value, int> = 0>
     static void construct(BasicNodeType& n, typename BasicNodeType::integer_type i) noexcept
     {
@@ -152,14 +150,14 @@ struct external_node_constructor<node_t::INTEGER>
     }
 };
 
-/**
- * @brief The specialization of external_node_constructor for float number scalar nodes.
- *
- * @tparam N/A
- */
+/// @brief The specialization of external_node_constructor for float number scalar nodes.
 template <>
 struct external_node_constructor<node_t::FLOAT_NUMBER>
 {
+    /// @brief Constructs a basic_node object with floating point numbers.
+    /// @tparam BasicNodeType A basic_node template instance type.
+    /// @param n A basic_node object.
+    /// @param f A floating point number.
     template <typename BasicNodeType, enable_if_t<is_basic_node<BasicNodeType>::value, int> = 0>
     static void construct(BasicNodeType& n, typename BasicNodeType::float_number_type f) noexcept
     {
@@ -169,14 +167,14 @@ struct external_node_constructor<node_t::FLOAT_NUMBER>
     }
 };
 
-/**
- * @brief The specialization of external_node_constructor for string scalar nodes.
- *
- * @tparam N/A
- */
+/// @brief The specialization of external_node_constructor for string scalar nodes.
 template <>
 struct external_node_constructor<node_t::STRING>
 {
+    /// @brief Constructs a basic_node object with const lvalue strings.
+    /// @tparam BasicNodeType A basic_node template instance type.
+    /// @param n A basic_node object.
+    /// @param s A constant lvalue string.
     template <typename BasicNodeType, enable_if_t<is_basic_node<BasicNodeType>::value, int> = 0>
     static void construct(BasicNodeType& n, const typename BasicNodeType::string_type& s) noexcept
     {
@@ -185,6 +183,10 @@ struct external_node_constructor<node_t::STRING>
         n.m_node_value.p_string = BasicNodeType::template create_object<typename BasicNodeType::string_type>(s);
     }
 
+    /// @brief Constructs a basic_node object with rvalue strings.
+    /// @tparam BasicNodeType A basic_node template instance type.
+    /// @param n A basic_node object.
+    /// @param s A rvalue string.
     template <typename BasicNodeType, enable_if_t<is_basic_node<BasicNodeType>::value, int> = 0>
     static void construct(BasicNodeType& n, typename BasicNodeType::string_type&& s) noexcept
     {
@@ -194,6 +196,11 @@ struct external_node_constructor<node_t::STRING>
             BasicNodeType::template create_object<typename BasicNodeType::string_type>(std::move(s));
     }
 
+    /// @brief Constructs a basic_node object with compatible strings.
+    /// @tparam BasicNodeType A basic_node template instance type.
+    /// @tparam CompatibleStringType A compatible string type.
+    /// @param n A basic_node object.
+    /// @param s A compatible string.
     template <
         typename BasicNodeType, typename CompatibleStringType,
         enable_if_t<
@@ -213,14 +220,11 @@ struct external_node_constructor<node_t::STRING>
 //   to_node   //
 /////////////////
 
-/**
- * @brief to_node function for BasicNodeType::sequence_type objects.
- *
- * @tparam BasicNodeType A basic_node template instance type.
- * @tparam T A sequence node value type.
- * @param n A basic_node object.
- * @param s A sequence node value object.
- */
+/// @brief to_node function for BasicNodeType::sequence_type objects.
+/// @tparam BasicNodeType A basic_node template instance type.
+/// @tparam T A sequence node value type.
+/// @param n A basic_node object.
+/// @param s A sequence node value object.
 template <
     typename BasicNodeType, typename T,
     enable_if_t<
@@ -233,14 +237,11 @@ inline void to_node(BasicNodeType& n, T&& s) noexcept
     external_node_constructor<node_t::SEQUENCE>::construct(n, std::forward<T>(s));
 }
 
-/**
- * @brief to_node function for BasicNodeType::mapping_type objects.
- *
- * @tparam BasicNodeType A basid_node template instance type.
- * @tparam T A mapping node value type.
- * @param n A basic_node object.
- * @param m A mapping node value object.
- */
+/// @brief to_node function for BasicNodeType::mapping_type objects.
+/// @tparam BasicNodeType A basid_node template instance type.
+/// @tparam T A mapping node value type.
+/// @param n A basic_node object.
+/// @param m A mapping node value object.
 template <
     typename BasicNodeType, typename T,
     enable_if_t<
@@ -252,12 +253,9 @@ inline void to_node(BasicNodeType& n, T&& m) noexcept
     external_node_constructor<node_t::MAPPING>::construct(n, std::forward<T>(m));
 }
 
-/**
- * @brief to_node function for null objects.
- *
- * @tparam BasicNodeType A mapping node value type.
- * @tparam NullType This must be std::nullptr_t type
- */
+/// @brief to_node function for null objects.
+/// @tparam BasicNodeType A mapping node value type.
+/// @tparam NullType This must be std::nullptr_t type
 template <
     typename BasicNodeType, typename NullType,
     enable_if_t<conjunction<is_basic_node<BasicNodeType>, std::is_same<NullType, std::nullptr_t>>::value, int> = 0>
@@ -266,14 +264,11 @@ inline void to_node(BasicNodeType& n, NullType /*unused*/)
     external_node_constructor<node_t::NULL_OBJECT>::construct(n, nullptr);
 }
 
-/**
- * @brief to_node function for BasicNodeType::boolean_type objects.
- *
- * @tparam BasicNodeType A basic_node template instance type.
- * @tparam T A boolean scalar node value type.
- * @param n A basic_node object.
- * @param b A boolean scalar node value object.
- */
+/// @brief to_node function for BasicNodeType::boolean_type objects.
+/// @tparam BasicNodeType A basic_node template instance type.
+/// @tparam T A boolean scalar node value type.
+/// @param n A basic_node object.
+/// @param b A boolean scalar node value object.
 template <
     typename BasicNodeType, typename T,
     enable_if_t<
@@ -284,14 +279,11 @@ inline void to_node(BasicNodeType& n, T b) noexcept
     external_node_constructor<node_t::BOOLEAN>::construct(n, b);
 }
 
-/**
- * @brief to_node function for integers.
- *
- * @tparam BasicNodeType A basic_node template instance type.
- * @tparam T An integer type.
- * @param n A basic_node object.
- * @param i An integer object.
- */
+/// @brief to_node function for integers.
+/// @tparam BasicNodeType A basic_node template instance type.
+/// @tparam T An integer type.
+/// @param n A basic_node object.
+/// @param i An integer object.
 template <
     typename BasicNodeType, typename T,
     enable_if_t<
@@ -303,14 +295,11 @@ inline void to_node(BasicNodeType& n, T i) noexcept
     external_node_constructor<node_t::INTEGER>::construct(n, i);
 }
 
-/**
- * @brief to_node function for floating point numbers.
- *
- * @tparam BasicNodeType A basic_node template instance type.
- * @tparam T A floating point number type.
- * @param n A basic_node object.
- * @param f A floating point number object.
- */
+/// @brief to_node function for floating point numbers.
+/// @tparam BasicNodeType A basic_node template instance type.
+/// @tparam T A floating point number type.
+/// @param n A basic_node object.
+/// @param f A floating point number object.
 template <
     typename BasicNodeType, typename T,
     enable_if_t<conjunction<is_basic_node<BasicNodeType>, std::is_floating_point<T>>::value, int> = 0>
@@ -319,14 +308,11 @@ inline void to_node(BasicNodeType& n, T f) noexcept
     external_node_constructor<node_t::FLOAT_NUMBER>::construct(n, f);
 }
 
-/**
- * @brief to_node function for compatible strings.
- *
- * @tparam BasicNodeType A basic_node template instance type.
- * @tparam T A compatible string type.
- * @param n A basic_node object.
- * @param s A compatible string object.
- */
+/// @brief to_node function for compatible strings.
+/// @tparam BasicNodeType A basic_node template instance type.
+/// @tparam T A compatible string type.
+/// @param n A basic_node object.
+/// @param s A compatible string object.
 template <
     typename BasicNodeType, typename T,
     enable_if_t<
@@ -339,34 +325,26 @@ inline void to_node(BasicNodeType& n, const T& s)
     external_node_constructor<node_t::STRING>::construct(n, s);
 }
 
-/**
- * @brief to_node function for rvalue string node values
- *
- * @tparam BasicNodeType A basic_node template instance type
- * @param n A basic_node object.
- * @param s An rvalue string node value.
- */
+/// @brief to_node function for rvalue string node values
+/// @tparam BasicNodeType A basic_node template instance type
+/// @param n A basic_node object.
+/// @param s An rvalue string node value.
 template <typename BasicNodeType, enable_if_t<is_basic_node<BasicNodeType>::value, int> = 0>
 inline void to_node(BasicNodeType& n, typename BasicNodeType::string_type&& s) noexcept
 {
     external_node_constructor<node_t::STRING>::construct(n, std::move(s));
 }
 
-/**
- * @brief A function object to call to_node functions.
- * @note User-defined specialization is available by providing implementation **OUTSIDE** fkyaml namespace.
- */
+/// @brief A function object to call to_node functions.
+/// @note User-defined specialization is available by providing implementation **OUTSIDE** fkyaml namespace.
 struct to_node_fn
 {
-    /**
-     * @brief Call to_node function suitable for the given T type.
-     *
-     * @tparam BasicNodeType A basic_node template instance type.
-     * @tparam T A target value type assigned to the basic_node object.
-     * @param n A basic_node object.
-     * @param val A target object assigned to the basic_node object.
-     * @return decltype(to_node(n, std::forward<T>(val))) void by default. User can set it to some other type.
-     */
+    /// @brief Call to_node function suitable for the given T type.
+    /// @tparam BasicNodeType A basic_node template instance type.
+    /// @tparam T A target value type assigned to the basic_node object.
+    /// @param n A basic_node object.
+    /// @param val A target object assigned to the basic_node object.
+    /// @return decltype(to_node(n, std::forward<T>(val))) void by default. User can set it to some other type.
     template <typename BasicNodeType, typename T>
     auto operator()(BasicNodeType& n, T&& val) const noexcept(noexcept(to_node(n, std::forward<T>(val))))
         -> decltype(to_node(n, std::forward<T>(val)))
@@ -384,9 +362,7 @@ namespace // NOLINT(cert-dcl59-cpp,fuchsia-header-anon-namespaces,google-build-n
 {
 #endif
 
-/**
- * @brief A blobal object to represent ADL friendly to_node functor.
- */
+/// @brief A blobal object to represent ADL friendly to_node functor.
 // NOLINTNEXTLINE(misc-definitions-in-headers)
 FK_YAML_INLINE_VAR constexpr const auto& to_node = detail::static_const<detail::to_node_fn>::value;
 

--- a/include/fkYAML/detail/conversions/to_string.hpp
+++ b/include/fkYAML/detail/conversions/to_string.hpp
@@ -21,40 +21,53 @@
 #include <fkYAML/detail/meta/stl_supplement.hpp>
 #include <fkYAML/detail/meta/type_traits.hpp>
 
-/**
- * @namespace fkyaml
- * @brief namespace for fkYAML library.
- */
+/// @brief namespace for fkYAML library.
 FK_YAML_NAMESPACE_BEGIN
 
-/**
- * @namespace detail
- * @brief namespace for internal implementations of fkYAML library.
- */
+/// @brief namespace for internal implementations of fkYAML library.
 namespace detail
 {
 
+/// @brief Converts a ValueType object to a string YAML token.
+/// @tparam ValueType A source value type.
+/// @tparam CharType The type of characters for the conversion result.
+/// @param s A resulting output string.
+/// @param v A source value.
 template <typename ValueType, typename CharType>
-inline void to_string(std::basic_string<CharType>& s, ValueType);
+inline void to_string(std::basic_string<CharType>& s, ValueType v);
 
+/// @brief Specialization of to_string() for null values.
+/// @param s A resulting string YAML token.
+/// @param (unused) nullptr
 template <>
 inline void to_string(std::string& s, std::nullptr_t /*unused*/)
 {
     s = "null";
 }
 
+/// @brief Specialization of to_string() for booleans.
+/// @param s A resulting string YAML token.
+/// @param b A boolean source value.
 template <>
 inline void to_string(std::string& s, bool b)
 {
     s = b ? "true" : "false";
 }
 
+/// @brief Specialization of to_string() for integers.
+/// @tparam IntegerType An integer type.
+/// @param s A resulting string YAML token.
+/// @param i An integer source value.
 template <typename IntegerType>
 inline enable_if_t<is_non_bool_integral<IntegerType>::value> to_string(std::string& s, IntegerType i)
 {
     s = std::to_string(i);
 }
 
+/// @brief Specialization of to_string() for floating point numbers.
+/// @tparam FloatType A floating point number type.
+/// @param s A resulting string YAML token.
+/// @param f A floating point number source value.
 template <typename FloatType>
 inline enable_if_t<std::is_floating_point<FloatType>::value> to_string(std::string& s, FloatType f)
 {

--- a/include/fkYAML/detail/input/deserializer.hpp
+++ b/include/fkYAML/detail/input/deserializer.hpp
@@ -24,25 +24,15 @@
 #include <fkYAML/detail/types/yaml_version_t.hpp>
 #include <fkYAML/exception.hpp>
 
-/**
- * @namespace fkyaml
- * @brief namespace for fkYAML library.
- */
+/// @brief namespace for fkYAML library.
 FK_YAML_NAMESPACE_BEGIN
 
-/**
- * @namespace detail
- * @brief namespace for internal implementations of fkYAML library.
- */
+/// @brief namespace for internal implementations of fkYAML library.
 namespace detail
 {
 
-/**
- * @class basic_deserializer
- * @brief A class which provides the feature of deserializing YAML documents.
- *
- * @tparam BasicNodeType A type of the container for deserialized YAML values.
- */
+/// @brief A class which provides the feature of deserializing YAML documents.
+/// @tparam BasicNodeType A type of the container for deserialized YAML values.
 template <typename BasicNodeType>
 class basic_deserializer
 {
@@ -62,18 +52,13 @@ class basic_deserializer
     using string_type = typename BasicNodeType::string_type;
 
 public:
-    /**
-     * @brief Construct a new basic_deserializer object.
-     */
+    /// @brief Construct a new basic_deserializer object.
     basic_deserializer() = default;
 
 public:
-    /**
-     * @brief Deserialize a YAML-formatted source string into a YAML node.
-     *
-     * @param source A YAML-formatted source string.
-     * @return BasicNodeType A root YAML node deserialized from the source string.
-     */
+    /// @brief Deserialize a YAML-formatted source string into a YAML node.
+    /// @param source A YAML-formatted source string.
+    /// @return BasicNodeType A root YAML node deserialized from the source string.
     template <typename InputAdapterType, enable_if_t<is_input_adapter<InputAdapterType>::value, int> = 0>
     BasicNodeType deserialize(InputAdapterType&& input_adapter)
     {
@@ -244,11 +229,8 @@ public:
     }
 
 private:
-    /**
-     * @brief Add new key string to the current YAML node.
-     *
-     * @param key a key string to be added to the current YAML node.
-     */
+    /// @brief Add new key string to the current YAML node.
+    /// @param key a key string to be added to the current YAML node.
     void add_new_key(const string_type& key, const std::size_t indent)
     {
         if (indent < m_indent_stack.back())
@@ -279,11 +261,8 @@ private:
         m_current_node = &(m_current_node->template get_value_ref<mapping_type&>().at(key));
     }
 
-    /**
-     * @brief Assign node value to the current node.
-     *
-     * @param node_value A rvalue BasicNodeType object to be assigned to the current node.
-     */
+    /// @brief Assign node value to the current node.
+    /// @param node_value A rvalue BasicNodeType object to be assigned to the current node.
     void assign_node_value(BasicNodeType&& node_value) noexcept
     {
         if (m_current_node->is_sequence())
@@ -314,21 +293,15 @@ private:
         m_node_stack.pop_back();
     }
 
-    /**
-     * @brief Set the yaml_version_t object to the given node.
-     *
-     * @param node A BasicNodeType object to be set the yaml_version_t object.
-     */
+    /// @brief Set the yaml_version_t object to the given node.
+    /// @param node A BasicNodeType object to be set the yaml_version_t object.
     void set_yaml_version(BasicNodeType& node) noexcept
     {
         node.set_yaml_version(m_yaml_version);
     }
 
-    /**
-     * @brief Update the target YAML version with an input string.
-     *
-     * @param version_str A YAML version string.
-     */
+    /// @brief Update the target YAML version with an input string.
+    /// @param version_str A YAML version string.
     void update_yaml_version_from(const string_type& version_str) noexcept
     {
         if (version_str == "1.1")
@@ -340,13 +313,20 @@ private:
     }
 
 private:
-    BasicNodeType* m_current_node {nullptr};     /** The currently focused YAML node. */
-    std::vector<BasicNodeType*> m_node_stack {}; /** The stack of YAML nodes. */
+    /// The currently focused YAML node.
+    BasicNodeType* m_current_node {nullptr};
+    /// The stack of YAML nodes.
+    std::vector<BasicNodeType*> m_node_stack {};
+    /// The stack of indentation widths.
     std::vector<std::size_t> m_indent_stack {};
-    yaml_version_t m_yaml_version {yaml_version_t::VER_1_2}; /** The YAML version specification type. */
-    bool m_needs_anchor_impl {false}; /** A flag to determine the need for YAML anchor node implementation */
-    string_type m_anchor_name {};     /** The last YAML anchor name. */
-    std::unordered_map<std::string, BasicNodeType> m_anchor_table {}; /** The table of YAML anchor nodes. */
+    /// The YAML version specification type.
+    yaml_version_t m_yaml_version {yaml_version_t::VER_1_2};
+    /// A flag to determine the need for YAML anchor node implementation.
+    bool m_needs_anchor_impl {false};
+    /// The last YAML anchor name.
+    string_type m_anchor_name {};
+    /// The table of YAML anchor nodes.
+    std::unordered_map<std::string, BasicNodeType> m_anchor_table {};
 };
 
 } // namespace detail

--- a/include/fkYAML/detail/input/input_adapter.hpp
+++ b/include/fkYAML/detail/input/input_adapter.hpp
@@ -21,16 +21,10 @@
 #include <fkYAML/detail/meta/stl_supplement.hpp>
 #include <fkYAML/exception.hpp>
 
-/**
- * @namespace fkyaml
- * @brief namespace for fkYAML library.
- */
+/// @brief namespace for fkYAML library.
 FK_YAML_NAMESPACE_BEGIN
 
-/**
- * @namespace detail
- * @brief namespace for internal implementations of fkYAML library.
- */
+/// @brief namespace for internal implementations of fkYAML library.
 namespace detail
 {
 
@@ -38,31 +32,22 @@ namespace detail
 //   input_adapter   //
 ///////////////////////
 
-/**
- * @class iterator_input_adapter
- * @brief An input adapter for iterators.
- * @note This adapter requires at least bidirectional iterator tag.
- *
- * @tparam IterType An iterator type.
- */
+/// @brief An input adapter for iterators.
+/// @note This adapter requires at least bidirectional iterator tag.
+/// @tparam IterType An iterator type.
 template <typename IterType>
 class iterator_input_adapter
 {
 public:
-    /** A type for characters used in this input adapter. */
+    /// A type for characters used in this input adapter.
     using char_type = typename std::iterator_traits<IterType>::value_type;
 
-    /**
-     * @brief Construct a new iterator_input_adapter object.
-     */
+    /// @brief Construct a new iterator_input_adapter object.
     iterator_input_adapter() = default;
 
-    /**
-     * @brief Construct a new iterator_input_adapter object.
-     *
-     * @param begin The beginning of iteraters.
-     * @param end The end of iterators.
-     */
+    /// @brief Construct a new iterator_input_adapter object.
+    /// @param begin The beginning of iteraters.
+    /// @param end The end of iterators.
     iterator_input_adapter(IterType begin, IterType end)
         : m_current(begin),
           m_end(end)
@@ -76,11 +61,8 @@ public:
     iterator_input_adapter& operator=(iterator_input_adapter&&) = default;
     ~iterator_input_adapter() = default;
 
-    /**
-     * @brief Get a character at the current position and move forward.
-     *
-     * @return std::char_traits<char_type>::int_type A character or EOF.
-     */
+    /// @brief Get a character at the current position and move forward.
+    /// @return std::char_traits<char_type>::int_type A character or EOF.
     typename std::char_traits<char_type>::int_type get_character()
     {
         if (m_current != m_end)
@@ -94,33 +76,27 @@ public:
     }
 
 private:
+    /// The iterator at the current position.
     IterType m_current {};
+    /// The iterator at the end of input.
     IterType m_end {};
 };
 
-/**
- * @class file_input_adapter
- * @brief An input adapter for C-style file handles.
- */
+/// @brief An input adapter for C-style file handles.
 class file_input_adapter
 {
 public:
-    /** A type for characters used in this input adapter. */
+    /// A type for characters used in this input adapter.
     using char_type = char;
 
-    /**
-     * @brief Construct a new file_input_adapter object.
-     */
+    /// @brief Construct a new file_input_adapter object.
     file_input_adapter() = default;
 
-    /**
-     * @brief Construct a new file_input_adapter object.
-     * @note
-     * This class doesn't call fopen() nor fclose().
-     * It's user's responsibility to call those functions.
-     *
-     * @param file A file handle for this adapter. (A non-null pointer is assumed.)
-     */
+    /// @brief Construct a new file_input_adapter object.
+    /// @note
+    /// This class doesn't call fopen() nor fclose().
+    /// It's user's responsibility to call those functions.
+    /// @param file A file handle for this adapter. (A non-null pointer is assumed.)
     explicit file_input_adapter(std::FILE* file)
         : m_file(file)
     {
@@ -133,11 +109,8 @@ public:
     file_input_adapter& operator=(file_input_adapter&&) = default;
     ~file_input_adapter() = default;
 
-    /**
-     * @brief Get a character at the current position and move forward.
-     *
-     * @return std::char_traits<char_type>::int_type A character or EOF.
-     */
+    /// @brief Get a character at the current position and move forward.
+    /// @return std::char_traits<char_type>::int_type A character or EOF.
     typename std::char_traits<char_type>::int_type get_character()
     {
         int ret = std::fgetc(m_file);
@@ -149,29 +122,22 @@ public:
     }
 
 private:
+    /// A pointer to the input file handle.
     std::FILE* m_file {nullptr};
 };
 
-/**
- * @class stream_input_adapter
- * @brief An input adapter for streams
- */
+/// @brief An input adapter for streams
 class stream_input_adapter
 {
 public:
-    /** A type for characters used in this input adapter. */
+    /// A type for characters used in this input adapter.
     using char_type = char;
 
-    /**
-     * @brief Construct a new stream_input_adapter object.
-     */
+    /// @brief Construct a new stream_input_adapter object.
     stream_input_adapter() = default;
 
-    /**
-     * @brief Construct a new stream_input_adapter object.
-     *
-     * @param is A reference to the target input stream.
-     */
+    /// @brief Construct a new stream_input_adapter object.
+    /// @param is A reference to the target input stream.
     explicit stream_input_adapter(std::istream& is)
         : m_istream(&is)
     {
@@ -184,17 +150,15 @@ public:
     stream_input_adapter& operator=(stream_input_adapter&&) = default;
     ~stream_input_adapter() = default;
 
-    /**
-     * @brief Get a character at the current position and move forward.
-     *
-     * @return std::char_traits<char_type>::int_type A character or EOF.
-     */
+    /// @brief Get a character at the current position and move forward.
+    /// @return std::char_traits<char_type>::int_type A character or EOF.
     std::char_traits<char_type>::int_type get_character()
     {
         return m_istream->get();
     }
 
 private:
+    /// A pointer to the input stream object.
     std::istream* m_istream {nullptr};
 };
 
@@ -202,27 +166,21 @@ private:
 //   iterator_adapter provider   //
 ///////////////////////////////////
 
-/**
- * @brief A factory method for iterator_input_adapter objects with ieterator values.
- *
- * @tparam ItrType An iterator type.
- * @param begin The beginning of iterators.
- * @param end The end of iterators.
- * @return iterator_input_adapter<ItrType> An iterator_input_adapter object for the target iterator type.
- */
+/// @brief A factory method for iterator_input_adapter objects with ieterator values.
+/// @tparam ItrType An iterator type.
+/// @param begin The beginning of iterators.
+/// @param end The end of iterators.
+/// @return iterator_input_adapter<ItrType> An iterator_input_adapter object for the target iterator type.
 template <typename ItrType>
 inline iterator_input_adapter<ItrType> input_adapter(ItrType begin, ItrType end)
 {
     return iterator_input_adapter<ItrType>(begin, end);
 }
 
-/**
- * @brief A factory method for iterator_input_adapter objects with C-style arrays.
- *
- * @tparam T A type of arrayed objects.
- * @tparam N A size of an array.
- * @return decltype(input_adapter(array, array + N)) An iterator_input_adapter object for the target array.
- */
+/// @brief A factory method for iterator_input_adapter objects with C-style arrays.
+/// @tparam T A type of arrayed objects.
+/// @tparam N A size of an array.
+/// @return decltype(input_adapter(array, array + N)) An iterator_input_adapter object for the target array.
 template <typename T, std::size_t N>
 inline auto input_adapter(T (&array)[N]) -> decltype(input_adapter(array, array + N))
 {
@@ -236,45 +194,34 @@ inline auto input_adapter(T (&array)[N]) -> decltype(input_adapter(array, array 
     return input_adapter(array, array + size);
 }
 
-/**
- * @brief A namespace to implement container_input_adapter_factory for internal use.
- */
+/// @brief A namespace to implement container_input_adapter_factory for internal use.
 namespace container_input_adapter_factory_impl
 {
 
 using std::begin;
 using std::end;
 
-/**
- * @brief A factory of input adapters for containers.
- *
- * @tparam ContainerType A container type.
- * @tparam typename N/A
- */
+/// @brief A factory of input adapters for containers.
+/// @tparam ContainerType A container type.
+/// @tparam typename N/A
 template <typename ContainerType, typename = void>
 struct container_input_adapter_factory
 {
 };
 
-/**
- * @brief A partial specialization of container_input_adapter_factory if begin()/end() are available for ContainerType.
- *
- * @tparam ContainerType A container type.
- */
+/// @brief A partial specialization of container_input_adapter_factory if begin()/end() are available for ContainerType.
+/// @tparam ContainerType A container type.
 template <typename ContainerType>
 struct container_input_adapter_factory<
     ContainerType, void_t<decltype(begin(std::declval<ContainerType>()), end(std::declval<ContainerType>()))>>
 {
-    /** A type for resulting input adapter object. */
+    /// A type for resulting input adapter object.
     using adapter_type =
         decltype(input_adapter(begin(std::declval<ContainerType>()), end(std::declval<ContainerType>())));
 
-    /**
-     * @brief A factory method of input adapter objects for the target container objects.
-     *
-     * @param container
-     * @return adapter_type
-     */
+    /// @brief A factory method of input adapter objects for the target container objects.
+    /// @param container
+    /// @return adapter_type
     static adapter_type create(const ContainerType& container)
     {
         return input_adapter(begin(container), end(container));
@@ -283,13 +230,10 @@ struct container_input_adapter_factory<
 
 } // namespace container_input_adapter_factory_impl
 
-/**
- * @brief A factory method for iterator_input_adapter objects with containers.
- *
- * @tparam ContainerType A container type.
- * @param container A container object.
- * @return container_input_adapter_factory_impl::container_input_adapter_factory<ContainerType>::adapter_type
- */
+/// @brief A factory method for iterator_input_adapter objects with containers.
+/// @tparam ContainerType A container type.
+/// @param container A container object.
+/// @return container_input_adapter_factory_impl::container_input_adapter_factory<ContainerType>::adapter_type
 template <typename ContainerType>
 inline typename container_input_adapter_factory_impl::container_input_adapter_factory<ContainerType>::adapter_type
 input_adapter(ContainerType&& container)
@@ -297,12 +241,9 @@ input_adapter(ContainerType&& container)
     return container_input_adapter_factory_impl::container_input_adapter_factory<ContainerType>::create(container);
 }
 
-/**
- * @brief A factory method for file_input_adapter objects with C-style file handles.
- *
- * @param file A file handle.
- * @return file_input_adapter A file_input_adapter object.
- */
+/// @brief A factory method for file_input_adapter objects with C-style file handles.
+/// @param file A file handle.
+/// @return file_input_adapter A file_input_adapter object.
 inline file_input_adapter input_adapter(std::FILE* file)
 {
     if (!file)
@@ -312,12 +253,9 @@ inline file_input_adapter input_adapter(std::FILE* file)
     return file_input_adapter(file);
 }
 
-/**
- * @brief
- *
- * @param stream
- * @return stream_input_adapter
- */
+/// @brief
+/// @param stream
+/// @return stream_input_adapter
 inline stream_input_adapter input_adapter(std::istream& stream) noexcept
 {
     return stream_input_adapter(stream);

--- a/include/fkYAML/detail/input/input_handler.hpp
+++ b/include/fkYAML/detail/input/input_handler.hpp
@@ -19,57 +19,43 @@
 #include <fkYAML/detail/meta/input_adapter_traits.hpp>
 #include <fkYAML/detail/meta/stl_supplement.hpp>
 
-/**
- * @namespace fkyaml
- * @brief namespace for fkYAML library.
- */
+/// @brief namespace for fkYAML library.
 FK_YAML_NAMESPACE_BEGIN
 
-/**
- * @namespace detail
- * @brief namespace for internal implementations of fkYAML library.
- */
+/// @brief namespace for internal implementations of fkYAML library.
 namespace detail
 {
 
-/**
- * @brief An input buffer handler.
- *
- * @tparam InputAdapterType The type of the input adapter.
- */
+/// @brief An input buffer handler.
+/// @tparam InputAdapterType The type of the input adapter.
 template <typename InputAdapterType, enable_if_t<is_input_adapter<InputAdapterType>::value, int> = 0>
 class input_handler
 {
 public:
-    //!< The type of character traits of the input buffer.
+    /// The type of character traits of the input buffer.
     using char_traits_type = std::char_traits<typename InputAdapterType::char_type>;
-    //!< The type of characters of the input buffer.
+    /// The type of characters of the input buffer.
     using char_type = typename char_traits_type::char_type;
-    //!< The type of integers for the input buffer.
+    /// The type of integers for the input buffer.
     using int_type = typename char_traits_type::int_type;
-    //!< The type of strings of the input buffer.
+    /// The type of strings of the input buffer.
     using string_type = std::basic_string<char_type>;
 
 private:
-    /**
-     * @brief A set of information on the current position in an input buffer.
-     */
+    /// @brief A set of information on the current position in an input buffer.
     struct position
     {
-        //!< The current position from the beginning of an input buffer.
+        /// The current position from the beginning of an input buffer.
         std::size_t cur_pos {0};
-        //!< The current position in the current line.
+        /// The current position in the current line.
         std::size_t cur_pos_in_line {0};
-        //!< The number of lines which have already been read.
+        /// The number of lines which have already been read.
         std::size_t lines_read {0};
     };
 
 public:
-    /**
-     * @brief Construct a new input_handler object.
-     *
-     * @param input_adapter An input adapter object
-     */
+    /// @brief Construct a new input_handler object.
+    /// @param input_adapter An input adapter object
     explicit input_handler(InputAdapterType&& input_adapter)
         : m_input_adapter(std::move(input_adapter))
     {
@@ -77,21 +63,15 @@ public:
         m_position.cur_pos = m_position.cur_pos_in_line = m_position.lines_read = 0;
     }
 
-    /**
-     * @brief Get the character at the current position.
-     *
-     * @return int_type A character or EOF.
-     */
+    /// @brief Get the character at the current position.
+    /// @return int_type A character or EOF.
     int_type get_current()
     {
         return m_cache[m_position.cur_pos];
     }
 
-    /**
-     * @brief Get the character at next position.
-     *
-     * @return int_type A character or EOF.
-     */
+    /// @brief Get the character at next position.
+    /// @return int_type A character or EOF.
     int_type get_next()
     {
         int_type ret = end_of_input;
@@ -123,13 +103,10 @@ public:
         return ret;
     }
 
-    /**
-     * @brief Get the characters in the given range.
-     *
-     * @param length The length of characters retrieved from the current position.
-     * @param str A string which will contain the resulting characters.
-     * @return int_type 0 (for success) or EOF (for error).
-     */
+    /// @brief Get the characters in the given range.
+    /// @param length The length of characters retrieved from the current position.
+    /// @param str A string which will contain the resulting characters.
+    /// @return int_type 0 (for success) or EOF (for error).
     int_type get_range(std::size_t length, string_type& str)
     {
         str.clear();
@@ -159,9 +136,7 @@ public:
         return 0;
     }
 
-    /**
-     * @brief Move backward the current position.
-     */
+    /// @brief Move backward the current position.
     void unget()
     {
         if (m_position.cur_pos > 0)
@@ -189,11 +164,8 @@ public:
         }
     }
 
-    /**
-     * @brief Move backward the current position to the given range.
-     *
-     * @param length The length of moving backward.
-     */
+    /// @brief Move backward the current position to the given range.
+    /// @param length The length of moving backward.
     void unget_range(std::size_t length)
     {
         for (std::size_t i = 0; i < length; i++)
@@ -202,13 +174,10 @@ public:
         }
     }
 
-    /**
-     * @brief Check if the next character is the expected one.
-     *
-     * @param expected An expected next character.
-     * @return true The next character is the expected one.
-     * @return false The next character is not the expected one.
-     */
+    /// @brief Check if the next character is the expected one.
+    /// @param expected An expected next character.
+    /// @return true The next character is the expected one.
+    /// @return false The next character is not the expected one.
     bool test_next_char(char_type expected)
     {
         if (get_current() == end_of_input)
@@ -228,35 +197,29 @@ public:
         return ret;
     }
 
-    /**
-     * @brief Get the current position in the current line.
-     *
-     * @return std::size_t The current position in the current line.
-     */
+    /// @brief Get the current position in the current line.
+    /// @return std::size_t The current position in the current line.
     std::size_t get_cur_pos_in_line() const noexcept
     {
         return m_position.cur_pos_in_line;
     }
 
-    /**
-     * @brief Get the number of lines which have already been read.
-     *
-     * @return std::size_t The number of lines which have already been read.
-     */
+    /// @brief Get the number of lines which have already been read.
+    /// @return std::size_t The number of lines which have already been read.
     std::size_t get_lines_read() const noexcept
     {
         return m_position.lines_read;
     }
 
 private:
-    //!< The value of EOF for the target character type.
+    /// The value of EOF for the target character type.
     static constexpr int_type end_of_input = char_traits_type::eof();
 
-    //!< An input adapter object.
+    /// An input adapter object.
     InputAdapterType m_input_adapter {};
-    //!< Cached characters retrieved from an input adapter object.
+    /// Cached characters retrieved from an input adapter object.
     std::vector<int_type> m_cache {};
-    //!< The current position in an input buffer.
+    /// The current position in an input buffer.
     position m_position {};
 };
 

--- a/include/fkYAML/detail/input/lexical_analyzer.hpp
+++ b/include/fkYAML/detail/input/lexical_analyzer.hpp
@@ -42,12 +42,8 @@ FK_YAML_NAMESPACE_BEGIN
 namespace detail
 {
 
-/**
- * @class lexical_analyzer
- * @brief A class which lexically analizes YAML formatted inputs.
- *
- * @tparam BasicNodeType A type of the container for YAML values.
- */
+/// @brief A class which lexically analizes YAML formatted inputs.
+/// @tparam BasicNodeType A type of the container for YAML values.
 template <
     typename BasicNodeType, typename InputAdapterType,
     enable_if_t<conjunction<is_basic_node<BasicNodeType>, is_input_adapter<InputAdapterType>>::value, int> = 0>
@@ -66,19 +62,15 @@ public:
     using float_number_type = typename BasicNodeType::float_number_type;
     using string_type = typename BasicNodeType::string_type;
 
-    /**
-     * @brief Construct a new lexical_analyzer object.
-     */
+    /// @brief Construct a new lexical_analyzer object.
+    /// @param input_adapter An input adapter object.
     explicit lexical_analyzer(InputAdapterType&& input_adapter)
         : m_input_handler(std::move(input_adapter))
     {
     }
 
-    /**
-     * @brief Get the next lexical token type by scanning the left of the input buffer.
-     *
-     * @return lexical_token_t The next lexical token type.
-     */
+    /// @brief Get the next lexical token type by scanning the left of the input buffer.
+    /// @return lexical_token_t The next lexical token type.
     lexical_token_t get_next_token()
     {
         skip_white_spaces();
@@ -297,21 +289,15 @@ public:
         }
     }
 
-    /**
-     * @brief Get the beginning position of a last token.
-     *
-     * @return std::size_t The beginning position of a last token.
-     */
+    /// @brief Get the beginning position of a last token.
+    /// @return std::size_t The beginning position of a last token.
     std::size_t get_last_token_begin_pos() const noexcept
     {
         return m_last_token_begin_pos;
     }
 
-    /**
-     * @brief Convert from string to null and get the converted value.
-     *
-     * @return std::nullptr_t A null value converted from one of the followings: "null", "Null", "NULL", "~".
-     */
+    /// @brief Convert from string to null and get the converted value.
+    /// @return std::nullptr_t A null value converted from one of the followings: "null", "Null", "NULL", "~".
     std::nullptr_t get_null() const
     {
         if (m_last_token_type == lexical_token_t::NULL_VALUE)
@@ -321,12 +307,9 @@ public:
         throw fkyaml::exception("Invalid request for a null value.");
     }
 
-    /**
-     * @brief Convert from string to boolean and get the converted value.
-     *
-     * @return true  A string token is one of the followings: "true", "True", "TRUE".
-     * @return false A string token is one of the followings: "false", "False", "FALSE".
-     */
+    /// @brief Convert from string to boolean and get the converted value.
+    /// @return true  A string token is one of the followings: "true", "True", "TRUE".
+    /// @return false A string token is one of the followings: "false", "False", "FALSE".
     boolean_type get_boolean() const
     {
         if (m_last_token_type == lexical_token_t::BOOLEAN_VALUE)
@@ -336,11 +319,8 @@ public:
         throw fkyaml::exception("Invalid request for a boolean value.");
     }
 
-    /**
-     * @brief Convert from string to integer and get the converted value.
-     *
-     * @return integer_type An integer value converted from the source string.
-     */
+    /// @brief Convert from string to integer and get the converted value.
+    /// @return integer_type An integer value converted from the source string.
     integer_type get_integer() const
     {
         if (m_last_token_type == lexical_token_t::INTEGER_VALUE)
@@ -350,11 +330,8 @@ public:
         throw fkyaml::exception("Invalid request for an integer value.");
     }
 
-    /**
-     * @brief Convert from string to float number and get the converted value.
-     *
-     * @return float_number_type A float number value converted from the source string.
-     */
+    /// @brief Convert from string to float number and get the converted value.
+    /// @return float_number_type A float number value converted from the source string.
     float_number_type get_float_number() const
     {
         if (m_last_token_type == lexical_token_t::FLOAT_NUMBER_VALUE)
@@ -364,11 +341,8 @@ public:
         throw fkyaml::exception("Invalid request for a float number value.");
     }
 
-    /**
-     * @brief Get a scanned string value.
-     *
-     * @return const string_type& Constant reference to a scanned string.
-     */
+    /// @brief Get a scanned string value.
+    /// @return const string_type& Constant reference to a scanned string.
     const string_type& get_string() const noexcept
     {
         // TODO: Provide support for different string types between nodes & inputs.
@@ -376,11 +350,8 @@ public:
         return m_value_buffer;
     }
 
-    /**
-     * @brief Get the YAML version specification.
-     *
-     * @return const string_type& A YAML version specification.
-     */
+    /// @brief Get the YAML version specification.
+    /// @return const string_type& A YAML version specification.
     const string_type& get_yaml_version() const
     {
         FK_YAML_ASSERT(!m_value_buffer.empty() && m_value_buffer.size() == 3);
@@ -390,12 +361,9 @@ public:
     }
 
 private:
-    /**
-     * @brief A utility function to convert a hexadecimal character to an integer.
-     *
-     * @param source A hexadecimal character ('0'~'9', 'A'~'F', 'a'~'f')
-     * @return char A integer converted from @a source.
-     */
+    /// @brief A utility function to convert a hexadecimal character to an integer.
+    /// @param source A hexadecimal character ('0'~'9', 'A'~'F', 'a'~'f')
+    /// @return char A integer converted from @a source.
     static char convert_hex_char_to_byte(char source)
     {
         if ('0' <= source && source <= '9')
@@ -419,11 +387,8 @@ private:
         throw fkyaml::exception("Non-hexadecimal character has been given.");
     }
 
-    /**
-     * @brief Skip until a newline code or a null character is found.
-     *
-     * @return lexical_token_t The lexical token type for comments
-     */
+    /// @brief Skip until a newline code or a null character is found.
+    /// @return lexical_token_t The lexical token type for comments
     lexical_token_t scan_comment()
     {
         FK_YAML_ASSERT(m_input_handler.get_current() == '#');
@@ -432,12 +397,9 @@ private:
         return lexical_token_t::COMMENT_PREFIX;
     }
 
-    /**
-     * @brief Scan directives starting with the prefix '%'
-     * @note Currently, only %YAML directive is supported. If not, returns invalid or throws an exception.
-     *
-     * @return lexical_token_t The lexical token type for directives.
-     */
+    /// @brief Scan directives starting with the prefix '%'
+    /// @note Currently, only %YAML directive is supported. If not, returns invalid or throws an exception.
+    /// @return lexical_token_t The lexical token type for directives.
     lexical_token_t scan_directive()
     {
         FK_YAML_ASSERT(m_input_handler.get_current() == '%');
@@ -477,12 +439,9 @@ private:
         }
     }
 
-    /**
-     * @brief Scan a YAML version directive.
-     * @note Only 1.1 and 1.2 are supported. If not, throws an exception.
-     *
-     * @return lexical_token_t The lexical token type for YAML version directives.
-     */
+    /// @brief Scan a YAML version directive.
+    /// @note Only 1.1 and 1.2 are supported. If not, throws an exception.
+    /// @return lexical_token_t The lexical token type for YAML version directives.
     lexical_token_t scan_yaml_version_directive()
     {
         m_value_buffer.clear();
@@ -527,12 +486,9 @@ private:
         return lexical_token_t::YAML_VER_DIRECTIVE;
     }
 
-    /**
-     * @brief Scan and determine a number type(integer/float). This method is the entrypoint for all number
-     * tokens.
-     *
-     * @return lexical_token_t A lexical token type for a determined number type.
-     */
+    /// @brief Scan and determine a number type(integer/float). This method is the entrypoint for all number
+    /// tokens.
+    /// @return lexical_token_t A lexical token type for a determined number type.
     lexical_token_t scan_number()
     {
         m_value_buffer.clear();
@@ -585,11 +541,8 @@ private:
         return ret;
     }
 
-    /**
-     * @brief Scan a next character after the negative sign(-).
-     *
-     * @return lexical_token_t The lexical token type for either integer or float numbers.
-     */
+    /// @brief Scan a next character after the negative sign(-).
+    /// @return lexical_token_t The lexical token type for either integer or float numbers.
     lexical_token_t scan_negative_number()
     {
         char_int_type next = m_input_handler.get_next();
@@ -620,11 +573,8 @@ private:
         throw fkyaml::exception("Invalid character found in a negative number token."); // LCOV_EXCL_LINE
     }
 
-    /**
-     * @brief Scan a next character after '0' at the beginning of a token.
-     *
-     * @return lexical_token_t The lexical token type for one of number types(integer/float).
-     */
+    /// @brief Scan a next character after '0' at the beginning of a token.
+    /// @return lexical_token_t The lexical token type for one of number types(integer/float).
     lexical_token_t scan_number_after_zero_at_first()
     {
         char_int_type next = m_input_handler.get_next();
@@ -646,11 +596,8 @@ private:
         }
     }
 
-    /**
-     * @brief Scan a next character after a decimal point.
-     *
-     * @return lexical_token_t The lexical token type for float numbers.
-     */
+    /// @brief Scan a next character after a decimal point.
+    /// @return lexical_token_t The lexical token type for float numbers.
     lexical_token_t scan_decimal_number_after_decimal_point()
     {
         char_int_type next = m_input_handler.get_next();
@@ -665,11 +612,8 @@ private:
         throw fkyaml::exception("Invalid character found after a decimal point."); // LCOV_EXCL_LINE
     }
 
-    /**
-     * @brief Scan a next character after exponent(e/E).
-     *
-     * @return lexical_token_t The lexical token type for float numbers.
-     */
+    /// @brief Scan a next character after exponent(e/E).
+    /// @return lexical_token_t The lexical token type for float numbers.
     lexical_token_t scan_decimal_number_after_exponent()
     {
         char_int_type next = m_input_handler.get_next();
@@ -690,11 +634,8 @@ private:
         return lexical_token_t::FLOAT_NUMBER_VALUE;
     }
 
-    /**
-     * @brief Scan a next character after a sign(+/-) after exponent(e/E).
-     *
-     * @return lexical_token_t The lexical token type for one of number types(integer/float)
-     */
+    /// @brief Scan a next character after a sign(+/-) after exponent(e/E).
+    /// @return lexical_token_t The lexical token type for one of number types(integer/float)
     lexical_token_t scan_decimal_number_after_sign()
     {
         char_int_type next = m_input_handler.get_next();
@@ -708,11 +649,8 @@ private:
         throw fkyaml::exception("Non-numeric character found after a sign(+/-) after exponent(e/E)."); // LCOV_EXCL_LINE
     }
 
-    /**
-     * @brief Scan a next character for decimal numbers.
-     *
-     * @return lexical_token_t The lexical token type for one of number types(integer/float)
-     */
+    /// @brief Scan a next character for decimal numbers.
+    /// @return lexical_token_t The lexical token type for one of number types(integer/float)
     lexical_token_t scan_decimal_number()
     {
         char_int_type next = m_input_handler.get_next();
@@ -744,11 +682,8 @@ private:
         return lexical_token_t::INTEGER_VALUE;
     }
 
-    /**
-     * @brief Scan a next character for octal numbers.
-     *
-     * @return lexical_token_t The lexical token type for integers.
-     */
+    /// @brief Scan a next character for octal numbers.
+    /// @return lexical_token_t The lexical token type for integers.
     lexical_token_t scan_octal_number()
     {
         char_int_type next = m_input_handler.get_next();
@@ -760,11 +695,8 @@ private:
         return lexical_token_t::INTEGER_VALUE;
     }
 
-    /**
-     * @brief Scan a next character for hexadecimal numbers.
-     *
-     * @return lexical_token_t The lexical token type for integers.
-     */
+    /// @brief Scan a next character for hexadecimal numbers.
+    /// @return lexical_token_t The lexical token type for integers.
     lexical_token_t scan_hexadecimal_number()
     {
         char_int_type next = m_input_handler.get_next();
@@ -776,12 +708,9 @@ private:
         return lexical_token_t::INTEGER_VALUE;
     }
 
-    /**
-     * @brief Scan a string token(unquoted/single-quoted/double-quoted).
-     * @note Multibyte characters(including escaped ones) are currently unsupported.
-     *
-     * @return lexical_token_t The lexical token type for strings.
-     */
+    /// @brief Scan a string token(unquoted/single-quoted/double-quoted).
+    /// @note Multibyte characters(including escaped ones) are currently unsupported.
+    /// @return lexical_token_t The lexical token type for strings.
     lexical_token_t scan_string()
     {
         m_value_buffer.clear();
@@ -1037,11 +966,8 @@ private:
         }
     }
 
-    /**
-     * @brief Handle unescaped control characters.
-     *
-     * @param c A target character.
-     */
+    /// @brief Handle unescaped control characters.
+    /// @param c A target character.
     void handle_unescaped_control_char(char_int_type c)
     {
         FK_YAML_ASSERT(0x00 <= c && c <= 0x1F);
@@ -1113,9 +1039,7 @@ private:
         }
     }
 
-    /**
-     * @brief Skip white spaces, tabs and newline codes until any other kind of character is found.
-     */
+    /// @brief Skip white spaces, tabs and newline codes until any other kind of character is found.
     void skip_white_spaces()
     {
         while (true)
@@ -1134,9 +1058,7 @@ private:
         }
     }
 
-    /**
-     * @brief Skip reading in the current line.
-     */
+    /// @brief Skip reading in the current line.
     void skip_until_line_end()
     {
         while (true)
@@ -1162,21 +1084,21 @@ private:
     }
 
 private:
-    //!< The value of EOF for the target characters.
+    /// The value of EOF for the target characters.
     static constexpr char_int_type end_of_input = char_traits_type::eof();
 
-    //!< An input buffer adapter to be analyzed.
+    /// An input buffer adapter to be analyzed.
     input_handler_type m_input_handler;
-    //!< A temporal buffer to store a string to be parsed to an actual datum.
+    /// A temporal buffer to store a string to be parsed to an actual datum.
     input_string_type m_value_buffer {};
     std::size_t m_last_token_begin_pos {0};
-    //!< The last found token type.
+    /// The last found token type.
     lexical_token_t m_last_token_type {lexical_token_t::END_OF_BUFFER};
-    //!< A temporal bool holder.
+    /// A temporal bool holder.
     boolean_type m_boolean_val {false};
-    //!< A temporal integer holder.
+    /// A temporal integer holder.
     integer_type m_integer_val {0};
-    //!< A temporal floating point number holder.
+    /// A temporal floating point number holder.
     float_number_type m_float_val {0.0};
 };
 

--- a/include/fkYAML/detail/iterator.hpp
+++ b/include/fkYAML/detail/iterator.hpp
@@ -18,158 +18,120 @@
 #include <fkYAML/detail/meta/node_traits.hpp>
 #include <fkYAML/exception.hpp>
 
-/**
- * @namespace fkyaml
- * @brief namespace for fkYAML library.
- */
+/// @brief namespace for fkYAML library.
 FK_YAML_NAMESPACE_BEGIN
 
-/**
- * @namespace detail
- * @brief namespace for internal implementations of fkYAML library.
- */
+/// @brief namespace for internal implementations of fkYAML library.
 namespace detail
 {
 
-/**
- * @struct sequence_iterator_tag
- * @brief A tag which tells Iterator will contain sequence value iterator.
- */
+/// @brief A tag which tells Iterator will contain sequence value iterator.
 struct sequence_iterator_tag
 {
 };
 
-/**
- * @struct mapping_iterator_tag
- * @brief A tag which tells Iterator will contain mapping value iterator.
- */
+/// @brief A tag which tells Iterator will contain mapping value iterator.
 struct mapping_iterator_tag
 {
 };
 
-/**
- * @struct iterator_traits
- * @brief The template definitions of type informations used in @ref Iterator class
- *
- * @tparam ValueType The type of iterated elements.
- */
+/// @brief The template definitions of type informations used in @ref Iterator class
+/// @tparam ValueType The type of iterated elements.
 template <typename ValueType>
 struct iterator_traits
 {
-    /** A type of iterated elements. */
+    /// A type of iterated elements.
     using value_type = ValueType;
-    /** A type to represent difference between iterators. */
+    /// A type to represent difference between iterators.
     using difference_type = std::ptrdiff_t;
-    /** A type to represent iterator sizes. */
+    /// A type to represent iterator sizes.
     using size_type = std::size_t;
-    /** A type of an element pointer. */
+    /// A type of an element pointer.
     using pointer = value_type*;
-    /** A type of reference to an element. */
+    /// A type of reference to an element.
     using reference = value_type&;
 };
 
-/**
- * @brief A specialization of @ref iterator_traits for constant value types.
- *
- * @tparam ValueType The type of iterated elements.
- */
+/// @brief A specialization of @ref iterator_traits for constant value types.
+/// @tparam ValueType The type of iterated elements.
 template <typename ValueType>
 struct iterator_traits<const ValueType>
 {
-    /** A type of iterated elements. */
+    /// A type of iterated elements.
     using value_type = ValueType;
-    /** A type to represent difference between iterators. */
+    /// A type to represent difference between iterators.
     using difference_type = std::ptrdiff_t;
-    /** A type to represent iterator sizes. */
+    /// A type to represent iterator sizes.
     using size_type = std::size_t;
-    /** A type of a constant element pointer. */
+    /// A type of a constant element pointer.
     using pointer = const value_type*;
-    /** A type of constant reference to an element. */
+    /// A type of constant reference to an element.
     using reference = const value_type&;
 };
 
-/**
- * @enum iterator_t
- * @brief Definitions of iterator types for iterators internally held.
- */
+/// @brief Definitions of iterator types for iterators internally held.
 enum class iterator_t
 {
     SEQUENCE, //!< sequence iterator type.
     MAPPING,  //!< mapping iterator type.
 };
 
-/**
- * @class iterator
- * @brief A class which holds iterators either of sequence or mapping type
- *
- * @tparam ValueType The type of iterated elements.
- */
+/// @brief A class which holds iterators either of sequence or mapping type
+/// @tparam ValueType The type of iterated elements.
 template <typename ValueType>
 class iterator
 {
 public:
-    /** A type for iterator traits of instantiated @Iterator template class. */
+    /// A type for iterator traits of instantiated @Iterator template class.
     using ItrTraitsType = iterator_traits<ValueType>;
 
-    /** A type for iterator category tag. */
+    /// A type for iterator category tag.
     using iterator_category = std::bidirectional_iterator_tag;
-    /** A type of iterated element. */
+    /// A type of iterated element.
     using value_type = typename ItrTraitsType::value_type;
-    /** A type to represent differences between iterators. */
+    /// A type to represent differences between iterators.
     using difference_type = typename ItrTraitsType::difference_type;
-    /** A type to represent container sizes. */
+    /// A type to represent container sizes.
     using size_type = typename ItrTraitsType::size_type;
-    /** A type of an element pointer. */
+    /// A type of an element pointer.
     using pointer = typename ItrTraitsType::pointer;
-    /** A type of reference to an element. */
+    /// A type of reference to an element.
     using reference = typename ItrTraitsType::reference;
 
 private:
-    /** A type of non-const version of iterated elements. */
+    /// A type of non-const version of iterated elements.
     using NonConstValueType = typename std::remove_const<ValueType>::type;
 
     static_assert(is_basic_node<NonConstValueType>::value, "Iterator only accepts basic_node<...>");
 
-    /**
-     * @struct iterator_holder
-     * @brief The actual storage for iterators internally held in @ref Iterator.
-     */
+    /// @brief The actual storage for iterators internally held in @ref Iterator.
     struct iterator_holder
     {
-        /** A sequence iterator object. */
+        /// A sequence iterator object.
         typename NonConstValueType::sequence_type::iterator sequence_iterator {};
-        /** A mapping iterator object. */
+        /// A mapping iterator object.
         typename NonConstValueType::mapping_type::iterator mapping_iterator {};
     };
 
 public:
-    /**
-     * @brief Construct a new iterator object with sequence iterator object.
-     *
-     * @param[in] itr An sequence iterator object.
-     */
+    /// @brief Construct a new iterator object with sequence iterator object.
+    /// @param[in] itr An sequence iterator object.
     iterator(sequence_iterator_tag /* unused */, const typename ValueType::sequence_type::iterator& itr) noexcept
         : m_inner_iterator_type(iterator_t::SEQUENCE)
     {
         m_iterator_holder.sequence_iterator = itr;
     }
 
-    /**
-     * @brief Construct a new iterator object with mapping iterator object.
-     *
-     * @param[in] itr An mapping iterator object.
-     */
+    /// @brief Construct a new iterator object with mapping iterator object.
+    /// @param[in] itr An mapping iterator object.
     iterator(mapping_iterator_tag /* unused */, const typename ValueType::mapping_type::iterator& itr) noexcept
         : m_inner_iterator_type(iterator_t::MAPPING)
     {
         m_iterator_holder.mapping_iterator = itr;
     }
 
-    /**
-     * @brief Copy constructor of the iterator class.
-     *
-     * @param other An iterator object to be copied with.
-     */
+    /// @brief Copy constructor of the iterator class.
+    /// @param other An iterator object to be copied with.
     iterator(const iterator& other)
         : m_inner_iterator_type(other.m_inner_iterator_type)
     {
@@ -186,11 +148,8 @@ public:
         }
     }
 
-    /**
-     * @brief Move constructor of the iterator class.
-     *
-     * @param other An iterator object to be moved from.
-     */
+    /// @brief Move constructor of the iterator class.
+    /// @param other An iterator object to be moved from.
     iterator(iterator&& other)
         : m_inner_iterator_type(other.m_inner_iterator_type)
     {
@@ -207,15 +166,13 @@ public:
         }
     }
 
+    /// @brief Destroys an iterator.
     ~iterator() = default;
 
 public:
-    /**
-     * @brief A copy assignment operator of the iterator class.
-     *
-     * @param rhs An iterator object to be copied with.
-     * @return iterator& Reference to this iterator object.
-     */
+    /// @brief A copy assignment operator of the iterator class.
+    /// @param rhs An iterator object to be copied with.
+    /// @return iterator& Reference to this iterator object.
     iterator& operator=(const iterator& rhs) // NOLINT(cert-oop54-cpp)
     {
         if (&rhs == this)
@@ -239,12 +196,9 @@ public:
         return *this;
     }
 
-    /**
-     * @brief A move assignment operator of the iterator class.
-     *
-     * @param rhs An iterator object to be moved from.
-     * @return iterator& Reference to this iterator object.
-     */
+    /// @brief A move assignment operator of the iterator class.
+    /// @param rhs An iterator object to be moved from.
+    /// @return iterator& Reference to this iterator object.
     iterator& operator=(iterator&& rhs)
     {
         if (&rhs == this)
@@ -268,11 +222,8 @@ public:
         return *this;
     }
 
-    /**
-     * @brief An arrow operator of the iterator class.
-     *
-     * @return pointer A pointer to the BasicNodeType object internally referenced by the actual iterator object.
-     */
+    /// @brief An arrow operator of the iterator class.
+    /// @return pointer A pointer to the BasicNodeType object internally referenced by the actual iterator object.
     pointer operator->()
     {
         switch (m_inner_iterator_type)
@@ -286,11 +237,8 @@ public:
         }
     }
 
-    /**
-     * @brief A dereference operator of the iterator class.
-     *
-     * @return reference Reference to the Node object internally referenced by the actual iterator object.
-     */
+    /// @brief A dereference operator of the iterator class.
+    /// @return reference Reference to the Node object internally referenced by the actual iterator object.
     reference operator*()
     {
         switch (m_inner_iterator_type)
@@ -304,12 +252,9 @@ public:
         }
     }
 
-    /**
-     * @brief A compound assignment operator by sum of the Iterator class.
-     *
-     * @param i The difference from this Iterator object with which it moves forward.
-     * @return Iterator& Reference to this Iterator object.
-     */
+    /// @brief A compound assignment operator by sum of the Iterator class.
+    /// @param i The difference from this Iterator object with which it moves forward.
+    /// @return Iterator& Reference to this Iterator object.
     iterator& operator+=(difference_type i)
     {
         switch (m_inner_iterator_type)
@@ -326,12 +271,9 @@ public:
         return *this;
     }
 
-    /**
-     * @brief A plus operator of the iterator class.
-     *
-     * @param i The difference from this iterator object.
-     * @return iterator An iterator object which has been added @a i.
-     */
+    /// @brief A plus operator of the iterator class.
+    /// @param i The difference from this iterator object.
+    /// @return iterator An iterator object which has been added @a i.
     iterator operator+(difference_type i) const noexcept
     {
         auto result = *this;
@@ -339,11 +281,8 @@ public:
         return result;
     }
 
-    /**
-     * @brief An pre-increment operator of the iterator class.
-     *
-     * @return iterator& Reference to this iterator object.
-     */
+    /// @brief An pre-increment operator of the iterator class.
+    /// @return iterator& Reference to this iterator object.
     iterator& operator++()
     {
         switch (m_inner_iterator_type)
@@ -360,11 +299,8 @@ public:
         return *this;
     }
 
-    /**
-     * @brief A post-increment opretor of the iterator class.
-     *
-     * @return iterator An iterator object which has been incremented.
-     */
+    /// @brief A post-increment opretor of the iterator class.
+    /// @return iterator An iterator object which has been incremented.
     iterator operator++(int) & noexcept // NOLINT(cert-dcl21-cpp)
     {
         auto result = *this;
@@ -372,23 +308,17 @@ public:
         return result;
     }
 
-    /**
-     * @brief A compound assignment operator by difference of the iterator class.
-     *
-     * @param i The difference from this iterator object with which it moves backward.
-     * @return iterator& Reference to this iterator object.
-     */
+    /// @brief A compound assignment operator by difference of the iterator class.
+    /// @param i The difference from this iterator object with which it moves backward.
+    /// @return iterator& Reference to this iterator object.
     iterator& operator-=(difference_type i)
     {
         return operator+=(-i);
     }
 
-    /**
-     * @brief A minus operator of the iterator class.
-     *
-     * @param i The difference from this iterator object.
-     * @return iterator An iterator object from which has been subtracted @ i.
-     */
+    /// @brief A minus operator of the iterator class.
+    /// @param i The difference from this iterator object.
+    /// @return iterator An iterator object from which has been subtracted @ i.
     iterator operator-(difference_type i) noexcept
     {
         auto result = *this;
@@ -396,11 +326,8 @@ public:
         return result;
     }
 
-    /**
-     * @brief A pre-decrement operator of the iterator class.
-     *
-     * @return iterator& Reference to this iterator object.
-     */
+    /// @brief A pre-decrement operator of the iterator class.
+    /// @return iterator& Reference to this iterator object.
     iterator& operator--()
     {
         switch (m_inner_iterator_type)
@@ -417,11 +344,8 @@ public:
         return *this;
     }
 
-    /**
-     * @brief A post-decrement operator of the iterator class
-     *
-     * @return iterator An iterator object which has been decremented.
-     */
+    /// @brief A post-decrement operator of the iterator class
+    /// @return iterator An iterator object which has been decremented.
     iterator operator--(int) & noexcept // NOLINT(cert-dcl21-cpp)
     {
         auto result = *this;
@@ -429,13 +353,10 @@ public:
         return result;
     }
 
-    /**
-     * @brief An equal-to operator of the iterator class.
-     *
-     * @param rhs An iterator object to be compared with this iterator object.
-     * @return true  This iterator object is equal to the other.
-     * @return false This iterator object is not equal to the other.
-     */
+    /// @brief An equal-to operator of the iterator class.
+    /// @param rhs An iterator object to be compared with this iterator object.
+    /// @return true  This iterator object is equal to the other.
+    /// @return false This iterator object is not equal to the other.
     bool operator==(const iterator& rhs) const
     {
         if (m_inner_iterator_type != rhs.m_inner_iterator_type)
@@ -454,25 +375,19 @@ public:
         }
     }
 
-    /**
-     * @brief An not-equal-to operator of the iterator class.
-     *
-     * @param rhs An iterator object to be compared with this iterator object.
-     * @return true  This iterator object is not equal to the other.
-     * @return false This iterator object is equal to the other.
-     */
+    /// @brief An not-equal-to operator of the iterator class.
+    /// @param rhs An iterator object to be compared with this iterator object.
+    /// @return true  This iterator object is not equal to the other.
+    /// @return false This iterator object is equal to the other.
     bool operator!=(const iterator& rhs) const
     {
         return !operator==(rhs);
     }
 
-    /**
-     * @brief A less-than operator of the iterator class.
-     *
-     * @param rhs An iterator object to be compared with this iterator object.
-     * @return true  This iterator object is less than the other.
-     * @return false This iterator object is not less than the other.
-     */
+    /// @brief A less-than operator of the iterator class.
+    /// @param rhs An iterator object to be compared with this iterator object.
+    /// @return true  This iterator object is less than the other.
+    /// @return false This iterator object is not less than the other.
     bool operator<(const iterator& rhs) const
     {
         if (m_inner_iterator_type != rhs.m_inner_iterator_type)
@@ -491,58 +406,43 @@ public:
         }
     }
 
-    /**
-     * @brief A less-than-or-equal-to operator of the iterator class.
-     *
-     * @param rhs An iterator object to be compared with this iterator object.
-     * @return true  This iterator object is either less than or equal to the other.
-     * @return false This iterator object is neither less than nor equal to the other.
-     */
+    ///  @brief A less-than-or-equal-to operator of the iterator class.
+    ///  @param rhs An iterator object to be compared with this iterator object.
+    ///  @return true  This iterator object is either less than or equal to the other.
+    ///  @return false This iterator object is neither less than nor equal to the other.
     bool operator<=(const iterator& rhs) const
     {
         return !rhs.operator<(*this);
     }
 
-    /**
-     * @brief A greater-than operator of the iterator class.
-     *
-     * @param rhs An iterator object to be compared with this iterator object.
-     * @return true  This iterator object is greater than the other.
-     * @return false This iterator object is not greater than the other.
-     */
+    /// @brief A greater-than operator of the iterator class.
+    /// @param rhs An iterator object to be compared with this iterator object.
+    /// @return true  This iterator object is greater than the other.
+    /// @return false This iterator object is not greater than the other.
     bool operator>(const iterator& rhs) const
     {
         return !operator<=(rhs);
     }
 
-    /**
-     * @brief A greater-than-or-equal-to operator of the iterator class.
-     *
-     * @param rhs An iterator object to be compared with this iterator object.
-     * @return true  This iterator object is either greater than or equal to the other.
-     * @return false This iterator object is neither greater than nor equal to the other.
-     */
+    /// @brief A greater-than-or-equal-to operator of the iterator class.
+    /// @param rhs An iterator object to be compared with this iterator object.
+    /// @return true  This iterator object is either greater than or equal to the other.
+    /// @return false This iterator object is neither greater than nor equal to the other.
     bool operator>=(const iterator& rhs) const
     {
         return !operator<(rhs);
     }
 
 public:
-    /**
-     * @brief Get the type of the internal iterator implementation.
-     *
-     * @return iterator_t The type of the internal iterator implementation.
-     */
+    /// @brief Get the type of the internal iterator implementation.
+    /// @return iterator_t The type of the internal iterator implementation.
     iterator_t type() const noexcept
     {
         return m_inner_iterator_type;
     }
 
-    /**
-     * @brief Get the key string of the YAML mapping node for the current iterator.
-     *
-     * @return const std::string& The key string of the YAML mapping node for the current iterator.
-     */
+    /// @brief Get the key string of the YAML mapping node for the current iterator.
+    /// @return const std::string& The key string of the YAML mapping node for the current iterator.
     const std::string& key() const
     {
         switch (m_inner_iterator_type)
@@ -556,20 +456,17 @@ public:
         }
     }
 
-    /**
-     * @brief Get the reference of the YAML node for the current iterator.
-     *
-     * @return reference A reference to the YAML node for the current iterator.
-     */
+    /// @brief Get the reference of the YAML node for the current iterator.
+    /// @return reference A reference to the YAML node for the current iterator.
     reference value()
     {
         return operator*();
     }
 
 private:
-    /** A type of the internally-held iterator. */
+    /// A type of the internally-held iterator.
     iterator_t m_inner_iterator_type {iterator_t::SEQUENCE};
-    /** A holder of actual iterators. */
+    /// A holder of actual iterators.
     mutable iterator_holder m_iterator_holder {};
 };
 

--- a/include/fkYAML/detail/meta/detect.hpp
+++ b/include/fkYAML/detail/meta/detect.hpp
@@ -16,23 +16,14 @@
 #include <fkYAML/detail/macros/version_macros.hpp>
 #include <fkYAML/detail/meta/stl_supplement.hpp>
 
-/**
- * @namespace fkyaml
- * @brief namespace for fkYAML library.
- */
+/// @brief namespace for fkYAML library.
 FK_YAML_NAMESPACE_BEGIN
 
-/**
- * @namespace detail
- * @brief namespace for internal implementations of fkYAML library.
- */
+/// @brief namespace for internal implementations of fkYAML library.
 namespace detail
 {
 
-/**
- * @struct nonesuch
- * @brief A dummy struct to represent detection failure.
- */
+/// @brief A dummy struct to represent detection failure.
 struct nonesuch
 {
     nonesuch() = delete;
@@ -43,63 +34,51 @@ struct nonesuch
     nonesuch& operator=(nonesuch&&) = delete;
 };
 
+/// @brief namespace to implement detector type traits
 namespace detector_impl
 {
 
-/**
- * @brief A helper for general type detection.
- *
- * @tparam Default A type to represent detection failure.
- * @tparam AlwaysVoid This must be void type.
- * @tparam Op A type for desired operation type.
- * @tparam Args Argument types passed to desired operation.
- */
+/// @brief A helper for general type detection.
+/// @tparam Default A type to represent detection failure.
+/// @tparam AlwaysVoid This must be void type.
+/// @tparam Op A type for desired operation type.
+/// @tparam Args Argument types passed to desired operation.
 template <typename Default, typename AlwaysVoid, template <typename...> class Op, typename... Args>
 struct detector : std::false_type
 {
+    /// @brief A type which represents detection failure.
     using type = Default;
 };
 
-/**
- * @brief A partial specialization of detector if desired operation type is found.
- *
- * @tparam Default A type to represent detection failure.
- * @tparam Op A type for desired operation type.
- * @tparam Args Argument types passed to desired operation.
- */
+/// @brief A partial specialization of detector if desired operation type is found.
+/// @tparam Default A type to represent detection failure.
+/// @tparam Op A type for desired operation type.
+/// @tparam Args Argument types passed to desired operation.
 template <typename Default, template <typename...> class Op, typename... Args>
 struct detector<Default, void_t<Op<Args...>>, Op, Args...> : std::true_type
 {
+    /// @brief A detected type.
     using type = Op<Args...>;
 };
 
 } // namespace detector_impl
 
-/**
- * @brief Type traits to detect Op operation with Args argument types
- *
- * @tparam Op A desired operation type.
- * @tparam Args Argument types passed to desired operation.
- */
+/// @brief Type traits to detect Op operation with Args argument types
+/// @tparam Op A desired operation type.
+/// @tparam Args Argument types passed to desired operation.
 template <template <typename...> class Op, typename... Args>
 using is_detected = detector_impl::detector<nonesuch, void, Op, Args...>;
 
-/**
- * @brief Type traits to represent a detected type.
- *
- * @tparam Op A type for desired operation type.
- * @tparam Args Argument types passed to desired operation.
- */
+/// @brief Type traits to represent a detected type.
+/// @tparam Op A type for desired operation type.
+/// @tparam Args Argument types passed to desired operation.
 template <template <typename...> class Op, typename... Args>
 using detected_t = typename detector_impl::detector<nonesuch, void, Op, Args...>::type;
 
-/**
- * @brief Type traits to check if Expected and a detected type are exactly the same.
- *
- * @tparam Expected An expected detection result type.
- * @tparam Op A type for desired operation.
- * @tparam Args Argument types passed to desired operation.
- */
+/// @brief Type traits to check if Expected and a detected type are exactly the same.
+/// @tparam Expected An expected detection result type.
+/// @tparam Op A type for desired operation.
+/// @tparam Args Argument types passed to desired operation.
 template <typename Expected, template <typename...> class Op, typename... Args>
 using is_detected_exact = std::is_same<Expected, detected_t<Op, Args...>>;
 

--- a/include/fkYAML/detail/meta/input_adapter_traits.hpp
+++ b/include/fkYAML/detail/meta/input_adapter_traits.hpp
@@ -17,16 +17,10 @@
 #include <fkYAML/detail/meta/detect.hpp>
 #include <fkYAML/detail/meta/stl_supplement.hpp>
 
-/**
- * @namespace fkyaml
- * @brief namespace for fkYAML library.
- */
+/// @brief namespace for fkYAML library.
 FK_YAML_NAMESPACE_BEGIN
 
-/**
- * @namespace detail
- * @brief namespace for internal implementations of fkYAML library.
- */
+/// @brief namespace for internal implementations of fkYAML library.
 namespace detail
 {
 
@@ -34,28 +28,19 @@ namespace detail
 //   API representative types
 /////////////////////////////////
 
-/**
- * @brief A type which represents T::char_type;
- *
- * @tparam T A target type to check if it has char_type;
- */
+/// @brief A type which represents T::char_type;
+/// @tparam T A target type to check if it has char_type;
 template <typename T>
 using detect_char_type_helper_t = typename T::char_type;
 
-/**
- * @brief A type which represents get_character function.
- *
- * @tparam T A target type.
- */
+/// @brief A type which represents get_character function.
+/// @tparam T A target type.
 template <typename T>
 using get_character_fn_t = decltype(std::declval<T>().get_character());
 
-/**
- * @brief Type traits to check if T has char_type as its member.
- *
- * @tparam T A target type.
- * @tparam typename N/A
- */
+/// @brief Type traits to check if T has char_type as its member.
+/// @tparam T A target type.
+/// @tparam typename N/A
 template <typename T, typename = void>
 struct has_char_type : std::false_type
 {
@@ -65,32 +50,23 @@ struct has_char_type : std::false_type
 //   Input Adapter API detection traits
 ///////////////////////////////////////////
 
-/**
- * @brief A partial specialization of has_char_type if T has char_type as its member.
- *
- * @tparam T A target type.
- */
+/// @brief A partial specialization of has_char_type if T has char_type as its member.
+/// @tparam T A target type.
 template <typename T>
 struct has_char_type<T, enable_if_t<is_detected<detect_char_type_helper_t, T>::value>> : std::true_type
 {
 };
 
-/**
- * @brief Type traits to check if InputAdapterType has get_character member function.
- *
- * @tparam InputAdapterType An input adapter type to check if it has get_character function.
- * @tparam typename N/A
- */
+/// @brief Type traits to check if InputAdapterType has get_character member function.
+/// @tparam InputAdapterType An input adapter type to check if it has get_character function.
+/// @tparam typename N/A
 template <typename InputAdapterType, typename = void>
 struct has_get_character : std::false_type
 {
 };
 
-/**
- * @brief A partial specialization of has_get_character if InputAdapterType has get_character member function.
- *
- * @tparam InputAdapterType A type of a target input adapter.
- */
+/// @brief A partial specialization of has_get_character if InputAdapterType has get_character member function.
+/// @tparam InputAdapterType A type of a target input adapter.
 template <typename InputAdapterType>
 struct has_get_character<InputAdapterType, enable_if_t<is_detected<get_character_fn_t, InputAdapterType>::value>>
     : std::true_type
@@ -101,22 +77,16 @@ struct has_get_character<InputAdapterType, enable_if_t<is_detected<get_character
 //   is_input_adapter traits
 ////////////////////////////////
 
-/**
- * @brief Type traits to check if T is an input adapter type.
- *
- * @tparam T A target type.
- * @tparam typename N/A
- */
+/// @brief Type traits to check if T is an input adapter type.
+/// @tparam T A target type.
+/// @tparam typename N/A
 template <typename T, typename = void>
 struct is_input_adapter : std::false_type
 {
 };
 
-/**
- * @brief A partial specialization of is_input_adapter if T is an input adapter type.
- *
- * @tparam InputAdapterType
- */
+/// @brief A partial specialization of is_input_adapter if T is an input adapter type.
+/// @tparam InputAdapterType
 template <typename InputAdapterType>
 struct is_input_adapter<
     InputAdapterType,

--- a/include/fkYAML/detail/meta/node_traits.hpp
+++ b/include/fkYAML/detail/meta/node_traits.hpp
@@ -16,10 +16,7 @@
 #include <fkYAML/detail/meta/stl_supplement.hpp>
 #include <fkYAML/detail/meta/type_traits.hpp>
 
-/**
- * @namespace fkyaml
- * @brief namespace for fkYAML library.
- */
+/// @brief namespace for fkYAML library.
 FK_YAML_NAMESPACE_BEGIN
 
 // forward declaration for basic_node<...>
@@ -29,10 +26,7 @@ template <
     template <typename, typename> class ConverterType>
 class basic_node;
 
-/**
- * @namespace detail
- * @brief namespace for internal implementations of fkYAML library.
- */
+/// @brief namespace for internal implementations of fkYAML library.
 namespace detail
 {
 
@@ -40,28 +34,21 @@ namespace detail
 //   is_basic_node traits
 /////////////////////////////
 
-/**
- * @struct is_basic_node
- * @brief A struct to check the template parameter class is a kind of basic_node template class.
- *
- * @tparam T A class to be checked if it's a kind of basic_node template class.
- */
+/// @brief A struct to check the template parameter class is a kind of basic_node template class.
+/// @tparam T A class to be checked if it's a kind of basic_node template class.
 template <typename T>
 struct is_basic_node : std::false_type
 {
 };
 
-/**
- * @brief A partial specialization of is_basic_node for basic_node template class.
- *
- * @tparam SequenceType A type for sequence node value containers.
- * @tparam MappingType A type for mapping node value containers.
- * @tparam BooleanType A type for boolean node values.
- * @tparam IntegerType A type for integer node values.
- * @tparam FloatNumberType A type for float number node values.
- * @tparam StringType A type for string node values.
- * @tparam Converter A type for
- */
+/// @brief A partial specialization of is_basic_node for basic_node template class.
+/// @tparam SequenceType A type for sequence node value containers.
+/// @tparam MappingType A type for mapping node value containers.
+/// @tparam BooleanType A type for boolean node values.
+/// @tparam IntegerType A type for integer node values.
+/// @tparam FloatNumberType A type for float number node values.
+/// @tparam StringType A type for string node values.
+/// @tparam Converter A type for
 template <
     template <typename, typename...> class SequenceType, template <typename, typename, typename...> class MappingType,
     typename BooleanType, typename IntegerType, typename FloatNumberType, typename StringType,
@@ -76,14 +63,19 @@ struct is_basic_node<
 //   is_node_ref_storage traits
 ///////////////////////////////////
 
+// forward declaration for node_ref_storage<...>
 template <typename>
 class node_ref_storage;
 
+/// @brief A struct to check the template parameter class is a kind of node_ref_storage_template class.
+/// @tparam T A type to be checked if it's a kind of node_ref_storage template class.
 template <typename T>
 struct is_node_ref_storage : std::false_type
 {
 };
 
+/// @brief A partial specialization for node_ref_storage template class.
+/// @tparam T A template parameter type of node_ref_storage template class.
 template <typename T>
 struct is_node_ref_storage<node_ref_storage<T>> : std::true_type
 {
@@ -93,21 +85,15 @@ struct is_node_ref_storage<node_ref_storage<T>> : std::true_type
 //   basic_node conversion API representative types
 ///////////////////////////////////////////////////////
 
-/**
- * @brief A type represent from_node function.
- *
- * @tparam T A type which provides from_node function.
- * @tparam Args Argument types passed to from_node function.
- */
+/// @brief A type represent from_node function.
+/// @tparam T A type which provides from_node function.
+/// @tparam Args Argument types passed to from_node function.
 template <typename T, typename... Args>
 using from_node_function_t = decltype(T::from_node(std::declval<Args>()...));
 
-/**
- * @brief A type which represent to_node function.
- *
- * @tparam T A type which provides to_node function.
- * @tparam Args Argument types passed to to_node function.
- */
+/// @brief A type which represent to_node function.
+/// @tparam T A type which provides to_node function.
+/// @tparam Args Argument types passed to to_node function.
 template <typename T, typename... Args>
 using to_node_funcion_t = decltype(T::to_node(std::declval<Args>()...));
 
@@ -115,24 +101,18 @@ using to_node_funcion_t = decltype(T::to_node(std::declval<Args>()...));
 //   basic_node conversion API detection traits
 ///////////////////////////////////////////////////
 
-/**
- * @brief Type traits to check if T is a compatible type for BasicNodeType in terms of from_node function.
- *
- * @tparam BasicNodeType A basic_node template instance type.
- * @tparam T A target type passed to from_node function.
- * @tparam typename N/A
- */
+/// @brief Type traits to check if T is a compatible type for BasicNodeType in terms of from_node function.
+/// @tparam BasicNodeType A basic_node template instance type.
+/// @tparam T A target type passed to from_node function.
+/// @tparam typename N/A
 template <typename BasicNodeType, typename T, typename = void>
 struct has_from_node : std::false_type
 {
 };
 
-/**
- * @brief A partial specialization of has_from_node if T is not a basic_node template instance type.
- *
- * @tparam BasicNodeType A basic_node template instance type.
- * @tparam T A target type passed to from_node function.
- */
+/// @brief A partial specialization of has_from_node if T is not a basic_node template instance type.
+/// @tparam BasicNodeType A basic_node template instance type.
+/// @tparam T A target type passed to from_node function.
 template <typename BasicNodeType, typename T>
 struct has_from_node<BasicNodeType, T, enable_if_t<!is_basic_node<T>::value>>
 {
@@ -143,25 +123,19 @@ struct has_from_node<BasicNodeType, T, enable_if_t<!is_basic_node<T>::value>>
         is_detected_exact<void, from_node_function_t, converter, const BasicNodeType&, T&>::value;
 };
 
-/**
- * @brief Type traits to check if T is a compatible type for BasicNodeType in terms of to_node function.
- * @warning Do not pass basic_node type as BasicNodeType to avoid infinite type instantiation.
- *
- * @tparam BasicNodeType A basic_node template instance type.
- * @tparam T A target type passed to to_node function.
- * @tparam typename N/A
- */
+/// @brief Type traits to check if T is a compatible type for BasicNodeType in terms of to_node function.
+/// @warning Do not pass basic_node type as BasicNodeType to avoid infinite type instantiation.
+/// @tparam BasicNodeType A basic_node template instance type.
+/// @tparam T A target type passed to to_node function.
+/// @tparam typename N/A
 template <typename BasicNodeType, typename T, typename = void>
 struct has_to_node : std::false_type
 {
 };
 
-/**
- * @brief A partial specialization of has_to_node if T is not a basic_node template instance type.
- *
- * @tparam BasicNodeType A basic_node template instance type.
- * @tparam T A target type passed to to_node function.
- */
+/// @brief A partial specialization of has_to_node if T is not a basic_node template instance type.
+/// @tparam BasicNodeType A basic_node template instance type.
+/// @tparam T A target type passed to to_node function.
 template <typename BasicNodeType, typename T>
 struct has_to_node<BasicNodeType, T, enable_if_t<!is_basic_node<T>::value>>
 {
@@ -175,26 +149,20 @@ struct has_to_node<BasicNodeType, T, enable_if_t<!is_basic_node<T>::value>>
 //   is_node_compatible_type traits
 ///////////////////////////////////////
 
-/**
- * @brief Type traits implementation of is_node_compatible_type to check if CompatibleType is a compatible type for
- * BasicNodeType.
- *
- * @tparam BasicNodeType A basic_node template instance type.
- * @tparam CompatibleType A target type for compatibility check.
- * @tparam typename N/A
- */
+/// @brief Type traits implementation of is_node_compatible_type to check if CompatibleType is a compatible type for
+/// BasicNodeType.
+/// @tparam BasicNodeType A basic_node template instance type.
+/// @tparam CompatibleType A target type for compatibility check.
+/// @tparam typename N/A
 template <typename BasicNodeType, typename CompatibleType, typename = void>
 struct is_node_compatible_type_impl : std::false_type
 {
 };
 
-/**
- * @brief A partial specialization of is_node_compatible_type_impl if CompatibleType is a complete type and is
- * compatible for BasicNodeType.
- *
- * @tparam BasicNodeType A basic_node template instance type.
- * @tparam CompatibleType A target type for compatibility check.
- */
+/// @brief A partial specialization of is_node_compatible_type_impl if CompatibleType is a complete type and is
+/// compatible for BasicNodeType.
+/// @tparam BasicNodeType A basic_node template instance type.
+/// @tparam CompatibleType A target type for compatibility check.
 template <typename BasicNodeType, typename CompatibleType>
 struct is_node_compatible_type_impl<
     BasicNodeType, CompatibleType,
@@ -203,12 +171,9 @@ struct is_node_compatible_type_impl<
 {
 };
 
-/**
- * @brief Type traits to check if CompatibleType is a compatible type for BasicNodeType.
- *
- * @tparam BasicNodeType A basic_node template instance type.
- * @tparam CompatibleType A target type for compatibility check.
- */
+/// @brief Type traits to check if CompatibleType is a compatible type for BasicNodeType.
+/// @tparam BasicNodeType A basic_node template instance type.
+/// @tparam CompatibleType A target type for compatibility check.
 template <typename BasicNodeType, typename CompatibleType>
 struct is_node_compatible_type : is_node_compatible_type_impl<BasicNodeType, CompatibleType>
 {

--- a/include/fkYAML/detail/meta/stl_supplement.hpp
+++ b/include/fkYAML/detail/meta/stl_supplement.hpp
@@ -22,10 +22,7 @@
  */
 FK_YAML_NAMESPACE_BEGIN
 
-/**
- * @namespace detail
- * @brief namespace for internal implementations of fkYAML library.
- */
+/// @brief namespace for internal implementations of fkYAML library.
 namespace detail
 {
 
@@ -40,66 +37,48 @@ namespace detail
 
 #ifndef FK_YAML_HAS_CXX_14
 
-/**
- * @brief An alias template for std::add_pointer::type with C++11.
- * @note std::add_pointer_t is available since C++14.
- * @sa https://en.cppreference.com/w/cpp/types/add_pointer
- *
- * @tparam T A type to be added a pointer.
- */
+/// @brief An alias template for std::add_pointer::type with C++11.
+/// @note std::add_pointer_t is available since C++14.
+/// @sa https://en.cppreference.com/w/cpp/types/add_pointer
+/// @tparam T A type to be added a pointer.
 template <typename T>
 using add_pointer_t = typename std::add_pointer<T>::type;
 
-/**
- * @brief An alias template for std::enable_if::type with C++11.
- * @note std::enable_if_t is available since C++14.
- * @sa https://en.cppreference.com/w/cpp/types/enable_if
- *
- * @tparam Condition A condition tested at compile time.
- * @tparam T The type defined only if Condition is true.
- */
+/// @brief An alias template for std::enable_if::type with C++11.
+/// @note std::enable_if_t is available since C++14.
+/// @sa https://en.cppreference.com/w/cpp/types/enable_if
+/// @tparam Condition A condition tested at compile time.
+/// @tparam T The type defined only if Condition is true.
 template <bool Condition, typename T = void>
 using enable_if_t = typename std::enable_if<Condition, T>::type;
 
-/**
- * @brief A simple implementation to use std::is_null_pointer with C++11.
- * @note std::is_null_pointer is available since C++14.
- * @sa https://en.cppreference.com/w/cpp/types/is_null_pointer
- *
- * @tparam T The type to be checked if it's equal to std::nullptr_t.
- */
+/// @brief A simple implementation to use std::is_null_pointer with C++11.
+/// @note std::is_null_pointer is available since C++14.
+/// @sa https://en.cppreference.com/w/cpp/types/is_null_pointer
+/// @tparam T The type to be checked if it's equal to std::nullptr_t.
 template <typename T>
 struct is_null_pointer : std::is_same<std::nullptr_t, typename std::remove_cv<T>::type>
 {
 };
 
-/**
- * @brief An alias template for std::remove_cv::type with C++11.
- * @note std::remove_cv_t is available since C++14.
- * @sa https://en.cppreference.com/w/cpp/types/remove_cv
- *
- * @tparam T A type from which const-volatile qualifiers are removed.
- */
+/// @brief An alias template for std::remove_cv::type with C++11.
+/// @note std::remove_cv_t is available since C++14.
+/// @sa https://en.cppreference.com/w/cpp/types/remove_cv
+/// @tparam T A type from which const-volatile qualifiers are removed.
 template <typename T>
 using remove_cv_t = typename std::remove_cv<T>::type;
 
-/**
- * @brief An alias template for std::remove_pointer::type with C++11.
- * @note std::remove_pointer_t is available since C++14.
- * @sa https://en.cppreference.com/w/cpp/types/remove_pointer
- *
- * @tparam T A type from which a pointer is removed.
- */
+/// @brief An alias template for std::remove_pointer::type with C++11.
+/// @note std::remove_pointer_t is available since C++14.
+/// @sa https://en.cppreference.com/w/cpp/types/remove_pointer
+/// @tparam T A type from which a pointer is removed.
 template <typename T>
 using remove_pointer_t = typename std::remove_pointer<T>::type;
 
-/**
- * @brief An alias template for std::remove_reference::type with C++11.
- * @note std::remove_reference_t is available since C++14.
- * @sa https://en.cppreference.com/w/cpp/types/remove_reference
- *
- * @tparam T A type from which a reference is removed.
- */
+/// @brief An alias template for std::remove_reference::type with C++11.
+/// @note std::remove_reference_t is available since C++14.
+/// @sa https://en.cppreference.com/w/cpp/types/remove_reference
+/// @tparam T A type from which a reference is removed.
 template <typename T>
 using remove_reference_t = typename std::remove_reference<T>::type;
 
@@ -116,114 +95,84 @@ using std::remove_reference_t;
 
 #ifndef FK_YAML_HAS_CXX_17
 
-/**
- * @brief A simple implementation to use std::bool_constant with C++11/C++14.
- *
- * @tparam Val
- */
+/// @brief A simple implementation to use std::bool_constant with C++11/C++14.
+/// @tparam Val
 template <bool Val>
 using bool_constant = std::integral_constant<bool, Val>;
 
-/**
- * @brief A simple implementation to use std::void_t with C++11/C++14.
- * @note
- * std::conjunction is available since C++17.
- * This is applied when no traits are specified as inputs.
- * @sa https://en.cppreference.com/w/cpp/types/conjunction
- *
- * @tparam Traits Type traits to be checked if their ::value are all true.
- */
+/// @brief A simple implementation to use std::void_t with C++11/C++14.
+/// @note
+/// std::conjunction is available since C++17.
+/// This is applied when no traits are specified as inputs.
+/// @sa https://en.cppreference.com/w/cpp/types/conjunction
+/// @tparam Traits Type traits to be checked if their ::value are all true.
 template <typename... Traits>
 struct conjunction : std::true_type
 {
 };
 
-/**
- * @brief A partial specialization of conjunction if only one Trait is given.
- *
- * @tparam Trait Type trait to be checked if its ::value is true.
- */
+/// @brief A partial specialization of conjunction if only one Trait is given.
+/// @tparam Trait Type trait to be checked if its ::value is true.
 template <typename Trait>
 struct conjunction<Trait> : Trait
 {
 };
 
-/**
- * @brief A partial specialization of conjunction if more than one traits are given.
- *
- * @tparam First The first type trait to be checked if its ::value is true.
- * @tparam Rest The rest of traits passed as another conjunction template arguments if First::value is true.
- */
+/// @brief A partial specialization of conjunction if more than one traits are given.
+/// @tparam First The first type trait to be checked if its ::value is true.
+/// @tparam Rest The rest of traits passed as another conjunction template arguments if First::value is true.
 template <typename First, typename... Rest>
 struct conjunction<First, Rest...> : std::conditional<First::value, conjunction<Rest...>, First>::type
 {
 };
 
-/**
- * @brief A simple implementation to use std::disjunction with C++11/C++14.
- * @note
- * std::disjunction is available since C++17.
- * This is applied when no traits are specified as inputs.
- * @sa https://en.cppreference.com/w/cpp/types/disjunction
- *
- * @tparam Traits Type traits to be checked if at least one of their ::value is true.
- */
+/// @brief A simple implementation to use std::disjunction with C++11/C++14.
+/// @note
+/// std::disjunction is available since C++17.
+/// This is applied when no traits are specified as inputs.
+/// @sa https://en.cppreference.com/w/cpp/types/disjunction
+/// @tparam Traits Type traits to be checked if at least one of their ::value is true.
 template <typename... Traits>
 struct disjunction : std::false_type
 {
 };
 
-/**
- * @brief A partial specialization of disjunction if only one Trait is given.
- *
- * @tparam Trait Type trait to be checked if its ::value is true.
- */
+/// @brief A partial specialization of disjunction if only one Trait is given.
+/// @tparam Trait Type trait to be checked if its ::value is true.
 template <typename Trait>
 struct disjunction<Trait> : Trait
 {
 };
 
-/**
- * @brief A partial specialization of disjunction if more than one traits are given.
- *
- * @tparam First The first type trait to be checked if its ::value is true.
- * @tparam Rest The rest of traits passed as another conjunction template arguments if First::value is false.
- */
+/// @brief A partial specialization of disjunction if more than one traits are given.
+/// @tparam First The first type trait to be checked if its ::value is true.
+/// @tparam Rest The rest of traits passed as another conjunction template arguments if First::value is false.
 template <typename First, typename... Rest>
 struct disjunction<First, Rest...> : std::conditional<First::value, First, disjunction<Rest...>>::type
 {
 };
 
-/**
- * @brief A simple implementation to use std::negation with C++11/C++14.
- * @note std::negation is available since C++17.
- * @sa https://en.cppreference.com/w/cpp/types/negation
- *
- * @tparam Trait Type trait whose ::value is negated.
- */
+/// @brief A simple implementation to use std::negation with C++11/C++14.
+/// @note std::negation is available since C++17.
+/// @sa https://en.cppreference.com/w/cpp/types/negation
+/// @tparam Trait Type trait whose ::value is negated.
 template <typename Trait>
 struct negation : std::integral_constant<bool, !Trait::value>
 {
 };
 
-/**
- * @brief A helper for void_t.
- *
- * @tparam Types Any types to be transformed to void type.
- */
+/// @brief A helper for void_t.
+/// @tparam Types Any types to be transformed to void type.
 template <typename... Types>
 struct make_void
 {
     using type = void;
 };
 
-/**
- * @brief A simple implementation to use std::void_t with C++11/C++14.
- * @note std::void_t is available since C++17.
- * @sa https://en.cppreference.com/w/cpp/types/void_t
- *
- * @tparam Types Any types to be transformed to void type.
- */
+/// @brief A simple implementation to use std::void_t with C++11/C++14.
+/// @note std::void_t is available since C++17.
+/// @sa https://en.cppreference.com/w/cpp/types/void_t
+/// @tparam Types Any types to be transformed to void type.
 template <typename... Types>
 using void_t = typename make_void<Types...>::type;
 
@@ -239,13 +188,10 @@ using std::void_t;
 
 #ifndef FK_YAML_HAS_CXX_20
 
-/**
- * @brief A simple implementation to use std::remove_cvref_t with C++11/C++14/C++17.
- * @note std::remove_cvref & std::remove_cvref_t are available since C++20.
- * @sa https://en.cppreference.com/w/cpp/types/remove_cvref
- *
- * @tparam T A type from which cv-qualifiers and reference are removed.
- */
+/// @brief A simple implementation to use std::remove_cvref_t with C++11/C++14/C++17.
+/// @note std::remove_cvref & std::remove_cvref_t are available since C++20.
+/// @sa https://en.cppreference.com/w/cpp/types/remove_cvref
+/// @tparam T A type from which cv-qualifiers and reference are removed.
 template <typename T>
 using remove_cvref_t = typename std::remove_cv<typename std::remove_reference<T>::type>::type;
 

--- a/include/fkYAML/detail/meta/type_traits.hpp
+++ b/include/fkYAML/detail/meta/type_traits.hpp
@@ -18,39 +18,27 @@
 #include <fkYAML/detail/meta/detect.hpp>
 #include <fkYAML/detail/meta/stl_supplement.hpp>
 
-/**
- * @namespace fkyaml
- * @brief namespace for fkYAML library.
- */
+/// @brief namespace for fkYAML library.
 FK_YAML_NAMESPACE_BEGIN
 
-/**
- * @namespace detail
- * @brief namespace for internal implementations of fkYAML library.
- */
+/// @brief namespace for internal implementations of fkYAML library.
 namespace detail
 {
 
-/**
- * @brief Type trait to check if T and U are comparable types.
- *
- * @tparam Comparator An object type to compare T and U objects.
- * @tparam T A type for comparison.
- * @tparam U The other type for comparison.
- * @tparam typename Placeholder for determining T and U are comparable types.
- */
+/// @brief Type trait to check if T and U are comparable types.
+/// @tparam Comparator An object type to compare T and U objects.
+/// @tparam T A type for comparison.
+/// @tparam U The other type for comparison.
+/// @tparam typename Placeholder for determining T and U are comparable types.
 template <typename Comparator, typename T, typename U, typename = void>
 struct is_comparable : std::false_type
 {
 };
 
-/**
- * @brief A partial specialization of is_comparable if T and U are comparable types.
- *
- * @tparam Comparator An object type to compare T and U objects.
- * @tparam T A type for comparison.
- * @tparam U Ther other type for comparison.
- */
+/// @brief A partial specialization of is_comparable if T and U are comparable types.
+/// @tparam Comparator An object type to compare T and U objects.
+/// @tparam T A type for comparison.
+/// @tparam U Ther other type for comparison.
 template <typename Comparator, typename T, typename U>
 struct is_comparable<
     Comparator, T, U,
@@ -60,33 +48,24 @@ struct is_comparable<
 {
 };
 
-/**
- * @brief Type trait to check if KeyType can be used as key type.
- *
- * @tparam Comparator An object type to compare T and U objects.
- * @tparam ObjectKeyType The original key type.
- * @tparam KeyType A type to be used as key type.
- */
+/// @brief Type trait to check if KeyType can be used as key type.
+/// @tparam Comparator An object type to compare T and U objects.
+/// @tparam ObjectKeyType The original key type.
+/// @tparam KeyType A type to be used as key type.
 template <typename Comparator, typename ObjectKeyType, typename KeyType>
 using is_usable_as_key_type = typename std::conditional<
     is_comparable<Comparator, ObjectKeyType, KeyType>::value, std::true_type, std::false_type>::type;
 
-/**
- * @brief Type trait to check if IntegralType is of non-boolean integral types.
- *
- * @tparam IntegralType A type to be checked.
- * @tparam typename N/A
- */
+/// @brief Type trait to check if IntegralType is of non-boolean integral types.
+/// @tparam IntegralType A type to be checked.
+/// @tparam typename N/A
 template <typename IntegralType, typename = void>
 struct is_non_bool_integral : std::false_type
 {
 };
 
-/**
- * @brief A partial specialization of is_non_bool_integral if IntegralType is of non-boolean integral types.
- *
- * @tparam IntegralType A type to be checked.
- */
+/// @brief A partial specialization of is_non_bool_integral if IntegralType is of non-boolean integral types.
+/// @tparam IntegralType A type to be checked.
 template <typename IntegralType>
 struct is_non_bool_integral<
     IntegralType,
@@ -95,42 +74,30 @@ struct is_non_bool_integral<
 {
 };
 
-/**
- * @brief Type traits to check if Types are all signed arithmetic types.
- *
- * @tparam Types Types to check if they are all signed arithmetic types.
- */
+/// @brief Type traits to check if Types are all signed arithmetic types.
+/// @tparam Types Types to check if they are all signed arithmetic types.
 template <typename... Types>
 using is_all_signed = conjunction<std::is_signed<Types>...>;
 
-/**
- * @brief Type traits to check if Types are all unsigned arithmetic types.
- *
- * @tparam Types Types to check if they are all unsigned arithmetic types.
- */
+/// @brief Type traits to check if Types are all unsigned arithmetic types.
+/// @tparam Types Types to check if they are all unsigned arithmetic types.
 template <typename... Types>
 using is_all_unsigned = conjunction<std::is_unsigned<Types>...>;
 
-/**
- * @brief Type trait implementation to check if TargetIntegerType and CompatibleIntegerType are compatible integer
- * types.
- *
- * @tparam TargetIntegerType A target integer type.
- * @tparam CompatibleIntegerType A compatible integer type.
- * @tparam typename N/A
- */
+/// @brief Type trait implementation to check if TargetIntegerType and CompatibleIntegerType are compatible integer
+/// types.
+/// @tparam TargetIntegerType A target integer type.
+/// @tparam CompatibleIntegerType A compatible integer type.
+/// @tparam typename N/A
 template <typename TargetIntegerType, typename CompatibleIntegerType, typename = void>
 struct is_compatible_integer_type_impl : std::false_type
 {
 };
 
-/**
- * @brief A partial specialization of is_compatible_integer_type_impl if TargetIntegerType and CompatibleIntegerType are
- * compatible integer types.
- *
- * @tparam TargetIntegerType A target integer type.
- * @tparam CompatibleIntegerType A compatible integer type.
- */
+/// @brief A partial specialization of is_compatible_integer_type_impl if TargetIntegerType and CompatibleIntegerType
+/// are compatible integer types.
+/// @tparam TargetIntegerType A target integer type.
+/// @tparam CompatibleIntegerType A compatible integer type.
 template <typename TargetIntegerType, typename CompatibleIntegerType>
 struct is_compatible_integer_type_impl<
     TargetIntegerType, CompatibleIntegerType,
@@ -143,43 +110,31 @@ struct is_compatible_integer_type_impl<
 {
 };
 
-/**
- * @brief Type traits to check if TargetIntegerType and CompatibleIntegerType are compatible integer types.
- *
- * @tparam TargetIntegerType A target integer type.
- * @tparam CompatibleIntegerType A compatible integer type.
- */
+/// @brief Type traits to check if TargetIntegerType and CompatibleIntegerType are compatible integer types.
+/// @tparam TargetIntegerType A target integer type.
+/// @tparam CompatibleIntegerType A compatible integer type.
 template <typename TargetIntegerType, typename CompatibleIntegerType>
 struct is_compatible_integer_type : is_compatible_integer_type_impl<TargetIntegerType, CompatibleIntegerType>
 {
 };
 
-/**
- * @brief Type traits to check if T is a complete type.
- *
- * @tparam T A type to be checked if a complete type.
- * @tparam typename N/A
- */
+/// @brief Type traits to check if T is a complete type.
+/// @tparam T A type to be checked if a complete type.
+/// @tparam typename N/A
 template <typename T, typename = void>
 struct is_complete_type : std::false_type
 {
 };
 
-/**
- * @brief A partial specialization of is_complete_type if T is a complete type.
- *
- * @tparam T
- */
+/// @brief A partial specialization of is_complete_type if T is a complete type.
+/// @tparam T
 template <typename T>
 struct is_complete_type<T, decltype(void(sizeof(T)))> : std::true_type
 {
 };
 
-/**
- * @brief A utility struct to generate static constant instance.
- *
- * @tparam T A target type for the resulting static constant instance.
- */
+/// @brief A utility struct to generate static constant instance.
+/// @tparam T A target type for the resulting static constant instance.
 template <typename T>
 struct static_const
 {
@@ -187,63 +142,48 @@ struct static_const
 };
 
 #ifndef FK_YAML_HAS_CXX_17
-/**
- * @brief A instantiation of static_const::value instance.
- * @note This is required if inline variables are not available. C++11-14 do not provide such a feature yet.
- *
- * @tparam T A target type for the resulting static constant instance.
- */
+/// @brief A instantiation of static_const::value instance.
+/// @note This is required if inline variables are not available. C++11-14 do not provide such a feature yet.
+/// @tparam T A target type for the resulting static constant instance.
 template <typename T>
 constexpr T static_const<T>::value;
 #endif
 
-/**
- * @brief A helper structure for tag dispatch.
- *
- * @tparam T A tag type.
- */
+/// @brief A helper structure for tag dispatch.
+/// @tparam T A tag type.
 template <typename T>
 struct type_tag
 {
+    /// @brief A tagged type.
     using type = T;
 };
 
-/**
- * @brief A utility struct to retrieve the first type in variadic template arguments.
- *
- * @tparam Types Types of variadic template arguments.
- */
+/// @brief A utility struct to retrieve the first type in variadic template arguments.
+/// @tparam Types Types of variadic template arguments.
 template <typename... Types>
 struct get_head_type;
 
-/**
- * @brief A specialization of get_head_type if variadic template has no arguments.
- *
- * @tparam  N/A
- */
+/// @brief A specialization of get_head_type if variadic template has no arguments.
+/// @tparam  N/A
 template <>
 struct get_head_type<>
 {
+    /// @brief A head type
     using type = void;
 };
 
-/**
- * @brief A partial specialization of get_head_type if variadic template has one or more argument(s).
- *
- * @tparam First The first type in the arguments
- * @tparam Rest The rest of the types in the arguments.
- */
+/// @brief A partial specialization of get_head_type if variadic template has one or more argument(s).
+/// @tparam First The first type in the arguments
+/// @tparam Rest The rest of the types in the arguments.
 template <typename First, typename... Rest>
 struct get_head_type<First, Rest...>
 {
+    /// @brief A head type.
     using type = First;
 };
 
-/**
- * @brief An alias template to retrieve the first type in variadic template arguments.
- *
- * @tparam Types Types of variadic template arguments.
- */
+/// @brief An alias template to retrieve the first type in variadic template arguments.
+/// @tparam Types Types of variadic template arguments.
 template <typename... Types>
 using head_type = typename get_head_type<Types...>::type;
 

--- a/include/fkYAML/detail/node_ref_storage.hpp
+++ b/include/fkYAML/detail/node_ref_storage.hpp
@@ -19,25 +19,16 @@
 #include <fkYAML/detail/meta/node_traits.hpp>
 #include <fkYAML/detail/meta/stl_supplement.hpp>
 
-/**
- * @namespace fkyaml
- * @brief namespace for fkYAML library.
- */
+/// @brief namespace for fkYAML library.
 FK_YAML_NAMESPACE_BEGIN
 
-/**
- * @namespace detail
- * @brief namespace for internal implementations of fkYAML library.
- */
+/// @brief namespace for internal implementations of fkYAML library.
 namespace detail
 {
 
-/**
- * @brief A temporal storage for basic_node class objects.
- * @note This class makes it easier to handle lvalue basic_node objects in basic_node ctor with std::initializer_list.
- *
- * @tparam BasicNodeType A basic_node template instance type.
- */
+/// @brief A temporal storage for basic_node class objects.
+/// @note This class makes it easier to handle lvalue basic_node objects in basic_node ctor with std::initializer_list.
+/// @tparam BasicNodeType A basic_node template instance type.
 template <typename BasicNodeType>
 class node_ref_storage
 {
@@ -46,42 +37,30 @@ class node_ref_storage
     using node_type = BasicNodeType;
 
 public:
-    /**
-     * @brief Construct a new node ref storage object with an rvalue basic_node object.
-     *
-     * @param n An rvalue basic_node object.
-     */
+    /// @brief Construct a new node ref storage object with an rvalue basic_node object.
+    /// @param n An rvalue basic_node object.
     node_ref_storage(node_type&& n)
         : owned_value(std::move(n))
     {
     }
 
-    /**
-     * @brief Construct a new node ref storage object with an lvalue basic_node object.
-     *
-     * @param n An lvalue basic_node object.
-     */
+    /// @brief Construct a new node ref storage object with an lvalue basic_node object.
+    /// @param n An lvalue basic_node object.
     node_ref_storage(const node_type& n)
         : value_ref(&n)
     {
     }
 
-    /**
-     * @brief Construct a new node ref storage object with a std::initializer_list object.
-     *
-     * @param init A std::initializer_list object.
-     */
+    /// @brief Construct a new node ref storage object with a std::initializer_list object.
+    /// @param init A std::initializer_list object.
     node_ref_storage(std::initializer_list<node_ref_storage> init)
         : owned_value(init)
     {
     }
 
-    /**
-     * @brief Construct a new node ref storage object with variadic template arguments
-     *
-     * @tparam Args Types of arguments to construct a basic_node object.
-     * @param args Arguments to construct a basic_node object.
-     */
+    /// @brief Construct a new node ref storage object with variadic template arguments
+    /// @tparam Args Types of arguments to construct a basic_node object.
+    /// @param args Arguments to construct a basic_node object.
     template <typename... Args, enable_if_t<std::is_constructible<node_type, Args...>::value, int> = 0>
     node_ref_storage(Args&&... args)
         : owned_value(std::forward<Args>(args)...)
@@ -95,30 +74,24 @@ public:
     node_ref_storage& operator=(node_ref_storage&&) = default;
 
 public:
-    /**
-     * @brief An arrow operator for node_ref_storage objects.
-     *
-     * @return const node_type* A constant pointer to a basic_node object.
-     */
+    /// @brief An arrow operator for node_ref_storage objects.
+    /// @return const node_type* A constant pointer to a basic_node object.
     const node_type* operator->() const
     {
         return value_ref ? value_ref : &owned_value;
     }
 
-    /**
-     * @brief Releases a basic_node object internally held.
-     *
-     * @return node_type A basic_node object internally held.
-     */
+    /// @brief Releases a basic_node object internally held.
+    /// @return node_type A basic_node object internally held.
     node_type release() const
     {
         return value_ref ? *value_ref : std::move(owned_value);
     }
 
 private:
-    /** A storage for a basic_node object given with rvalue reference. */
+    /// A storage for a basic_node object given with rvalue reference.
     mutable node_type owned_value = nullptr;
-    /** A pointer to a basic_node object given with lvalue reference. */
+    /// A pointer to a basic_node object given with lvalue reference.
     const node_type* value_ref = nullptr;
 };
 

--- a/include/fkYAML/detail/output/serializer.hpp
+++ b/include/fkYAML/detail/output/serializer.hpp
@@ -23,35 +23,24 @@
 
 FK_YAML_NAMESPACE_BEGIN
 
-/**
- * @namespace detail
- * @brief namespace for internal implementations of fkYAML library.
- */
+/// @brief namespace for internal implementations of fkYAML library.
 namespace detail
 {
 
-/**
- * @brief A basic implementation of serialization feature for YAML nodes.
- *
- * @tparam BasicNodeType A BasicNode template class instantiation.
- */
+/// @brief A basic implementation of serialization feature for YAML nodes.
+/// @tparam BasicNodeType A BasicNode template class instantiation.
 template <typename BasicNodeType>
 class basic_serializer
 {
     static_assert(detail::is_basic_node<BasicNodeType>::value, "basic_serializer only accepts basic_node<...>");
 
 public:
-    /**
-     * @brief Construct a new basic_serializer object.
-     */
+    /// @brief Construct a new basic_serializer object.
     basic_serializer() = default;
 
-    /**
-     * @brief Serialize the given Node value.
-     *
-     * @param node A Node object to be serialized.
-     * @return std::string A serialization result of the given Node value.
-     */
+    /// @brief Serialize the given Node value.
+    /// @param node A Node object to be serialized.
+    /// @return std::string A serialization result of the given Node value.
     std::string serialize(const BasicNodeType& node)
     {
         std::string str {};
@@ -60,13 +49,10 @@ public:
     } // LCOV_EXCL_LINE
 
 private:
-    /**
-     * @brief Recursively serialize each Node object.
-     *
-     * @param node A Node object to be serialized.
-     * @param cur_indent The current indent width
-     * @param str A string to hold serialization result.
-     */
+    /// @brief Recursively serialize each Node object.
+    /// @param node A Node object to be serialized.
+    /// @param cur_indent The current indent width
+    /// @param str A string to hold serialization result.
     void serialize_node(const BasicNodeType& node, const uint32_t cur_indent, std::string& str)
     {
         switch (node.type())
@@ -133,23 +119,17 @@ private:
         }
     }
 
-    /**
-     * @brief Serialize mapping keys.
-     *
-     * @param key A key string to be serialized.
-     * @param str A string to hold serialization result.
-     */
+    /// @brief Serialize mapping keys.
+    /// @param key A key string to be serialized.
+    /// @param str A string to hold serialization result.
     void serialize_key(const std::string& key, std::string& str)
     {
         str += key + ":";
     }
 
-    /**
-     * @brief Insert indentation to the serialization result.
-     *
-     * @param cur_indent The current indent width to be inserted.
-     * @param str A string to hold serialization result.
-     */
+    /// @brief Insert indentation to the serialization result.
+    /// @param cur_indent The current indent width to be inserted.
+    /// @param str A string to hold serialization result.
     void insert_indentation(const uint32_t cur_indent, std::string& str)
     {
         for (uint32_t i = 0; i < cur_indent; ++i)
@@ -159,7 +139,7 @@ private:
     }
 
 private:
-    /** A temporal buffer for conversion from a scalar to a string. */
+    /// A temporal buffer for conversion from a scalar to a string.
     std::string m_tmp_str_buff;
 };
 

--- a/include/fkYAML/detail/types/lexical_token_t.hpp
+++ b/include/fkYAML/detail/types/lexical_token_t.hpp
@@ -13,23 +13,14 @@
 
 #include <fkYAML/detail/macros/version_macros.hpp>
 
-/**
- * @namespace fkyaml
- * @brief namespace for fkYAML library.
- */
+/// @brief namespace for fkYAML library.
 FK_YAML_NAMESPACE_BEGIN
 
-/**
- * @namespace detail
- * @brief namespace for internal implementations of fkYAML library.
- */
+/// @brief namespace for internal implementations of fkYAML library.
 namespace detail
 {
 
-/**
- * @enum lexical_token_t
- * @brief Definition of lexical token types.
- */
+/// @brief Definition of lexical token types.
 enum class lexical_token_t
 {
     END_OF_BUFFER,         //!< the end of input buffer.

--- a/include/fkYAML/detail/types/node_t.hpp
+++ b/include/fkYAML/detail/types/node_t.hpp
@@ -15,23 +15,14 @@
 
 #include <fkYAML/detail/macros/version_macros.hpp>
 
-/**
- * @namespace fkyaml
- * @brief namespace for fkYAML library.
- */
+/// @brief namespace for fkYAML library.
 FK_YAML_NAMESPACE_BEGIN
 
-/**
- * @namespace detail
- * @brief namespace for internal implementations of fkYAML library.
- */
+/// @brief namespace for internal implementations of fkYAML library.
 namespace detail
 {
 
-/**
- * @enum node_t
- * @brief Definition of node value types.
- */
+/// @brief Definition of node value types.
 enum class node_t : std::uint32_t
 {
     SEQUENCE,     //!< sequence value type

--- a/include/fkYAML/detail/types/yaml_version_t.hpp
+++ b/include/fkYAML/detail/types/yaml_version_t.hpp
@@ -15,23 +15,14 @@
 
 #include <fkYAML/detail/macros/version_macros.hpp>
 
-/**
- * @namespace fkyaml
- * @brief namespace for fkYAML library.
- */
+/// @brief namespace for fkYAML library.
 FK_YAML_NAMESPACE_BEGIN
 
-/**
- * @namespace detail
- * @brief namespace for internal implementations of fkYAML library.
- */
+/// @brief namespace for internal implementations of fkYAML library.
 namespace detail
 {
 
-/**
- * @enum yaml_version_t
- * @brief Definition of YAML version types.
- */
+/// @brief Definition of YAML version types.
 enum class yaml_version_t : std::uint32_t
 {
     VER_1_1, //!< YAML version 1.1


### PR DESCRIPTION
Before this PR, library source files in the include directory uses different style for doxygen comments between public and private APIs.  
To make the source files organized, doxygen comment style is unified into `///` style, not `/* */` style.  
