### PR TITLE
Fixed wrong URLs in the releases page of the documentation

### DIFF
--- a/docs/mkdocs/docs/home/releases.md
+++ b/docs/mkdocs/docs/home/releases.md
@@ -2,8 +2,8 @@
 
 !!! abstract Release Packages
 
-    * [fkYAML.tgz](https://github.com/fktn-k/fkYAML/releases/download/v0.2.1/fkYAML.tgz)
-    * [fkYAML.zip](https://github.com/fktn-k/fkYAML/releases/download/v0.2.1/fkYAML.zip)
+    * [fkYAML.tgz](https://github.com/fktn-k/fkYAML/releases/download/v0.2.2/fkYAML.tgz)
+    * [fkYAML.zip](https://github.com/fktn-k/fkYAML/releases/download/v0.2.2/fkYAML.zip)
 
 ## Summary
 


### PR DESCRIPTION
The release note for v0.2.2 contains typos in the URLs to the related release packages.  
So this PR has corrected them.  