### PR TITLE
#207 Support markers for the end of directives/documents

### DIFF
--- a/include/fkYAML/detail/input/deserializer.hpp
+++ b/include/fkYAML/detail/input/deserializer.hpp
@@ -212,6 +212,11 @@ public:
                 }
                 assign_node_value(BasicNodeType(lexer.get_string()));
                 break;
+            case lexical_token_t::END_OF_DIRECTIVES:
+                break;
+            case lexical_token_t::END_OF_DOCUMENT:
+                // TODO: This token should be handled to support multiple documents.
+                break;
             default:                                                         // LCOV_EXCL_LINE
                 throw fkyaml::exception("Unsupported lexical token found."); // LCOV_EXCL_LINE
             }

--- a/include/fkYAML/detail/types/lexical_token_t.hpp
+++ b/include/fkYAML/detail/types/lexical_token_t.hpp
@@ -43,6 +43,8 @@ enum class lexical_token_t
     INTEGER_VALUE,         //!< an integer value found. use get_integer() to get a value.
     FLOAT_NUMBER_VALUE,    //!< a float number value found. use get_float_number() to get a value.
     STRING_VALUE,          //!< the character for string begin `"` or any character except the above ones
+    END_OF_DIRECTIVES,     //!< the end of declaration of directives specified by `---`.
+    END_OF_DOCUMENT,       //!< the end of a YAML document specified by `...`.
 };
 
 } // namespace detail

--- a/test/unit_test/test_deserializer_class.cpp
+++ b/test/unit_test/test_deserializer_class.cpp
@@ -750,3 +750,17 @@ TEST_CASE("DeserializerClassTest_DeserializeNoMachingAnchorTest", "[Deserializer
     fkyaml::detail::basic_deserializer<fkyaml::node> deserializer;
     REQUIRE_THROWS_AS(deserializer.deserialize(fkyaml::detail::input_adapter("foo: *anchor")), fkyaml::exception);
 }
+
+TEST_CASE("DeserializerClassTest_DeserializeDocumentWithMarkersTest", "[DeserializerClassTest]")
+{
+    fkyaml::detail::basic_deserializer<fkyaml::node> deserializer;
+    fkyaml::node root;
+
+    REQUIRE_NOTHROW(root = deserializer.deserialize(fkyaml::detail::input_adapter("%YAML 1.2\n---\nfoo: one\n...")));
+    REQUIRE(root.is_mapping());
+    REQUIRE(root.size() == 1);
+    REQUIRE(root.get_yaml_version() == fkyaml::node::yaml_version_t::VER_1_2);
+
+    REQUIRE(root.contains("foo"));
+    REQUIRE(root["foo"].get_value_ref<std::string&>() == "one");
+}

--- a/test/unit_test/test_lexical_analyzer_class.cpp
+++ b/test/unit_test/test_lexical_analyzer_class.cpp
@@ -124,6 +124,44 @@ TEST_CASE("LexicalAnalyzerClassTest_ScanEmptyDirectiveTest", "[LexicalAnalyzerCl
     REQUIRE_THROWS_AS(lexer.get_next_token(), fkyaml::exception);
 }
 
+TEST_CASE("LexicalAnalyzerClassTest_ScanEndOfDirectivesTest", "[LexicalAnalyzerClassTest]")
+{
+    pchar_lexer_t lexer(fkyaml::detail::input_adapter("%YAML 1.2\n---\nfoo: bar"));
+    fkyaml::detail::lexical_token_t token;
+
+    REQUIRE_NOTHROW(token = lexer.get_next_token());
+    REQUIRE(token == fkyaml::detail::lexical_token_t::YAML_VER_DIRECTIVE);
+    REQUIRE(lexer.get_yaml_version() == "1.2");
+    REQUIRE_NOTHROW(token = lexer.get_next_token());
+    REQUIRE(token == fkyaml::detail::lexical_token_t::END_OF_DIRECTIVES);
+    REQUIRE_NOTHROW(token = lexer.get_next_token());
+    REQUIRE(token == fkyaml::detail::lexical_token_t::STRING_VALUE);
+    REQUIRE(lexer.get_string() == "foo");
+    REQUIRE_NOTHROW(token = lexer.get_next_token());
+    REQUIRE(token == fkyaml::detail::lexical_token_t::KEY_SEPARATOR);
+    REQUIRE_NOTHROW(token = lexer.get_next_token());
+    REQUIRE(token == fkyaml::detail::lexical_token_t::STRING_VALUE);
+    REQUIRE(lexer.get_string() == "bar");
+    REQUIRE_NOTHROW(token = lexer.get_next_token());
+    REQUIRE(token == fkyaml::detail::lexical_token_t::END_OF_BUFFER);
+}
+
+TEST_CASE("LexicalAnalyzerClassTest_ScanEndOfDocumentsTest", "[LexicalAnalyzerClassTest]")
+{
+    pchar_lexer_t lexer(fkyaml::detail::input_adapter("%YAML 1.2\n---\n..."));
+    fkyaml::detail::lexical_token_t token;
+
+    REQUIRE_NOTHROW(token = lexer.get_next_token());
+    REQUIRE(token == fkyaml::detail::lexical_token_t::YAML_VER_DIRECTIVE);
+    REQUIRE(lexer.get_yaml_version() == "1.2");
+    REQUIRE_NOTHROW(token = lexer.get_next_token());
+    REQUIRE(token == fkyaml::detail::lexical_token_t::END_OF_DIRECTIVES);
+    REQUIRE_NOTHROW(token = lexer.get_next_token());
+    REQUIRE(token == fkyaml::detail::lexical_token_t::END_OF_DOCUMENT);
+    REQUIRE_NOTHROW(token = lexer.get_next_token());
+    REQUIRE(token == fkyaml::detail::lexical_token_t::END_OF_BUFFER);
+}
+
 TEST_CASE("LexicalAnalyzerClassTest_ScanColonTest", "[LexicalAnalyzerClassTest]")
 {
     fkyaml::detail::lexical_token_t token;
@@ -396,6 +434,7 @@ TEST_CASE("LexicalAnalyzerClassTest_ScanStringTokenTest", "[LexicalAnalyzerClass
         value_pair_t(std::string("none"), fkyaml::node::string_type("none")),
         value_pair_t(std::string(".NET"), fkyaml::node::string_type(".NET")),
         value_pair_t(std::string(".on"), fkyaml::node::string_type(".on")),
+        value_pair_t(std::string(".n"), fkyaml::node::string_type(".n")),
         value_pair_t(std::string("foo]"), fkyaml::node::string_type("foo")),
         value_pair_t(std::string("foo:bar"), fkyaml::node::string_type("foo:bar")),
         value_pair_t(std::string("foo bar"), fkyaml::node::string_type("foo bar")),


### PR DESCRIPTION
The YAML specification allows markers for the end of directives(---) and documents(...) to avoid ambiguity by declaring tags or having multiple YAML documents in the same YAML stream.  
So, this PR has supported the feature in fkYAML.  

Note that multiple YAML documents are not yet supported in fkYAML.  
Only the second or later YAML document will be merged into the first one during deserialization.