### PR TITLE
Feature/209 support unescaped utf8 input chars

### DIFF
--- a/include/fkYAML/detail/input/lexical_analyzer.hpp
+++ b/include/fkYAML/detail/input/lexical_analyzer.hpp
@@ -986,7 +986,166 @@ private:
                 continue;
             }
 
-            // TODO: multibyte characters are not yet supported.
+            // Handle 2-byte characters encoded in UTF-8. (U+0080..U+07FF)
+            //   1st Byte: 0xC2..0xDF
+            //   2nd Byte: 0x80..0xBF
+            if (0xC2 <= current && current <= 0xDF)
+            {
+                char_int_type second_byte_char = m_input_handler.get_next();
+                if (0x80 <= second_byte_char && second_byte_char <= 0xBF)
+                {
+                    m_value_buffer.push_back(char_traits_type::to_char_type(current));
+                    m_value_buffer.push_back(char_traits_type::to_char_type(second_byte_char));
+                    continue;
+                }
+                throw fkyaml::exception("ill-formed UTF-8 encoded character found");
+            }
+
+            // Handle 3-byte characters encoded in UTF-8. (U+1000..U+CFFF)
+            //   1st Byte: 0xE0..0xEC
+            //   2nd Byte: 0x80..0xBF
+            //   3rd Byte: 0x80..0xBF
+            if (0xE0 <= current && current <= 0xEC)
+            {
+                char_int_type second_byte_char = m_input_handler.get_next();
+                if (0x80 <= second_byte_char && second_byte_char <= 0xBF)
+                {
+                    char_int_type third_byte_char = m_input_handler.get_next();
+                    if (0x80 <= third_byte_char && third_byte_char <= 0xBF)
+                    {
+                        m_value_buffer.push_back(char_traits_type::to_char_type(current));
+                        m_value_buffer.push_back(char_traits_type::to_char_type(second_byte_char));
+                        m_value_buffer.push_back(char_traits_type::to_char_type(third_byte_char));
+                        continue;
+                    }
+                }
+                throw fkyaml::exception("ill-formed UTF-8 encoded character found");
+            }
+
+            // Handle 3-byte characters encoded in UTF-8. (U+D000..U+D7FF)
+            //   1st Byte: 0xED
+            //   2nd Byte: 0x80..0x9F
+            //   3rd Byte: 0x80..0xBF
+            if (current == 0xED)
+            {
+                char_int_type second_byte_char = m_input_handler.get_next();
+                if (0x80 <= second_byte_char && second_byte_char <= 0x9F)
+                {
+                    char_int_type third_byte_char = m_input_handler.get_next();
+                    if (0x80 <= third_byte_char && third_byte_char <= 0xBF)
+                    {
+                        m_value_buffer.push_back(char_traits_type::to_char_type(current));
+                        m_value_buffer.push_back(char_traits_type::to_char_type(second_byte_char));
+                        m_value_buffer.push_back(char_traits_type::to_char_type(third_byte_char));
+                        continue;
+                    }
+                }
+                throw fkyaml::exception("ill-formed UTF-8 encoded character found");
+            }
+
+            // Handle 3-byte characters encoded in UTF-8. (U+E000..U+FFFF)
+            //   1st Byte: 0xEE..0xEF
+            //   2nd Byte: 0x80..0xBF
+            //   3rd Byte: 0x80..0xBF
+            if (current == 0xEE || current == 0xEF)
+            {
+                char_int_type second_byte_char = m_input_handler.get_next();
+                if (0x80 <= second_byte_char && second_byte_char <= 0xBF)
+                {
+                    char_int_type third_byte_char = m_input_handler.get_next();
+                    if (0x80 <= third_byte_char && third_byte_char <= 0xBF)
+                    {
+                        m_value_buffer.push_back(char_traits_type::to_char_type(current));
+                        m_value_buffer.push_back(char_traits_type::to_char_type(second_byte_char));
+                        m_value_buffer.push_back(char_traits_type::to_char_type(third_byte_char));
+                        continue;
+                    }
+                }
+                throw fkyaml::exception("ill-formed UTF-8 encoded character found");
+            }
+
+            // Handle 4-byte characters encoded in UTF-8. (U+10000..U+3FFFF)
+            //   1st Byte: 0xF0
+            //   2nd Byte: 0x90..0xBF
+            //   3rd Byte: 0x80..0xBF
+            //   4th Byte: 0x80..0xBF
+            if (current == 0xF0)
+            {
+                char_int_type second_byte_char = m_input_handler.get_next();
+                if (0x90 <= second_byte_char && second_byte_char <= 0xBF)
+                {
+                    char_int_type third_byte_char = m_input_handler.get_next();
+                    if (0x80 <= third_byte_char && third_byte_char <= 0xBF)
+                    {
+                        char_int_type fourth_byte_char = m_input_handler.get_next();
+                        if (0x80 <= fourth_byte_char && fourth_byte_char <= 0xBF)
+                        {
+                            m_value_buffer.push_back(char_traits_type::to_char_type(current));
+                            m_value_buffer.push_back(char_traits_type::to_char_type(second_byte_char));
+                            m_value_buffer.push_back(char_traits_type::to_char_type(third_byte_char));
+                            m_value_buffer.push_back(char_traits_type::to_char_type(fourth_byte_char));
+                            continue;
+                        }
+                    }
+                }
+                throw fkyaml::exception("ill-formed UTF-8 encoded character found");
+            }
+
+            // Handle 4-byte characters encoded in UTF-8. (U+40000..U+FFFFF)
+            //   1st Byte: 0xF1..0xF3
+            //   2nd Byte: 0x80..0xBF
+            //   3rd Byte: 0x80..0xBF
+            //   4th Byte: 0x80..0xBF
+            if (0xF1 <= current && current <= 0xF3)
+            {
+                char_int_type second_byte_char = m_input_handler.get_next();
+                if (0x80 <= second_byte_char && second_byte_char <= 0xBF)
+                {
+                    char_int_type third_byte_char = m_input_handler.get_next();
+                    if (0x80 <= third_byte_char && third_byte_char <= 0xBF)
+                    {
+                        char_int_type fourth_byte_char = m_input_handler.get_next();
+                        if (0x80 <= fourth_byte_char && fourth_byte_char <= 0xBF)
+                        {
+                            m_value_buffer.push_back(char_traits_type::to_char_type(current));
+                            m_value_buffer.push_back(char_traits_type::to_char_type(second_byte_char));
+                            m_value_buffer.push_back(char_traits_type::to_char_type(third_byte_char));
+                            m_value_buffer.push_back(char_traits_type::to_char_type(fourth_byte_char));
+                            continue;
+                        }
+                    }
+                }
+                throw fkyaml::exception("ill-formed UTF-8 encoded character found");
+            }
+
+            // Handle 4-byte characters encoded in UTF-8. (U+100000..U+10FFFF)
+            //   1st Byte: 0xF4
+            //   2nd Byte: 0x80..0x8F
+            //   3rd Byte: 0x80..0xBF
+            //   4th Byte: 0x80..0xBF
+            if (current == 0xF4)
+            {
+                char_int_type second_byte_char = m_input_handler.get_next();
+                if (0x80 <= second_byte_char && second_byte_char <= 0x8F)
+                {
+                    char_int_type third_byte_char = m_input_handler.get_next();
+                    if (0x80 <= third_byte_char && third_byte_char <= 0xBF)
+                    {
+                        char_int_type fourth_byte_char = m_input_handler.get_next();
+                        if (0x80 <= fourth_byte_char && fourth_byte_char <= 0xBF)
+                        {
+                            m_value_buffer.push_back(char_traits_type::to_char_type(current));
+                            m_value_buffer.push_back(char_traits_type::to_char_type(second_byte_char));
+                            m_value_buffer.push_back(char_traits_type::to_char_type(third_byte_char));
+                            m_value_buffer.push_back(char_traits_type::to_char_type(fourth_byte_char));
+                            continue;
+                        }
+                    }
+                }
+                throw fkyaml::exception("ill-formed UTF-8 encoded character found");
+            }
+
+            // remaining bytes (0x80..0xC1 and 0xF5..0xFF) are ill formed.
             throw fkyaml::exception("Unsupported multibytes character found.");
         }
     }

--- a/test/unit_test/test_lexical_analyzer_class.cpp
+++ b/test/unit_test/test_lexical_analyzer_class.cpp
@@ -474,6 +474,64 @@ TEST_CASE("LexicalAnalyzerClassTest_ScanStringTokenTest", "[LexicalAnalyzerClass
     REQUIRE(lexer.get_string() == value_pair.second);
 }
 
+TEST_CASE("LexicalAnalyzerClassTest_ScanMultiByteCharStringTokenTest", "[LexicalAnalyzerClassTest]")
+{
+    using char_traits_t = std::char_traits<char>;
+    auto mb_char = GENERATE(
+        std::string {char_traits_t::to_char_type(0xC2), char_traits_t::to_char_type(0x80)},
+        std::string {char_traits_t::to_char_type(0xDF), char_traits_t::to_char_type(0xBF)},
+        std::string {
+            char_traits_t::to_char_type(0xE0), char_traits_t::to_char_type(0x80), char_traits_t::to_char_type(0x80)},
+        std::string {
+            char_traits_t::to_char_type(0xEC), char_traits_t::to_char_type(0xBF), char_traits_t::to_char_type(0xBF)},
+        std::string {
+            char_traits_t::to_char_type(0xED), char_traits_t::to_char_type(0x80), char_traits_t::to_char_type(0x80)},
+        std::string {
+            char_traits_t::to_char_type(0xED), char_traits_t::to_char_type(0x9F), char_traits_t::to_char_type(0xBF)},
+        std::string {
+            char_traits_t::to_char_type(0xEE), char_traits_t::to_char_type(0x80), char_traits_t::to_char_type(0x80)},
+        std::string {
+            char_traits_t::to_char_type(0xEF), char_traits_t::to_char_type(0xBF), char_traits_t::to_char_type(0xBF)},
+        std::string {
+            char_traits_t::to_char_type(0xF0),
+            char_traits_t::to_char_type(0x90),
+            char_traits_t::to_char_type(0x80),
+            char_traits_t::to_char_type(0x80)},
+        std::string {
+            char_traits_t::to_char_type(0xF0),
+            char_traits_t::to_char_type(0xBF),
+            char_traits_t::to_char_type(0xBF),
+            char_traits_t::to_char_type(0xBF)},
+        std::string {
+            char_traits_t::to_char_type(0xF1),
+            char_traits_t::to_char_type(0x80),
+            char_traits_t::to_char_type(0x80),
+            char_traits_t::to_char_type(0x80)},
+        std::string {
+            char_traits_t::to_char_type(0xF3),
+            char_traits_t::to_char_type(0xBF),
+            char_traits_t::to_char_type(0xBF),
+            char_traits_t::to_char_type(0xBF)},
+        std::string {
+            char_traits_t::to_char_type(0xF4),
+            char_traits_t::to_char_type(0x80),
+            char_traits_t::to_char_type(0x80),
+            char_traits_t::to_char_type(0x80)},
+        std::string {
+            char_traits_t::to_char_type(0xF4),
+            char_traits_t::to_char_type(0x8F),
+            char_traits_t::to_char_type(0xBF),
+            char_traits_t::to_char_type(0xBF)});
+
+    str_lexer_t lexer(fkyaml::detail::input_adapter(mb_char));
+    fkyaml::detail::lexical_token_t token;
+
+    REQUIRE_NOTHROW(token = lexer.get_next_token());
+    REQUIRE(token == fkyaml::detail::lexical_token_t::STRING_VALUE);
+    REQUIRE_NOTHROW(lexer.get_string());
+    REQUIRE(lexer.get_string() == mb_char);
+}
+
 TEST_CASE("LexicalAnalyzerClassTest_ScanInvalidStringTokenTest", "[LexicalAnalyzerClassTest]")
 {
     auto buffer = GENERATE(
@@ -492,10 +550,141 @@ TEST_CASE("LexicalAnalyzerClassTest_ScanInvalidStringTokenTest", "[LexicalAnalyz
         std::string("\"\\x^\""),
         std::string("\"\\x{\""),
         std::string("\'\\t\'"),
-        std::string("\"\\N\""),
-        std::string("\u7F80"));
+        std::string("\"\\N\""));
 
     str_lexer_t lexer(fkyaml::detail::input_adapter(buffer));
+    REQUIRE_THROWS_AS(lexer.get_next_token(), fkyaml::exception);
+}
+
+TEST_CASE("LexicalAnalyzerClassTest_ScanInvalidMultiByteCharStringTokenTest", "[LexicalAnalyzerClassTest]")
+{
+    using char_traits_t = std::char_traits<char>;
+    auto mb_char = GENERATE(
+        std::string {char_traits_t::to_char_type(0x80), char_traits_t::to_char_type(0x80)},
+        std::string {char_traits_t::to_char_type(0xC1), char_traits_t::to_char_type(0x80)},
+        std::string {char_traits_t::to_char_type(0xC2), char_traits_t::to_char_type(0x7F)},
+        std::string {char_traits_t::to_char_type(0xC2), char_traits_t::to_char_type(0xC0)},
+        std::string {
+            char_traits_t::to_char_type(0xE0), char_traits_t::to_char_type(0x7F), char_traits_t::to_char_type(0x80)},
+        std::string {
+            char_traits_t::to_char_type(0xE0), char_traits_t::to_char_type(0xC0), char_traits_t::to_char_type(0x80)},
+        std::string {
+            char_traits_t::to_char_type(0xE0), char_traits_t::to_char_type(0x80), char_traits_t::to_char_type(0x7F)},
+        std::string {
+            char_traits_t::to_char_type(0xE0), char_traits_t::to_char_type(0x80), char_traits_t::to_char_type(0xC0)},
+        std::string {
+            char_traits_t::to_char_type(0xED), char_traits_t::to_char_type(0x7F), char_traits_t::to_char_type(0x80)},
+        std::string {
+            char_traits_t::to_char_type(0xED), char_traits_t::to_char_type(0xA0), char_traits_t::to_char_type(0x80)},
+        std::string {
+            char_traits_t::to_char_type(0xED), char_traits_t::to_char_type(0x80), char_traits_t::to_char_type(0x7F)},
+        std::string {
+            char_traits_t::to_char_type(0xED), char_traits_t::to_char_type(0x80), char_traits_t::to_char_type(0xC0)},
+        std::string {
+            char_traits_t::to_char_type(0xEE), char_traits_t::to_char_type(0x7F), char_traits_t::to_char_type(0x80)},
+        std::string {
+            char_traits_t::to_char_type(0xEE), char_traits_t::to_char_type(0xC0), char_traits_t::to_char_type(0x80)},
+        std::string {
+            char_traits_t::to_char_type(0xEF), char_traits_t::to_char_type(0x80), char_traits_t::to_char_type(0x7F)},
+        std::string {
+            char_traits_t::to_char_type(0xEF), char_traits_t::to_char_type(0x80), char_traits_t::to_char_type(0xC0)},
+        std::string {
+            char_traits_t::to_char_type(0xF0),
+            char_traits_t::to_char_type(0x8F),
+            char_traits_t::to_char_type(0x80),
+            char_traits_t::to_char_type(0x80)},
+        std::string {
+            char_traits_t::to_char_type(0xF0),
+            char_traits_t::to_char_type(0xC0),
+            char_traits_t::to_char_type(0x80),
+            char_traits_t::to_char_type(0x80)},
+        std::string {
+            char_traits_t::to_char_type(0xF0),
+            char_traits_t::to_char_type(0x90),
+            char_traits_t::to_char_type(0x7F),
+            char_traits_t::to_char_type(0x80)},
+        std::string {
+            char_traits_t::to_char_type(0xF0),
+            char_traits_t::to_char_type(0x90),
+            char_traits_t::to_char_type(0xC0),
+            char_traits_t::to_char_type(0x80)},
+        std::string {
+            char_traits_t::to_char_type(0xF0),
+            char_traits_t::to_char_type(0x90),
+            char_traits_t::to_char_type(0x80),
+            char_traits_t::to_char_type(0x7F)},
+        std::string {
+            char_traits_t::to_char_type(0xF0),
+            char_traits_t::to_char_type(0x90),
+            char_traits_t::to_char_type(0x80),
+            char_traits_t::to_char_type(0xC0)},
+        std::string {
+            char_traits_t::to_char_type(0xF1),
+            char_traits_t::to_char_type(0x7F),
+            char_traits_t::to_char_type(0x80),
+            char_traits_t::to_char_type(0x80)},
+        std::string {
+            char_traits_t::to_char_type(0xF1),
+            char_traits_t::to_char_type(0xC0),
+            char_traits_t::to_char_type(0x80),
+            char_traits_t::to_char_type(0x80)},
+        std::string {
+            char_traits_t::to_char_type(0xF1),
+            char_traits_t::to_char_type(0x80),
+            char_traits_t::to_char_type(0x7F),
+            char_traits_t::to_char_type(0x80)},
+        std::string {
+            char_traits_t::to_char_type(0xF1),
+            char_traits_t::to_char_type(0x80),
+            char_traits_t::to_char_type(0xC0),
+            char_traits_t::to_char_type(0x80)},
+        std::string {
+            char_traits_t::to_char_type(0xF1),
+            char_traits_t::to_char_type(0x80),
+            char_traits_t::to_char_type(0x80),
+            char_traits_t::to_char_type(0x7F)},
+        std::string {
+            char_traits_t::to_char_type(0xF1),
+            char_traits_t::to_char_type(0x80),
+            char_traits_t::to_char_type(0x80),
+            char_traits_t::to_char_type(0xC0)},
+        std::string {
+            char_traits_t::to_char_type(0xF4),
+            char_traits_t::to_char_type(0x7F),
+            char_traits_t::to_char_type(0x80),
+            char_traits_t::to_char_type(0x80)},
+        std::string {
+            char_traits_t::to_char_type(0xF4),
+            char_traits_t::to_char_type(0x90),
+            char_traits_t::to_char_type(0x80),
+            char_traits_t::to_char_type(0x80)},
+        std::string {
+            char_traits_t::to_char_type(0xF4),
+            char_traits_t::to_char_type(0x80),
+            char_traits_t::to_char_type(0x7F),
+            char_traits_t::to_char_type(0x80)},
+        std::string {
+            char_traits_t::to_char_type(0xF4),
+            char_traits_t::to_char_type(0x80),
+            char_traits_t::to_char_type(0xC0),
+            char_traits_t::to_char_type(0x80)},
+        std::string {
+            char_traits_t::to_char_type(0xF4),
+            char_traits_t::to_char_type(0x80),
+            char_traits_t::to_char_type(0x80),
+            char_traits_t::to_char_type(0x7F)},
+        std::string {
+            char_traits_t::to_char_type(0xF4),
+            char_traits_t::to_char_type(0x80),
+            char_traits_t::to_char_type(0x80),
+            char_traits_t::to_char_type(0xC0)},
+        std::string {
+            char_traits_t::to_char_type(0xF5),
+            char_traits_t::to_char_type(0x80),
+            char_traits_t::to_char_type(0x80),
+            char_traits_t::to_char_type(0x80)});
+
+    str_lexer_t lexer(fkyaml::detail::input_adapter(mb_char));
     REQUIRE_THROWS_AS(lexer.get_next_token(), fkyaml::exception);
 }
 


### PR DESCRIPTION
The YAML specificates says that YAML processors must support unicode characters.  
To follow the specification, this PR has added support for unescaped UTF-8 characters as inputs for deserialization.  
The exclusive test cases for the new support have also been added to the unit test app.  