### PR TITLE
#205 Detect duplicate keys as an error

### DIFF
--- a/include/fkYAML/detail/input/deserializer.hpp
+++ b/include/fkYAML/detail/input/deserializer.hpp
@@ -256,7 +256,15 @@ private:
             m_indent_stack.push_back(indent);
         }
 
-        m_current_node->template get_value_ref<mapping_type&>().emplace(key, BasicNodeType());
+        // check key duplication in the current mapping.
+        mapping_type& map = m_current_node->template get_value_ref<mapping_type&>();
+        auto itr = map.find(key);
+        if (itr != map.end())
+        {
+            throw fkyaml::exception("Detected duplication in mapping keys.");
+        }
+
+        map.emplace(key, BasicNodeType());
         m_node_stack.push_back(m_current_node);
         m_current_node = &(m_current_node->template get_value_ref<mapping_type&>().at(key));
     }

--- a/test/unit_test/test_deserializer_class.cpp
+++ b/test/unit_test/test_deserializer_class.cpp
@@ -98,8 +98,7 @@ TEST_CASE("DeserializerClassTest_DeserializeDuplicateKeys", "[DeserializerClassT
     fkyaml::node root;
 
     REQUIRE_THROWS_AS(
-        root = deserializer.deserialize(fkyaml::detail::input_adapter("foo: bar\nfoo: baz")),
-        fkyaml::exception);
+        root = deserializer.deserialize(fkyaml::detail::input_adapter("foo: bar\nfoo: baz")), fkyaml::exception);
 }
 
 TEST_CASE("DeserializerClassTest_DeserializeBlockSequenceTest", "[DeserializerClassTest]")

--- a/test/unit_test/test_deserializer_class.cpp
+++ b/test/unit_test/test_deserializer_class.cpp
@@ -92,6 +92,16 @@ TEST_CASE("DeserializerClassTest_DeserializeInvalidIndentation", "[DeserializerC
         fkyaml::exception);
 }
 
+TEST_CASE("DeserializerClassTest_DeserializeDuplicateKeys", "[DeserializerClassTest]")
+{
+    fkyaml::detail::basic_deserializer<fkyaml::node> deserializer;
+    fkyaml::node root;
+
+    REQUIRE_THROWS_AS(
+        root = deserializer.deserialize(fkyaml::detail::input_adapter("foo: bar\nfoo: baz")),
+        fkyaml::exception);
+}
+
 TEST_CASE("DeserializerClassTest_DeserializeBlockSequenceTest", "[DeserializerClassTest]")
 {
     fkyaml::detail::basic_deserializer<fkyaml::node> deserializer;


### PR DESCRIPTION
The YAML specification says mapping keys must be unique, but fkYAML doesn't check duplication of keys while parsing the input stream.  
To follow the specification, this PR has fixed the bug.  

Furthermore, to check that the fix works as expected, a new test case has also been added.  