### PR TITLE
#211 fixed bug in parsing single quoted strings

### DIFF
--- a/include/fkYAML/detail/input/lexical_analyzer.hpp
+++ b/include/fkYAML/detail/input/lexical_analyzer.hpp
@@ -827,6 +827,8 @@ private:
                     continue;
                 }
 
+                // move the current position for next scanning.
+                m_input_handler.get_next();
                 return lexical_token_t::STRING_VALUE;
             }
 

--- a/test/unit_test/test_deserializer_class.cpp
+++ b/test/unit_test/test_deserializer_class.cpp
@@ -108,7 +108,7 @@ TEST_CASE("DeserializerClassTest_DeserializeBlockSequenceTest", "[DeserializerCl
 
     SECTION("Input source No.1.")
     {
-        REQUIRE_NOTHROW(root = deserializer.deserialize(fkyaml::detail::input_adapter("test:\n  - foo\n  - bar")));
+        REQUIRE_NOTHROW(root = deserializer.deserialize(fkyaml::detail::input_adapter("test:\n  - \'foo\'\n  - bar")));
 
         REQUIRE(root.is_mapping());
         REQUIRE_NOTHROW(root.size());

--- a/test/unit_test/test_lexical_analyzer_class.cpp
+++ b/test/unit_test/test_lexical_analyzer_class.cpp
@@ -1292,7 +1292,7 @@ TEST_CASE("LexicalAnalyzerClassTest_ScanBlockMappingTokenTest", "[LexicalAnalyze
 
     SECTION("Input source No.1.")
     {
-        pchar_lexer_t lexer(fkyaml::detail::input_adapter("test:\n  bool: true\n  foo: bar\n  pi: 3.14"));
+        pchar_lexer_t lexer(fkyaml::detail::input_adapter("test:\n  bool: true\n  foo: \'bar\'\n  pi: 3.14"));
 
         REQUIRE_NOTHROW(token = lexer.get_next_token());
         REQUIRE(token == fkyaml::detail::lexical_token_t::STRING_VALUE);


### PR DESCRIPTION
As reported in #211, parsing single quoted strings causes an unexpected error.  
This PR has fixed the bug and modified some test cases to ensure that parsing single quoted strings does not cause any error.  