### PR TITLE
#214 Emit more descriptive errors

### DIFF
--- a/docs/mkdocs/docs/api/exception/index.md
+++ b/docs/mkdocs/docs/api/exception/index.md
@@ -13,6 +13,7 @@ A basic exception class used in the fkYAML library.
 | Type                                    | Description                                          |
 | --------------------------------------- | ---------------------------------------------------- |
 | [invalid_encoding](invalid_encoding.md) | The exception indicating an encoding error.          |
+| [parse_error](parse_error.md)           | The exception indicating an error in parsing.        |
 | [type_error](type_error.md)             | The exception indicating an invalid type conversion. |
 
 ## Member Functions

--- a/docs/mkdocs/docs/api/exception/index.md
+++ b/docs/mkdocs/docs/api/exception/index.md
@@ -8,17 +8,24 @@ class exception : public std::exception;
 
 A basic exception class used in the fkYAML library.
 
+## Derived Classes
+
+| Type                                    | Description                                          |
+| --------------------------------------- | ---------------------------------------------------- |
+| [invalid_encoding](invalid_encoding.md) | The exception indicating an encoding error.          |
+| [type_error](type_error.md)             | The exception indicating an invalid type conversion. |
+
 ## Member Functions
 
 ### Construction/Destruction
 
-| Type                            | Description              |
-|---------------------------------|--------------------------|
+| Name                            | Description              |
+| ------------------------------- | ------------------------ |
 | [(constructor)](constructor.md) | constructs an exception. |
 | [(destructor)](destructor.md)   | destroys an exception.   |
 
 ### Operation
 
-| Type            | Description                                |
-|-----------------|--------------------------------------------|
+| Name            | Description                                |
+| --------------- | ------------------------------------------ |
 | [what](what.md) | provides an error message for a exception. |

--- a/docs/mkdocs/docs/api/exception/invalid_encoding.md
+++ b/docs/mkdocs/docs/api/exception/invalid_encoding.md
@@ -1,0 +1,19 @@
+<small>Defined in header [`<fkYAML/exception.hpp>`](https://github.com/fktn-k/fkYAML/blob/develop/include/fkYAML/exception.hpp)</small>
+
+# <small>fkyaml::</small>invalid_encoding
+
+```cpp
+class invalid_encoding : public exception;
+```
+
+A exception class indicating an encoding error.  
+This class extends the [`fkyaml::exception`](index.md) class and the [`what()`](what.md) function emits an error message in the following format.  
+
+```
+invalid_encoding: [error message] in=[array of elements detected an error]
+```
+
+## **See Also**
+
+* [exception](index.md)
+* [what](what.md)

--- a/docs/mkdocs/docs/api/exception/parse_error.md
+++ b/docs/mkdocs/docs/api/exception/parse_error.md
@@ -1,0 +1,19 @@
+<small>Defined in header [`<fkYAML/exception.hpp>`](https://github.com/fktn-k/fkYAML/blob/develop/include/fkYAML/exception.hpp)</small>
+
+# <small>fkyaml::</small>parse_error
+
+```cpp
+class parse_error : public exception;
+```
+
+A exception class indicating an error in parsing.  
+This class extends the [`fkyaml::exception`](index.md) class and the [`what()`](what.md) function emits an error message in the following format.  
+
+```
+parse_error: [error message] (at line [LINE], column [COLUMN])
+```
+
+## **See Also**
+
+* [exception](index.md)
+* [what](what.md)

--- a/docs/mkdocs/docs/api/exception/type_error.md
+++ b/docs/mkdocs/docs/api/exception/type_error.md
@@ -1,0 +1,19 @@
+<small>Defined in header [`<fkYAML/exception.hpp>`](https://github.com/fktn-k/fkYAML/blob/develop/include/fkYAML/exception.hpp)</small>
+
+# <small>fkyaml::</small>type_error
+
+```cpp
+class type_error : public exception;
+```
+
+A exception class indicating an invalid type conversion.  
+This class extends the [`fkyaml::exception`](index.md) class and the [`what()`](what.md) function emits an error message in the following format.  
+
+```
+type_error: [error message] type=[source node type]
+```
+
+## **See Also**
+
+* [exception](index.md)
+* [what](what.md)

--- a/docs/mkdocs/mkdocs.yml
+++ b/docs/mkdocs/mkdocs.yml
@@ -147,6 +147,8 @@ nav:
           - (constructor): api/exception/constructor.md
           - (destructor): api/exception/destructor.md
           - what: api/exception/what.md
+          - invalid_encoding: api/exception/invalid_encoding.md
+          - type_error: api/exception/type_error.md
       - macros: api/macros.md
       - node_value_converter:
           - node_value_converter: api/node_value_converter/index.md

--- a/docs/mkdocs/mkdocs.yml
+++ b/docs/mkdocs/mkdocs.yml
@@ -148,6 +148,7 @@ nav:
           - (destructor): api/exception/destructor.md
           - what: api/exception/what.md
           - invalid_encoding: api/exception/invalid_encoding.md
+          - parse_error: api/exception/parse_error.md
           - type_error: api/exception/type_error.md
       - macros: api/macros.md
       - node_value_converter:

--- a/include/fkYAML/detail/conversions/from_node.hpp
+++ b/include/fkYAML/detail/conversions/from_node.hpp
@@ -48,7 +48,7 @@ inline void from_node(const BasicNodeType& n, typename BasicNodeType::sequence_t
 {
     if (!n.is_sequence())
     {
-        throw exception("The target node value type is not sequence type.");
+        throw type_error("The target node value type is not sequence type.", n.type());
     }
     s = n.template get_value_ref<const typename BasicNodeType::sequence_type&>();
 }
@@ -70,7 +70,7 @@ inline void from_node(const BasicNodeType& n, std::vector<CompatibleValueType>& 
 {
     if (!n.is_sequence())
     {
-        throw exception("The target node value is not sequence type.");
+        throw type_error("The target node value is not sequence type.", n.type());
     }
 
     s.reserve(n.size());
@@ -90,7 +90,7 @@ inline void from_node(const BasicNodeType& n, typename BasicNodeType::mapping_ty
 {
     if (!n.is_mapping())
     {
-        throw exception("The target node value type is not mapping type.");
+        throw type_error("The target node value type is not mapping type.", n.type());
     }
 
     for (auto pair : n.template get_value_ref<const typename BasicNodeType::mapping_type&>())
@@ -109,7 +109,7 @@ inline void from_node(const BasicNodeType& n, std::nullptr_t& null)
     // to ensure the target node value type is null.
     if (!n.is_null())
     {
-        throw exception("The target node value type is not null type.");
+        throw type_error("The target node value type is not null type.", n.type());
     }
     null = nullptr;
 }
@@ -123,7 +123,7 @@ inline void from_node(const BasicNodeType& n, typename BasicNodeType::boolean_ty
 {
     if (!n.is_boolean())
     {
-        throw exception("The target node value type is not boolean type.");
+        throw type_error("The target node value type is not boolean type.", n.type());
     }
     b = n.template get_value_ref<const typename BasicNodeType::boolean_type&>();
 }
@@ -137,7 +137,7 @@ inline void from_node(const BasicNodeType& n, typename BasicNodeType::integer_ty
 {
     if (!n.is_integer())
     {
-        throw exception("The target node value type is not integer type.");
+        throw type_error("The target node value type is not integer type.", n.type());
     }
     i = n.template get_value_ref<const typename BasicNodeType::integer_type&>();
 }
@@ -158,7 +158,7 @@ inline void from_node(const BasicNodeType& n, IntegerType& i)
 {
     if (!n.is_integer())
     {
-        throw exception("The target node value type is not integer type.");
+        throw type_error("The target node value type is not integer type.", n.type());
     }
 
     // under/overflow check.
@@ -185,7 +185,7 @@ inline void from_node(const BasicNodeType& n, typename BasicNodeType::float_numb
 {
     if (!n.is_float_number())
     {
-        throw exception("The target node value type is not float number type.");
+        throw type_error("The target node value type is not float number type.", n.type());
     }
     f = n.template get_value_ref<const typename BasicNodeType::float_number_type&>();
 }
@@ -206,7 +206,7 @@ inline void from_node(const BasicNodeType& n, FloatType& f)
 {
     if (!n.is_float_number())
     {
-        throw exception("The target node value type is not float number type.");
+        throw type_error("The target node value type is not float number type.", n.type());
     }
 
     auto tmp_float = n.template get_value_ref<const typename BasicNodeType::float_number_type&>();
@@ -231,7 +231,7 @@ inline void from_node(const BasicNodeType& n, typename BasicNodeType::string_typ
 {
     if (!n.is_string())
     {
-        throw exception("The target node value type is not string type.");
+        throw type_error("The target node value type is not string type.", n.type());
     }
     s = n.template get_value_ref<const typename BasicNodeType::string_type&>();
 }

--- a/include/fkYAML/detail/encodings/utf8_encoding.hpp
+++ b/include/fkYAML/detail/encodings/utf8_encoding.hpp
@@ -256,7 +256,7 @@ public:
 
         if (!is_valid)
         {
-            throw fkyaml::exception("Invalid UTF-16 encoding detected.");
+            throw fkyaml::invalid_encoding("Invalid UTF-16 encoding detected.", utf16);
         }
     }
 
@@ -315,7 +315,7 @@ public:
 
         if (!is_valid)
         {
-            throw fkyaml::exception("Invalid UTF-32 encoding detected.");
+            throw fkyaml::invalid_encoding("Invalid UTF-32 encoding detected.", utf32);
         }
     }
 };

--- a/include/fkYAML/detail/input/deserializer.hpp
+++ b/include/fkYAML/detail/input/deserializer.hpp
@@ -69,6 +69,7 @@ public:
 
         lexical_token_t type = lexer.get_next_token();
         std::size_t cur_indent = lexer.get_last_token_begin_pos();
+        std::size_t cur_line = lexer.get_lines_processed();
 
         while (type != lexical_token_t::END_OF_BUFFER)
         {
@@ -78,7 +79,7 @@ public:
                 bool is_stack_empty = m_node_stack.empty();
                 if (is_stack_empty)
                 {
-                    throw fkyaml::exception("A key separator found without key.");
+                    throw fkyaml::parse_error("A key separator found without key.", cur_line, cur_indent);
                 }
                 break;
             }
@@ -94,7 +95,8 @@ public:
                 auto itr = m_anchor_table.find(alias_name);
                 if (itr == m_anchor_table.end())
                 {
-                    throw fkyaml::exception("The given anchor name must appear prior to the alias node.");
+                    throw fkyaml::parse_error(
+                        "The given anchor name must appear prior to the alias node.", cur_line, cur_indent);
                 }
                 assign_node_value(BasicNodeType::alias_of(m_anchor_table.at(alias_name)));
                 break;
@@ -135,7 +137,7 @@ public:
                 // if the current node is a mapping.
                 if (m_node_stack.empty())
                 {
-                    throw fkyaml::exception("Invalid sequence block prefix(- ) found.");
+                    throw fkyaml::parse_error("Invalid sequence block prefix(- ) found.", cur_line, cur_indent);
                 }
 
                 // move back to the previous sequence if necessary.
@@ -167,12 +169,14 @@ public:
                     *m_current_node = BasicNodeType::sequence();
                     set_yaml_version(*m_current_node);
                     cur_indent = lexer.get_last_token_begin_pos();
+                    cur_line = lexer.get_lines_processed();
                     continue;
                 }
 
                 *m_current_node = BasicNodeType::mapping();
                 set_yaml_version(*m_current_node);
                 cur_indent = lexer.get_last_token_begin_pos();
+                cur_line = lexer.get_lines_processed();
                 continue;
             case lexical_token_t::MAPPING_FLOW_BEGIN:
                 *m_current_node = BasicNodeType::mapping();
@@ -181,7 +185,7 @@ public:
             case lexical_token_t::MAPPING_FLOW_END:
                 if (!m_current_node->is_mapping())
                 {
-                    throw fkyaml::exception("Invalid mapping flow ending found.");
+                    throw fkyaml::parse_error("Invalid mapping flow ending found.", cur_line, cur_indent);
                 }
                 m_current_node = m_node_stack.back();
                 m_node_stack.pop_back();
@@ -189,7 +193,7 @@ public:
             case lexical_token_t::NULL_VALUE: {
                 if (m_current_node->is_mapping())
                 {
-                    add_new_key(lexer.get_string(), cur_indent);
+                    add_new_key(lexer.get_string(), cur_indent, cur_line);
                     break;
                 }
 
@@ -201,13 +205,15 @@ public:
                     // check if the current target token is a key or not.
                     if (type == lexical_token_t::KEY_SEPARATOR || type == lexical_token_t::MAPPING_BLOCK_PREFIX)
                     {
-                        add_new_key(str, cur_indent);
+                        add_new_key(str, cur_indent, cur_line);
                         cur_indent = lexer.get_last_token_begin_pos();
+                        cur_line = lexer.get_lines_processed();
                         continue;
                     }
 
                     assign_node_value(BasicNodeType());
                     cur_indent = lexer.get_last_token_begin_pos();
+                    cur_line = lexer.get_lines_processed();
                     continue;
                 }
 
@@ -217,7 +223,7 @@ public:
             case lexical_token_t::BOOLEAN_VALUE: {
                 if (m_current_node->is_mapping())
                 {
-                    add_new_key(lexer.get_string(), cur_indent);
+                    add_new_key(lexer.get_string(), cur_indent, cur_line);
                     break;
                 }
 
@@ -230,13 +236,15 @@ public:
                     // check if the current target token is a key or not.
                     if (type == lexical_token_t::KEY_SEPARATOR || type == lexical_token_t::MAPPING_BLOCK_PREFIX)
                     {
-                        add_new_key(str, cur_indent);
+                        add_new_key(str, cur_indent, cur_line);
                         cur_indent = lexer.get_last_token_begin_pos();
+                        cur_line = lexer.get_lines_processed();
                         continue;
                     }
 
                     assign_node_value(BasicNodeType(boolean));
                     cur_indent = lexer.get_last_token_begin_pos();
+                    cur_line = lexer.get_lines_processed();
                     continue;
                 }
 
@@ -246,7 +254,7 @@ public:
             case lexical_token_t::INTEGER_VALUE: {
                 if (m_current_node->is_mapping())
                 {
-                    add_new_key(lexer.get_string(), cur_indent);
+                    add_new_key(lexer.get_string(), cur_indent, cur_line);
                     break;
                 }
 
@@ -259,13 +267,15 @@ public:
                     // check if the current target token is a key or not.
                     if (type == lexical_token_t::KEY_SEPARATOR || type == lexical_token_t::MAPPING_BLOCK_PREFIX)
                     {
-                        add_new_key(str, cur_indent);
+                        add_new_key(str, cur_indent, cur_line);
                         cur_indent = lexer.get_last_token_begin_pos();
+                        cur_line = lexer.get_lines_processed();
                         continue;
                     }
 
                     assign_node_value(BasicNodeType(integer));
                     cur_indent = lexer.get_last_token_begin_pos();
+                    cur_line = lexer.get_lines_processed();
                     continue;
                 }
 
@@ -275,7 +285,7 @@ public:
             case lexical_token_t::FLOAT_NUMBER_VALUE: {
                 if (m_current_node->is_mapping())
                 {
-                    add_new_key(lexer.get_string(), cur_indent);
+                    add_new_key(lexer.get_string(), cur_indent, cur_line);
                     break;
                 }
 
@@ -288,13 +298,15 @@ public:
                     // check if the current target token is a key or not.
                     if (type == lexical_token_t::KEY_SEPARATOR || type == lexical_token_t::MAPPING_BLOCK_PREFIX)
                     {
-                        add_new_key(str, cur_indent);
+                        add_new_key(str, cur_indent, cur_line);
                         cur_indent = lexer.get_last_token_begin_pos();
+                        cur_line = lexer.get_lines_processed();
                         continue;
                     }
 
                     assign_node_value(BasicNodeType(float_val));
                     cur_indent = lexer.get_last_token_begin_pos();
+                    cur_line = lexer.get_lines_processed();
                     continue;
                 }
 
@@ -304,7 +316,7 @@ public:
             case lexical_token_t::STRING_VALUE: {
                 if (m_current_node->is_mapping())
                 {
-                    add_new_key(lexer.get_string(), cur_indent);
+                    add_new_key(lexer.get_string(), cur_indent, cur_line);
                     break;
                 }
 
@@ -316,13 +328,15 @@ public:
                     // check if the current target token is a key or not.
                     if (type == lexical_token_t::KEY_SEPARATOR || type == lexical_token_t::MAPPING_BLOCK_PREFIX)
                     {
-                        add_new_key(str, cur_indent);
+                        add_new_key(str, cur_indent, cur_line);
                         cur_indent = lexer.get_last_token_begin_pos();
+                        cur_line = lexer.get_lines_processed();
                         continue;
                     }
 
                     assign_node_value(BasicNodeType(str));
                     cur_indent = lexer.get_last_token_begin_pos();
+                    cur_line = lexer.get_lines_processed();
                     continue;
                 }
 
@@ -334,12 +348,13 @@ public:
             case lexical_token_t::END_OF_DOCUMENT:
                 // TODO: This token should be handled to support multiple documents.
                 break;
-            default:                                                         // LCOV_EXCL_LINE
-                throw fkyaml::exception("Unsupported lexical token found."); // LCOV_EXCL_LINE
+            default:                                                                                 // LCOV_EXCL_LINE
+                throw fkyaml::parse_error("Unsupported lexical token found.", cur_line, cur_indent); // LCOV_EXCL_LINE
             }
 
             type = lexer.get_next_token();
             cur_indent = lexer.get_last_token_begin_pos();
+            cur_line = lexer.get_lines_processed();
         }
 
         m_current_node = nullptr;
@@ -354,7 +369,7 @@ public:
 private:
     /// @brief Add new key string to the current YAML node.
     /// @param key a key string to be added to the current YAML node.
-    void add_new_key(const string_type& key, const std::size_t indent)
+    void add_new_key(const string_type& key, const std::size_t indent, const std::size_t line)
     {
         if (!m_indent_stack.empty() && indent < m_indent_stack.back())
         {
@@ -362,7 +377,7 @@ private:
             bool is_indent_valid = (target_itr != m_indent_stack.rend());
             if (!is_indent_valid)
             {
-                throw fkyaml::exception("Detected invalid indentaion.");
+                throw fkyaml::parse_error("Detected invalid indentaion.", line, indent);
             }
 
             auto pop_num = std::distance(m_indent_stack.rbegin(), target_itr);
@@ -394,7 +409,7 @@ private:
             auto itr = map.find(key);
             if (itr != map.end())
             {
-                throw fkyaml::exception("Detected duplication in mapping keys.");
+                throw fkyaml::parse_error("Detected duplication in mapping keys.", line, indent);
             }
         }
 

--- a/include/fkYAML/detail/input/lexical_analyzer.hpp
+++ b/include/fkYAML/detail/input/lexical_analyzer.hpp
@@ -1014,7 +1014,7 @@ private:
                 std::array<char_int_type, 2> byte_array = {{current, m_input_handler.get_next()}};
                 if (!utf8_encoding::validate(byte_array))
                 {
-                    throw fkyaml::exception("ill-formed UTF-8 encoded character found");
+                    throw fkyaml::invalid_encoding("ill-formed UTF-8 encoded character found", byte_array);
                 }
 
                 m_value_buffer.push_back(char_traits_type::to_char_type(byte_array[0]));
@@ -1029,7 +1029,7 @@ private:
                     {current, m_input_handler.get_next(), m_input_handler.get_next()}};
                 if (!utf8_encoding::validate(byte_array))
                 {
-                    throw fkyaml::exception("ill-formed UTF-8 encoded character found");
+                    throw fkyaml::invalid_encoding("ill-formed UTF-8 encoded character found", byte_array);
                 }
 
                 m_value_buffer.push_back(char_traits_type::to_char_type(byte_array[0]));
@@ -1044,7 +1044,7 @@ private:
                 {current, m_input_handler.get_next(), m_input_handler.get_next(), m_input_handler.get_next()}};
             if (!utf8_encoding::validate(byte_array))
             {
-                throw fkyaml::exception("ill-formed UTF-8 encoded character found");
+                throw fkyaml::invalid_encoding("ill-formed UTF-8 encoded character found", byte_array);
             }
 
             m_value_buffer.push_back(char_traits_type::to_char_type(byte_array[0]));

--- a/include/fkYAML/detail/input/lexical_analyzer.hpp
+++ b/include/fkYAML/detail/input/lexical_analyzer.hpp
@@ -105,7 +105,7 @@ public:
                 m_input_handler.get_next();
                 return m_last_token_type = lexical_token_t::MAPPING_BLOCK_PREFIX;
             default:
-                throw fkyaml::exception("Half-width spaces or newline codes are required after a key separater(:).");
+                emit_error("Half-width spaces or newline codes are required after a key separater(:).");
             }
             m_input_handler.get_next();
             return m_last_token_type = lexical_token_t::KEY_SEPARATOR;
@@ -119,7 +119,7 @@ public:
                 char_int_type next = m_input_handler.get_next();
                 if (next == end_of_input || next == '\r' || next == '\n')
                 {
-                    throw fkyaml::exception("An anchor label must be followed by some value.");
+                    emit_error("An anchor label must be followed by some value.");
                 }
                 if (next == ' ')
                 {
@@ -139,7 +139,7 @@ public:
                 {
                     if (m_value_buffer.empty())
                     {
-                        throw fkyaml::exception("An alias prefix must be followed by some anchor name.");
+                        emit_error("An alias prefix must be followed by some anchor name.");
                     }
                     m_input_handler.get_next();
                     break;
@@ -191,10 +191,9 @@ public:
             m_input_handler.get_next();
             return m_last_token_type = lexical_token_t::MAPPING_FLOW_END;
         case '@':
-            throw fkyaml::exception("Any token cannot start with at(@). It is a reserved indicator for YAML.");
+            emit_error("Any token cannot start with at(@). It is a reserved indicator for YAML.");
         case '`':
-            throw fkyaml::exception(
-                "Any token cannot start with grave accent(`). It is a reserved indicator for YAML.");
+            emit_error("Any token cannot start with grave accent(`). It is a reserved indicator for YAML.");
         case '\"':
         case '\'':
             return m_last_token_type = scan_string();
@@ -322,6 +321,13 @@ public:
         return m_last_token_begin_pos;
     }
 
+    /// @brief Get the number of lines already processed.
+    /// @return std::size_t The number of lines already processed.
+    std::size_t get_lines_processed() const noexcept
+    {
+        return m_input_handler.get_lines_read();
+    }
+
     /// @brief Convert from string to null and get the converted value.
     /// @return std::nullptr_t A null value converted from one of the followings: "null", "Null", "NULL", "~".
     std::nullptr_t get_null() const
@@ -330,7 +336,7 @@ public:
         {
             return nullptr;
         }
-        throw fkyaml::exception("Invalid request for a null value.");
+        emit_error("Invalid request for a null value.");
     }
 
     /// @brief Convert from string to boolean and get the converted value.
@@ -342,7 +348,7 @@ public:
         {
             return m_boolean_val;
         }
-        throw fkyaml::exception("Invalid request for a boolean value.");
+        emit_error("Invalid request for a boolean value.");
     }
 
     /// @brief Convert from string to integer and get the converted value.
@@ -353,7 +359,7 @@ public:
         {
             return m_integer_val;
         }
-        throw fkyaml::exception("Invalid request for an integer value.");
+        emit_error("Invalid request for an integer value.");
     }
 
     /// @brief Convert from string to float number and get the converted value.
@@ -364,7 +370,7 @@ public:
         {
             return m_float_val;
         }
-        throw fkyaml::exception("Invalid request for a float number value.");
+        emit_error("Invalid request for a float number value.");
     }
 
     /// @brief Get a scanned string value.
@@ -390,7 +396,7 @@ private:
     /// @brief A utility function to convert a hexadecimal character to an integer.
     /// @param source A hexadecimal character ('0'~'9', 'A'~'F', 'a'~'f')
     /// @return char A integer converted from @a source.
-    static char convert_hex_char_to_byte(char_int_type source)
+    char convert_hex_char_to_byte(char_int_type source)
     {
         if ('0' <= source && source <= '9')
         {
@@ -410,7 +416,7 @@ private:
             return static_cast<char>(source - 'a' + 10);
         }
 
-        throw fkyaml::exception("Non-hexadecimal character has been given.");
+        emit_error("Non-hexadecimal character has been given.");
     }
 
     /// @brief Skip until a newline code or a null character is found.
@@ -433,7 +439,7 @@ private:
         switch (m_input_handler.get_next())
         {
         case end_of_input:
-            throw fkyaml::exception("invalid eof in a directive.");
+            emit_error("invalid eof in a directive.");
         case 'T': {
             if (m_input_handler.get_next() != 'A' || m_input_handler.get_next() != 'G')
             {
@@ -442,7 +448,7 @@ private:
             }
             if (m_input_handler.get_next() != ' ')
             {
-                throw fkyaml::exception("There must be a half-width space between \"%TAG\" and tag info.");
+                emit_error("There must be a half-width space between \"%TAG\" and tag info.");
             }
             // TODO: parse tag directives' information
             return lexical_token_t::TAG_DIRECTIVE;
@@ -456,7 +462,7 @@ private:
             }
             if (m_input_handler.get_next() != ' ')
             {
-                throw fkyaml::exception("There must be a half-width space between \"%YAML\" and a version number.");
+                emit_error("There must be a half-width space between \"%YAML\" and a version number.");
             }
             return scan_yaml_version_directive();
         default:
@@ -474,13 +480,13 @@ private:
 
         if (m_input_handler.get_next() != '1')
         {
-            throw fkyaml::exception("Invalid YAML major version found.");
+            emit_error("Invalid YAML major version found.");
         }
         m_value_buffer.push_back(char_traits_type::to_char_type(m_input_handler.get_current()));
 
         if (m_input_handler.get_next() != '.')
         {
-            throw fkyaml::exception("A period must be followed after the YAML major version.");
+            emit_error("A period must be followed after the YAML major version.");
         }
         m_value_buffer.push_back(char_traits_type::to_char_type(m_input_handler.get_current()));
 
@@ -498,15 +504,15 @@ private:
         case '7':
         case '8':
         case '9':
-            throw fkyaml::exception("Unsupported YAML version.");
+            emit_error("Unsupported YAML version.");
         default:
-            throw fkyaml::exception("YAML version must be specified with digits and periods.");
+            emit_error("YAML version must be specified with digits and periods.");
         }
 
         if (m_input_handler.get_next() != ' ' && m_input_handler.get_current() != '\r' &&
             m_input_handler.get_current() != '\n')
         {
-            throw fkyaml::exception("Only YAML version 1.1/1.2 are supported.");
+            emit_error("Only YAML version 1.1/1.2 are supported.");
         }
 
         return lexical_token_t::YAML_VER_DIRECTIVE;
@@ -548,8 +554,8 @@ private:
             m_value_buffer.push_back(char_traits_type::to_char_type(current));
             ret = scan_decimal_number();
             break;
-        default:                                                                   // LCOV_EXCL_LINE
-            throw fkyaml::exception("Invalid character found in a number token."); // LCOV_EXCL_LINE
+        default:                                                      // LCOV_EXCL_LINE
+            emit_error("Invalid character found in a number token."); // LCOV_EXCL_LINE
         }
 
         switch (ret)
@@ -596,7 +602,7 @@ private:
             }
         }
 
-        throw fkyaml::exception("Invalid character found in a negative number token."); // LCOV_EXCL_LINE
+        emit_error("Invalid character found in a negative number token."); // LCOV_EXCL_LINE
     }
 
     /// @brief Scan a next character after '0' at the beginning of a token.
@@ -635,7 +641,7 @@ private:
             return lexical_token_t::FLOAT_NUMBER_VALUE;
         }
 
-        throw fkyaml::exception("Invalid character found after a decimal point."); // LCOV_EXCL_LINE
+        emit_error("Invalid character found after a decimal point."); // LCOV_EXCL_LINE
     }
 
     /// @brief Scan a next character after exponent(e/E).
@@ -655,7 +661,7 @@ private:
         }
         else
         {
-            throw fkyaml::exception("unexpected character found after exponent.");
+            emit_error("unexpected character found after exponent.");
         }
         return lexical_token_t::FLOAT_NUMBER_VALUE;
     }
@@ -672,7 +678,7 @@ private:
             return scan_decimal_number();
         }
 
-        throw fkyaml::exception("Non-numeric character found after a sign(+/-) after exponent(e/E)."); // LCOV_EXCL_LINE
+        emit_error("Non-numeric character found after a sign(+/-) after exponent(e/E)."); // LCOV_EXCL_LINE
     }
 
     /// @brief Scan a next character for decimal numbers.
@@ -693,7 +699,7 @@ private:
             if (m_value_buffer.find(char_traits_type::to_char_type(next)) != string_type::npos)
             {
                 // TODO: support this use case (e.g. version info like 1.0.0)
-                throw fkyaml::exception("Multiple decimal points found in a token.");
+                emit_error("Multiple decimal points found in a token.");
             }
             m_value_buffer.push_back(char_traits_type::to_char_type(next));
             return scan_decimal_number_after_decimal_point();
@@ -753,12 +759,12 @@ private:
             {
                 if (needs_last_double_quote)
                 {
-                    throw fkyaml::exception("Invalid end of input buffer in a double-quoted string token.");
+                    emit_error("Invalid end of input buffer in a double-quoted string token.");
                 }
 
                 if (needs_last_single_quote)
                 {
-                    throw fkyaml::exception("Invalid end of input buffer in a single-quoted string token.");
+                    emit_error("Invalid end of input buffer in a single-quoted string token.");
                 }
 
                 return lexical_token_t::STRING_VALUE;
@@ -803,7 +809,7 @@ private:
 
                 if (!needs_last_single_quote)
                 {
-                    throw fkyaml::exception("Invalid double quotation mark found in a string token.");
+                    emit_error("Invalid double quotation mark found in a string token.");
                 }
 
                 // if the target is a single-quoted string token.
@@ -900,7 +906,7 @@ private:
                 }
 
                 // TODO: Support multi-line string tokens.
-                throw fkyaml::exception("multi-line string tokens are unsupported.");
+                emit_error("multi-line string tokens are unsupported.");
             }
 
             // Handle escaped characters.
@@ -909,7 +915,7 @@ private:
             {
                 if (!needs_last_double_quote)
                 {
-                    throw fkyaml::exception("Escaped characters are only available in a double-quoted string token.");
+                    emit_error("Escaped characters are only available in a double-quoted string token.");
                 }
 
                 current = m_input_handler.get_next();
@@ -989,7 +995,7 @@ private:
                     handle_escaped_unicode(4);
                     break;
                 default:
-                    throw fkyaml::exception("Unsupported escape sequence found in a string token.");
+                    emit_error("Unsupported escape sequence found in a string token.");
                 }
                 continue;
             }
@@ -1064,66 +1070,66 @@ private:
         {
         // 0x00(NULL) has already been handled above.
         case 0x01:
-            throw fkyaml::exception("Control character U+0001 (SOH) must be escaped to \\u0001.");
+            emit_error("Control character U+0001 (SOH) must be escaped to \\u0001.");
         case 0x02:
-            throw fkyaml::exception("Control character U+0002 (STX) must be escaped to \\u0002.");
+            emit_error("Control character U+0002 (STX) must be escaped to \\u0002.");
         case 0x03:
-            throw fkyaml::exception("Control character U+0003 (ETX) must be escaped to \\u0003.");
+            emit_error("Control character U+0003 (ETX) must be escaped to \\u0003.");
         case 0x04:
-            throw fkyaml::exception("Control character U+0004 (EOT) must be escaped to \\u0004.");
+            emit_error("Control character U+0004 (EOT) must be escaped to \\u0004.");
         case 0x05:
-            throw fkyaml::exception("Control character U+0005 (ENQ) must be escaped to \\u0005.");
+            emit_error("Control character U+0005 (ENQ) must be escaped to \\u0005.");
         case 0x06:
-            throw fkyaml::exception("Control character U+0006 (ACK) must be escaped to \\u0006.");
+            emit_error("Control character U+0006 (ACK) must be escaped to \\u0006.");
         case 0x07:
-            throw fkyaml::exception("Control character U+0007 (BEL) must be escaped to \\a or \\u0007.");
+            emit_error("Control character U+0007 (BEL) must be escaped to \\a or \\u0007.");
         case 0x08:
-            throw fkyaml::exception("Control character U+0008 (BS) must be escaped to \\b or \\u0008.");
+            emit_error("Control character U+0008 (BS) must be escaped to \\b or \\u0008.");
         case 0x09: // HT
             m_value_buffer.push_back(char_traits_type::to_char_type(c));
             break;
         // 0x0A(LF) has already been handled above.
         case 0x0B:
-            throw fkyaml::exception("Control character U+000B (VT) must be escaped to \\v or \\u000B.");
+            emit_error("Control character U+000B (VT) must be escaped to \\v or \\u000B.");
         case 0x0C:
-            throw fkyaml::exception("Control character U+000C (FF) must be escaped to \\f or \\u000C.");
+            emit_error("Control character U+000C (FF) must be escaped to \\f or \\u000C.");
         // 0x0D(CR) has already been handled above.
         case 0x0E:
-            throw fkyaml::exception("Control character U+000E (SO) must be escaped to \\u000E.");
+            emit_error("Control character U+000E (SO) must be escaped to \\u000E.");
         case 0x0F:
-            throw fkyaml::exception("Control character U+000F (SI) must be escaped to \\u000F.");
+            emit_error("Control character U+000F (SI) must be escaped to \\u000F.");
         case 0x10:
-            throw fkyaml::exception("Control character U+0010 (DLE) must be escaped to \\u0010.");
+            emit_error("Control character U+0010 (DLE) must be escaped to \\u0010.");
         case 0x11:
-            throw fkyaml::exception("Control character U+0011 (DC1) must be escaped to \\u0011.");
+            emit_error("Control character U+0011 (DC1) must be escaped to \\u0011.");
         case 0x12:
-            throw fkyaml::exception("Control character U+0012 (DC2) must be escaped to \\u0012.");
+            emit_error("Control character U+0012 (DC2) must be escaped to \\u0012.");
         case 0x13:
-            throw fkyaml::exception("Control character U+0013 (DC3) must be escaped to \\u0013.");
+            emit_error("Control character U+0013 (DC3) must be escaped to \\u0013.");
         case 0x14:
-            throw fkyaml::exception("Control character U+0014 (DC4) must be escaped to \\u0014.");
+            emit_error("Control character U+0014 (DC4) must be escaped to \\u0014.");
         case 0x15:
-            throw fkyaml::exception("Control character U+0015 (NAK) must be escaped to \\u0015.");
+            emit_error("Control character U+0015 (NAK) must be escaped to \\u0015.");
         case 0x16:
-            throw fkyaml::exception("Control character U+0016 (SYN) must be escaped to \\u0016.");
+            emit_error("Control character U+0016 (SYN) must be escaped to \\u0016.");
         case 0x17:
-            throw fkyaml::exception("Control character U+0017 (ETB) must be escaped to \\u0017.");
+            emit_error("Control character U+0017 (ETB) must be escaped to \\u0017.");
         case 0x18:
-            throw fkyaml::exception("Control character U+0018 (CAN) must be escaped to \\u0018.");
+            emit_error("Control character U+0018 (CAN) must be escaped to \\u0018.");
         case 0x19:
-            throw fkyaml::exception("Control character U+0019 (EM) must be escaped to \\u0019.");
+            emit_error("Control character U+0019 (EM) must be escaped to \\u0019.");
         case 0x1A:
-            throw fkyaml::exception("Control character U+001A (SUB) must be escaped to \\u001A.");
+            emit_error("Control character U+001A (SUB) must be escaped to \\u001A.");
         case 0x1B:
-            throw fkyaml::exception("Control character U+001B (ESC) must be escaped to \\e or \\u001B.");
+            emit_error("Control character U+001B (ESC) must be escaped to \\e or \\u001B.");
         case 0x1C:
-            throw fkyaml::exception("Control character U+001C (FS) must be escaped to \\u001C.");
+            emit_error("Control character U+001C (FS) must be escaped to \\u001C.");
         case 0x1D:
-            throw fkyaml::exception("Control character U+001D (GS) must be escaped to \\u001D.");
+            emit_error("Control character U+001D (GS) must be escaped to \\u001D.");
         case 0x1E:
-            throw fkyaml::exception("Control character U+001E (RS) must be escaped to \\u001E.");
+            emit_error("Control character U+001E (RS) must be escaped to \\u001E.");
         case 0x1F:
-            throw fkyaml::exception("Control character U+001F (US) must be escaped to \\u001F.");
+            emit_error("Control character U+001F (US) must be escaped to \\u001F.");
         }
     }
 
@@ -1188,6 +1194,11 @@ private:
             }
             m_input_handler.get_next();
         }
+    }
+
+    [[noreturn]] void emit_error(const char* msg) const
+    {
+        throw fkyaml::parse_error(msg, m_input_handler.get_lines_read(), m_input_handler.get_cur_pos_in_line());
     }
 
 private:

--- a/include/fkYAML/detail/types/node_t.hpp
+++ b/include/fkYAML/detail/types/node_t.hpp
@@ -39,14 +39,22 @@ inline std::string to_string(node_t t)
 {
     switch (t)
     {
-    case node_t::SEQUENCE: return "sequence";
-    case node_t::MAPPING: return "mapping";
-    case node_t::NULL_OBJECT: return "null";
-    case node_t::BOOLEAN: return "boolean";
-    case node_t::INTEGER: return "integer";
-    case node_t::FLOAT_NUMBER: return "float";
-    case node_t::STRING: return "string";
-    default: return "";
+    case node_t::SEQUENCE:
+        return "sequence";
+    case node_t::MAPPING:
+        return "mapping";
+    case node_t::NULL_OBJECT:
+        return "null";
+    case node_t::BOOLEAN:
+        return "boolean";
+    case node_t::INTEGER:
+        return "integer";
+    case node_t::FLOAT_NUMBER:
+        return "float";
+    case node_t::STRING:
+        return "string";
+    default:       // LCOV_EXCL_LINE
+        return ""; // LCOV_EXCL_LINE
     }
 }
 

--- a/include/fkYAML/detail/types/node_t.hpp
+++ b/include/fkYAML/detail/types/node_t.hpp
@@ -12,6 +12,7 @@
 #define FK_YAML_DETAIL_TYPES_NODE_T_HPP_
 
 #include <cstdint>
+#include <string>
 
 #include <fkYAML/detail/macros/version_macros.hpp>
 
@@ -33,6 +34,21 @@ enum class node_t : std::uint32_t
     FLOAT_NUMBER, //!< float number value type
     STRING,       //!< string value type
 };
+
+inline std::string to_string(node_t t)
+{
+    switch (t)
+    {
+    case node_t::SEQUENCE: return "sequence";
+    case node_t::MAPPING: return "mapping";
+    case node_t::NULL_OBJECT: return "null";
+    case node_t::BOOLEAN: return "boolean";
+    case node_t::INTEGER: return "integer";
+    case node_t::FLOAT_NUMBER: return "float";
+    case node_t::STRING: return "string";
+    default: return "";
+    }
+}
 
 } // namespace detail
 

--- a/include/fkYAML/exception.hpp
+++ b/include/fkYAML/exception.hpp
@@ -15,6 +15,7 @@
 #include <string>
 
 #include <fkYAML/detail/macros/version_macros.hpp>
+#include <fkYAML/detail/types/node_t.hpp>
 
 /// @brief namespace for fkYAML library.
 FK_YAML_NAMESPACE_BEGIN
@@ -51,6 +52,20 @@ public:
 private:
     /// An error message holder.
     std::string m_error_msg {};
+};
+
+/// @brief A exception class indicating an invalid type conversion.
+/// @sa https://fktn-k.github.io/fkYAML/api/exception/
+class type_error : public exception
+{
+public:
+    /// @brief Construct a new type_error object with an error message and a node type.
+    /// @param[in] msg An error message.
+    /// @param[in] type The type of a source node value.
+    explicit type_error(const char* msg, detail::node_t type)
+        : exception(std::string(std::string("type_error: ") + std::string(msg) + " type=" + detail::to_string(type)).c_str())
+    {
+    }
 };
 
 FK_YAML_NAMESPACE_END

--- a/include/fkYAML/exception.hpp
+++ b/include/fkYAML/exception.hpp
@@ -122,6 +122,24 @@ private:
     }
 };
 
+/// @brief An exception class indicating an error in parsing.
+class parse_error : public exception
+{
+public:
+    explicit parse_error(const char* msg, std::size_t lines, std::size_t cols_in_line)
+        : exception(generate_error_message(msg, lines, cols_in_line).c_str())
+    {
+    }
+
+private:
+    std::string generate_error_message(const char* msg, std::size_t lines, std::size_t cols_in_line)
+    {
+        std::stringstream ss;
+        ss << "parse_error: " << msg << " (at line " << lines << ", column " << cols_in_line << ")";
+        return ss.str();
+    }
+};
+
 /// @brief An exception class indicating an invalid type conversion.
 /// @sa https://fktn-k.github.io/fkYAML/api/exception/type_error/
 class type_error : public exception

--- a/include/fkYAML/exception.hpp
+++ b/include/fkYAML/exception.hpp
@@ -106,7 +106,9 @@ private:
     std::string generate_error_message(const char* msg, std::array<char16_t, 2> u16)
     {
         std::stringstream ss;
-        ss << "invalid_encoding: " << msg << " in=[ 0x" << std::hex << u16[0] << ", 0x" << std::hex << u16[1] << " ]";
+        ss << "invalid_encoding: " << msg;
+        // uint16_t is large enough for UTF-16 encoded elements.
+        ss << " in=[ 0x" << std::hex << uint16_t(u16[0]) << ", 0x" << std::hex << uint16_t(u16[1]) << " ]";
         return ss.str();
     }
 
@@ -117,7 +119,8 @@ private:
     std::string generate_error_message(const char* msg, char32_t u32)
     {
         std::stringstream ss;
-        ss << "invalid_encoding: " << msg << " in=0x" << std::hex << u32;
+        // uint32_t is large enough for UTF-32 encoded elements.
+        ss << "invalid_encoding: " << msg << " in=0x" << std::hex << uint32_t(u32);
         return ss.str();
     }
 };

--- a/include/fkYAML/node.hpp
+++ b/include/fkYAML/node.hpp
@@ -603,7 +603,7 @@ public:
     {
         if (!is_sequence())
         {
-            throw fkyaml::exception("The target node is not of a sequence type.");
+            throw fkyaml::type_error("The target node is not of a sequence type.", m_node_type);
         }
 
         FK_YAML_ASSERT(m_node_value.p_sequence != nullptr);
@@ -619,7 +619,7 @@ public:
     {
         if (!is_sequence())
         {
-            throw fkyaml::exception("The target node is not of a sequence type.");
+            throw fkyaml::type_error("The target node is not of a sequence type.", m_node_type);
         }
 
         FK_YAML_ASSERT(m_node_value.p_sequence != nullptr);
@@ -641,7 +641,7 @@ public:
     {
         if (!is_mapping())
         {
-            throw fkyaml::exception("The target node is not of a mapping type.");
+            throw fkyaml::type_error("The target node is not of a mapping type.", m_node_type);
         }
 
         FK_YAML_ASSERT(m_node_value.p_mapping != nullptr);
@@ -662,7 +662,7 @@ public:
     {
         if (!is_mapping())
         {
-            throw fkyaml::exception("The target node is not of a mapping type.");
+            throw fkyaml::type_error("The target node is not of a mapping type.", m_node_type);
         }
 
         FK_YAML_ASSERT(m_node_value.p_mapping != nullptr);
@@ -759,7 +759,7 @@ public:
             FK_YAML_ASSERT(m_node_value.p_string != nullptr);
             return m_node_value.p_string->empty();
         default:
-            throw fkyaml::exception("The target node is not of a container type.");
+            throw fkyaml::type_error("The target node is not of a container type.", m_node_type);
         }
     }
 
@@ -780,7 +780,7 @@ public:
             FK_YAML_ASSERT(m_node_value.p_string != nullptr);
             return m_node_value.p_string->size();
         default:
-            throw fkyaml::exception("The target node is not of a container type.");
+            throw fkyaml::type_error("The target node is not of a container type.", m_node_type);
         }
     }
 
@@ -944,7 +944,7 @@ public:
             FK_YAML_ASSERT(m_node_value.p_mapping != nullptr);
             return {detail::mapping_iterator_tag(), m_node_value.p_mapping->begin()};
         default:
-            throw fkyaml::exception("The target node is neither of sequence nor mapping types.");
+            throw fkyaml::type_error("The target node is neither of sequence nor mapping types.", m_node_type);
         }
     }
 
@@ -963,7 +963,7 @@ public:
             FK_YAML_ASSERT(m_node_value.p_mapping != nullptr);
             return {detail::mapping_iterator_tag(), m_node_value.p_mapping->begin()};
         default:
-            throw fkyaml::exception("The target node is neither of sequence nor mapping types.");
+            throw fkyaml::type_error("The target node is neither of sequence nor mapping types.", m_node_type);
         }
     }
 
@@ -982,7 +982,7 @@ public:
             FK_YAML_ASSERT(m_node_value.p_mapping != nullptr);
             return {detail::mapping_iterator_tag(), m_node_value.p_mapping->end()};
         default:
-            throw fkyaml::exception("The target node is neither of sequence nor mapping types.");
+            throw fkyaml::type_error("The target node is neither of sequence nor mapping types.", m_node_type);
         }
     }
 
@@ -1001,7 +1001,7 @@ public:
             FK_YAML_ASSERT(m_node_value.p_mapping != nullptr);
             return {detail::mapping_iterator_tag(), m_node_value.p_mapping->end()};
         default:
-            throw fkyaml::exception("The target node is neither of sequence nor mapping types.");
+            throw fkyaml::type_error("The target node is neither of sequence nor mapping types.", m_node_type);
         }
     }
 
@@ -1013,7 +1013,7 @@ private:
     {
         if (!is_sequence())
         {
-            throw fkyaml::exception("The node value is not a sequence.");
+            throw fkyaml::type_error("The node value is not a sequence.", m_node_type);
         }
         return *(m_node_value.p_sequence);
     }
@@ -1025,7 +1025,7 @@ private:
     {
         if (!is_sequence())
         {
-            throw fkyaml::exception("The node value is not a sequence.");
+            throw fkyaml::type_error("The node value is not a sequence.", m_node_type);
         }
         return *(m_node_value.p_sequence);
     }
@@ -1037,7 +1037,7 @@ private:
     {
         if (!is_mapping())
         {
-            throw fkyaml::exception("The node value is not a mapping.");
+            throw fkyaml::type_error("The node value is not a mapping.", m_node_type);
         }
         return *(m_node_value.p_mapping);
     }
@@ -1049,7 +1049,7 @@ private:
     {
         if (!is_mapping())
         {
-            throw fkyaml::exception("The node value is not a mapping.");
+            throw fkyaml::type_error("The node value is not a mapping.", m_node_type);
         }
         return *(m_node_value.p_mapping);
     }
@@ -1061,7 +1061,7 @@ private:
     {
         if (!is_boolean())
         {
-            throw fkyaml::exception("The node value is not a boolean.");
+            throw fkyaml::type_error("The node value is not a boolean.", m_node_type);
         }
         return m_node_value.boolean;
     }
@@ -1073,7 +1073,7 @@ private:
     {
         if (!is_boolean())
         {
-            throw fkyaml::exception("The node value is not a boolean.");
+            throw fkyaml::type_error("The node value is not a boolean.", m_node_type);
         }
         return m_node_value.boolean;
     }
@@ -1085,7 +1085,7 @@ private:
     {
         if (!is_integer())
         {
-            throw fkyaml::exception("The node value is not an integer.");
+            throw fkyaml::type_error("The node value is not an integer.", m_node_type);
         }
         return m_node_value.integer;
     }
@@ -1097,7 +1097,7 @@ private:
     {
         if (!is_integer())
         {
-            throw fkyaml::exception("The node value is not an integer.");
+            throw fkyaml::type_error("The node value is not an integer.", m_node_type);
         }
         return m_node_value.integer;
     }
@@ -1109,7 +1109,7 @@ private:
     {
         if (!is_float_number())
         {
-            throw fkyaml::exception("The node value is not a floating point number.");
+            throw fkyaml::type_error("The node value is not a floating point number.", m_node_type);
         }
         return m_node_value.float_val;
     }
@@ -1121,7 +1121,7 @@ private:
     {
         if (!is_float_number())
         {
-            throw fkyaml::exception("The node value is not a floating point number.");
+            throw fkyaml::type_error("The node value is not a floating point number.", m_node_type);
         }
         return m_node_value.float_val;
     }
@@ -1133,7 +1133,7 @@ private:
     {
         if (!is_string())
         {
-            throw fkyaml::exception("The node value is not a string.");
+            throw fkyaml::type_error("The node value is not a string.", m_node_type);
         }
         return *(m_node_value.p_string);
     }
@@ -1145,7 +1145,7 @@ private:
     {
         if (!is_string())
         {
-            throw fkyaml::exception("The node value is not a string.");
+            throw fkyaml::type_error("The node value is not a string.", m_node_type);
         }
         return *(m_node_value.p_string);
     }

--- a/test/unit_test/test_deserializer_class.cpp
+++ b/test/unit_test/test_deserializer_class.cpp
@@ -29,7 +29,8 @@ TEST_CASE("DeserializerClassTest_DeserializeKeySeparator", "[DeserializerClassTe
     SECTION("error cases")
     {
         auto input_str = GENERATE(std::string(": foo"), std::string("- : foo"), std::string("- - : foo"));
-        REQUIRE_THROWS_AS(root = deserializer.deserialize(fkyaml::detail::input_adapter(input_str)), fkyaml::exception);
+        REQUIRE_THROWS_AS(
+            root = deserializer.deserialize(fkyaml::detail::input_adapter(input_str)), fkyaml::parse_error);
     }
 }
 
@@ -175,7 +176,7 @@ TEST_CASE("DeserializerClassTest_DeserializeInvalidIndentation", "[DeserializerC
 
     REQUIRE_THROWS_AS(
         root = deserializer.deserialize(fkyaml::detail::input_adapter("foo:\n  bar: baz\n qux: true")),
-        fkyaml::exception);
+        fkyaml::parse_error);
 }
 
 TEST_CASE("DeserializerClassTest_DeserializeDuplicateKeys", "[DeserializerClassTest]")
@@ -184,7 +185,7 @@ TEST_CASE("DeserializerClassTest_DeserializeDuplicateKeys", "[DeserializerClassT
     fkyaml::node root;
 
     REQUIRE_THROWS_AS(
-        root = deserializer.deserialize(fkyaml::detail::input_adapter("foo: bar\nfoo: baz")), fkyaml::exception);
+        root = deserializer.deserialize(fkyaml::detail::input_adapter("foo: bar\nfoo: baz")), fkyaml::parse_error);
 }
 
 TEST_CASE("DeserializerClassTest_DeserializeBlockSequenceTest", "[DeserializerClassTest]")
@@ -944,7 +945,7 @@ TEST_CASE("DeserializerClassTest_DeserializeFlowMappingTest", "[DeserializerClas
 
     SECTION("Input source No.2. (invalid)")
     {
-        REQUIRE_THROWS_AS(deserializer.deserialize(fkyaml::detail::input_adapter("test: }")), fkyaml::exception);
+        REQUIRE_THROWS_AS(deserializer.deserialize(fkyaml::detail::input_adapter("test: }")), fkyaml::parse_error);
     }
 }
 
@@ -1028,7 +1029,7 @@ TEST_CASE("DeserializerClassTest_TagDirectiveTest", "[DeserializerClassTest]")
 TEST_CASE("DeserializerClassTest_DeserializeNoMachingAnchorTest", "[DeserializerClassTest]")
 {
     fkyaml::detail::basic_deserializer<fkyaml::node> deserializer;
-    REQUIRE_THROWS_AS(deserializer.deserialize(fkyaml::detail::input_adapter("foo: *anchor")), fkyaml::exception);
+    REQUIRE_THROWS_AS(deserializer.deserialize(fkyaml::detail::input_adapter("foo: *anchor")), fkyaml::parse_error);
 }
 
 TEST_CASE("DeserializerClassTest_DeserializeDocumentWithMarkersTest", "[DeserializerClassTest]")

--- a/test/unit_test/test_lexical_analyzer_class.cpp
+++ b/test/unit_test/test_lexical_analyzer_class.cpp
@@ -789,7 +789,7 @@ TEST_CASE("LexicalAnalyzerClassTest_ScanInvalidMultiByteCharStringTokenTest", "[
             char_traits_t::to_char_type(0x80)});
 
     str_lexer_t lexer(fkyaml::detail::input_adapter(mb_char));
-    REQUIRE_THROWS_AS(lexer.get_next_token(), fkyaml::exception);
+    REQUIRE_THROWS_AS(lexer.get_next_token(), fkyaml::invalid_encoding);
 }
 
 TEST_CASE("LexicalAnalyzerClassTest_ScanUnescapedControlCharacter", "[LexicalAnalyzerClassTest]")

--- a/test/unit_test/test_node_class.cpp
+++ b/test/unit_test/test_node_class.cpp
@@ -656,25 +656,25 @@ TEST_CASE("NodeClassTest_StringSubscriptOperatorTest", "[NodeClassTest]")
         SECTION("Test non-const lvalue throwing invocation.")
         {
             std::string key = "test";
-            REQUIRE_THROWS_AS(node[key], fkyaml::exception);
+            REQUIRE_THROWS_AS(node[key], fkyaml::type_error);
         }
 
         SECTION("Test const lvalue throwing invocation.")
         {
             std::string key = "test";
             const fkyaml::node const_node = node;
-            REQUIRE_THROWS_AS(const_node[key], fkyaml::exception);
+            REQUIRE_THROWS_AS(const_node[key], fkyaml::type_error);
         }
 
         SECTION("Test non-const rvalue throwing invocation.")
         {
-            REQUIRE_THROWS_AS(node["test"], fkyaml::exception);
+            REQUIRE_THROWS_AS(node["test"], fkyaml::type_error);
         }
 
         SECTION("Test const rvalue throwing invocation.")
         {
             const fkyaml::node const_node = node;
-            REQUIRE_THROWS_AS(const_node["test"], fkyaml::exception);
+            REQUIRE_THROWS_AS(const_node["test"], fkyaml::type_error);
         }
     }
 }
@@ -724,13 +724,13 @@ TEST_CASE("NodeClassTest_IntegerSubscriptOperatorTest", "[NodeClassTest]")
 
         SECTION("Test non-const non-sequence nodes.")
         {
-            REQUIRE_THROWS_AS(node[0], fkyaml::exception);
+            REQUIRE_THROWS_AS(node[0], fkyaml::type_error);
         }
 
         SECTION("Test const non-sequence nodes.")
         {
             const fkyaml::node const_node = node;
-            REQUIRE_THROWS_AS(const_node[0], fkyaml::exception);
+            REQUIRE_THROWS_AS(const_node[0], fkyaml::type_error);
         }
     }
 }
@@ -1176,27 +1176,27 @@ TEST_CASE("NodeClassTest_EmptyTest", "[NodeClassTest]")
 
         SECTION("Test non-const non-alias non-container node emptiness.")
         {
-            REQUIRE_THROWS_AS(node.empty(), fkyaml::exception);
+            REQUIRE_THROWS_AS(node.empty(), fkyaml::type_error);
         }
 
         SECTION("Test const non-alias non-container node emptiness.")
         {
             const fkyaml::node const_node = node;
-            REQUIRE_THROWS_AS(const_node.empty(), fkyaml::exception);
+            REQUIRE_THROWS_AS(const_node.empty(), fkyaml::type_error);
         }
 
         SECTION("Test non-const alias non-container node emptiness.")
         {
             node.add_anchor_name("anchor_name");
             fkyaml::node alias = fkyaml::node::alias_of(node);
-            REQUIRE_THROWS_AS(alias.empty(), fkyaml::exception);
+            REQUIRE_THROWS_AS(alias.empty(), fkyaml::type_error);
         }
 
         SECTION("Test const alias non-container node emptiness.")
         {
             node.add_anchor_name("anchor_name");
             const fkyaml::node alias = fkyaml::node::alias_of(node);
-            REQUIRE_THROWS_AS(alias.empty(), fkyaml::exception);
+            REQUIRE_THROWS_AS(alias.empty(), fkyaml::type_error);
         }
     }
 }
@@ -1323,27 +1323,27 @@ TEST_CASE("NodeClassTest_SizeGetterTest", "[NodeClassTest]")
 
         SECTION("Test non-const non-alias non-container node size.")
         {
-            REQUIRE_THROWS_AS(node.size(), fkyaml::exception);
+            REQUIRE_THROWS_AS(node.size(), fkyaml::type_error);
         }
 
         SECTION("Test const non-alias non-container node size.")
         {
             const fkyaml::node const_node = node;
-            REQUIRE_THROWS_AS(const_node.size(), fkyaml::exception);
+            REQUIRE_THROWS_AS(const_node.size(), fkyaml::type_error);
         }
 
         SECTION("Test non-const alias non-container node size.")
         {
             node.add_anchor_name("anchor_name");
             fkyaml::node alias = fkyaml::node::alias_of(node);
-            REQUIRE_THROWS_AS(alias.size(), fkyaml::exception);
+            REQUIRE_THROWS_AS(alias.size(), fkyaml::type_error);
         }
 
         SECTION("Test const alias non-container node size.")
         {
             node.add_anchor_name("anchor_name");
             const fkyaml::node alias = fkyaml::node::alias_of(node);
-            REQUIRE_THROWS_AS(alias.size(), fkyaml::exception);
+            REQUIRE_THROWS_AS(alias.size(), fkyaml::type_error);
         }
     }
 }
@@ -1459,12 +1459,12 @@ TEST_CASE("NodeClassTest_GetValueTest", "[NodeClassTest]")
 
         SECTION("test for non-sequence value.")
         {
-            REQUIRE_THROWS_AS(node.get_value<fkyaml::node::mapping_type>(), fkyaml::exception);
-            REQUIRE_THROWS_AS(node.get_value<std::nullptr_t>(), fkyaml::exception);
-            REQUIRE_THROWS_AS(node.get_value<fkyaml::node::boolean_type>(), fkyaml::exception);
-            REQUIRE_THROWS_AS(node.get_value<fkyaml::node::integer_type>(), fkyaml::exception);
-            REQUIRE_THROWS_AS(node.get_value<fkyaml::node::float_number_type>(), fkyaml::exception);
-            REQUIRE_THROWS_AS(node.get_value<fkyaml::node::string_type>(), fkyaml::exception);
+            REQUIRE_THROWS_AS(node.get_value<fkyaml::node::mapping_type>(), fkyaml::type_error);
+            REQUIRE_THROWS_AS(node.get_value<std::nullptr_t>(), fkyaml::type_error);
+            REQUIRE_THROWS_AS(node.get_value<fkyaml::node::boolean_type>(), fkyaml::type_error);
+            REQUIRE_THROWS_AS(node.get_value<fkyaml::node::integer_type>(), fkyaml::type_error);
+            REQUIRE_THROWS_AS(node.get_value<fkyaml::node::float_number_type>(), fkyaml::type_error);
+            REQUIRE_THROWS_AS(node.get_value<fkyaml::node::string_type>(), fkyaml::type_error);
         }
     }
 
@@ -1486,12 +1486,12 @@ TEST_CASE("NodeClassTest_GetValueTest", "[NodeClassTest]")
 
         SECTION("test for non-mapping values.")
         {
-            REQUIRE_THROWS_AS(node.get_value<fkyaml::node::sequence_type>(), fkyaml::exception);
-            REQUIRE_THROWS_AS(node.get_value<std::nullptr_t>(), fkyaml::exception);
-            REQUIRE_THROWS_AS(node.get_value<fkyaml::node::boolean_type>(), fkyaml::exception);
-            REQUIRE_THROWS_AS(node.get_value<fkyaml::node::integer_type>(), fkyaml::exception);
-            REQUIRE_THROWS_AS(node.get_value<fkyaml::node::float_number_type>(), fkyaml::exception);
-            REQUIRE_THROWS_AS(node.get_value<fkyaml::node::string_type>(), fkyaml::exception);
+            REQUIRE_THROWS_AS(node.get_value<fkyaml::node::sequence_type>(), fkyaml::type_error);
+            REQUIRE_THROWS_AS(node.get_value<std::nullptr_t>(), fkyaml::type_error);
+            REQUIRE_THROWS_AS(node.get_value<fkyaml::node::boolean_type>(), fkyaml::type_error);
+            REQUIRE_THROWS_AS(node.get_value<fkyaml::node::integer_type>(), fkyaml::type_error);
+            REQUIRE_THROWS_AS(node.get_value<fkyaml::node::float_number_type>(), fkyaml::type_error);
+            REQUIRE_THROWS_AS(node.get_value<fkyaml::node::string_type>(), fkyaml::type_error);
         }
     }
 
@@ -1507,12 +1507,12 @@ TEST_CASE("NodeClassTest_GetValueTest", "[NodeClassTest]")
 
         SECTION("test for non-null values.")
         {
-            REQUIRE_THROWS_AS(node.get_value<fkyaml::node::sequence_type>(), fkyaml::exception);
-            REQUIRE_THROWS_AS(node.get_value<fkyaml::node::mapping_type>(), fkyaml::exception);
-            REQUIRE_THROWS_AS(node.get_value<fkyaml::node::boolean_type>(), fkyaml::exception);
-            REQUIRE_THROWS_AS(node.get_value<fkyaml::node::integer_type>(), fkyaml::exception);
-            REQUIRE_THROWS_AS(node.get_value<fkyaml::node::float_number_type>(), fkyaml::exception);
-            REQUIRE_THROWS_AS(node.get_value<fkyaml::node::string_type>(), fkyaml::exception);
+            REQUIRE_THROWS_AS(node.get_value<fkyaml::node::sequence_type>(), fkyaml::type_error);
+            REQUIRE_THROWS_AS(node.get_value<fkyaml::node::mapping_type>(), fkyaml::type_error);
+            REQUIRE_THROWS_AS(node.get_value<fkyaml::node::boolean_type>(), fkyaml::type_error);
+            REQUIRE_THROWS_AS(node.get_value<fkyaml::node::integer_type>(), fkyaml::type_error);
+            REQUIRE_THROWS_AS(node.get_value<fkyaml::node::float_number_type>(), fkyaml::type_error);
+            REQUIRE_THROWS_AS(node.get_value<fkyaml::node::string_type>(), fkyaml::type_error);
         }
     }
 
@@ -1527,12 +1527,12 @@ TEST_CASE("NodeClassTest_GetValueTest", "[NodeClassTest]")
 
         SECTION("test for non-boolean values.")
         {
-            REQUIRE_THROWS_AS(node.get_value<fkyaml::node::sequence_type>(), fkyaml::exception);
-            REQUIRE_THROWS_AS(node.get_value<fkyaml::node::mapping_type>(), fkyaml::exception);
-            REQUIRE_THROWS_AS(node.get_value<std::nullptr_t>(), fkyaml::exception);
-            REQUIRE_THROWS_AS(node.get_value<fkyaml::node::integer_type>(), fkyaml::exception);
-            REQUIRE_THROWS_AS(node.get_value<fkyaml::node::float_number_type>(), fkyaml::exception);
-            REQUIRE_THROWS_AS(node.get_value<fkyaml::node::string_type>(), fkyaml::exception);
+            REQUIRE_THROWS_AS(node.get_value<fkyaml::node::sequence_type>(), fkyaml::type_error);
+            REQUIRE_THROWS_AS(node.get_value<fkyaml::node::mapping_type>(), fkyaml::type_error);
+            REQUIRE_THROWS_AS(node.get_value<std::nullptr_t>(), fkyaml::type_error);
+            REQUIRE_THROWS_AS(node.get_value<fkyaml::node::integer_type>(), fkyaml::type_error);
+            REQUIRE_THROWS_AS(node.get_value<fkyaml::node::float_number_type>(), fkyaml::type_error);
+            REQUIRE_THROWS_AS(node.get_value<fkyaml::node::string_type>(), fkyaml::type_error);
         }
     }
 
@@ -1554,12 +1554,12 @@ TEST_CASE("NodeClassTest_GetValueTest", "[NodeClassTest]")
 
         SECTION("test for non-integer values.")
         {
-            REQUIRE_THROWS_AS(node.get_value<fkyaml::node::sequence_type>(), fkyaml::exception);
-            REQUIRE_THROWS_AS(node.get_value<fkyaml::node::mapping_type>(), fkyaml::exception);
-            REQUIRE_THROWS_AS(node.get_value<std::nullptr_t>(), fkyaml::exception);
-            REQUIRE_THROWS_AS(node.get_value<fkyaml::node::boolean_type>(), fkyaml::exception);
-            REQUIRE_THROWS_AS(node.get_value<fkyaml::node::float_number_type>(), fkyaml::exception);
-            REQUIRE_THROWS_AS(node.get_value<fkyaml::node::string_type>(), fkyaml::exception);
+            REQUIRE_THROWS_AS(node.get_value<fkyaml::node::sequence_type>(), fkyaml::type_error);
+            REQUIRE_THROWS_AS(node.get_value<fkyaml::node::mapping_type>(), fkyaml::type_error);
+            REQUIRE_THROWS_AS(node.get_value<std::nullptr_t>(), fkyaml::type_error);
+            REQUIRE_THROWS_AS(node.get_value<fkyaml::node::boolean_type>(), fkyaml::type_error);
+            REQUIRE_THROWS_AS(node.get_value<fkyaml::node::float_number_type>(), fkyaml::type_error);
+            REQUIRE_THROWS_AS(node.get_value<fkyaml::node::string_type>(), fkyaml::type_error);
         }
 
         SECTION("test for non-integer node value.")
@@ -1594,12 +1594,12 @@ TEST_CASE("NodeClassTest_GetValueTest", "[NodeClassTest]")
 
         SECTION("test for non-float-number values.")
         {
-            REQUIRE_THROWS_AS(node.get_value<fkyaml::node::sequence_type>(), fkyaml::exception);
-            REQUIRE_THROWS_AS(node.get_value<fkyaml::node::mapping_type>(), fkyaml::exception);
-            REQUIRE_THROWS_AS(node.get_value<std::nullptr_t>(), fkyaml::exception);
-            REQUIRE_THROWS_AS(node.get_value<fkyaml::node::boolean_type>(), fkyaml::exception);
-            REQUIRE_THROWS_AS(node.get_value<fkyaml::node::integer_type>(), fkyaml::exception);
-            REQUIRE_THROWS_AS(node.get_value<fkyaml::node::string_type>(), fkyaml::exception);
+            REQUIRE_THROWS_AS(node.get_value<fkyaml::node::sequence_type>(), fkyaml::type_error);
+            REQUIRE_THROWS_AS(node.get_value<fkyaml::node::mapping_type>(), fkyaml::type_error);
+            REQUIRE_THROWS_AS(node.get_value<std::nullptr_t>(), fkyaml::type_error);
+            REQUIRE_THROWS_AS(node.get_value<fkyaml::node::boolean_type>(), fkyaml::type_error);
+            REQUIRE_THROWS_AS(node.get_value<fkyaml::node::integer_type>(), fkyaml::type_error);
+            REQUIRE_THROWS_AS(node.get_value<fkyaml::node::string_type>(), fkyaml::type_error);
         }
 
         SECTION("test for non-float-number node value.")
@@ -1634,12 +1634,12 @@ TEST_CASE("NodeClassTest_GetValueTest", "[NodeClassTest]")
 
         SECTION("test for non-string values.")
         {
-            REQUIRE_THROWS_AS(node.get_value<fkyaml::node::sequence_type>(), fkyaml::exception);
-            REQUIRE_THROWS_AS(node.get_value<fkyaml::node::mapping_type>(), fkyaml::exception);
-            REQUIRE_THROWS_AS(node.get_value<std::nullptr_t>(), fkyaml::exception);
-            REQUIRE_THROWS_AS(node.get_value<fkyaml::node::boolean_type>(), fkyaml::exception);
-            REQUIRE_THROWS_AS(node.get_value<fkyaml::node::integer_type>(), fkyaml::exception);
-            REQUIRE_THROWS_AS(node.get_value<fkyaml::node::float_number_type>(), fkyaml::exception);
+            REQUIRE_THROWS_AS(node.get_value<fkyaml::node::sequence_type>(), fkyaml::type_error);
+            REQUIRE_THROWS_AS(node.get_value<fkyaml::node::mapping_type>(), fkyaml::type_error);
+            REQUIRE_THROWS_AS(node.get_value<std::nullptr_t>(), fkyaml::type_error);
+            REQUIRE_THROWS_AS(node.get_value<fkyaml::node::boolean_type>(), fkyaml::type_error);
+            REQUIRE_THROWS_AS(node.get_value<fkyaml::node::integer_type>(), fkyaml::type_error);
+            REQUIRE_THROWS_AS(node.get_value<fkyaml::node::float_number_type>(), fkyaml::type_error);
         }
     }
 }
@@ -1713,27 +1713,27 @@ TEST_CASE("NodeClassTest_GetValueRefForSequenceTest", "[NodeClassTest]")
 
         SECTION("Test non-alias non-sequence nodes.")
         {
-            REQUIRE_THROWS_AS(node.get_value_ref<fkyaml::node::sequence_type&>(), fkyaml::exception);
+            REQUIRE_THROWS_AS(node.get_value_ref<fkyaml::node::sequence_type&>(), fkyaml::type_error);
         }
 
         SECTION("Test const non-alias non-sequence nodes.")
         {
             const fkyaml::node const_node = node;
-            REQUIRE_THROWS_AS(const_node.get_value_ref<const fkyaml::node::sequence_type&>(), fkyaml::exception);
+            REQUIRE_THROWS_AS(const_node.get_value_ref<const fkyaml::node::sequence_type&>(), fkyaml::type_error);
         }
 
         SECTION("Test alias non-sequence nodes.")
         {
             node.add_anchor_name("anchor_name");
             fkyaml::node alias = fkyaml::node::alias_of(node);
-            REQUIRE_THROWS_AS(alias.get_value_ref<fkyaml::node::sequence_type&>(), fkyaml::exception);
+            REQUIRE_THROWS_AS(alias.get_value_ref<fkyaml::node::sequence_type&>(), fkyaml::type_error);
         }
 
         SECTION("Test const alias non-sequence nodes.")
         {
             node.add_anchor_name("anchor_name");
             const fkyaml::node alias = fkyaml::node::alias_of(node);
-            REQUIRE_THROWS_AS(alias.get_value_ref<const fkyaml::node::sequence_type&>(), fkyaml::exception);
+            REQUIRE_THROWS_AS(alias.get_value_ref<const fkyaml::node::sequence_type&>(), fkyaml::type_error);
         }
     }
 }
@@ -1798,27 +1798,27 @@ TEST_CASE("NodeClassTest_GetValueRefForMappingTest", "[NodeClassTest]")
 
         SECTION("Test non-alias non-mapping nodes.")
         {
-            REQUIRE_THROWS_AS(node.get_value_ref<fkyaml::node::mapping_type&>(), fkyaml::exception);
+            REQUIRE_THROWS_AS(node.get_value_ref<fkyaml::node::mapping_type&>(), fkyaml::type_error);
         }
 
         SECTION("Test const non-alias non-mapping nodes.")
         {
             const fkyaml::node const_node = node;
-            REQUIRE_THROWS_AS(const_node.get_value_ref<const fkyaml::node::mapping_type&>(), fkyaml::exception);
+            REQUIRE_THROWS_AS(const_node.get_value_ref<const fkyaml::node::mapping_type&>(), fkyaml::type_error);
         }
 
         SECTION("Test alias non-mapping nodes.")
         {
             node.add_anchor_name("anchor_name");
             fkyaml::node alias = fkyaml::node::alias_of(node);
-            REQUIRE_THROWS_AS(alias.get_value_ref<fkyaml::node::mapping_type&>(), fkyaml::exception);
+            REQUIRE_THROWS_AS(alias.get_value_ref<fkyaml::node::mapping_type&>(), fkyaml::type_error);
         }
 
         SECTION("Test const alias non-mapping nodes.")
         {
             node.add_anchor_name("anchor_name");
             const fkyaml::node alias = fkyaml::node::alias_of(node);
-            REQUIRE_THROWS_AS(alias.get_value_ref<const fkyaml::node::mapping_type&>(), fkyaml::exception);
+            REQUIRE_THROWS_AS(alias.get_value_ref<const fkyaml::node::mapping_type&>(), fkyaml::type_error);
         }
     }
 }
@@ -1871,27 +1871,27 @@ TEST_CASE("NodeClassTest_GetValueRefForBooleanTest", "[NodeClassTest]")
 
         SECTION("Test non-alias non-boolean nodes.")
         {
-            REQUIRE_THROWS_AS(node.get_value_ref<fkyaml::node::boolean_type&>(), fkyaml::exception);
+            REQUIRE_THROWS_AS(node.get_value_ref<fkyaml::node::boolean_type&>(), fkyaml::type_error);
         }
 
         SECTION("Test const non-alias non-boolean nodes.")
         {
             const fkyaml::node const_node = node;
-            REQUIRE_THROWS_AS(const_node.get_value_ref<const fkyaml::node::boolean_type&>(), fkyaml::exception);
+            REQUIRE_THROWS_AS(const_node.get_value_ref<const fkyaml::node::boolean_type&>(), fkyaml::type_error);
         }
 
         SECTION("Test alias non-boolean nodes.")
         {
             node.add_anchor_name("anchor_name");
             fkyaml::node alias = fkyaml::node::alias_of(node);
-            REQUIRE_THROWS_AS(alias.get_value_ref<fkyaml::node::boolean_type&>(), fkyaml::exception);
+            REQUIRE_THROWS_AS(alias.get_value_ref<fkyaml::node::boolean_type&>(), fkyaml::type_error);
         }
 
         SECTION("Test const alias non-boolean nodes.")
         {
             node.add_anchor_name("anchor_name");
             const fkyaml::node alias = fkyaml::node::alias_of(node);
-            REQUIRE_THROWS_AS(alias.get_value_ref<const fkyaml::node::boolean_type&>(), fkyaml::exception);
+            REQUIRE_THROWS_AS(alias.get_value_ref<const fkyaml::node::boolean_type&>(), fkyaml::type_error);
         }
     }
 }
@@ -1945,27 +1945,27 @@ TEST_CASE("NodeClassTest_GetValueRefForIntegerTest", "[NodeClassTest]")
 
         SECTION("Test non-alias non-integer nodes.")
         {
-            REQUIRE_THROWS_AS(node.get_value_ref<fkyaml::node::integer_type&>(), fkyaml::exception);
+            REQUIRE_THROWS_AS(node.get_value_ref<fkyaml::node::integer_type&>(), fkyaml::type_error);
         }
 
         SECTION("Test const non-alias non-integer nodes.")
         {
             const fkyaml::node const_node = node;
-            REQUIRE_THROWS_AS(const_node.get_value_ref<const fkyaml::node::integer_type&>(), fkyaml::exception);
+            REQUIRE_THROWS_AS(const_node.get_value_ref<const fkyaml::node::integer_type&>(), fkyaml::type_error);
         }
 
         SECTION("Test alias non-integer nodes.")
         {
             node.add_anchor_name("anchor_name");
             fkyaml::node alias = fkyaml::node::alias_of(node);
-            REQUIRE_THROWS_AS(alias.get_value_ref<fkyaml::node::integer_type&>(), fkyaml::exception);
+            REQUIRE_THROWS_AS(alias.get_value_ref<fkyaml::node::integer_type&>(), fkyaml::type_error);
         }
 
         SECTION("Test const alias non-integer nodes.")
         {
             node.add_anchor_name("anchor_name");
             const fkyaml::node alias = fkyaml::node::alias_of(node);
-            REQUIRE_THROWS_AS(alias.get_value_ref<const fkyaml::node::integer_type&>(), fkyaml::exception);
+            REQUIRE_THROWS_AS(alias.get_value_ref<const fkyaml::node::integer_type&>(), fkyaml::type_error);
         }
     }
 }
@@ -2019,27 +2019,27 @@ TEST_CASE("NodeClassTest_GetValueRefForFloatNumberTest", "[NodeClassTest]")
 
         SECTION("Test non-alias non-float-number nodes.")
         {
-            REQUIRE_THROWS_AS(node.get_value_ref<fkyaml::node::float_number_type&>(), fkyaml::exception);
+            REQUIRE_THROWS_AS(node.get_value_ref<fkyaml::node::float_number_type&>(), fkyaml::type_error);
         }
 
         SECTION("Test const non-alias non-float-number nodes.")
         {
             const fkyaml::node const_node = node;
-            REQUIRE_THROWS_AS(const_node.get_value_ref<const fkyaml::node::float_number_type&>(), fkyaml::exception);
+            REQUIRE_THROWS_AS(const_node.get_value_ref<const fkyaml::node::float_number_type&>(), fkyaml::type_error);
         }
 
         SECTION("Test alias non-float-number nodes.")
         {
             node.add_anchor_name("anchor_name");
             fkyaml::node alias = fkyaml::node::alias_of(node);
-            REQUIRE_THROWS_AS(alias.get_value_ref<fkyaml::node::float_number_type&>(), fkyaml::exception);
+            REQUIRE_THROWS_AS(alias.get_value_ref<fkyaml::node::float_number_type&>(), fkyaml::type_error);
         }
 
         SECTION("Test const alias non-float-number nodes.")
         {
             node.add_anchor_name("anchor_name");
             const fkyaml::node alias = fkyaml::node::alias_of(node);
-            REQUIRE_THROWS_AS(alias.get_value_ref<const fkyaml::node::float_number_type&>(), fkyaml::exception);
+            REQUIRE_THROWS_AS(alias.get_value_ref<const fkyaml::node::float_number_type&>(), fkyaml::type_error);
         }
     }
 }
@@ -2093,27 +2093,27 @@ TEST_CASE("NodeClassTest_GetValueRefForStringTest", "[NodeClassTest]")
 
         SECTION("Test non-alias non-string nodes.")
         {
-            REQUIRE_THROWS_AS(node.get_value_ref<fkyaml::node::string_type&>(), fkyaml::exception);
+            REQUIRE_THROWS_AS(node.get_value_ref<fkyaml::node::string_type&>(), fkyaml::type_error);
         }
 
         SECTION("Test const non-alias non-string nodes.")
         {
             const fkyaml::node const_node = node;
-            REQUIRE_THROWS_AS(const_node.get_value_ref<const fkyaml::node::string_type&>(), fkyaml::exception);
+            REQUIRE_THROWS_AS(const_node.get_value_ref<const fkyaml::node::string_type&>(), fkyaml::type_error);
         }
 
         SECTION("Test alias non-string nodes.")
         {
             node.add_anchor_name("anchor_name");
             fkyaml::node alias = fkyaml::node::alias_of(node);
-            REQUIRE_THROWS_AS(alias.get_value_ref<fkyaml::node::string_type&>(), fkyaml::exception);
+            REQUIRE_THROWS_AS(alias.get_value_ref<fkyaml::node::string_type&>(), fkyaml::type_error);
         }
 
         SECTION("Test const alias non-string nodes.")
         {
             node.add_anchor_name("anchor_name");
             const fkyaml::node alias = fkyaml::node::alias_of(node);
-            REQUIRE_THROWS_AS(alias.get_value_ref<const fkyaml::node::string_type&>(), fkyaml::exception);
+            REQUIRE_THROWS_AS(alias.get_value_ref<const fkyaml::node::string_type&>(), fkyaml::type_error);
         }
     }
 }
@@ -2171,13 +2171,13 @@ TEST_CASE("NodeClassTest_BeginTest", "[NodeClassTest]")
 
         SECTION("Test non-const throwing node.")
         {
-            REQUIRE_THROWS_AS(node.begin(), fkyaml::exception);
+            REQUIRE_THROWS_AS(node.begin(), fkyaml::type_error);
         }
 
         SECTION("Test const throwing node.")
         {
             const fkyaml::node const_node = node;
-            REQUIRE_THROWS_AS(const_node.begin(), fkyaml::exception);
+            REQUIRE_THROWS_AS(const_node.begin(), fkyaml::type_error);
         }
     }
 }
@@ -2231,13 +2231,13 @@ TEST_CASE("NodeClassTest_EndTest", "[NodeClassTest]")
 
         SECTION("Test non-const throwing node.")
         {
-            REQUIRE_THROWS_AS(node.end(), fkyaml::exception);
+            REQUIRE_THROWS_AS(node.end(), fkyaml::type_error);
         }
 
         SECTION("Test const throwing node.")
         {
             const fkyaml::node const_node = node;
-            REQUIRE_THROWS_AS(const_node.end(), fkyaml::exception);
+            REQUIRE_THROWS_AS(const_node.end(), fkyaml::type_error);
         }
     }
 }

--- a/test/unit_test/test_node_class.cpp
+++ b/test/unit_test/test_node_class.cpp
@@ -1565,7 +1565,7 @@ TEST_CASE("NodeClassTest_GetValueTest", "[NodeClassTest]")
         SECTION("test for non-integer node value.")
         {
             fkyaml::node non_int_node(true);
-            REQUIRE_THROWS_AS(non_int_node.get_value<int32_t>(), fkyaml::exception);
+            REQUIRE_THROWS_AS(non_int_node.get_value<int32_t>(), fkyaml::type_error);
         }
 
         SECTION("test underflowable integer type.")
@@ -1605,7 +1605,7 @@ TEST_CASE("NodeClassTest_GetValueTest", "[NodeClassTest]")
         SECTION("test for non-float-number node value.")
         {
             fkyaml::node non_float_num_node(true);
-            REQUIRE_THROWS_AS(non_float_num_node.get_value<float>(), fkyaml::exception);
+            REQUIRE_THROWS_AS(non_float_num_node.get_value<float>(), fkyaml::type_error);
         }
 
         SECTION("test underflowable float number type.")

--- a/test/unit_test/test_utf8_encoding_class.cpp
+++ b/test/unit_test/test_utf8_encoding_class.cpp
@@ -296,7 +296,6 @@ TEST_CASE("UTF8EncodingClassTest_FromUTF32Test", "[UTF8EncodingClassTest]")
         std::size_t encoded_size;
 
         REQUIRE_THROWS_AS(
-            fkyaml::detail::utf8_encoding::from_utf32(utf32, utf8_bytes, encoded_size),
-            fkyaml::invalid_encoding);
+            fkyaml::detail::utf8_encoding::from_utf32(utf32, utf8_bytes, encoded_size), fkyaml::invalid_encoding);
     }
 }


### PR DESCRIPTION
Currently, fkYAML emits an `fkyaml::exception` object when some error is detected at runtime.  
The fkyaml::exception object only contains information of what kind of error detected without any runtime information.  
Such information makes it too difficult to dig into the actual issue causing the error.  
So, this PR has made error descriptions emitted from fkYAML more useful for further debugging.  
See the API documentation for the newly added exception classes and their error message contents.  