### PR TITLE
#209 support escaped unicode

### DIFF
--- a/include/fkYAML/detail/input/lexical_analyzer.hpp
+++ b/include/fkYAML/detail/input/lexical_analyzer.hpp
@@ -1259,23 +1259,23 @@ private:
 
     void handle_unicode_code_point(uint32_t code_point)
     {
+        bool is_valid = false;
+
         if (code_point < 0x80)
         {
             m_value_buffer.push_back(static_cast<char_type>(code_point & 0x007F));
-            return;
+            is_valid = true;
         }
-
-        if (0x80 <= code_point && code_point <= 0x7FF)
+        else if (code_point <= 0x7FF)
         {
             uint16_t utf8_encoded = 0b1100'0000'1000'0000;
             utf8_encoded |= static_cast<uint16_t>((code_point & 0x07C0) << 2);
             utf8_encoded |= static_cast<uint16_t>((code_point & 0x003F));
             m_value_buffer.push_back(static_cast<char_type>((utf8_encoded & 0xFF00) >> 8));
             m_value_buffer.push_back(static_cast<char_type>(utf8_encoded & 0x00FF));
-            return;
+            is_valid = true;
         }
-
-        if (0x800 <= code_point && code_point <= 0xFFFF)
+        else if (code_point <= 0xFFFF)
         {
             uint32_t utf8_encoded = 0b1110'0000'1000'0000'1000'0000;
             utf8_encoded |= static_cast<uint32_t>((code_point & 0xF000) << 4);
@@ -1284,10 +1284,9 @@ private:
             m_value_buffer.push_back(static_cast<char_type>((utf8_encoded & 0xFF0000) >> 16));
             m_value_buffer.push_back(static_cast<char_type>((utf8_encoded & 0x00FF00) >> 8));
             m_value_buffer.push_back(static_cast<char_type>(utf8_encoded & 0x0000FF));
-            return;
+            is_valid = true;
         }
-
-        if (0x10000 <= code_point && code_point <= 0x10FFFF)
+        else if (code_point <= 0x10FFFF)
         {
             uint32_t utf8_encoded = 0b1111'0000'1000'0000'1000'0000'1000'0000;
             utf8_encoded |= static_cast<uint32_t>((code_point & 0x1C0000) << 6);
@@ -1298,10 +1297,13 @@ private:
             m_value_buffer.push_back(static_cast<char_type>((utf8_encoded & 0x00FF0000) >> 16));
             m_value_buffer.push_back(static_cast<char_type>((utf8_encoded & 0x0000FF00) >> 8));
             m_value_buffer.push_back(static_cast<char_type>(utf8_encoded & 0x000000FF));
-            return;
+            is_valid = true;
         }
 
-        throw fkyaml::exception("Invalid Unicode code point.");
+        if (!is_valid)
+        {
+            throw fkyaml::exception("Invalid Unicode code point.");
+        }
     }
 
     /// @brief Skip white spaces, tabs and newline codes until any other kind of character is found.

--- a/include/fkYAML/detail/input/lexical_analyzer.hpp
+++ b/include/fkYAML/detail/input/lexical_analyzer.hpp
@@ -1268,7 +1268,7 @@ private:
         }
         else if (code_point <= 0x7FF)
         {
-            uint16_t utf8_encoded = 0b1100'0000'1000'0000;
+            uint16_t utf8_encoded = 0b1100000010000000;
             utf8_encoded |= static_cast<uint16_t>((code_point & 0x07C0) << 2);
             utf8_encoded |= static_cast<uint16_t>((code_point & 0x003F));
             m_value_buffer.push_back(static_cast<char_type>((utf8_encoded & 0xFF00) >> 8));
@@ -1277,7 +1277,7 @@ private:
         }
         else if (code_point <= 0xFFFF)
         {
-            uint32_t utf8_encoded = 0b1110'0000'1000'0000'1000'0000;
+            uint32_t utf8_encoded = 0b111000001000000010000000;
             utf8_encoded |= static_cast<uint32_t>((code_point & 0xF000) << 4);
             utf8_encoded |= static_cast<uint32_t>((code_point & 0x0FC0) << 2);
             utf8_encoded |= static_cast<uint32_t>((code_point & 0x003F));
@@ -1288,7 +1288,7 @@ private:
         }
         else if (code_point <= 0x10FFFF)
         {
-            uint32_t utf8_encoded = 0b1111'0000'1000'0000'1000'0000'1000'0000;
+            uint32_t utf8_encoded = 0b11110000100000001000000010000000;
             utf8_encoded |= static_cast<uint32_t>((code_point & 0x1C0000) << 6);
             utf8_encoded |= static_cast<uint32_t>((code_point & 0x03F000) << 4);
             utf8_encoded |= static_cast<uint32_t>((code_point & 0x000FC0) << 2);

--- a/include/fkYAML/detail/input/lexical_analyzer.hpp
+++ b/include/fkYAML/detail/input/lexical_analyzer.hpp
@@ -389,7 +389,7 @@ private:
     /// @brief A utility function to convert a hexadecimal character to an integer.
     /// @param source A hexadecimal character ('0'~'9', 'A'~'F', 'a'~'f')
     /// @return char A integer converted from @a source.
-    static char convert_hex_char_to_byte(char source)
+    static char convert_hex_char_to_byte(char_int_type source)
     {
         if ('0' <= source && source <= '9')
         {
@@ -940,7 +940,7 @@ private:
                     m_value_buffer.push_back('\r');
                     break;
                 case 'e':
-                    m_value_buffer.push_back('\u001B');
+                    m_value_buffer.push_back(char_type(0x1B));
                     break;
                 case ' ':
                     m_value_buffer.push_back(' ');
@@ -954,20 +954,52 @@ private:
                 case '\\':
                     m_value_buffer.push_back('\\');
                     break;
+                case 'N': // next line
+                    handle_unicode_code_point(0x85u);
+                    break;
+                case '_': // non-breaking space
+                    handle_unicode_code_point(0xA0u);
+                    break;
+                case 'L': // line separator
+                    handle_unicode_code_point(0x2028u);
+                    break;
+                case 'P': // paragraph separator
+                    handle_unicode_code_point(0x2029u);
+                    break;
                 case 'x': {
-                    char byte = 0;
+                    uint32_t code_point = 0;
                     for (int i = 1; i >= 0; --i)
                     {
-                        char four_bits =
-                            convert_hex_char_to_byte(char_traits_type::to_char_type(m_input_handler.get_next()));
+                        char four_bits = convert_hex_char_to_byte(m_input_handler.get_next());
                         // NOLINTNEXTLINE(bugprone-narrowing-conversions,cppcoreguidelines-narrowing-conversions)
-                        byte |= static_cast<char>(four_bits << (4 * i));
+                        code_point |= static_cast<uint32_t>(four_bits << (4 * i));
                     }
-                    m_value_buffer.push_back(byte);
+                    handle_unicode_code_point(code_point);
                     break;
                 }
-                // TODO: Multibyte characters are not yet supported.
-                // Thus \N, \_, \L, \P \uXX, \UXXXX are currently unavailable.
+                case 'u': {
+                    uint32_t code_point = 0;
+                    for (int i = 3; i >= 0; --i)
+                    {
+                        char four_bits = convert_hex_char_to_byte(m_input_handler.get_next());
+                        // NOLINTNEXTLINE(bugprone-narrowing-conversions,cppcoreguidelines-narrowing-conversions)
+                        code_point |= static_cast<uint32_t>(four_bits << (4 * i));
+                    }
+                    handle_unicode_code_point(code_point);
+                    break;
+                }
+                case 'U': {
+                    uint32_t code_point = 0;
+                    for (int i = 7; i >= 0; --i)
+                    {
+                        current = m_input_handler.get_next();
+                        char four_bits = convert_hex_char_to_byte(current);
+                        // NOLINTNEXTLINE(bugprone-narrowing-conversions,cppcoreguidelines-narrowing-conversions)
+                        code_point |= static_cast<uint32_t>(four_bits << (4 * i));
+                    }
+                    handle_unicode_code_point(code_point);
+                    break;
+                }
                 default:
                     throw fkyaml::exception("Unsupported escape sequence found in a string token.");
                 }
@@ -1223,6 +1255,53 @@ private:
         case 0x1F:
             throw fkyaml::exception("Control character U+001F (US) must be escaped to \\u001F.");
         }
+    }
+
+    void handle_unicode_code_point(uint32_t code_point)
+    {
+        if (code_point < 0x80)
+        {
+            m_value_buffer.push_back(static_cast<char_type>(code_point & 0x007F));
+            return;
+        }
+
+        if (0x80 <= code_point && code_point <= 0x7FF)
+        {
+            uint16_t utf8_encoded = 0b1100'0000'1000'0000;
+            utf8_encoded |= static_cast<uint16_t>((code_point & 0x07C0) << 2);
+            utf8_encoded |= static_cast<uint16_t>((code_point & 0x003F));
+            m_value_buffer.push_back(static_cast<char_type>((utf8_encoded & 0xFF00) >> 8));
+            m_value_buffer.push_back(static_cast<char_type>(utf8_encoded & 0x00FF));
+            return;
+        }
+
+        if (0x800 <= code_point && code_point <= 0xFFFF)
+        {
+            uint32_t utf8_encoded = 0b1110'0000'1000'0000'1000'0000;
+            utf8_encoded |= static_cast<uint32_t>((code_point & 0xF000) << 4);
+            utf8_encoded |= static_cast<uint32_t>((code_point & 0x0FC0) << 2);
+            utf8_encoded |= static_cast<uint32_t>((code_point & 0x003F));
+            m_value_buffer.push_back(static_cast<char_type>((utf8_encoded & 0xFF0000) >> 16));
+            m_value_buffer.push_back(static_cast<char_type>((utf8_encoded & 0x00FF00) >> 8));
+            m_value_buffer.push_back(static_cast<char_type>(utf8_encoded & 0x0000FF));
+            return;
+        }
+
+        if (0x10000 <= code_point && code_point <= 0x10FFFF)
+        {
+            uint32_t utf8_encoded = 0b1111'0000'1000'0000'1000'0000'1000'0000;
+            utf8_encoded |= static_cast<uint32_t>((code_point & 0x1C0000) << 6);
+            utf8_encoded |= static_cast<uint32_t>((code_point & 0x03F000) << 4);
+            utf8_encoded |= static_cast<uint32_t>((code_point & 0x000FC0) << 2);
+            utf8_encoded |= static_cast<uint32_t>((code_point & 0x00003F));
+            m_value_buffer.push_back(static_cast<char_type>((utf8_encoded & 0xFF000000) >> 24));
+            m_value_buffer.push_back(static_cast<char_type>((utf8_encoded & 0x00FF0000) >> 16));
+            m_value_buffer.push_back(static_cast<char_type>((utf8_encoded & 0x0000FF00) >> 8));
+            m_value_buffer.push_back(static_cast<char_type>(utf8_encoded & 0x000000FF));
+            return;
+        }
+
+        throw fkyaml::exception("Invalid Unicode code point.");
     }
 
     /// @brief Skip white spaces, tabs and newline codes until any other kind of character is found.

--- a/test/unit_test/test_lexical_analyzer_class.cpp
+++ b/test/unit_test/test_lexical_analyzer_class.cpp
@@ -550,7 +550,7 @@ TEST_CASE("LexicalAnalyzerClassTest_ScanInvalidStringTokenTest", "[LexicalAnalyz
         std::string("\"\\x^\""),
         std::string("\"\\x{\""),
         std::string("\'\\t\'"),
-        std::string("\"\\N\""));
+        std::string("\"\\Q\""));
 
     str_lexer_t lexer(fkyaml::detail::input_adapter(buffer));
     REQUIRE_THROWS_AS(lexer.get_next_token(), fkyaml::exception);

--- a/test/unit_test/test_lexical_analyzer_class.cpp
+++ b/test/unit_test/test_lexical_analyzer_class.cpp
@@ -547,25 +547,84 @@ TEST_CASE("LexicalAnalyzerClassTest_ScanEscapedUnicodeStringTokenTest", "[Lexica
         value_pair_t(std::string("\"\\u0000\""), std::string {char_traits_t::to_char_type(0x00)}),
         value_pair_t(std::string("\"\\u0040\""), std::string {char_traits_t::to_char_type(0x40)}),
         value_pair_t(std::string("\"\\u007F\""), std::string {char_traits_t::to_char_type(0x7F)}),
-        value_pair_t(std::string("\"\\u0080\""), std::string {char_traits_t::to_char_type(0xC2), char_traits_t::to_char_type(0x80)}),
-        value_pair_t(std::string("\"\\u0400\""), std::string {char_traits_t::to_char_type(0xD0), char_traits_t::to_char_type(0x80)}),
-        value_pair_t(std::string("\"\\u07FF\""), std::string {char_traits_t::to_char_type(0xDF), char_traits_t::to_char_type(0xBF)}),
-        value_pair_t(std::string("\"\\u0800\""), std::string {char_traits_t::to_char_type(0xE0), char_traits_t::to_char_type(0xA0), char_traits_t::to_char_type(0x80)}),
-        value_pair_t(std::string("\"\\u8000\""), std::string {char_traits_t::to_char_type(0xE8), char_traits_t::to_char_type(0x80), char_traits_t::to_char_type(0x80)}),
-        value_pair_t(std::string("\"\\uFFFF\""), std::string {char_traits_t::to_char_type(0xEF), char_traits_t::to_char_type(0xBF), char_traits_t::to_char_type(0xBF)}),
+        value_pair_t(
+            std::string("\"\\u0080\""),
+            std::string {char_traits_t::to_char_type(0xC2), char_traits_t::to_char_type(0x80)}),
+        value_pair_t(
+            std::string("\"\\u0400\""),
+            std::string {char_traits_t::to_char_type(0xD0), char_traits_t::to_char_type(0x80)}),
+        value_pair_t(
+            std::string("\"\\u07FF\""),
+            std::string {char_traits_t::to_char_type(0xDF), char_traits_t::to_char_type(0xBF)}),
+        value_pair_t(
+            std::string("\"\\u0800\""),
+            std::string {
+                char_traits_t::to_char_type(0xE0),
+                char_traits_t::to_char_type(0xA0),
+                char_traits_t::to_char_type(0x80)}),
+        value_pair_t(
+            std::string("\"\\u8000\""),
+            std::string {
+                char_traits_t::to_char_type(0xE8),
+                char_traits_t::to_char_type(0x80),
+                char_traits_t::to_char_type(0x80)}),
+        value_pair_t(
+            std::string("\"\\uFFFF\""),
+            std::string {
+                char_traits_t::to_char_type(0xEF),
+                char_traits_t::to_char_type(0xBF),
+                char_traits_t::to_char_type(0xBF)}),
         value_pair_t(std::string("\"\\U00000000\""), std::string {char_traits_t::to_char_type(0x00)}),
         value_pair_t(std::string("\"\\U00000040\""), std::string {char_traits_t::to_char_type(0x40)}),
         value_pair_t(std::string("\"\\U0000007F\""), std::string {char_traits_t::to_char_type(0x7F)}),
-        value_pair_t(std::string("\"\\U00000080\""), std::string {char_traits_t::to_char_type(0xC2), char_traits_t::to_char_type(0x80)}),
-        value_pair_t(std::string("\"\\U00000400\""), std::string {char_traits_t::to_char_type(0xD0), char_traits_t::to_char_type(0x80)}),
-        value_pair_t(std::string("\"\\U000007FF\""), std::string {char_traits_t::to_char_type(0xDF), char_traits_t::to_char_type(0xBF)}),
-        value_pair_t(std::string("\"\\U00000800\""), std::string {char_traits_t::to_char_type(0xE0), char_traits_t::to_char_type(0xA0), char_traits_t::to_char_type(0x80)}),
-        value_pair_t(std::string("\"\\U00008000\""), std::string {char_traits_t::to_char_type(0xE8), char_traits_t::to_char_type(0x80), char_traits_t::to_char_type(0x80)}),
-        value_pair_t(std::string("\"\\U0000FFFF\""), std::string {char_traits_t::to_char_type(0xEF), char_traits_t::to_char_type(0xBF), char_traits_t::to_char_type(0xBF)}),
-        value_pair_t(std::string("\"\\U00010000\""), std::string {char_traits_t::to_char_type(0xF0), char_traits_t::to_char_type(0x90), char_traits_t::to_char_type(0x80), char_traits_t::to_char_type(0x80)}),
-        value_pair_t(std::string("\"\\U00080000\""), std::string {char_traits_t::to_char_type(0xF2), char_traits_t::to_char_type(0x80), char_traits_t::to_char_type(0x80), char_traits_t::to_char_type(0x80)}),
-        value_pair_t(std::string("\"\\U0010FFFF\""), std::string {char_traits_t::to_char_type(0xF4), char_traits_t::to_char_type(0x8F), char_traits_t::to_char_type(0xBF), char_traits_t::to_char_type(0xBF)})
-    );
+        value_pair_t(
+            std::string("\"\\U00000080\""),
+            std::string {char_traits_t::to_char_type(0xC2), char_traits_t::to_char_type(0x80)}),
+        value_pair_t(
+            std::string("\"\\U00000400\""),
+            std::string {char_traits_t::to_char_type(0xD0), char_traits_t::to_char_type(0x80)}),
+        value_pair_t(
+            std::string("\"\\U000007FF\""),
+            std::string {char_traits_t::to_char_type(0xDF), char_traits_t::to_char_type(0xBF)}),
+        value_pair_t(
+            std::string("\"\\U00000800\""),
+            std::string {
+                char_traits_t::to_char_type(0xE0),
+                char_traits_t::to_char_type(0xA0),
+                char_traits_t::to_char_type(0x80)}),
+        value_pair_t(
+            std::string("\"\\U00008000\""),
+            std::string {
+                char_traits_t::to_char_type(0xE8),
+                char_traits_t::to_char_type(0x80),
+                char_traits_t::to_char_type(0x80)}),
+        value_pair_t(
+            std::string("\"\\U0000FFFF\""),
+            std::string {
+                char_traits_t::to_char_type(0xEF),
+                char_traits_t::to_char_type(0xBF),
+                char_traits_t::to_char_type(0xBF)}),
+        value_pair_t(
+            std::string("\"\\U00010000\""),
+            std::string {
+                char_traits_t::to_char_type(0xF0),
+                char_traits_t::to_char_type(0x90),
+                char_traits_t::to_char_type(0x80),
+                char_traits_t::to_char_type(0x80)}),
+        value_pair_t(
+            std::string("\"\\U00080000\""),
+            std::string {
+                char_traits_t::to_char_type(0xF2),
+                char_traits_t::to_char_type(0x80),
+                char_traits_t::to_char_type(0x80),
+                char_traits_t::to_char_type(0x80)}),
+        value_pair_t(
+            std::string("\"\\U0010FFFF\""),
+            std::string {
+                char_traits_t::to_char_type(0xF4),
+                char_traits_t::to_char_type(0x8F),
+                char_traits_t::to_char_type(0xBF),
+                char_traits_t::to_char_type(0xBF)}));
 
     str_lexer_t lexer(fkyaml::detail::input_adapter(value_pair.first));
     fkyaml::detail::lexical_token_t token;


### PR DESCRIPTION
The YAML specificates says that YAML processors must support unicode characters.  
To follow the specification, this PR has added support for escaped UTF-8 characters as inputs for deserialization.  
The exclusive test cases for the new support have also been added to the unit test app.  