### PR TITLE
#217 Fix parse errors on strings containing single quotes

### DIFF
--- a/include/fkYAML/detail/input/lexical_analyzer.hpp
+++ b/include/fkYAML/detail/input/lexical_analyzer.hpp
@@ -813,23 +813,19 @@ private:
             // Handle single quotation marks.
             if (current == '\'')
             {
-                if (needs_last_double_quote || !needs_last_single_quote)
+                if (needs_last_single_quote)
                 {
-                    throw fkyaml::exception("Invalid single quotation mark found in a string token.");
+                    // If single quotation marks are repeated twice in a single-quoted string token, they are considered as
+                    // an escaped single quotation mark.
+                    current = m_input_handler.get_next();
+                    if (current != '\'')
+                    {
+                        return lexical_token_t::STRING_VALUE;
+                    }
                 }
 
-                // If single quotation marks are repeated twice in a single-quoted string token. they are considered as
-                // an escaped single quotation mark.
-                bool is_next_single_quote = m_input_handler.test_next_char('\'');
-                if (is_next_single_quote)
-                {
-                    m_value_buffer.push_back(char_traits_type::to_char_type(m_input_handler.get_next()));
-                    continue;
-                }
-
-                // move the current position for next scanning.
-                m_input_handler.get_next();
-                return lexical_token_t::STRING_VALUE;
+                m_value_buffer.push_back(char_traits_type::to_char_type(current));
+                continue;
             }
 
             // Handle colons.

--- a/include/fkYAML/detail/input/lexical_analyzer.hpp
+++ b/include/fkYAML/detail/input/lexical_analyzer.hpp
@@ -815,8 +815,8 @@ private:
             {
                 if (needs_last_single_quote)
                 {
-                    // If single quotation marks are repeated twice in a single-quoted string token, they are considered as
-                    // an escaped single quotation mark.
+                    // If single quotation marks are repeated twice in a single-quoted string token, they are considered
+                    // as an escaped single quotation mark.
                     current = m_input_handler.get_next();
                     if (current != '\'')
                     {

--- a/test/unit_test/test_input_handler.cpp
+++ b/test/unit_test/test_input_handler.cpp
@@ -192,6 +192,8 @@ TEST_CASE("InputHandlerTest_TestNextCharTest", "[InputHandlerTest]")
 
     REQUIRE(handler.get_next() == 's');
     REQUIRE(handler.get_next() == 't');
+    REQUIRE(handler.test_next_char('t') == false);
+
     REQUIRE(handler.get_next() == pchar_input_handler::char_traits_type::eof());
     REQUIRE(handler.test_next_char('t') == false);
     REQUIRE(handler.get_cur_pos_in_line() == 4);

--- a/test/unit_test/test_lexical_analyzer_class.cpp
+++ b/test/unit_test/test_lexical_analyzer_class.cpp
@@ -438,7 +438,9 @@ TEST_CASE("LexicalAnalyzerClassTest_ScanStringTokenTest", "[LexicalAnalyzerClass
         value_pair_t(std::string("foo]"), fkyaml::node::string_type("foo")),
         value_pair_t(std::string("foo:bar"), fkyaml::node::string_type("foo:bar")),
         value_pair_t(std::string("foo bar"), fkyaml::node::string_type("foo bar")),
+        value_pair_t(std::string("foo\'s bar"), fkyaml::node::string_type("foo\'s bar")),
         value_pair_t(std::string("\"foo bar\""), fkyaml::node::string_type("foo bar")),
+        value_pair_t(std::string("\"foo's bar\""), fkyaml::node::string_type("foo's bar")),
         value_pair_t(std::string("\"foo:bar\""), fkyaml::node::string_type("foo:bar")),
         value_pair_t(std::string("\"foo,bar\""), fkyaml::node::string_type("foo,bar")),
         value_pair_t(std::string("\"foo]bar\""), fkyaml::node::string_type("foo]bar")),
@@ -639,10 +641,8 @@ TEST_CASE("LexicalAnalyzerClassTest_ScanInvalidStringTokenTest", "[LexicalAnalyz
 {
     auto buffer = GENERATE(
         std::string("foo\"bar"),
-        std::string("foo\'bar"),
         std::string("foo\\tbar"),
         std::string("-.a"),
-        std::string("\"foo\'bar\""),
         std::string("\"test"),
         std::string("\'test"),
         std::string("\'test\n\'"),


### PR DESCRIPTION
As reported in #217, fkYAML had a bug in parsing strings containing single quotes.  
So this PR has fixed the bug and modified test cases to ensure such strings can be parsed without an error.  