### PR TITLE
#159 Support block scalar styles

### DIFF
--- a/include/fkYAML/detail/input/lexical_analyzer.hpp
+++ b/include/fkYAML/detail/input/lexical_analyzer.hpp
@@ -253,13 +253,15 @@ public:
             chomping_indicator_t chomp_type = chomping_indicator_t::KEEP;
             std::size_t indent = 0;
             get_block_style_metadata(chomp_type, indent);
-            return m_last_token_type = scan_block_style_string_token(block_style_indicator_t::LITERAL, chomp_type, indent);
+            return m_last_token_type =
+                       scan_block_style_string_token(block_style_indicator_t::LITERAL, chomp_type, indent);
         }
         case '>': {
             chomping_indicator_t chomp_type = chomping_indicator_t::KEEP;
             std::size_t indent = 0;
             get_block_style_metadata(chomp_type, indent);
-            return m_last_token_type = scan_block_style_string_token(block_style_indicator_t::FOLDED, chomp_type, indent);
+            return m_last_token_type =
+                       scan_block_style_string_token(block_style_indicator_t::FOLDED, chomp_type, indent);
         }
         case 'F':
         case 'f': {
@@ -1085,7 +1087,8 @@ private:
         }
     }
 
-    lexical_token_t scan_block_style_string_token(block_style_indicator_t style, chomping_indicator_t chomp, std::size_t indent)
+    lexical_token_t scan_block_style_string_token(
+        block_style_indicator_t style, chomping_indicator_t chomp, std::size_t indent)
     {
         m_value_buffer.clear();
 

--- a/test/unit_test/test_lexical_analyzer_class.cpp
+++ b/test/unit_test/test_lexical_analyzer_class.cpp
@@ -845,9 +845,8 @@ TEST_CASE("LexicalAnalyzerClassTest_ScanLiteralStringScalar", "[LexicalAnalyzerC
 
     SECTION("empty literal string scalar with strip chomping")
     {
-        const char input[] =
-            "|-\r\n"
-            "  \r\n";
+        const char input[] = "|-\r\n"
+                             "  \r\n";
         pchar_lexer_t lexer(fkyaml::detail::input_adapter(input));
 
         REQUIRE_NOTHROW(token = lexer.get_next_token());
@@ -857,9 +856,8 @@ TEST_CASE("LexicalAnalyzerClassTest_ScanLiteralStringScalar", "[LexicalAnalyzerC
 
     SECTION("empty literal string scalar with clip chomping")
     {
-        const char input[] =
-            "|\r\n"
-            "  \r\n";
+        const char input[] = "|\r\n"
+                             "  \r\n";
         pchar_lexer_t lexer(fkyaml::detail::input_adapter(input));
 
         REQUIRE_NOTHROW(token = lexer.get_next_token());
@@ -869,9 +867,8 @@ TEST_CASE("LexicalAnalyzerClassTest_ScanLiteralStringScalar", "[LexicalAnalyzerC
 
     SECTION("empty literal string scalar with keep chomping")
     {
-        const char input[] =
-            "|+\r\n"
-            "  \r\n";
+        const char input[] = "|+\r\n"
+                             "  \r\n";
         pchar_lexer_t lexer(fkyaml::detail::input_adapter(input));
 
         REQUIRE_NOTHROW(token = lexer.get_next_token());
@@ -881,9 +878,8 @@ TEST_CASE("LexicalAnalyzerClassTest_ScanLiteralStringScalar", "[LexicalAnalyzerC
 
     SECTION("literal string scalar with 0 indent level.")
     {
-        const char input[] =
-            "|0\n"
-            "foo";
+        const char input[] = "|0\n"
+                             "foo";
 
         pchar_lexer_t lexer(fkyaml::detail::input_adapter(input));
         REQUIRE_THROWS_AS(lexer.get_next_token(), fkyaml::parse_error);
@@ -891,9 +887,8 @@ TEST_CASE("LexicalAnalyzerClassTest_ScanLiteralStringScalar", "[LexicalAnalyzerC
 
     SECTION("less indented literal string scalar")
     {
-        const char input[] =
-            "|2\n"
-            " foo";
+        const char input[] = "|2\n"
+                             " foo";
 
         pchar_lexer_t lexer(fkyaml::detail::input_adapter(input));
         REQUIRE_THROWS_AS(lexer.get_next_token(), fkyaml::parse_error);
@@ -901,10 +896,9 @@ TEST_CASE("LexicalAnalyzerClassTest_ScanLiteralStringScalar", "[LexicalAnalyzerC
 
     SECTION("literal scalar with the first line being more indented than the indicated level")
     {
-        const char input[] =
-            "|2\n"
-            "    foo\n"
-            "  bar\n";
+        const char input[] = "|2\n"
+                             "    foo\n"
+                             "  bar\n";
         pchar_lexer_t lexer(fkyaml::detail::input_adapter(input));
 
         REQUIRE_NOTHROW(token = lexer.get_next_token());
@@ -914,10 +908,9 @@ TEST_CASE("LexicalAnalyzerClassTest_ScanLiteralStringScalar", "[LexicalAnalyzerC
 
     SECTION("literal string scalar with windows style newlines.")
     {
-        const char input[] =
-            "|\r\n"
-            "  foo\r\n"
-            "  bar\r\n";
+        const char input[] = "|\r\n"
+                             "  foo\r\n"
+                             "  bar\r\n";
         pchar_lexer_t lexer(fkyaml::detail::input_adapter(input));
 
         REQUIRE_NOTHROW(token = lexer.get_next_token());
@@ -927,14 +920,13 @@ TEST_CASE("LexicalAnalyzerClassTest_ScanLiteralStringScalar", "[LexicalAnalyzerC
 
     SECTION("literal string scalar with implicit indentation and strip chomping.")
     {
-        const char input[] =
-            "|-\n"
-            "\n"
-            "  foo\n"
-            "  bar\n"
-            "\n"
-            "  baz\n"
-            "\n";
+        const char input[] = "|-\n"
+                             "\n"
+                             "  foo\n"
+                             "  bar\n"
+                             "\n"
+                             "  baz\n"
+                             "\n";
         pchar_lexer_t lexer(fkyaml::detail::input_adapter(input));
 
         REQUIRE_NOTHROW(token = lexer.get_next_token());
@@ -944,13 +936,12 @@ TEST_CASE("LexicalAnalyzerClassTest_ScanLiteralStringScalar", "[LexicalAnalyzerC
 
     SECTION("literal string scalar with explicit indentation and strip chomping.")
     {
-        const char input[] =
-            "|-2\n"
-            "  foo\n"
-            "    bar\n"
-            "\n"
-            "  baz\n"
-            "\n";
+        const char input[] = "|-2\n"
+                             "  foo\n"
+                             "    bar\n"
+                             "\n"
+                             "  baz\n"
+                             "\n";
         pchar_lexer_t lexer(fkyaml::detail::input_adapter(input));
 
         REQUIRE_NOTHROW(token = lexer.get_next_token());
@@ -960,14 +951,13 @@ TEST_CASE("LexicalAnalyzerClassTest_ScanLiteralStringScalar", "[LexicalAnalyzerC
 
     SECTION("literal string scalar with implicit indentation and clip chomping.")
     {
-        const char input[] =
-            "|\n"
-            "\n"
-            "  foo\n"
-            "  bar\n"
-            "\n"
-            "  baz\n"
-            "\n";
+        const char input[] = "|\n"
+                             "\n"
+                             "  foo\n"
+                             "  bar\n"
+                             "\n"
+                             "  baz\n"
+                             "\n";
         pchar_lexer_t lexer(fkyaml::detail::input_adapter(input));
 
         REQUIRE_NOTHROW(token = lexer.get_next_token());
@@ -977,13 +967,12 @@ TEST_CASE("LexicalAnalyzerClassTest_ScanLiteralStringScalar", "[LexicalAnalyzerC
 
     SECTION("literal string scalar with explicit indentation and clip chomping.")
     {
-        const char input[] =
-            "|2\n"
-            "  foo\n"
-            "    bar\n"
-            "\n"
-            "  baz\n"
-            "\n";
+        const char input[] = "|2\n"
+                             "  foo\n"
+                             "    bar\n"
+                             "\n"
+                             "  baz\n"
+                             "\n";
         pchar_lexer_t lexer(fkyaml::detail::input_adapter(input));
 
         REQUIRE_NOTHROW(token = lexer.get_next_token());
@@ -993,12 +982,11 @@ TEST_CASE("LexicalAnalyzerClassTest_ScanLiteralStringScalar", "[LexicalAnalyzerC
 
     SECTION("literal string scalar with clip chomping and no trailing newlines")
     {
-        const char input[] =
-            "|2\n"
-            "  foo\n"
-            "    bar\n"
-            "\n"
-            "  baz";
+        const char input[] = "|2\n"
+                             "  foo\n"
+                             "    bar\n"
+                             "\n"
+                             "  baz";
         pchar_lexer_t lexer(fkyaml::detail::input_adapter(input));
 
         REQUIRE_NOTHROW(token = lexer.get_next_token());
@@ -1008,14 +996,13 @@ TEST_CASE("LexicalAnalyzerClassTest_ScanLiteralStringScalar", "[LexicalAnalyzerC
 
     SECTION("literal string scalar with implicit indentation and keep chomping.")
     {
-        const char input[] =
-            "|+\n"
-            "\n"
-            "  foo\n"
-            "  bar\n"
-            "\n"
-            "  baz\n"
-            "\n";
+        const char input[] = "|+\n"
+                             "\n"
+                             "  foo\n"
+                             "  bar\n"
+                             "\n"
+                             "  baz\n"
+                             "\n";
         pchar_lexer_t lexer(fkyaml::detail::input_adapter(input));
 
         REQUIRE_NOTHROW(token = lexer.get_next_token());
@@ -1025,13 +1012,12 @@ TEST_CASE("LexicalAnalyzerClassTest_ScanLiteralStringScalar", "[LexicalAnalyzerC
 
     SECTION("literal string scalar with explicit indentation and keep chomping.")
     {
-        const char input[] =
-            "|+2\n"
-            "  foo\n"
-            "    bar\n"
-            "\n"
-            "  baz\n"
-            "\n";
+        const char input[] = "|+2\n"
+                             "  foo\n"
+                             "    bar\n"
+                             "\n"
+                             "  baz\n"
+                             "\n";
         pchar_lexer_t lexer(fkyaml::detail::input_adapter(input));
 
         REQUIRE_NOTHROW(token = lexer.get_next_token());
@@ -1046,9 +1032,8 @@ TEST_CASE("LexicalAnalyzerClassTest_ScanFoldedStringScalar", "[LexicalAnalyzerCl
 
     SECTION("empty folded string scalar with strip chomping")
     {
-        const char input[] =
-            ">-\r\n"
-            "  \r\n";
+        const char input[] = ">-\r\n"
+                             "  \r\n";
         pchar_lexer_t lexer(fkyaml::detail::input_adapter(input));
 
         REQUIRE_NOTHROW(token = lexer.get_next_token());
@@ -1058,9 +1043,8 @@ TEST_CASE("LexicalAnalyzerClassTest_ScanFoldedStringScalar", "[LexicalAnalyzerCl
 
     SECTION("empty folded string scalar with clip chomping")
     {
-        const char input[] =
-            ">\r\n"
-            "  \r\n";
+        const char input[] = ">\r\n"
+                             "  \r\n";
         pchar_lexer_t lexer(fkyaml::detail::input_adapter(input));
 
         REQUIRE_NOTHROW(token = lexer.get_next_token());
@@ -1070,9 +1054,8 @@ TEST_CASE("LexicalAnalyzerClassTest_ScanFoldedStringScalar", "[LexicalAnalyzerCl
 
     SECTION("empty folded string scalar with keep chomping")
     {
-        const char input[] =
-            ">+\r\n"
-            "  \r\n";
+        const char input[] = ">+\r\n"
+                             "  \r\n";
         pchar_lexer_t lexer(fkyaml::detail::input_adapter(input));
 
         REQUIRE_NOTHROW(token = lexer.get_next_token());
@@ -1082,9 +1065,8 @@ TEST_CASE("LexicalAnalyzerClassTest_ScanFoldedStringScalar", "[LexicalAnalyzerCl
 
     SECTION("folded string scalar with 0 indent level.")
     {
-        const char input[] =
-            "|0\n"
-            "foo";
+        const char input[] = "|0\n"
+                             "foo";
 
         pchar_lexer_t lexer(fkyaml::detail::input_adapter(input));
         REQUIRE_THROWS_AS(lexer.get_next_token(), fkyaml::parse_error);
@@ -1092,9 +1074,8 @@ TEST_CASE("LexicalAnalyzerClassTest_ScanFoldedStringScalar", "[LexicalAnalyzerCl
 
     SECTION("less indented folded string scalar")
     {
-        const char input[] =
-            ">2\n"
-            " foo";
+        const char input[] = ">2\n"
+                             " foo";
 
         pchar_lexer_t lexer(fkyaml::detail::input_adapter(input));
         REQUIRE_THROWS_AS(lexer.get_next_token(), fkyaml::parse_error);
@@ -1102,10 +1083,9 @@ TEST_CASE("LexicalAnalyzerClassTest_ScanFoldedStringScalar", "[LexicalAnalyzerCl
 
     SECTION("folded string scalar with the first line being more indented than the indicated level")
     {
-        const char input[] =
-            ">2\n"
-            "    foo\n"
-            "  bar\n";
+        const char input[] = ">2\n"
+                             "    foo\n"
+                             "  bar\n";
         pchar_lexer_t lexer(fkyaml::detail::input_adapter(input));
 
         REQUIRE_NOTHROW(token = lexer.get_next_token());
@@ -1115,10 +1095,9 @@ TEST_CASE("LexicalAnalyzerClassTest_ScanFoldedStringScalar", "[LexicalAnalyzerCl
 
     SECTION("folded string scalar with the non-first line being more indented than the indicated level")
     {
-        const char input[] =
-            ">2\n"
-            "  foo\n"
-            "    bar\n";
+        const char input[] = ">2\n"
+                             "  foo\n"
+                             "    bar\n";
         pchar_lexer_t lexer(fkyaml::detail::input_adapter(input));
 
         REQUIRE_NOTHROW(token = lexer.get_next_token());
@@ -1128,13 +1107,12 @@ TEST_CASE("LexicalAnalyzerClassTest_ScanFoldedStringScalar", "[LexicalAnalyzerCl
 
     SECTION("folded string scalar with windows style newlines.")
     {
-        const char input[] =
-            ">\r\n"
-            "  foo\r\n"
-            "  \r\n"
-            "\r\n"
-            "  bar\r\n"
-            " \r\n";
+        const char input[] = ">\r\n"
+                             "  foo\r\n"
+                             "  \r\n"
+                             "\r\n"
+                             "  bar\r\n"
+                             " \r\n";
         pchar_lexer_t lexer(fkyaml::detail::input_adapter(input));
 
         REQUIRE_NOTHROW(token = lexer.get_next_token());
@@ -1144,12 +1122,11 @@ TEST_CASE("LexicalAnalyzerClassTest_ScanFoldedStringScalar", "[LexicalAnalyzerCl
 
     SECTION("folded string scalar with implicit indentation and strip chomping.")
     {
-        const char input[] =
-            ">-\n"
-            "  foo\n"
-            "  bar\n"
-            " \n"
-            "\n";
+        const char input[] = ">-\n"
+                             "  foo\n"
+                             "  bar\n"
+                             " \n"
+                             "\n";
         pchar_lexer_t lexer(fkyaml::detail::input_adapter(input));
 
         REQUIRE_NOTHROW(token = lexer.get_next_token());
@@ -1159,12 +1136,11 @@ TEST_CASE("LexicalAnalyzerClassTest_ScanFoldedStringScalar", "[LexicalAnalyzerCl
 
     SECTION("folded string scalar with implicit indentation and clip chomping.")
     {
-        const char input[] =
-            ">\n"
-            "  foo\n"
-            "  bar\n"
-            "  \n"
-            "\n";
+        const char input[] = ">\n"
+                             "  foo\n"
+                             "  bar\n"
+                             "  \n"
+                             "\n";
         pchar_lexer_t lexer(fkyaml::detail::input_adapter(input));
 
         REQUIRE_NOTHROW(token = lexer.get_next_token());
@@ -1174,12 +1150,11 @@ TEST_CASE("LexicalAnalyzerClassTest_ScanFoldedStringScalar", "[LexicalAnalyzerCl
 
     SECTION("folded string scalar with implicit indentation and keep chomping.")
     {
-        const char input[] =
-            ">+\n"
-            "  foo\n"
-            "  bar\n"
-            " \n"
-            "\n";
+        const char input[] = ">+\n"
+                             "  foo\n"
+                             "  bar\n"
+                             " \n"
+                             "\n";
         pchar_lexer_t lexer(fkyaml::detail::input_adapter(input));
 
         REQUIRE_NOTHROW(token = lexer.get_next_token());

--- a/test/unit_test/test_lexical_analyzer_class.cpp
+++ b/test/unit_test/test_lexical_analyzer_class.cpp
@@ -839,6 +839,355 @@ TEST_CASE("LexicalAnalyzerClassTest_ScanUnescapedControlCharacter", "[LexicalAna
     REQUIRE_THROWS_AS(lexer.get_next_token(), fkyaml::parse_error);
 }
 
+TEST_CASE("LexicalAnalyzerClassTest_ScanLiteralStringScalar", "[LexicalAnalyzerClassTest]")
+{
+    fkyaml::detail::lexical_token_t token;
+
+    SECTION("empty literal string scalar with strip chomping")
+    {
+        const char input[] =
+            "|-\r\n"
+            "  \r\n";
+        pchar_lexer_t lexer(fkyaml::detail::input_adapter(input));
+
+        REQUIRE_NOTHROW(token = lexer.get_next_token());
+        REQUIRE(token == fkyaml::detail::lexical_token_t::STRING_VALUE);
+        REQUIRE(lexer.get_string() == "");
+    }
+
+    SECTION("empty literal string scalar with clip chomping")
+    {
+        const char input[] =
+            "|\r\n"
+            "  \r\n";
+        pchar_lexer_t lexer(fkyaml::detail::input_adapter(input));
+
+        REQUIRE_NOTHROW(token = lexer.get_next_token());
+        REQUIRE(token == fkyaml::detail::lexical_token_t::STRING_VALUE);
+        REQUIRE(lexer.get_string() == "");
+    }
+
+    SECTION("empty literal string scalar with keep chomping")
+    {
+        const char input[] =
+            "|+\r\n"
+            "  \r\n";
+        pchar_lexer_t lexer(fkyaml::detail::input_adapter(input));
+
+        REQUIRE_NOTHROW(token = lexer.get_next_token());
+        REQUIRE(token == fkyaml::detail::lexical_token_t::STRING_VALUE);
+        REQUIRE(lexer.get_string() == "\n");
+    }
+
+    SECTION("literal string scalar with 0 indent level.")
+    {
+        const char input[] =
+            "|0\n"
+            "foo";
+
+        pchar_lexer_t lexer(fkyaml::detail::input_adapter(input));
+        REQUIRE_THROWS_AS(lexer.get_next_token(), fkyaml::parse_error);
+    }
+
+    SECTION("less indented literal string scalar")
+    {
+        const char input[] =
+            "|2\n"
+            " foo";
+
+        pchar_lexer_t lexer(fkyaml::detail::input_adapter(input));
+        REQUIRE_THROWS_AS(lexer.get_next_token(), fkyaml::parse_error);
+    }
+
+    SECTION("literal scalar with the first line being more indented than the indicated level")
+    {
+        const char input[] =
+            "|2\n"
+            "    foo\n"
+            "  bar\n";
+        pchar_lexer_t lexer(fkyaml::detail::input_adapter(input));
+
+        REQUIRE_NOTHROW(token = lexer.get_next_token());
+        REQUIRE(token == fkyaml::detail::lexical_token_t::STRING_VALUE);
+        REQUIRE(lexer.get_string() == "  foo\nbar\n");
+    }
+
+    SECTION("literal string scalar with windows style newlines.")
+    {
+        const char input[] =
+            "|\r\n"
+            "  foo\r\n"
+            "  bar\r\n";
+        pchar_lexer_t lexer(fkyaml::detail::input_adapter(input));
+
+        REQUIRE_NOTHROW(token = lexer.get_next_token());
+        REQUIRE(token == fkyaml::detail::lexical_token_t::STRING_VALUE);
+        REQUIRE(lexer.get_string() == "foo\nbar\n");
+    }
+
+    SECTION("literal string scalar with implicit indentation and strip chomping.")
+    {
+        const char input[] =
+            "|-\n"
+            "\n"
+            "  foo\n"
+            "  bar\n"
+            "\n"
+            "  baz\n"
+            "\n";
+        pchar_lexer_t lexer(fkyaml::detail::input_adapter(input));
+
+        REQUIRE_NOTHROW(token = lexer.get_next_token());
+        REQUIRE(token == fkyaml::detail::lexical_token_t::STRING_VALUE);
+        REQUIRE(lexer.get_string() == "\nfoo\nbar\n\nbaz");
+    }
+
+    SECTION("literal string scalar with explicit indentation and strip chomping.")
+    {
+        const char input[] =
+            "|-2\n"
+            "  foo\n"
+            "    bar\n"
+            "\n"
+            "  baz\n"
+            "\n";
+        pchar_lexer_t lexer(fkyaml::detail::input_adapter(input));
+
+        REQUIRE_NOTHROW(token = lexer.get_next_token());
+        REQUIRE(token == fkyaml::detail::lexical_token_t::STRING_VALUE);
+        REQUIRE(lexer.get_string() == "foo\n  bar\n\nbaz");
+    }
+
+    SECTION("literal string scalar with implicit indentation and clip chomping.")
+    {
+        const char input[] =
+            "|\n"
+            "\n"
+            "  foo\n"
+            "  bar\n"
+            "\n"
+            "  baz\n"
+            "\n";
+        pchar_lexer_t lexer(fkyaml::detail::input_adapter(input));
+
+        REQUIRE_NOTHROW(token = lexer.get_next_token());
+        REQUIRE(token == fkyaml::detail::lexical_token_t::STRING_VALUE);
+        REQUIRE(lexer.get_string() == "\nfoo\nbar\n\nbaz\n");
+    }
+
+    SECTION("literal string scalar with explicit indentation and clip chomping.")
+    {
+        const char input[] =
+            "|2\n"
+            "  foo\n"
+            "    bar\n"
+            "\n"
+            "  baz\n"
+            "\n";
+        pchar_lexer_t lexer(fkyaml::detail::input_adapter(input));
+
+        REQUIRE_NOTHROW(token = lexer.get_next_token());
+        REQUIRE(token == fkyaml::detail::lexical_token_t::STRING_VALUE);
+        REQUIRE(lexer.get_string() == "foo\n  bar\n\nbaz\n");
+    }
+
+    SECTION("literal string scalar with clip chomping and no trailing newlines")
+    {
+        const char input[] =
+            "|2\n"
+            "  foo\n"
+            "    bar\n"
+            "\n"
+            "  baz";
+        pchar_lexer_t lexer(fkyaml::detail::input_adapter(input));
+
+        REQUIRE_NOTHROW(token = lexer.get_next_token());
+        REQUIRE(token == fkyaml::detail::lexical_token_t::STRING_VALUE);
+        REQUIRE(lexer.get_string() == "foo\n  bar\n\nbaz");
+    }
+
+    SECTION("literal string scalar with implicit indentation and keep chomping.")
+    {
+        const char input[] =
+            "|+\n"
+            "\n"
+            "  foo\n"
+            "  bar\n"
+            "\n"
+            "  baz\n"
+            "\n";
+        pchar_lexer_t lexer(fkyaml::detail::input_adapter(input));
+
+        REQUIRE_NOTHROW(token = lexer.get_next_token());
+        REQUIRE(token == fkyaml::detail::lexical_token_t::STRING_VALUE);
+        REQUIRE(lexer.get_string() == "\nfoo\nbar\n\nbaz\n\n");
+    }
+
+    SECTION("literal string scalar with explicit indentation and keep chomping.")
+    {
+        const char input[] =
+            "|+2\n"
+            "  foo\n"
+            "    bar\n"
+            "\n"
+            "  baz\n"
+            "\n";
+        pchar_lexer_t lexer(fkyaml::detail::input_adapter(input));
+
+        REQUIRE_NOTHROW(token = lexer.get_next_token());
+        REQUIRE(token == fkyaml::detail::lexical_token_t::STRING_VALUE);
+        REQUIRE(lexer.get_string() == "foo\n  bar\n\nbaz\n\n");
+    }
+}
+
+TEST_CASE("LexicalAnalyzerClassTest_ScanFoldedStringScalar", "[LexicalAnalyzerClassTest]")
+{
+    fkyaml::detail::lexical_token_t token;
+
+    SECTION("empty folded string scalar with strip chomping")
+    {
+        const char input[] =
+            ">-\r\n"
+            "  \r\n";
+        pchar_lexer_t lexer(fkyaml::detail::input_adapter(input));
+
+        REQUIRE_NOTHROW(token = lexer.get_next_token());
+        REQUIRE(token == fkyaml::detail::lexical_token_t::STRING_VALUE);
+        REQUIRE(lexer.get_string() == "");
+    }
+
+    SECTION("empty folded string scalar with clip chomping")
+    {
+        const char input[] =
+            ">\r\n"
+            "  \r\n";
+        pchar_lexer_t lexer(fkyaml::detail::input_adapter(input));
+
+        REQUIRE_NOTHROW(token = lexer.get_next_token());
+        REQUIRE(token == fkyaml::detail::lexical_token_t::STRING_VALUE);
+        REQUIRE(lexer.get_string() == "");
+    }
+
+    SECTION("empty folded string scalar with keep chomping")
+    {
+        const char input[] =
+            ">+\r\n"
+            "  \r\n";
+        pchar_lexer_t lexer(fkyaml::detail::input_adapter(input));
+
+        REQUIRE_NOTHROW(token = lexer.get_next_token());
+        REQUIRE(token == fkyaml::detail::lexical_token_t::STRING_VALUE);
+        REQUIRE(lexer.get_string() == "\n");
+    }
+
+    SECTION("folded string scalar with 0 indent level.")
+    {
+        const char input[] =
+            "|0\n"
+            "foo";
+
+        pchar_lexer_t lexer(fkyaml::detail::input_adapter(input));
+        REQUIRE_THROWS_AS(lexer.get_next_token(), fkyaml::parse_error);
+    }
+
+    SECTION("less indented folded string scalar")
+    {
+        const char input[] =
+            ">2\n"
+            " foo";
+
+        pchar_lexer_t lexer(fkyaml::detail::input_adapter(input));
+        REQUIRE_THROWS_AS(lexer.get_next_token(), fkyaml::parse_error);
+    }
+
+    SECTION("folded string scalar with the first line being more indented than the indicated level")
+    {
+        const char input[] =
+            ">2\n"
+            "    foo\n"
+            "  bar\n";
+        pchar_lexer_t lexer(fkyaml::detail::input_adapter(input));
+
+        REQUIRE_NOTHROW(token = lexer.get_next_token());
+        REQUIRE(token == fkyaml::detail::lexical_token_t::STRING_VALUE);
+        REQUIRE(lexer.get_string() == "\n  foo\nbar\n");
+    }
+
+    SECTION("folded string scalar with the non-first line being more indented than the indicated level")
+    {
+        const char input[] =
+            ">2\n"
+            "  foo\n"
+            "    bar\n";
+        pchar_lexer_t lexer(fkyaml::detail::input_adapter(input));
+
+        REQUIRE_NOTHROW(token = lexer.get_next_token());
+        REQUIRE(token == fkyaml::detail::lexical_token_t::STRING_VALUE);
+        REQUIRE(lexer.get_string() == "foo\n  bar\n");
+    }
+
+    SECTION("folded string scalar with windows style newlines.")
+    {
+        const char input[] =
+            ">\r\n"
+            "  foo\r\n"
+            "  \r\n"
+            "\r\n"
+            "  bar\r\n"
+            " \r\n";
+        pchar_lexer_t lexer(fkyaml::detail::input_adapter(input));
+
+        REQUIRE_NOTHROW(token = lexer.get_next_token());
+        REQUIRE(token == fkyaml::detail::lexical_token_t::STRING_VALUE);
+        REQUIRE(lexer.get_string() == "foo\n\nbar\n");
+    }
+
+    SECTION("folded string scalar with implicit indentation and strip chomping.")
+    {
+        const char input[] =
+            ">-\n"
+            "  foo\n"
+            "  bar\n"
+            " \n"
+            "\n";
+        pchar_lexer_t lexer(fkyaml::detail::input_adapter(input));
+
+        REQUIRE_NOTHROW(token = lexer.get_next_token());
+        REQUIRE(token == fkyaml::detail::lexical_token_t::STRING_VALUE);
+        REQUIRE(lexer.get_string() == "foo bar");
+    }
+
+    SECTION("folded string scalar with implicit indentation and clip chomping.")
+    {
+        const char input[] =
+            ">\n"
+            "  foo\n"
+            "  bar\n"
+            "  \n"
+            "\n";
+        pchar_lexer_t lexer(fkyaml::detail::input_adapter(input));
+
+        REQUIRE_NOTHROW(token = lexer.get_next_token());
+        REQUIRE(token == fkyaml::detail::lexical_token_t::STRING_VALUE);
+        REQUIRE(lexer.get_string() == "foo bar\n");
+    }
+
+    SECTION("folded string scalar with implicit indentation and keep chomping.")
+    {
+        const char input[] =
+            ">+\n"
+            "  foo\n"
+            "  bar\n"
+            " \n"
+            "\n";
+        pchar_lexer_t lexer(fkyaml::detail::input_adapter(input));
+
+        REQUIRE_NOTHROW(token = lexer.get_next_token());
+        REQUIRE(token == fkyaml::detail::lexical_token_t::STRING_VALUE);
+        REQUIRE(lexer.get_string() == "foo bar\n\n");
+    }
+}
+
 TEST_CASE("LexicalAnalyzerClassTest_ScanAnchorTokenTest", "[LexicalAnalyzerClassTest]")
 {
     fkyaml::detail::lexical_token_t token;
@@ -1445,6 +1794,100 @@ TEST_CASE("LexicalAnalyzerClassTest_ScanBlockMappingTokenTest", "[LexicalAnalyze
         REQUIRE(token == fkyaml::detail::lexical_token_t::STRING_VALUE);
         REQUIRE_NOTHROW(lexer.get_string());
         REQUIRE(lexer.get_string().compare("pi") == 0);
+
+        REQUIRE_NOTHROW(token = lexer.get_next_token());
+        REQUIRE(token == fkyaml::detail::lexical_token_t::KEY_SEPARATOR);
+
+        REQUIRE_NOTHROW(token = lexer.get_next_token());
+        REQUIRE(token == fkyaml::detail::lexical_token_t::FLOAT_NUMBER_VALUE);
+        REQUIRE_NOTHROW(lexer.get_float_number());
+        REQUIRE(lexer.get_float_number() == 3.14);
+
+        REQUIRE_NOTHROW(token = lexer.get_next_token());
+        REQUIRE(token == fkyaml::detail::lexical_token_t::END_OF_BUFFER);
+    }
+
+    SECTION("input soure No.2.")
+    {
+        pchar_lexer_t lexer(fkyaml::detail::input_adapter("test: |\n  a literal scalar.\nfoo: \'bar\'\npi: 3.14"));
+
+        REQUIRE_NOTHROW(token = lexer.get_next_token());
+        REQUIRE(token == fkyaml::detail::lexical_token_t::STRING_VALUE);
+        REQUIRE_NOTHROW(lexer.get_string());
+        REQUIRE(lexer.get_string() == "test");
+
+        REQUIRE_NOTHROW(token = lexer.get_next_token());
+        REQUIRE(token == fkyaml::detail::lexical_token_t::KEY_SEPARATOR);
+
+        REQUIRE_NOTHROW(token = lexer.get_next_token());
+        REQUIRE(token == fkyaml::detail::lexical_token_t::STRING_VALUE);
+        REQUIRE_NOTHROW(lexer.get_string());
+        REQUIRE(lexer.get_string() == "a literal scalar.\n");
+
+        REQUIRE_NOTHROW(token = lexer.get_next_token());
+        REQUIRE(token == fkyaml::detail::lexical_token_t::STRING_VALUE);
+        REQUIRE_NOTHROW(lexer.get_string());
+        REQUIRE(lexer.get_string() == "foo");
+
+        REQUIRE_NOTHROW(token = lexer.get_next_token());
+        REQUIRE(token == fkyaml::detail::lexical_token_t::KEY_SEPARATOR);
+
+        REQUIRE_NOTHROW(token = lexer.get_next_token());
+        REQUIRE(token == fkyaml::detail::lexical_token_t::STRING_VALUE);
+        REQUIRE_NOTHROW(lexer.get_string());
+        REQUIRE(lexer.get_string() == "bar");
+
+        REQUIRE_NOTHROW(token = lexer.get_next_token());
+        REQUIRE(token == fkyaml::detail::lexical_token_t::STRING_VALUE);
+        REQUIRE_NOTHROW(lexer.get_string());
+        REQUIRE(lexer.get_string() == "pi");
+
+        REQUIRE_NOTHROW(token = lexer.get_next_token());
+        REQUIRE(token == fkyaml::detail::lexical_token_t::KEY_SEPARATOR);
+
+        REQUIRE_NOTHROW(token = lexer.get_next_token());
+        REQUIRE(token == fkyaml::detail::lexical_token_t::FLOAT_NUMBER_VALUE);
+        REQUIRE_NOTHROW(lexer.get_float_number());
+        REQUIRE(lexer.get_float_number() == 3.14);
+
+        REQUIRE_NOTHROW(token = lexer.get_next_token());
+        REQUIRE(token == fkyaml::detail::lexical_token_t::END_OF_BUFFER);
+    }
+
+    SECTION("input soure No.3.")
+    {
+        pchar_lexer_t lexer(fkyaml::detail::input_adapter("test: >\n  a literal scalar.\nfoo: \'bar\'\npi: 3.14"));
+
+        REQUIRE_NOTHROW(token = lexer.get_next_token());
+        REQUIRE(token == fkyaml::detail::lexical_token_t::STRING_VALUE);
+        REQUIRE_NOTHROW(lexer.get_string());
+        REQUIRE(lexer.get_string() == "test");
+
+        REQUIRE_NOTHROW(token = lexer.get_next_token());
+        REQUIRE(token == fkyaml::detail::lexical_token_t::KEY_SEPARATOR);
+
+        REQUIRE_NOTHROW(token = lexer.get_next_token());
+        REQUIRE(token == fkyaml::detail::lexical_token_t::STRING_VALUE);
+        REQUIRE_NOTHROW(lexer.get_string());
+        REQUIRE(lexer.get_string() == "a literal scalar.\n");
+
+        REQUIRE_NOTHROW(token = lexer.get_next_token());
+        REQUIRE(token == fkyaml::detail::lexical_token_t::STRING_VALUE);
+        REQUIRE_NOTHROW(lexer.get_string());
+        REQUIRE(lexer.get_string() == "foo");
+
+        REQUIRE_NOTHROW(token = lexer.get_next_token());
+        REQUIRE(token == fkyaml::detail::lexical_token_t::KEY_SEPARATOR);
+
+        REQUIRE_NOTHROW(token = lexer.get_next_token());
+        REQUIRE(token == fkyaml::detail::lexical_token_t::STRING_VALUE);
+        REQUIRE_NOTHROW(lexer.get_string());
+        REQUIRE(lexer.get_string() == "bar");
+
+        REQUIRE_NOTHROW(token = lexer.get_next_token());
+        REQUIRE(token == fkyaml::detail::lexical_token_t::STRING_VALUE);
+        REQUIRE_NOTHROW(lexer.get_string());
+        REQUIRE(lexer.get_string() == "pi");
 
         REQUIRE_NOTHROW(token = lexer.get_next_token());
         REQUIRE(token == fkyaml::detail::lexical_token_t::KEY_SEPARATOR);


### PR DESCRIPTION
This PR has supported block style scalars for deserialization.  
Furthermore, unit test cases have also been added to ensure the deserialization of block style scalars works as it's expected.  