### PR TITLE
#209 support UTF-16 / UTF-32 for deserialization input characters

### DIFF
--- a/docs/mkdocs/docs/api/basic_node/deserialize.md
+++ b/docs/mkdocs/docs/api/basic_node/deserialize.md
@@ -16,6 +16,13 @@ static basic_node deserialize(PtrType&& ptr, std::size_t size); // (3)
 Deserializes from compatible input sources.  
 Throws a [`fkyaml::exception`](../exception/index.md) if the deserialization process detects an error from the input sources.  
 
+!!! note "Supported Unicode Encodings"
+
+    fkYAML supports UTF-8, UTF-16 and UTF-32 encodings for input characters.  
+    Note that input characters must be encoded in the UTF-8 format when deserializing with `FILE*` or `std::istreams` objects.  
+    An array/container of `char`, `char16_t` and `char32_t` denotes that its contents are encoded in the UTF-8, UTF-16 and UTF-32 format, respectively.  
+    The deserialization process internally converts input characters into the the UTF-8 encoded ones if they are encoded in the UTF-16 or UTF-32 format.  
+
 ## Overload (1)
 
 ```cpp
@@ -30,10 +37,10 @@ static basic_node deserialize(InputType&& input);
 
     * an `std::istream` object
     * a `FILE` pointer (must not be `nullptr`)
-    * a C-style array of characters
-    * a pointer to a null-terminated string of single byte characters.
+    * a C-style array of characters (`char`, `char16_t` or `char32_t`. See the "Supported Unicode Encodings" above.)
+        * char[N], char16_t[N], or char32_t[N] (N: the size of an array)
     * a container `obj` for which `begin(obj)` and `end(obj)` produces a valid pair of iterators
-        * std::string, std::array<char>, and the likes.
+        * std::basic_string, std::array, and the likes.
 
 ### **Parameters**
 

--- a/docs/mkdocs/docs/api/basic_node/extraction_operator.md
+++ b/docs/mkdocs/docs/api/basic_node/extraction_operator.md
@@ -9,6 +9,7 @@ inline std::istream& operator>>(std::istream& is, basic_node& n);
 Insertion operator for basic_node template class.  
 Deserializes an input stream into a [`basic_node`](index.md).  
 This API is a wrapper of [`basic_node::deserialize()`](deserialize.md) function for input streams to simplify the implementation in the user's code.  
+Note that the contents of the input stream must be encoded in the UTF-8 format.  
 
 ## **Parameters**
 

--- a/docs/mkdocs/docs/tutorials/index.md
+++ b/docs/mkdocs/docs/tutorials/index.md
@@ -56,6 +56,7 @@ Let's start with a really simple example.
 Say you have an example.yaml file and now you want to load the contents.  
 Note that the following example files assumes that you have installed the fkYAML library somewhere on your machine.  
 See [the CMake Integration section]() for the other ways and modify the implementation if necessary.  
+Also, Make sure the example.yaml file is encoded in the UTF-8 format.  
 
 ```title="Project Structure"
 .

--- a/include/fkYAML/detail/encodings/utf8_encoding.hpp
+++ b/include/fkYAML/detail/encodings/utf8_encoding.hpp
@@ -197,7 +197,9 @@ public:
     /// @param[out] utf8_bytes UTF-8 encoded bytes.
     /// @param[out] consumed_size The number of UTF-16 encoded characters used for the conversion.
     /// @param[out] encoded_size The size of UTF-encoded bytes.
-    static void from_utf16(std::array<char16_t, 2> utf16, std::array<char, 4>& utf8_bytes, std::size_t& consumed_size, std::size_t& encoded_size)
+    static void from_utf16(
+        std::array<char16_t, 2> utf16, std::array<char, 4>& utf8_bytes, std::size_t& consumed_size,
+        std::size_t& encoded_size)
     {
         utf8_bytes.fill(0);
         consumed_size = 0;

--- a/include/fkYAML/detail/encodings/utf8_encoding.hpp
+++ b/include/fkYAML/detail/encodings/utf8_encoding.hpp
@@ -1,0 +1,326 @@
+///  _______   __ __   __  _____   __  __  __
+/// |   __| |_/  |  \_/  |/  _  \ /  \/  \|  |     fkYAML: A C++ header-only YAML library
+/// |   __|  _  < \_   _/|  ___  |    _   |  |___  version 0.2.1
+/// |__|  |_| \__|  |_|  |_|   |_|___||___|______| https://github.com/fktn-k/fkYAML
+///
+/// SPDX-FileCopyrightText: 2023 Kensuke Fukutani <fktn.dev@gmail.com>
+/// SPDX-License-Identifier: MIT
+///
+/// @file
+
+#ifndef FK_YAML_DETAIL_ENCODINGS_UTF_ENCODING_HPP_
+#define FK_YAML_DETAIL_ENCODINGS_UTF_ENCODING_HPP_
+
+#include <array>
+#include <cstdint>
+#include <cuchar>
+
+#include <fkYAML/detail/macros/version_macros.hpp>
+#include <fkYAML/exception.hpp>
+
+/// @brief namespace for fkYAML library.
+FK_YAML_NAMESPACE_BEGIN
+
+/// @brief namespace for internal implementations of fkYAML library.
+namespace detail
+{
+
+template <typename CharType>
+class utf_encoding;
+
+/////////////////////////
+//   UTF-8 Encoding   ///
+/////////////////////////
+
+class utf8_encoding
+{
+    using int_type = std::char_traits<char>::int_type;
+
+public:
+    /// @brief Validates the encoding of a given byte array whose length is 1.
+    /// @param[in] byte_array The byte array to be validated.
+    /// @return true if a given byte array is valid, false otherwise.
+    static bool validate(std::array<int_type, 1> byte_array) noexcept
+    {
+        // U+0000..U+007F
+        return (0x00 <= byte_array[0] && byte_array[0] <= 0x7F);
+    }
+
+    /// @brief Validates the encoding of a given byte array whose length is 2.
+    /// @param[in] byte_array The byte array to be validated.
+    /// @return true if a given byte array is valid, false otherwise.
+    static bool validate(std::array<int_type, 2> byte_array) noexcept
+    {
+        // U+0080..U+07FF
+        //   1st Byte: 0xC2..0xDF
+        //   2nd Byte: 0x80..0xBF
+        if (0xC2 <= byte_array[0] && byte_array[0] <= 0xDF)
+        {
+            if (0x80 <= byte_array[1] && byte_array[1] <= 0xBF)
+            {
+                return true;
+            }
+        }
+
+        // The rest of byte combinations are invalid.
+        return false;
+    }
+
+    /// @brief Validates the encoding of a given byte array whose length is 3.
+    /// @param[in] byte_array The byte array to be validated.
+    /// @return true if a given byte array is valid, false otherwise.
+    static bool validate(std::array<int_type, 3> byte_array) noexcept
+    {
+        // U+1000..U+CFFF:
+        //   1st Byte: 0xE0..0xEC
+        //   2nd Byte: 0x80..0xBF
+        //   3rd Byte: 0x80..0xBF
+        if (0xE0 <= byte_array[0] && byte_array[0] <= 0xEC)
+        {
+            if (0x80 <= byte_array[1] && byte_array[1] <= 0xBF)
+            {
+                if (0x80 <= byte_array[2] && byte_array[2] <= 0xBF)
+                {
+                    return true;
+                }
+            }
+            return false;
+        }
+
+        // U+D000..U+D7FF:
+        //   1st Byte: 0xED
+        //   2nd Byte: 0x80..0x9F
+        //   3rd Byte: 0x80..0xBF
+        if (byte_array[0] == 0xED)
+        {
+            if (0x80 <= byte_array[1] && byte_array[1] <= 0x9F)
+            {
+                if (0x80 <= byte_array[2] && byte_array[2] <= 0xBF)
+                {
+                    return true;
+                }
+            }
+            return false;
+        }
+
+        // U+E000..U+FFFF:
+        //   1st Byte: 0xEE..0xEF
+        //   2nd Byte: 0x80..0xBF
+        //   3rd Byte: 0x80..0xBF
+        if (byte_array[0] == 0xEE || byte_array[0] == 0xEF)
+        {
+            if (0x80 <= byte_array[1] && byte_array[1] <= 0xBF)
+            {
+                if (0x80 <= byte_array[2] && byte_array[2] <= 0xBF)
+                {
+                    return true;
+                }
+            }
+            return false;
+        }
+
+        // The rest of byte combinations are invalid.
+        return false;
+    }
+
+    /// @brief Validates the encoding of a given byte array whose length is 4.
+    /// @param[in] byte_array The byte array to be validated.
+    /// @return true if a given byte array is valid, false otherwise.
+    static bool validate(std::array<int_type, 4> byte_array) noexcept
+    {
+        // U+10000..U+3FFFF:
+        //   1st Byte: 0xF0
+        //   2nd Byte: 0x90..0xBF
+        //   3rd Byte: 0x80..0xBF
+        //   4th Byte: 0x80..0xBF
+        if (byte_array[0] == 0xF0)
+        {
+            if (0x90 <= byte_array[1] && byte_array[1] <= 0xBF)
+            {
+                if (0x80 <= byte_array[2] && byte_array[2] <= 0xBF)
+                {
+                    if (0x80 <= byte_array[3] && byte_array[3] <= 0xBF)
+                    {
+                        return true;
+                    }
+                }
+            }
+            return false;
+        }
+
+        // U+40000..U+FFFFF:
+        //   1st Byte: 0xF1..0xF3
+        //   2nd Byte: 0x80..0xBF
+        //   3rd Byte: 0x80..0xBF
+        //   4th Byte: 0x80..0xBF
+        if (0xF1 <= byte_array[0] && byte_array[0] <= 0xF3)
+        {
+            if (0x80 <= byte_array[1] && byte_array[1] <= 0xBF)
+            {
+                if (0x80 <= byte_array[2] && byte_array[2] <= 0xBF)
+                {
+                    if (0x80 <= byte_array[3] && byte_array[3] <= 0xBF)
+                    {
+                        return true;
+                    }
+                }
+            }
+            return false;
+        }
+
+        // U+100000..U+10FFFF:
+        //   1st Byte: 0xF4
+        //   2nd Byte: 0x80..0x8F
+        //   3rd Byte: 0x80..0xBF
+        //   4th Byte: 0x80..0xBF
+        if (byte_array[0] == 0xF4)
+        {
+            if (0x80 <= byte_array[1] && byte_array[1] <= 0x8F)
+            {
+                if (0x80 <= byte_array[2] && byte_array[2] <= 0xBF)
+                {
+                    if (0x80 <= byte_array[3] && byte_array[3] <= 0xBF)
+                    {
+                        return true;
+                    }
+                }
+            }
+            return false;
+        }
+
+        // The rest of byte combinations are invalid.
+        return false;
+    }
+
+    /// @brief Converts UTF-16 encoded characters to UTF-8 encoded bytes.
+    /// @param[in] utf16 UTF-16 encoded character(s).
+    /// @param[out] utf8_bytes UTF-8 encoded bytes.
+    /// @param[out] consumed_size The number of UTF-16 encoded characters used for the conversion.
+    /// @param[out] encoded_size The size of UTF-encoded bytes.
+    static void from_utf16(std::array<char16_t, 2> utf16, std::array<char, 4>& utf8_bytes, std::size_t& consumed_size, std::size_t& encoded_size)
+    {
+        utf8_bytes.fill(0);
+        consumed_size = 0;
+        encoded_size = 0;
+        bool is_valid = false;
+
+        if (utf16[0] < char16_t(0x80u))
+        {
+            utf8_bytes[0] = static_cast<char>(utf16[0] & 0x7Fu);
+            consumed_size = 1;
+            encoded_size = 1;
+            is_valid = true;
+        }
+        else if (utf16[0] <= char16_t(0x7FFu))
+        {
+            uint16_t utf8_encoded = 0b1100000010000000;
+            utf8_encoded |= static_cast<uint16_t>((utf16[0] & 0x07C0u) << 2);
+            utf8_encoded |= static_cast<uint16_t>(utf16[0] & 0x003Fu);
+            utf8_bytes[0] = static_cast<char>((utf8_encoded & 0xFF00u) >> 8);
+            utf8_bytes[1] = static_cast<char>(utf8_encoded & 0x00FFu);
+            consumed_size = 1;
+            encoded_size = 2;
+            is_valid = true;
+        }
+        else if (utf16[0] < char16_t(0xD800u) || char16_t(0xE000u) <= utf16[0])
+        {
+            uint32_t utf8_encoded = 0b111000001000000010000000;
+            utf8_encoded |= static_cast<uint32_t>((utf16[0] & 0xF000u) << 4);
+            utf8_encoded |= static_cast<uint32_t>((utf16[0] & 0x0FC0u) << 2);
+            utf8_encoded |= static_cast<uint32_t>(utf16[0] & 0x003Fu);
+            utf8_bytes[0] = static_cast<char>((utf8_encoded & 0xFF0000u) >> 16);
+            utf8_bytes[1] = static_cast<char>((utf8_encoded & 0x00FF00u) >> 8);
+            utf8_bytes[2] = static_cast<char>(utf8_encoded & 0x0000FFu);
+            consumed_size = 1;
+            encoded_size = 3;
+            is_valid = true;
+        }
+        else if (utf16[0] <= char16_t(0xDBFFu) && char16_t(0xDC00u) <= utf16[1] && utf16[1] <= char16_t(0xDFFFu))
+        {
+            // for surrogate pairs
+            uint32_t code_point = 0x10000u + ((utf16[0] & 0x03FFu) << 10) + (utf16[1] & 0x03FFu);
+            uint32_t utf8_encoded = 0b11110000100000001000000010000000;
+            utf8_encoded |= static_cast<uint32_t>((code_point & 0x1C0000u) << 6);
+            utf8_encoded |= static_cast<uint32_t>((code_point & 0x03F000u) << 4);
+            utf8_encoded |= static_cast<uint32_t>((code_point & 0x000FC0u) << 2);
+            utf8_encoded |= static_cast<uint32_t>(code_point & 0x00003Fu);
+            utf8_bytes[0] = static_cast<char>((utf8_encoded & 0xFF000000u) >> 24);
+            utf8_bytes[1] = static_cast<char>((utf8_encoded & 0x00FF0000u) >> 16);
+            utf8_bytes[2] = static_cast<char>((utf8_encoded & 0x0000FF00u) >> 8);
+            utf8_bytes[3] = static_cast<char>(utf8_encoded & 0x000000FFu);
+            consumed_size = 2;
+            encoded_size = 4;
+            is_valid = true;
+        }
+
+        if (!is_valid)
+        {
+            throw fkyaml::exception("Invalid UTF-16 encoding detected.");
+        }
+    }
+
+    /// @brief Converts a UTF-32 encoded character to UTF-8 encoded bytes.
+    /// @param[in] utf32 A UTF-32 encoded character.
+    /// @param[out] utf8_bytes UTF-8 encoded bytes.
+    /// @param[in] encoded_size The size of UTF-encoded bytes.
+    static void from_utf32(const char32_t utf32, std::array<char, 4>& utf8_bytes, std::size_t& encoded_size)
+    {
+        utf8_bytes.fill(0);
+        encoded_size = 0;
+        bool is_valid = false;
+
+        if (utf32 < char32_t(0x80u))
+        {
+            utf8_bytes[0] = static_cast<char>(utf32 & 0x007F);
+            encoded_size = 1;
+            is_valid = true;
+        }
+        else if (utf32 <= char32_t(0x7FFu))
+        {
+            uint16_t utf8_encoded = 0b1100000010000000;
+            utf8_encoded |= static_cast<uint16_t>((utf32 & 0x07C0u) << 2);
+            utf8_encoded |= static_cast<uint16_t>(utf32 & 0x003Fu);
+            utf8_bytes[0] = static_cast<char>((utf8_encoded & 0xFF00u) >> 8);
+            utf8_bytes[1] = static_cast<char>(utf8_encoded & 0x00FFu);
+            encoded_size = 2;
+            is_valid = true;
+        }
+        else if (utf32 <= char32_t(0xFFFFu))
+        {
+            uint32_t utf8_encoded = 0b111000001000000010000000;
+            utf8_encoded |= static_cast<uint32_t>((utf32 & 0xF000u) << 4);
+            utf8_encoded |= static_cast<uint32_t>((utf32 & 0x0FC0u) << 2);
+            utf8_encoded |= static_cast<uint32_t>(utf32 & 0x003F);
+            utf8_bytes[0] = static_cast<char>((utf8_encoded & 0xFF0000u) >> 16);
+            utf8_bytes[1] = static_cast<char>((utf8_encoded & 0x00FF00u) >> 8);
+            utf8_bytes[2] = static_cast<char>(utf8_encoded & 0x0000FFu);
+            encoded_size = 3;
+            is_valid = true;
+        }
+        else if (utf32 <= char32_t(0x10FFFFu))
+        {
+            uint32_t utf8_encoded = 0b11110000100000001000000010000000;
+            utf8_encoded |= static_cast<uint32_t>((utf32 & 0x1C0000u) << 6);
+            utf8_encoded |= static_cast<uint32_t>((utf32 & 0x03F000u) << 4);
+            utf8_encoded |= static_cast<uint32_t>((utf32 & 0x000FC0u) << 2);
+            utf8_encoded |= static_cast<uint32_t>(utf32 & 0x00003Fu);
+            utf8_bytes[0] = static_cast<char>((utf8_encoded & 0xFF000000u) >> 24);
+            utf8_bytes[1] = static_cast<char>((utf8_encoded & 0x00FF0000u) >> 16);
+            utf8_bytes[2] = static_cast<char>((utf8_encoded & 0x0000FF00u) >> 8);
+            utf8_bytes[3] = static_cast<char>(utf8_encoded & 0x000000FFu);
+            encoded_size = 4;
+            is_valid = true;
+        }
+
+        if (!is_valid)
+        {
+            throw fkyaml::exception("Invalid UTF-32 encoding detected.");
+        }
+    }
+};
+
+} // namespace detail
+
+FK_YAML_NAMESPACE_END
+
+#endif /* FK_YAML_DETAIL_ENCODINGS_UTF_ENCODING_HPP_ */

--- a/include/fkYAML/detail/encodings/utf8_encoding.hpp
+++ b/include/fkYAML/detail/encodings/utf8_encoding.hpp
@@ -13,7 +13,6 @@
 
 #include <array>
 #include <cstdint>
-#include <cuchar>
 
 #include <fkYAML/detail/macros/version_macros.hpp>
 #include <fkYAML/exception.hpp>

--- a/include/fkYAML/detail/input/input_adapter.hpp
+++ b/include/fkYAML/detail/input/input_adapter.hpp
@@ -226,10 +226,6 @@ private:
     IterType m_current {};
     /// The iterator at the end of input.
     IterType m_end {};
-    /// The buffer for decoding characters read from the input.
-    std::array<char16_t, 2> m_encoded_buffer {{0, 0}};
-    /// The number of elements to be read from the input next time.
-    std::size_t m_elems_to_read {2};
     /// The buffer for UTF-8 encoded characters.
     std::array<char, 4> m_utf8_buffer {{0, 0, 0, 0}};
     /// The next index in `m_utf8_buffer` to read.

--- a/include/fkYAML/detail/input/input_adapter.hpp
+++ b/include/fkYAML/detail/input/input_adapter.hpp
@@ -169,6 +169,75 @@ private:
     std::size_t m_utf8_buf_size {0};
 };
 
+/// @brief An input adapter for iterators of type char32_t.
+/// @note This adapter requires at least bidirectional iterator tag.
+/// @tparam IterType An iterator type.
+template <typename IterType>
+class iterator_input_adapter<
+    IterType,
+    enable_if_t<std::is_same<remove_cv_t<typename std::iterator_traits<IterType>::value_type>, char32_t>::value>>
+{
+public:
+    /// A type for characters used in this input adapter.
+    using char_type = char;
+
+    /// @brief Construct a new iterator_input_adapter object.
+    iterator_input_adapter() = default;
+
+    /// @brief Construct a new iterator_input_adapter object.
+    /// @param begin The beginning of iteraters.
+    /// @param end The end of iterators.
+    iterator_input_adapter(IterType begin, IterType end)
+        : m_current(begin),
+          m_end(end)
+    {
+    }
+
+    // allow only move construct/assignment like other input adapters.
+    iterator_input_adapter(const iterator_input_adapter&) = delete;
+    iterator_input_adapter(iterator_input_adapter&& rhs) = default;
+    iterator_input_adapter& operator=(const iterator_input_adapter&) = delete;
+    iterator_input_adapter& operator=(iterator_input_adapter&&) = default;
+    ~iterator_input_adapter() = default;
+
+    /// @brief Get a character at the current position and move forward.
+    /// @return std::char_traits<char_type>::int_type A character or EOF.
+    typename std::char_traits<char_type>::int_type get_character()
+    {
+        if (m_utf8_buf_index == m_utf8_buf_size)
+        {
+            if (m_current == m_end)
+            {
+                return std::char_traits<char_type>::eof();
+            }
+
+            utf8_encoding::from_utf32(*m_current, m_utf8_buffer, m_utf8_buf_size);
+            ++m_current;
+            m_utf8_buf_index = 0;
+        }
+
+        auto ret = std::char_traits<char_type>::to_int_type(m_utf8_buffer[m_utf8_buf_index]);
+        ++m_utf8_buf_index;
+        return ret;
+    }
+
+private:
+    /// The iterator at the current position.
+    IterType m_current {};
+    /// The iterator at the end of input.
+    IterType m_end {};
+    /// The buffer for decoding characters read from the input.
+    std::array<char16_t, 2> m_encoded_buffer {{0, 0}};
+    /// The number of elements to be read from the input next time.
+    std::size_t m_elems_to_read {2};
+    /// The buffer for UTF-8 encoded characters.
+    std::array<char, 4> m_utf8_buffer {{0, 0, 0, 0}};
+    /// The next index in `m_utf8_buffer` to read.
+    std::size_t m_utf8_buf_index {0};
+    /// The number of bytes in `m_utf8_buffer`.
+    std::size_t m_utf8_buf_size {0};
+};
+
 /// @brief An input adapter for C-style file handles.
 class file_input_adapter
 {

--- a/test/unit_test/CMakeLists.txt
+++ b/test/unit_test/CMakeLists.txt
@@ -162,6 +162,7 @@ add_executable(
   test_node_ref_storage_class.cpp
   test_ordered_map_class.cpp
   test_serializer_class.cpp
+  test_utf8_encoding_class.cpp
   main.cpp)
 
 target_link_libraries(${TEST_TARGET} PRIVATE unit_test_config)

--- a/test/unit_test/test_input_adapter.cpp
+++ b/test/unit_test/test_input_adapter.cpp
@@ -43,6 +43,13 @@ TEST_CASE("InputAdapterTest_IteratorInputAdapterProviderTest", "[InputAdapterTes
         REQUIRE(std::is_same<decltype(input_adapter), fkyaml::detail::iterator_input_adapter<char*>>::value);
     }
 
+    SECTION("c-style char16_t array")
+    {
+        char16_t input16[] = u"test";
+        auto input_adapter = fkyaml::detail::input_adapter(input16);
+        REQUIRE(std::is_same<decltype(input_adapter), fkyaml::detail::iterator_input_adapter<char16_t*>>::value);
+    }
+
     SECTION("std::string")
     {
         std::string input_str(input);
@@ -84,7 +91,7 @@ TEST_CASE("InputAdapterTest_StreamInputAdapterProviderTest", "[InputAdapterTest]
 
 TEST_CASE("InputAdapterTest_GetCharacterTest", "[InputAdapterTest]")
 {
-    SECTION("iterator_input_adapter")
+    SECTION("iterator_input_adapter for char")
     {
         char input[] = "test source.";
         auto input_adapter = fkyaml::detail::input_adapter(input);
@@ -104,6 +111,26 @@ TEST_CASE("InputAdapterTest_GetCharacterTest", "[InputAdapterTest]")
         REQUIRE(input_adapter.get_character() == 'c');
         REQUIRE(input_adapter.get_character() == 'e');
         REQUIRE(input_adapter.get_character() == '.');
+        REQUIRE(input_adapter.get_character() == char_traits_type::eof());
+    }
+
+    SECTION("iterator_input_adapter for char16_t")
+    {
+        char16_t input[] = u"aあ\U0002000B";
+        auto input_adapter = fkyaml::detail::input_adapter(input);
+        REQUIRE(std::is_same<decltype(input_adapter), fkyaml::detail::iterator_input_adapter<char16_t*>>::value);
+
+        using char_traits_type = std::char_traits<typename decltype(input_adapter)::char_type>;
+        using int_type = typename char_traits_type::int_type;
+
+        REQUIRE(input_adapter.get_character() == 'a');
+        REQUIRE(input_adapter.get_character() == int_type(0xE3u));
+        REQUIRE(input_adapter.get_character() == int_type(0x81u));
+        REQUIRE(input_adapter.get_character() == int_type(0x82u));
+        REQUIRE(input_adapter.get_character() == int_type(0xF0u));
+        REQUIRE(input_adapter.get_character() == int_type(0xA0u));
+        REQUIRE(input_adapter.get_character() == int_type(0x80u));
+        REQUIRE(input_adapter.get_character() == int_type(0x8Bu));
         REQUIRE(input_adapter.get_character() == char_traits_type::eof());
     }
 

--- a/test/unit_test/test_input_adapter.cpp
+++ b/test/unit_test/test_input_adapter.cpp
@@ -50,6 +50,13 @@ TEST_CASE("InputAdapterTest_IteratorInputAdapterProviderTest", "[InputAdapterTes
         REQUIRE(std::is_same<decltype(input_adapter), fkyaml::detail::iterator_input_adapter<char16_t*>>::value);
     }
 
+    SECTION("c-style char32_t array")
+    {
+        char32_t intput32[] = U"test";
+        auto input_adapter = fkyaml::detail::input_adapter(intput32);
+        REQUIRE(std::is_same<decltype(input_adapter), fkyaml::detail::iterator_input_adapter<char32_t*>>::value);
+    }
+
     SECTION("std::string")
     {
         std::string input_str(input);
@@ -114,11 +121,97 @@ TEST_CASE("InputAdapterTest_GetCharacterTest", "[InputAdapterTest]")
         REQUIRE(input_adapter.get_character() == char_traits_type::eof());
     }
 
+    SECTION("iterator_input_adapter for std::string")
+    {
+        std::string input = "test source.";
+        auto input_adapter = fkyaml::detail::input_adapter(input);
+        using itr_type = typename std::string::iterator;
+        REQUIRE(std::is_same<decltype(input_adapter), fkyaml::detail::iterator_input_adapter<itr_type>>::value);
+
+        using char_traits_type = std::char_traits<typename decltype(input_adapter)::char_type>;
+
+        REQUIRE(input_adapter.get_character() == 't');
+        REQUIRE(input_adapter.get_character() == 'e');
+        REQUIRE(input_adapter.get_character() == 's');
+        REQUIRE(input_adapter.get_character() == 't');
+        REQUIRE(input_adapter.get_character() == ' ');
+        REQUIRE(input_adapter.get_character() == 's');
+        REQUIRE(input_adapter.get_character() == 'o');
+        REQUIRE(input_adapter.get_character() == 'u');
+        REQUIRE(input_adapter.get_character() == 'r');
+        REQUIRE(input_adapter.get_character() == 'c');
+        REQUIRE(input_adapter.get_character() == 'e');
+        REQUIRE(input_adapter.get_character() == '.');
+        REQUIRE(input_adapter.get_character() == char_traits_type::eof());
+    }
+
     SECTION("iterator_input_adapter for char16_t")
     {
         char16_t input[] = u"aあ\U0002000B";
         auto input_adapter = fkyaml::detail::input_adapter(input);
         REQUIRE(std::is_same<decltype(input_adapter), fkyaml::detail::iterator_input_adapter<char16_t*>>::value);
+
+        using char_traits_type = std::char_traits<typename decltype(input_adapter)::char_type>;
+        using int_type = typename char_traits_type::int_type;
+
+        REQUIRE(input_adapter.get_character() == 'a');
+        REQUIRE(input_adapter.get_character() == int_type(0xE3u));
+        REQUIRE(input_adapter.get_character() == int_type(0x81u));
+        REQUIRE(input_adapter.get_character() == int_type(0x82u));
+        REQUIRE(input_adapter.get_character() == int_type(0xF0u));
+        REQUIRE(input_adapter.get_character() == int_type(0xA0u));
+        REQUIRE(input_adapter.get_character() == int_type(0x80u));
+        REQUIRE(input_adapter.get_character() == int_type(0x8Bu));
+        REQUIRE(input_adapter.get_character() == char_traits_type::eof());
+    }
+
+    SECTION("iterator_input_adapter for std::u16string")
+    {
+        std::u16string input = u"aあ\U0002000B";
+        auto input_adapter = fkyaml::detail::input_adapter(input);
+        using itr_type = typename std::u16string::iterator;
+        REQUIRE(std::is_same<decltype(input_adapter), fkyaml::detail::iterator_input_adapter<itr_type>>::value);
+
+        using char_traits_type = std::char_traits<typename decltype(input_adapter)::char_type>;
+        using int_type = typename char_traits_type::int_type;
+
+        REQUIRE(input_adapter.get_character() == 'a');
+        REQUIRE(input_adapter.get_character() == int_type(0xE3u));
+        REQUIRE(input_adapter.get_character() == int_type(0x81u));
+        REQUIRE(input_adapter.get_character() == int_type(0x82u));
+        REQUIRE(input_adapter.get_character() == int_type(0xF0u));
+        REQUIRE(input_adapter.get_character() == int_type(0xA0u));
+        REQUIRE(input_adapter.get_character() == int_type(0x80u));
+        REQUIRE(input_adapter.get_character() == int_type(0x8Bu));
+        REQUIRE(input_adapter.get_character() == char_traits_type::eof());
+    }
+
+    SECTION("iterator_input_adapter for char32_t")
+    {
+        char32_t input[] = U"aあ\U0002000B";
+        auto input_adapter = fkyaml::detail::input_adapter(input);
+        REQUIRE(std::is_same<decltype(input_adapter), fkyaml::detail::iterator_input_adapter<char32_t*>>::value);
+
+        using char_traits_type = std::char_traits<typename decltype(input_adapter)::char_type>;
+        using int_type = typename char_traits_type::int_type;
+
+        REQUIRE(input_adapter.get_character() == 'a');
+        REQUIRE(input_adapter.get_character() == int_type(0xE3u));
+        REQUIRE(input_adapter.get_character() == int_type(0x81u));
+        REQUIRE(input_adapter.get_character() == int_type(0x82u));
+        REQUIRE(input_adapter.get_character() == int_type(0xF0u));
+        REQUIRE(input_adapter.get_character() == int_type(0xA0u));
+        REQUIRE(input_adapter.get_character() == int_type(0x80u));
+        REQUIRE(input_adapter.get_character() == int_type(0x8Bu));
+        REQUIRE(input_adapter.get_character() == char_traits_type::eof());
+    }
+
+    SECTION("iterator_input_adapter for std::u32string")
+    {
+        std::u32string input = U"aあ\U0002000B";
+        auto input_adapter = fkyaml::detail::input_adapter(input);
+        using itr_type = typename std::u32string::iterator;
+        REQUIRE(std::is_same<decltype(input_adapter), fkyaml::detail::iterator_input_adapter<itr_type>>::value);
 
         using char_traits_type = std::char_traits<typename decltype(input_adapter)::char_type>;
         using int_type = typename char_traits_type::int_type;

--- a/test/unit_test/test_utf8_encoding_class.cpp
+++ b/test/unit_test/test_utf8_encoding_class.cpp
@@ -210,13 +210,21 @@ TEST_CASE("UTF8EncodingClassTest_FromUTF16Test", "[UTF8EncodingClassTest]")
             test_params {{{char16_t(0xD7FFu)}}, {{char(0xEDu), char(0x9Fu), char(0xBFu)}}, 1, 3},
             test_params {{{char16_t(0xE000u)}}, {{char(0xEEu), char(0x80u), char(0x80u)}}, 1, 3},
             test_params {{{char16_t(0xE001u)}}, {{char(0xEEu), char(0x80u), char(0x81u)}}, 1, 3},
-            test_params {{{char16_t(0xD800u), char16_t(0xDC00u)}}, {{char(0xF0u), char(0x90u), char(0x80u), char(0x80u)}}, 2, 4},
-            test_params {{{char16_t(0xD801u), char16_t(0xDC00u)}}, {{char(0xF0u), char(0x90u), char(0x90u), char(0x80u)}}, 2, 4},
-            test_params {{{char16_t(0xD800u), char16_t(0xDC01u)}}, {{char(0xF0u), char(0x90u), char(0x80u), char(0x81u)}}, 2, 4},
-            test_params {{{char16_t(0xDBFEu), char16_t(0xDFFFu)}}, {{char(0xF4u), char(0x8Fu), char(0xAFu), char(0xBFu)}}, 2, 4},
-            test_params {{{char16_t(0xDBFFu), char16_t(0xDFFEu)}}, {{char(0xF4u), char(0x8Fu), char(0xBFu), char(0xBEu)}}, 2, 4},
-            test_params {{{char16_t(0xDBFFu), char16_t(0xDFFFu)}}, {{char(0xF4u), char(0x8Fu), char(0xBFu), char(0xBFu)}}, 2, 4}
-        );
+            test_params {
+                {{char16_t(0xD800u), char16_t(0xDC00u)}}, {{char(0xF0u), char(0x90u), char(0x80u), char(0x80u)}}, 2, 4},
+            test_params {
+                {{char16_t(0xD801u), char16_t(0xDC00u)}}, {{char(0xF0u), char(0x90u), char(0x90u), char(0x80u)}}, 2, 4},
+            test_params {
+                {{char16_t(0xD800u), char16_t(0xDC01u)}}, {{char(0xF0u), char(0x90u), char(0x80u), char(0x81u)}}, 2, 4},
+            test_params {
+                {{char16_t(0xDBFEu), char16_t(0xDFFFu)}}, {{char(0xF4u), char(0x8Fu), char(0xAFu), char(0xBFu)}}, 2, 4},
+            test_params {
+                {{char16_t(0xDBFFu), char16_t(0xDFFEu)}}, {{char(0xF4u), char(0x8Fu), char(0xBFu), char(0xBEu)}}, 2, 4},
+            test_params {
+                {{char16_t(0xDBFFu), char16_t(0xDFFFu)}},
+                {{char(0xF4u), char(0x8Fu), char(0xBFu), char(0xBFu)}},
+                2,
+                4});
 
         std::array<char, 4> utf8_bytes;
         std::size_t consumed_size;
@@ -234,14 +242,15 @@ TEST_CASE("UTF8EncodingClassTest_FromUTF16Test", "[UTF8EncodingClassTest]")
         auto utf16 = GENERATE(
             std::array<char16_t, 2> {{char16_t(0xDC00u), char16_t(0xDC00u)}},
             std::array<char16_t, 2> {{char16_t(0xDBFFu), char16_t(0xDBFFu)}},
-            std::array<char16_t, 2> {{char16_t(0xDBFFu), char16_t(0xE000u)}}
-        );
+            std::array<char16_t, 2> {{char16_t(0xDBFFu), char16_t(0xE000u)}});
 
         std::array<char, 4> utf8_bytes;
         std::size_t consumed_size;
         std::size_t encoded_size;
 
-        REQUIRE_THROWS_AS(fkyaml::detail::utf8_encoding::from_utf16(utf16, utf8_bytes, consumed_size, encoded_size), fkyaml::exception);
+        REQUIRE_THROWS_AS(
+            fkyaml::detail::utf8_encoding::from_utf16(utf16, utf8_bytes, consumed_size, encoded_size),
+            fkyaml::exception);
     }
 }
 
@@ -268,8 +277,7 @@ TEST_CASE("UTF8EncodingClassTest_FromUTF32Test", "[UTF8EncodingClassTest]")
         test_params {0x010000u, {{char(0xF0u), char(0x90u), char(0x80u), char(0x80u)}}, 4},
         test_params {0x010001u, {{char(0xF0u), char(0x90u), char(0x80u), char(0x81u)}}, 4},
         test_params {0x10FFFEu, {{char(0xF4u), char(0x8Fu), char(0xBFu), char(0xBEu)}}, 4},
-        test_params {0x10FFFFu, {{char(0xF4u), char(0x8Fu), char(0xBFu), char(0xBFu)}}, 4}
-    );
+        test_params {0x10FFFFu, {{char(0xF4u), char(0x8Fu), char(0xBFu), char(0xBFu)}}, 4});
 
     std::array<char, 4> utf8_bytes;
     std::size_t size;

--- a/test/unit_test/test_utf8_encoding_class.cpp
+++ b/test/unit_test/test_utf8_encoding_class.cpp
@@ -1,0 +1,280 @@
+//  _______   __ __   __  _____   __  __  __
+// |   __| |_/  |  \_/  |/  _  \ /  \/  \|  |     fkYAML: A C++ header-only YAML library (supporting code)
+// |   __|  _  < \_   _/|  ___  |    _   |  |___  version 0.2.1
+// |__|  |_| \__|  |_|  |_|   |_|___||___|______| https://github.com/fktn-k/fkYAML
+//
+// SPDX-FileCopyrightText: 2023 Kensuke Fukutani <fktn.dev@gmail.com>
+// SPDX-License-Identifier: MIT
+
+#include <array>
+#include <cstdint>
+#include <tuple>
+
+#include <catch2/catch.hpp>
+
+#include <fkYAML/detail/encodings/utf8_encoding.hpp>
+
+TEST_CASE("UTF8EncodingClassTest_ValidateTest", "[UTFEncodingClassTest]")
+{
+    using int_type = std::char_traits<char>::int_type;
+
+    SECTION("1 byte character encoded in UTF-8.")
+    {
+        using array_ret_pair_t = std::pair<std::array<int_type, 1>, bool>;
+        auto pair = GENERATE(
+            array_ret_pair_t({{-2}}, false),
+            array_ret_pair_t({{-1}}, false),
+            array_ret_pair_t({{0x00}}, true),
+            array_ret_pair_t({{0x01}}, true),
+            array_ret_pair_t({{0x02}}, true),
+            array_ret_pair_t({{0x7D}}, true),
+            array_ret_pair_t({{0x7E}}, true),
+            array_ret_pair_t({{0x7F}}, true),
+            array_ret_pair_t({{0x80}}, false),
+            array_ret_pair_t({{0x81}}, false));
+
+        REQUIRE(fkyaml::detail::utf8_encoding::validate(pair.first) == pair.second);
+    }
+
+    SECTION("2 byte characters encoded in UTF-8.")
+    {
+        using array_ret_pair_t = std::pair<std::array<int_type, 2>, bool>;
+        auto pair = GENERATE(
+            array_ret_pair_t({{0xC0, 0x80}}, false),
+            array_ret_pair_t({{0xC1, 0x80}}, false),
+            array_ret_pair_t({{0xC2, 0x7E}}, false),
+            array_ret_pair_t({{0xC2, 0x7F}}, false),
+            array_ret_pair_t({{0xC2, 0x80}}, true),
+            array_ret_pair_t({{0xC3, 0x81}}, true),
+            array_ret_pair_t({{0xD0, 0xA0}}, true),
+            array_ret_pair_t({{0xDE, 0xBE}}, true),
+            array_ret_pair_t({{0xDF, 0xBF}}, true),
+            array_ret_pair_t({{0xDF, 0xC0}}, false),
+            array_ret_pair_t({{0xDF, 0xC1}}, false),
+            array_ret_pair_t({{0xE0, 0xBF}}, false),
+            array_ret_pair_t({{0xE1, 0xBF}}, false));
+
+        REQUIRE(fkyaml::detail::utf8_encoding::validate(pair.first) == pair.second);
+    }
+
+    SECTION("3 byte characters encoded in UTF-8.")
+    {
+        using array_ret_pair_t = std::pair<std::array<int_type, 3>, bool>;
+        auto pair = GENERATE(
+            array_ret_pair_t({{0xDE, 0x80, 0x80}}, false),
+            array_ret_pair_t({{0xDF, 0x80, 0x80}}, false),
+            array_ret_pair_t({{0xE0, 0x7E, 0x80}}, false),
+            array_ret_pair_t({{0xE0, 0x7F, 0x80}}, false),
+            array_ret_pair_t({{0xE0, 0x80, 0x7E}}, false),
+            array_ret_pair_t({{0xE0, 0x80, 0x7F}}, false),
+
+            array_ret_pair_t({{0xE0, 0x80, 0x80}}, true),
+            array_ret_pair_t({{0xE6, 0xA0, 0xA0}}, true),
+            array_ret_pair_t({{0xEC, 0xBF, 0xBF}}, true),
+
+            array_ret_pair_t({{0xEC, 0xC0, 0xBF}}, false),
+            array_ret_pair_t({{0xEC, 0xC1, 0xBF}}, false),
+            array_ret_pair_t({{0xEC, 0xBF, 0xC0}}, false),
+            array_ret_pair_t({{0xEC, 0xBF, 0xC1}}, false),
+
+            //////////////////////////////////////////////
+
+            array_ret_pair_t({{0xED, 0x7E, 0x80}}, false),
+            array_ret_pair_t({{0xED, 0x7F, 0x80}}, false),
+            array_ret_pair_t({{0xED, 0x80, 0x7E}}, false),
+            array_ret_pair_t({{0xED, 0x80, 0x7F}}, false),
+
+            array_ret_pair_t({{0xED, 0x80, 0x80}}, true),
+            array_ret_pair_t({{0xED, 0x90, 0xA0}}, true),
+            array_ret_pair_t({{0xED, 0x9F, 0xBF}}, true),
+
+            array_ret_pair_t({{0xED, 0xA0, 0xBF}}, false),
+            array_ret_pair_t({{0xED, 0xA1, 0xBF}}, false),
+            array_ret_pair_t({{0xED, 0x9F, 0xC0}}, false),
+            array_ret_pair_t({{0xED, 0x9F, 0xC1}}, false),
+
+            //////////////////////////////////////////////
+
+            array_ret_pair_t({{0xEE, 0x7E, 0x80}}, false),
+            array_ret_pair_t({{0xEE, 0x7F, 0x80}}, false),
+            array_ret_pair_t({{0xEE, 0x80, 0x7E}}, false),
+            array_ret_pair_t({{0xEE, 0x80, 0x7F}}, false),
+
+            array_ret_pair_t({{0xEE, 0x80, 0x80}}, true),
+            array_ret_pair_t({{0xEE, 0xA0, 0xA0}}, true),
+            array_ret_pair_t({{0xEF, 0xBF, 0xBF}}, true),
+
+            array_ret_pair_t({{0xEF, 0xC0, 0xBF}}, false),
+            array_ret_pair_t({{0xEF, 0xC1, 0xBF}}, false),
+            array_ret_pair_t({{0xEF, 0xBF, 0xC0}}, false),
+            array_ret_pair_t({{0xEF, 0xBF, 0xC1}}, false),
+            array_ret_pair_t({{0xF0, 0xBF, 0xBF}}, false),
+            array_ret_pair_t({{0xF1, 0xBF, 0xBF}}, false));
+
+        REQUIRE(fkyaml::detail::utf8_encoding::validate(pair.first) == pair.second);
+    }
+
+    SECTION("4 byte characters encoded in UTF-8.")
+    {
+        using array_ret_pair_t = std::pair<std::array<int_type, 4>, bool>;
+        auto pair = GENERATE(
+            array_ret_pair_t({{0xDE, 0x90, 0x80, 0x80}}, false),
+            array_ret_pair_t({{0xDF, 0x90, 0x80, 0x80}}, false),
+            array_ret_pair_t({{0xE0, 0x8E, 0x80, 0x80}}, false),
+            array_ret_pair_t({{0xE0, 0x8F, 0x80, 0x80}}, false),
+            array_ret_pair_t({{0xE0, 0x90, 0x7E, 0x80}}, false),
+            array_ret_pair_t({{0xE0, 0x90, 0x7F, 0x80}}, false),
+            array_ret_pair_t({{0xE0, 0x90, 0x80, 0x7E}}, false),
+            array_ret_pair_t({{0xE0, 0x90, 0x80, 0x7F}}, false),
+
+            array_ret_pair_t({{0xF0, 0x90, 0x80, 0x80}}, true),
+            array_ret_pair_t({{0xF0, 0xA8, 0xA0, 0xA0}}, true),
+            array_ret_pair_t({{0xF0, 0xBF, 0xBF, 0xBF}}, true),
+
+            array_ret_pair_t({{0xF0, 0xC0, 0xBF, 0xBF}}, false),
+            array_ret_pair_t({{0xF0, 0xC1, 0xBF, 0xBF}}, false),
+            array_ret_pair_t({{0xF0, 0xBF, 0xC0, 0xBF}}, false),
+            array_ret_pair_t({{0xF0, 0xBF, 0xC1, 0xBF}}, false),
+            array_ret_pair_t({{0xF0, 0xBF, 0xBF, 0xC0}}, false),
+            array_ret_pair_t({{0xF0, 0xBF, 0xBF, 0xC1}}, false),
+
+            ////////////////////////////////////////////////////
+
+            array_ret_pair_t({{0xF1, 0x7E, 0x80, 0x80}}, false),
+            array_ret_pair_t({{0xF1, 0x7F, 0x80, 0x80}}, false),
+            array_ret_pair_t({{0xF1, 0x80, 0x7E, 0x80}}, false),
+            array_ret_pair_t({{0xF1, 0x80, 0x7F, 0x80}}, false),
+            array_ret_pair_t({{0xF1, 0x80, 0x80, 0x7E}}, false),
+            array_ret_pair_t({{0xF1, 0x80, 0x80, 0x7F}}, false),
+
+            array_ret_pair_t({{0xF1, 0x80, 0x80, 0x80}}, true),
+            array_ret_pair_t({{0xF2, 0xA0, 0xA0, 0xA0}}, true),
+            array_ret_pair_t({{0xF3, 0xBF, 0xBF, 0xBF}}, true),
+
+            array_ret_pair_t({{0xF3, 0xC0, 0xBF, 0xBF}}, false),
+            array_ret_pair_t({{0xF3, 0xC1, 0xBF, 0xBF}}, false),
+            array_ret_pair_t({{0xF3, 0xBF, 0xC0, 0xBF}}, false),
+            array_ret_pair_t({{0xF3, 0xBF, 0xC1, 0xBF}}, false),
+            array_ret_pair_t({{0xF3, 0xBF, 0xBF, 0xC0}}, false),
+            array_ret_pair_t({{0xF3, 0xBF, 0xBF, 0xC1}}, false),
+
+            ////////////////////////////////////////////////////
+
+            array_ret_pair_t({{0xF4, 0x7E, 0x80, 0x80}}, false),
+            array_ret_pair_t({{0xF4, 0x7F, 0x80, 0x80}}, false),
+            array_ret_pair_t({{0xF4, 0x80, 0x7E, 0x80}}, false),
+            array_ret_pair_t({{0xF4, 0x80, 0x7F, 0x80}}, false),
+            array_ret_pair_t({{0xF4, 0x80, 0x80, 0x7E}}, false),
+            array_ret_pair_t({{0xF4, 0x80, 0x80, 0x7F}}, false),
+
+            array_ret_pair_t({{0xF4, 0x80, 0x80, 0x80}}, true),
+            array_ret_pair_t({{0xF4, 0x88, 0xA0, 0x80}}, true),
+            array_ret_pair_t({{0xF4, 0x8F, 0xBF, 0xBF}}, true),
+
+            array_ret_pair_t({{0xF4, 0x90, 0xBF, 0xBF}}, false),
+            array_ret_pair_t({{0xF4, 0x91, 0xBF, 0xBF}}, false),
+            array_ret_pair_t({{0xF4, 0x8F, 0xC0, 0xBF}}, false),
+            array_ret_pair_t({{0xF4, 0x8F, 0xC1, 0xBF}}, false),
+            array_ret_pair_t({{0xF4, 0x8F, 0xBF, 0xC0}}, false),
+            array_ret_pair_t({{0xF4, 0x8F, 0xBF, 0xC1}}, false),
+            array_ret_pair_t({{0xF5, 0x8F, 0xBF, 0xBF}}, false),
+            array_ret_pair_t({{0xF6, 0x8F, 0xBF, 0xBF}}, false));
+
+        REQUIRE(fkyaml::detail::utf8_encoding::validate(pair.first) == pair.second);
+    }
+}
+
+TEST_CASE("UTF8EncodingClassTest_FromUTF16Test", "[UTF8EncodingClassTest]")
+{
+    SECTION("valid UTF-16 character(s)")
+    {
+        struct test_params
+        {
+            std::array<char16_t, 2> utf16;
+            std::array<char, 4> utf8_bytes;
+            std::size_t consumed_size;
+            std::size_t encoded_size;
+        };
+        auto params = GENERATE(
+            test_params {{{char16_t(0x00u)}}, {{char(0x00u)}}, 1, 1},
+            test_params {{{char16_t(0x01u)}}, {{char(0x01u)}}, 1, 1},
+            test_params {{{char16_t(0x7Eu)}}, {{char(0x7Eu)}}, 1, 1},
+            test_params {{{char16_t(0x7Fu)}}, {{char(0x7Fu)}}, 1, 1},
+            test_params {{{char16_t(0x0080u)}}, {{char(0xC2u), char(0x80u)}}, 1, 2},
+            test_params {{{char16_t(0x0081u)}}, {{char(0xC2u), char(0x81u)}}, 1, 2},
+            test_params {{{char16_t(0x07FEu)}}, {{char(0xDFu), char(0xBEu)}}, 1, 2},
+            test_params {{{char16_t(0x07FFu)}}, {{char(0xDFu), char(0xBFu)}}, 1, 2},
+            test_params {{{char16_t(0x0800u)}}, {{char(0xE0u), char(0xA0u), char(0x80u)}}, 1, 3},
+            test_params {{{char16_t(0x0801u)}}, {{char(0xE0u), char(0xA0u), char(0x81u)}}, 1, 3},
+            test_params {{{char16_t(0xD7FEu)}}, {{char(0xEDu), char(0x9Fu), char(0xBEu)}}, 1, 3},
+            test_params {{{char16_t(0xD7FFu)}}, {{char(0xEDu), char(0x9Fu), char(0xBFu)}}, 1, 3},
+            test_params {{{char16_t(0xE000u)}}, {{char(0xEEu), char(0x80u), char(0x80u)}}, 1, 3},
+            test_params {{{char16_t(0xE001u)}}, {{char(0xEEu), char(0x80u), char(0x81u)}}, 1, 3},
+            test_params {{{char16_t(0xD800u), char16_t(0xDC00u)}}, {{char(0xF0u), char(0x90u), char(0x80u), char(0x80u)}}, 2, 4},
+            test_params {{{char16_t(0xD801u), char16_t(0xDC00u)}}, {{char(0xF0u), char(0x90u), char(0x90u), char(0x80u)}}, 2, 4},
+            test_params {{{char16_t(0xD800u), char16_t(0xDC01u)}}, {{char(0xF0u), char(0x90u), char(0x80u), char(0x81u)}}, 2, 4},
+            test_params {{{char16_t(0xDBFEu), char16_t(0xDFFFu)}}, {{char(0xF4u), char(0x8Fu), char(0xAFu), char(0xBFu)}}, 2, 4},
+            test_params {{{char16_t(0xDBFFu), char16_t(0xDFFEu)}}, {{char(0xF4u), char(0x8Fu), char(0xBFu), char(0xBEu)}}, 2, 4},
+            test_params {{{char16_t(0xDBFFu), char16_t(0xDFFFu)}}, {{char(0xF4u), char(0x8Fu), char(0xBFu), char(0xBFu)}}, 2, 4}
+        );
+
+        std::array<char, 4> utf8_bytes;
+        std::size_t consumed_size;
+        std::size_t encoded_size;
+
+        fkyaml::detail::utf8_encoding::from_utf16(params.utf16, utf8_bytes, consumed_size, encoded_size);
+
+        REQUIRE(utf8_bytes == params.utf8_bytes);
+        REQUIRE(consumed_size == params.consumed_size);
+        REQUIRE(encoded_size == params.encoded_size);
+    }
+
+    SECTION("invalid UTF-16 character(s)")
+    {
+        auto utf16 = GENERATE(
+            std::array<char16_t, 2> {{char16_t(0xDC00u), char16_t(0xDC00u)}},
+            std::array<char16_t, 2> {{char16_t(0xDBFFu), char16_t(0xDBFFu)}},
+            std::array<char16_t, 2> {{char16_t(0xDBFFu), char16_t(0xE000u)}}
+        );
+
+        std::array<char, 4> utf8_bytes;
+        std::size_t consumed_size;
+        std::size_t encoded_size;
+
+        REQUIRE_THROWS_AS(fkyaml::detail::utf8_encoding::from_utf16(utf16, utf8_bytes, consumed_size, encoded_size), fkyaml::exception);
+    }
+}
+
+TEST_CASE("UTF8EncodingClassTest_FromUTF32Test", "[UTF8EncodingClassTest]")
+{
+    struct test_params
+    {
+        char32_t utf32;
+        std::array<char, 4> utf8_bytes;
+        std::size_t size;
+    };
+    auto params = GENERATE(
+        test_params {0x00u, {{char(0x00u)}}, 1},
+        test_params {0x01u, {{char(0x01u)}}, 1},
+        test_params {0x7Eu, {{char(0x7Eu)}}, 1},
+        test_params {0x7Fu, {{char(0x7Fu)}}, 1},
+        test_params {0x0080u, {{char(0xC2u), char(0x80u)}}, 2},
+        test_params {0x0081u, {{char(0xC2u), char(0x81u)}}, 2},
+        test_params {0x07FEu, {{char(0xDFu), char(0xBEu)}}, 2},
+        test_params {0x07FFu, {{char(0xDFu), char(0xBFu)}}, 2},
+        test_params {0x0800u, {{char(0xE0u), char(0xA0u), char(0x80u)}}, 3},
+        test_params {0x0801u, {{char(0xE0u), char(0xA0u), char(0x81u)}}, 3},
+        test_params {0xFFFFu, {{char(0xEFu), char(0xBFu), char(0xBFu)}}, 3},
+        test_params {0x010000u, {{char(0xF0u), char(0x90u), char(0x80u), char(0x80u)}}, 4},
+        test_params {0x010001u, {{char(0xF0u), char(0x90u), char(0x80u), char(0x81u)}}, 4},
+        test_params {0x10FFFEu, {{char(0xF4u), char(0x8Fu), char(0xBFu), char(0xBEu)}}, 4},
+        test_params {0x10FFFFu, {{char(0xF4u), char(0x8Fu), char(0xBFu), char(0xBFu)}}, 4}
+    );
+
+    std::array<char, 4> utf8_bytes;
+    std::size_t size;
+    fkyaml::detail::utf8_encoding::from_utf32(params.utf32, utf8_bytes, size);
+
+    REQUIRE(utf8_bytes == params.utf8_bytes);
+    REQUIRE(size == params.size);
+}


### PR DESCRIPTION
This PR has supported UTF-16 and UTF-20 for input characters passed to the deserialization process.  
Note that input characters must be encoded in the UTF-8 format when deserializing with `FILE*` or `std::istreams` objects.  
The deserialization process internally converts input characters into the UTF-8 encoded ones if they are encoded in the UTF-16 or UTF-32 format because the other features assume that the string values are encoded in the UTF-8 format.  

Furthermore, the test suite and documentation have also been updated along with the implementation above.  