### PR TITLE
Feature/238 apply correct noexcept

### DIFF
--- a/docs/mkdocs/docs/api/basic_node/add_anchor_name.md
+++ b/docs/mkdocs/docs/api/basic_node/add_anchor_name.md
@@ -12,7 +12,7 @@ If the basic_node has already had any anchor name, the new anchor name overwrite
 
 ## **Parameters**
 
-***anchor_name***
+***`anchor_name`*** [in]
 :   An anchor name. This should not be empty.
 
 ???+ Example

--- a/docs/mkdocs/docs/api/basic_node/constructor.md
+++ b/docs/mkdocs/docs/api/basic_node/constructor.md
@@ -18,12 +18,13 @@ template <
             detail::negation<detail::is_basic_json<U>>,
             detail::disjunction<detail::is_node_compatible_type<basic_node, U>>>::value,
         int> = 0>
-basic_node(CompatibleType&& val); // (5)
+basic_node(CompatibleType&& val) noexcept(
+    noexcept(ConverterType<U>::to_node(std::declval<basic_node&>(), std::declval<CompatibleType>()))); // (5)
 
 template <
     typename NodeRefStorageType,
     detail::enable_if_t<detail::is_node_ref_storage<NodeRefStorageType>::value, int> = 0>
-basic_node(const NodeRefStorageType& node_ref_storage); // (6)
+basic_node(const NodeRefStorageType& node_ref_storage) noexcept; // (6)
 
 basic_node(initializer_list_t init); // (7)
 ```
@@ -167,7 +168,8 @@ template <
             detail::negation<detail::is_basic_json<U>>,
             detail::disjunction<detail::is_node_compatible_type<basic_node, U>>>::value,
         int> = 0>
-basic_node(CompatibleType&& val);
+basic_node(CompatibleType&& val) noexcept(
+    noexcept(ConverterType<U>::to_node(std::declval<basic_node&>(), std::declval<CompatibleType>()))); // (5)
 ```
 Constructs a basic_node with a value of a compatible type.  
 The resulting basic_node has the value of `val` and the type which is associated with `CompatibleType`.  
@@ -211,7 +213,7 @@ The resulting basic_node has the value of `val` and the type which is associated
 template <
     typename NodeRefStorageType,
     detail::enable_if_t<detail::is_node_ref_storage<NodeRefStorageType>::value, int> = 0>
-basic_node(const NodeRefStorageType& node_ref_storage);
+basic_node(const NodeRefStorageType& node_ref_storage) noexcept;
 ```
 Constructs a basic_node with a node_ref_storage.  
 The resulting basic_node has the value of the referenced basic_node by `node_ref_storage`.  

--- a/docs/mkdocs/docs/api/basic_node/contains.md
+++ b/docs/mkdocs/docs/api/basic_node/contains.md
@@ -21,7 +21,7 @@ If the node value is not a mapping, this API will throw an [`fkyaml::exception`]
 
 ## **Parameters**
 
-***key*** [in]
+***`key`*** [in]
 :   A key to the target value in the YAML mapping node value.
 
 ## **Return Value**

--- a/docs/mkdocs/docs/api/basic_node/deserialize.md
+++ b/docs/mkdocs/docs/api/basic_node/deserialize.md
@@ -8,9 +8,6 @@ static basic_node deserialize(InputType&& input); // (1)
 
 template <typename ItrType>
 static basic_node deserialize(ItrType&& begin, ItrType&& end); // (2)
-
-template <typename PtrType, detail::enable_if_t<std::is_pointer<PtrType>::value, int> = 0>
-static basic_node deserialize(PtrType&& ptr, std::size_t size); // (3)
 ```
 
 Deserializes from compatible input sources.  

--- a/docs/mkdocs/docs/api/basic_node/operator[].md
+++ b/docs/mkdocs/docs/api/basic_node/operator[].md
@@ -104,7 +104,7 @@ If the node is not a mapping, a [`fkyaml::exception`](../exception/index.md) wil
 
 ### **Parameters**
 
-***key*** [in]
+***`key`*** [in]
 :   A key to the target value in the YAML mapping node.
 
 ### **Return Value**

--- a/docs/mkdocs/docs/api/basic_node/serialize.md
+++ b/docs/mkdocs/docs/api/basic_node/serialize.md
@@ -12,7 +12,7 @@ That means that, even if a deserialized source input is written in flow styles, 
 
 ### **Parameters**
 
-***node*** [in]
+***`node`*** [in]
 :   A `basic_node` object to be serialized.
 
 ### **Return Value**

--- a/docs/mkdocs/docs/api/exception/constructor.md
+++ b/docs/mkdocs/docs/api/exception/constructor.md
@@ -5,7 +5,7 @@
 ```cpp
 exception() = default; // (1)
 
-explicit exception(const char* msg); // (2)
+explicit exception(const char* msg) noexcept; // (2)
 ```
 
 Constructs an exception object.   
@@ -47,7 +47,7 @@ Constructs an exception object without an error message.
 ## Overloads (2)
 
 ```cpp
-explicit exception(const char* msg); // (2)
+explicit exception(const char* msg) noexcept; // (2)
 ```
 
 Constructs an exception with a given error message.  

--- a/docs/mkdocs/docs/api/exception/what.md
+++ b/docs/mkdocs/docs/api/exception/what.md
@@ -3,7 +3,7 @@
 # <small>fkyaml::exception::</small>what
 
 ```cpp
-const char* what();
+const char* what() const noexcept;
 ```
 
 Returns an error message for an exception. If nothing, a non-null, empty string will be returned.  

--- a/include/fkYAML/detail/conversions/from_node.hpp
+++ b/include/fkYAML/detail/conversions/from_node.hpp
@@ -32,9 +32,6 @@ FK_YAML_NAMESPACE_BEGIN
 namespace detail
 {
 
-// Avoid ambiguity between fkyaml::exception and std::exception
-using fkyaml::exception;
-
 ///////////////////
 //   from_node   //
 ///////////////////

--- a/include/fkYAML/detail/conversions/from_string.hpp
+++ b/include/fkYAML/detail/conversions/from_string.hpp
@@ -28,8 +28,6 @@ FK_YAML_NAMESPACE_BEGIN
 namespace detail
 {
 
-using fkyaml::exception;
-
 /// @brief Convert a string YAML token to a ValueType object.
 /// @tparam ValueType A target value type.
 /// @tparam CharType The type of characters in a source string.

--- a/include/fkYAML/detail/conversions/to_string.hpp
+++ b/include/fkYAML/detail/conversions/to_string.hpp
@@ -34,13 +34,13 @@ namespace detail
 /// @param s A resulting output string.
 /// @param v A source value.
 template <typename ValueType, typename CharType>
-inline void to_string(std::basic_string<CharType>& s, ValueType v);
+inline void to_string(std::basic_string<CharType>& s, ValueType v) noexcept;
 
 /// @brief Specialization of to_string() for null values.
 /// @param s A resulting string YAML token.
 /// @param (unused) nullptr
 template <>
-inline void to_string(std::string& s, std::nullptr_t /*unused*/)
+inline void to_string(std::string& s, std::nullptr_t /*unused*/) noexcept
 {
     s = "null";
 }
@@ -49,7 +49,7 @@ inline void to_string(std::string& s, std::nullptr_t /*unused*/)
 /// @param s A resulting string YAML token.
 /// @param b A boolean source value.
 template <>
-inline void to_string(std::string& s, bool b)
+inline void to_string(std::string& s, bool b) noexcept
 {
     s = b ? "true" : "false";
 }
@@ -59,7 +59,7 @@ inline void to_string(std::string& s, bool b)
 /// @param s A resulting string YAML token.
 /// @param i An integer source value.
 template <typename IntegerType>
-inline enable_if_t<is_non_bool_integral<IntegerType>::value> to_string(std::string& s, IntegerType i)
+inline enable_if_t<is_non_bool_integral<IntegerType>::value> to_string(std::string& s, IntegerType i) noexcept
 {
     s = std::to_string(i);
 }
@@ -69,7 +69,7 @@ inline enable_if_t<is_non_bool_integral<IntegerType>::value> to_string(std::stri
 /// @param s A resulting string YAML token.
 /// @param f A floating point number source value.
 template <typename FloatType>
-inline enable_if_t<std::is_floating_point<FloatType>::value> to_string(std::string& s, FloatType f)
+inline enable_if_t<std::is_floating_point<FloatType>::value> to_string(std::string& s, FloatType f) noexcept
 {
     if (std::isnan(f))
     {

--- a/include/fkYAML/detail/encodings/encode_detector.hpp
+++ b/include/fkYAML/detail/encodings/encode_detector.hpp
@@ -31,7 +31,7 @@ namespace detail
 /// @param b2 The 3rd byte of an input character sequence.
 /// @param b3 The 4th byte of an input character sequence.
 /// @return A detected encoding type.
-inline encode_t detect_encoding_type(uint8_t b0, uint8_t b1, uint8_t b2, uint8_t b3)
+inline encode_t detect_encoding_type(uint8_t b0, uint8_t b1, uint8_t b2, uint8_t b3) noexcept
 {
     // Check if a BOM exists.
 
@@ -180,7 +180,7 @@ inline encode_t detect_encoding_and_skip_bom(ItrType& begin, const ItrType& end)
     }
 }
 
-inline encode_t detect_encoding_and_skip_bom(std::FILE* file)
+inline encode_t detect_encoding_and_skip_bom(std::FILE* file) noexcept
 {
     uint8_t bytes[4] = {0xFFu, 0xFFu, 0xFFu, 0xFFu};
     for (std::size_t i = 0; i < 4; i++)
@@ -217,7 +217,7 @@ inline encode_t detect_encoding_and_skip_bom(std::FILE* file)
     return encode_type;
 }
 
-inline encode_t detect_encoding_and_skip_bom(std::istream& is)
+inline encode_t detect_encoding_and_skip_bom(std::istream& is) noexcept
 {
     uint8_t bytes[4] = {0xFFu, 0xFFu, 0xFFu, 0xFFu};
     for (std::size_t i = 0; i < 4; i++)

--- a/include/fkYAML/detail/encodings/utf8_encoding.hpp
+++ b/include/fkYAML/detail/encodings/utf8_encoding.hpp
@@ -256,7 +256,7 @@ public:
 
         if (!is_valid)
         {
-            throw fkyaml::invalid_encoding("Invalid UTF-16 encoding detected.", utf16);
+            throw invalid_encoding("Invalid UTF-16 encoding detected.", utf16);
         }
     }
 
@@ -315,7 +315,7 @@ public:
 
         if (!is_valid)
         {
-            throw fkyaml::invalid_encoding("Invalid UTF-32 encoding detected.", utf32);
+            throw invalid_encoding("Invalid UTF-32 encoding detected.", utf32);
         }
     }
 };

--- a/include/fkYAML/detail/input/input_adapter.hpp
+++ b/include/fkYAML/detail/input/input_adapter.hpp
@@ -56,7 +56,7 @@ public:
     /// @param begin The beginning of iteraters.
     /// @param end The end of iterators.
     /// @param encode_type The encoding type for this input adapter.
-    iterator_input_adapter(IterType begin, IterType end, encode_t encode_type)
+    iterator_input_adapter(IterType begin, IterType end, encode_t encode_type) noexcept
         : m_current(begin),
           m_end(end),
           m_encode_type(encode_type)
@@ -74,31 +74,33 @@ public:
     /// @return std::char_traits<char_type>::int_type A character or EOF.
     typename std::char_traits<char_type>::int_type get_character()
     {
+        typename std::char_traits<char_type>::int_type ret = 0;
         switch (m_encode_type)
         {
         case encode_t::UTF_8_N:
         case encode_t::UTF_8_BOM:
-            return get_character_for_utf8();
+            ret = get_character_for_utf8();
+            break;
         case encode_t::UTF_16BE_N:
         case encode_t::UTF_16BE_BOM:
         case encode_t::UTF_16LE_N:
         case encode_t::UTF_16LE_BOM:
-            return get_character_for_utf16();
+            ret = get_character_for_utf16();
+            break;
         case encode_t::UTF_32BE_N:
         case encode_t::UTF_32BE_BOM:
         case encode_t::UTF_32LE_N:
         case encode_t::UTF_32LE_BOM:
-            return get_character_for_utf32();
-        default: // LCOV_EXCL_LINE
-            // should not come here.
-            return std::char_traits<char_type>::eof(); // LCOV_EXCL_LINE
+            ret = get_character_for_utf32();
+            break;
         }
+        return ret;
     }
 
 private:
     /// @brief The concrete implementation of get_character() for UTF-8 encoded inputs.
     /// @return A UTF-8 encoded byte at the current position, or EOF.
-    typename std::char_traits<char_type>::int_type get_character_for_utf8()
+    typename std::char_traits<char_type>::int_type get_character_for_utf8() noexcept
     {
         if (m_current != m_end)
         {
@@ -254,7 +256,7 @@ public:
     /// @param begin The beginning of iteraters.
     /// @param end The end of iterators.
     /// @param encode_type The encoding type for this input adapter.
-    iterator_input_adapter(IterType begin, IterType end, encode_t encode_type)
+    iterator_input_adapter(IterType begin, IterType end, encode_t encode_type) noexcept
         : m_current(begin),
           m_end(end),
           m_encode_type(encode_type)
@@ -361,7 +363,7 @@ public:
     /// @param begin The beginning of iteraters.
     /// @param end The end of iterators.
     /// @param encode_type The encoding type for this input adapter.
-    iterator_input_adapter(IterType begin, IterType end, encode_t encode_type)
+    iterator_input_adapter(IterType begin, IterType end, encode_t encode_type) noexcept
         : m_current(begin),
           m_end(end),
           m_encode_type(encode_type)
@@ -448,7 +450,7 @@ public:
     /// It's user's responsibility to call those functions.
     /// @param file A file handle for this adapter. (A non-null pointer is assumed.)
     /// @param encode_type The encoding type for this input adapter.
-    explicit file_input_adapter(std::FILE* file, encode_t encode_type)
+    explicit file_input_adapter(std::FILE* file, encode_t encode_type) noexcept
         : m_file(file),
           m_encode_type(encode_type)
     {
@@ -465,31 +467,33 @@ public:
     /// @return std::char_traits<char_type>::int_type A character or EOF.
     typename std::char_traits<char_type>::int_type get_character()
     {
+        typename std::char_traits<char_type>::int_type ret = 0;
         switch (m_encode_type)
         {
         case encode_t::UTF_8_N:
         case encode_t::UTF_8_BOM:
-            return get_character_for_utf8();
+            ret = get_character_for_utf8();
+            break;
         case encode_t::UTF_16BE_N:
         case encode_t::UTF_16BE_BOM:
         case encode_t::UTF_16LE_N:
         case encode_t::UTF_16LE_BOM:
-            return get_character_for_utf16();
+            ret = get_character_for_utf16();
+            break;
         case encode_t::UTF_32BE_N:
         case encode_t::UTF_32BE_BOM:
         case encode_t::UTF_32LE_N:
         case encode_t::UTF_32LE_BOM:
-            return get_character_for_utf32();
-        default: // LCOV_EXCL_LINE
-            // should not come here.
-            return std::char_traits<char_type>::eof(); // LCOV_EXCL_LINE
+            ret = get_character_for_utf32();
+            break;
         }
+        return ret;
     }
 
 private:
     /// @brief The concrete implementation of get_character() for UTF-8 encoded inputs.
     /// @return A UTF-8 encoded byte at the current position, or EOF.
-    typename std::char_traits<char_type>::int_type get_character_for_utf8()
+    typename std::char_traits<char_type>::int_type get_character_for_utf8() noexcept
     {
         char ch = 0;
         size_t size = std::fread(&ch, sizeof(char), 1, m_file);
@@ -627,7 +631,7 @@ public:
 
     /// @brief Construct a new stream_input_adapter object.
     /// @param is A reference to the target input stream.
-    explicit stream_input_adapter(std::istream& is, encode_t encode_type)
+    explicit stream_input_adapter(std::istream& is, encode_t encode_type) noexcept
         : m_istream(&is),
           m_encode_type(encode_type)
     {
@@ -642,33 +646,35 @@ public:
 
     /// @brief Get a character at the current position and move forward.
     /// @return std::char_traits<char_type>::int_type A character or EOF.
-    std::char_traits<char_type>::int_type get_character()
+    typename std::char_traits<char_type>::int_type get_character()
     {
+        typename std::char_traits<char_type>::int_type ret = 0;
         switch (m_encode_type)
         {
         case encode_t::UTF_8_N:
         case encode_t::UTF_8_BOM:
-            return get_character_for_utf8();
+            ret = get_character_for_utf8();
+            break;
         case encode_t::UTF_16BE_N:
         case encode_t::UTF_16BE_BOM:
         case encode_t::UTF_16LE_N:
         case encode_t::UTF_16LE_BOM:
-            return get_character_for_utf16();
+            ret = get_character_for_utf16();
+            break;
         case encode_t::UTF_32BE_N:
         case encode_t::UTF_32BE_BOM:
         case encode_t::UTF_32LE_N:
         case encode_t::UTF_32LE_BOM:
-            return get_character_for_utf32();
-        default: // LCOV_EXCL_LINE
-            // should not come here.
-            return std::char_traits<char_type>::eof(); // LCOV_EXCL_LINE
+            ret = get_character_for_utf32();
+            break;
         }
+        return ret;
     }
 
 private:
     /// @brief The concrete implementation of get_character() for UTF-8 encoded inputs.
     /// @return A UTF-8 encoded byte at the current position, or EOF.
-    typename std::char_traits<char_type>::int_type get_character_for_utf8()
+    typename std::char_traits<char_type>::int_type get_character_for_utf8() noexcept
     {
         return m_istream->get();
     }

--- a/include/fkYAML/detail/input/input_handler.hpp
+++ b/include/fkYAML/detail/input/input_handler.hpp
@@ -65,7 +65,7 @@ public:
 
     /// @brief Get the character at the current position.
     /// @return int_type A character or EOF.
-    int_type get_current()
+    int_type get_current() const noexcept
     {
         return m_cache[m_position.cur_pos];
     }

--- a/include/fkYAML/detail/input/lexical_analyzer.hpp
+++ b/include/fkYAML/detail/input/lexical_analyzer.hpp
@@ -423,7 +423,7 @@ private:
     /// @brief A utility function to convert a hexadecimal character to an integer.
     /// @param source A hexadecimal character ('0'~'9', 'A'~'F', 'a'~'f')
     /// @return char A integer converted from @a source.
-    char convert_hex_char_to_byte(char_int_type source)
+    char convert_hex_char_to_byte(char_int_type source) const
     {
         if ('0' <= source && source <= '9')
         {

--- a/include/fkYAML/detail/iterator.hpp
+++ b/include/fkYAML/detail/iterator.hpp
@@ -132,7 +132,7 @@ public:
 
     /// @brief Copy constructor of the iterator class.
     /// @param other An iterator object to be copied with.
-    iterator(const iterator& other)
+    iterator(const iterator& other) noexcept
         : m_inner_iterator_type(other.m_inner_iterator_type)
     {
         switch (m_inner_iterator_type)
@@ -143,14 +143,12 @@ public:
         case iterator_t::MAPPING:
             m_iterator_holder.mapping_iterator = other.m_iterator_holder.mapping_iterator;
             break;
-        default:                                                         // LCOV_EXCL_LINE
-            throw fkyaml::exception("Unsupported inner iterator type."); // LCOV_EXCL_LINE
         }
     }
 
     /// @brief Move constructor of the iterator class.
     /// @param other An iterator object to be moved from.
-    iterator(iterator&& other)
+    iterator(iterator&& other) noexcept
         : m_inner_iterator_type(other.m_inner_iterator_type)
     {
         switch (m_inner_iterator_type)
@@ -161,8 +159,6 @@ public:
         case iterator_t::MAPPING:
             m_iterator_holder.mapping_iterator = std::move(other.m_iterator_holder.mapping_iterator);
             break;
-        default:                                                         // LCOV_EXCL_LINE
-            throw fkyaml::exception("Unsupported inner iterator type."); // LCOV_EXCL_LINE
         }
     }
 
@@ -173,7 +169,7 @@ public:
     /// @brief A copy assignment operator of the iterator class.
     /// @param rhs An iterator object to be copied with.
     /// @return iterator& Reference to this iterator object.
-    iterator& operator=(const iterator& rhs) // NOLINT(cert-oop54-cpp)
+    iterator& operator=(const iterator& rhs) noexcept
     {
         if (&rhs == this)
         {
@@ -189,8 +185,6 @@ public:
         case iterator_t::MAPPING:
             m_iterator_holder.mapping_iterator = rhs.m_iterator_holder.mapping_iterator;
             break;
-        default:                                                         // LCOV_EXCL_LINE
-            throw fkyaml::exception("Unsupported inner iterator type."); // LCOV_EXCL_LINE
         }
 
         return *this;
@@ -199,7 +193,7 @@ public:
     /// @brief A move assignment operator of the iterator class.
     /// @param rhs An iterator object to be moved from.
     /// @return iterator& Reference to this iterator object.
-    iterator& operator=(iterator&& rhs)
+    iterator& operator=(iterator&& rhs) noexcept
     {
         if (&rhs == this)
         {
@@ -215,8 +209,6 @@ public:
         case iterator_t::MAPPING:
             m_iterator_holder.mapping_iterator = std::move(rhs.m_iterator_holder.mapping_iterator);
             break;
-        default:                                                         // LCOV_EXCL_LINE
-            throw fkyaml::exception("Unsupported inner iterator type."); // LCOV_EXCL_LINE
         }
 
         return *this;
@@ -224,38 +216,34 @@ public:
 
     /// @brief An arrow operator of the iterator class.
     /// @return pointer A pointer to the BasicNodeType object internally referenced by the actual iterator object.
-    pointer operator->()
+    pointer operator->() noexcept
     {
-        switch (m_inner_iterator_type)
+        if (m_inner_iterator_type == iterator_t::SEQUENCE)
         {
-        case iterator_t::SEQUENCE:
             return &(*(m_iterator_holder.sequence_iterator));
-        case iterator_t::MAPPING:
-            return &(m_iterator_holder.mapping_iterator->second);
-        default:                                                         // LCOV_EXCL_LINE
-            throw fkyaml::exception("Unsupported inner iterator type."); // LCOV_EXCL_LINE
         }
+
+        // m_inner_iterator_type == iterator_t::MAPPING:
+        return &(m_iterator_holder.mapping_iterator->second);
     }
 
     /// @brief A dereference operator of the iterator class.
     /// @return reference Reference to the Node object internally referenced by the actual iterator object.
-    reference operator*()
+    reference operator*() noexcept
     {
-        switch (m_inner_iterator_type)
+        if (m_inner_iterator_type == iterator_t::SEQUENCE)
         {
-        case iterator_t::SEQUENCE:
             return *(m_iterator_holder.sequence_iterator);
-        case iterator_t::MAPPING:
-            return m_iterator_holder.mapping_iterator->second;
-        default:                                                         // LCOV_EXCL_LINE
-            throw fkyaml::exception("Unsupported inner iterator type."); // LCOV_EXCL_LINE
         }
+
+        // m_inner_iterator_type == iterator_t::MAPPING:
+        return m_iterator_holder.mapping_iterator->second;
     }
 
     /// @brief A compound assignment operator by sum of the Iterator class.
     /// @param i The difference from this Iterator object with which it moves forward.
     /// @return Iterator& Reference to this Iterator object.
-    iterator& operator+=(difference_type i)
+    iterator& operator+=(difference_type i) noexcept
     {
         switch (m_inner_iterator_type)
         {
@@ -265,8 +253,6 @@ public:
         case iterator_t::MAPPING:
             std::advance(m_iterator_holder.mapping_iterator, i);
             break;
-        default:                                                         // LCOV_EXCL_LINE
-            throw fkyaml::exception("Unsupported inner iterator type."); // LCOV_EXCL_LINE
         }
         return *this;
     }
@@ -283,7 +269,7 @@ public:
 
     /// @brief An pre-increment operator of the iterator class.
     /// @return iterator& Reference to this iterator object.
-    iterator& operator++()
+    iterator& operator++() noexcept
     {
         switch (m_inner_iterator_type)
         {
@@ -293,15 +279,13 @@ public:
         case iterator_t::MAPPING:
             std::advance(m_iterator_holder.mapping_iterator, 1);
             break;
-        default:                                                         // LCOV_EXCL_LINE
-            throw fkyaml::exception("Unsupported inner iterator type."); // LCOV_EXCL_LINE
         }
         return *this;
     }
 
     /// @brief A post-increment opretor of the iterator class.
     /// @return iterator An iterator object which has been incremented.
-    iterator operator++(int) & noexcept // NOLINT(cert-dcl21-cpp)
+    iterator operator++(int) & noexcept
     {
         auto result = *this;
         ++(*this);
@@ -311,7 +295,7 @@ public:
     /// @brief A compound assignment operator by difference of the iterator class.
     /// @param i The difference from this iterator object with which it moves backward.
     /// @return iterator& Reference to this iterator object.
-    iterator& operator-=(difference_type i)
+    iterator& operator-=(difference_type i) noexcept
     {
         return operator+=(-i);
     }
@@ -328,7 +312,7 @@ public:
 
     /// @brief A pre-decrement operator of the iterator class.
     /// @return iterator& Reference to this iterator object.
-    iterator& operator--()
+    iterator& operator--() noexcept
     {
         switch (m_inner_iterator_type)
         {
@@ -338,15 +322,13 @@ public:
         case iterator_t::MAPPING:
             std::advance(m_iterator_holder.mapping_iterator, -1);
             break;
-        default:                                                         // LCOV_EXCL_LINE
-            throw fkyaml::exception("Unsupported inner iterator type."); // LCOV_EXCL_LINE
         }
         return *this;
     }
 
     /// @brief A post-decrement operator of the iterator class
     /// @return iterator An iterator object which has been decremented.
-    iterator operator--(int) & noexcept // NOLINT(cert-dcl21-cpp)
+    iterator operator--(int) & noexcept
     {
         auto result = *this;
         --(*this);
@@ -364,15 +346,13 @@ public:
             throw fkyaml::exception("Cannot compare iterators of different container types.");
         }
 
-        switch (m_inner_iterator_type)
+        if (m_inner_iterator_type == iterator_t::SEQUENCE)
         {
-        case iterator_t::SEQUENCE:
             return (m_iterator_holder.sequence_iterator == rhs.m_iterator_holder.sequence_iterator);
-        case iterator_t::MAPPING:
-            return (m_iterator_holder.mapping_iterator == rhs.m_iterator_holder.mapping_iterator);
-        default:                                                         // LCOV_EXCL_LINE
-            throw fkyaml::exception("Unsupported inner iterator type."); // LCOV_EXCL_LINE
         }
+
+        // m_inner_iterator_type == iterator_t::MAPPING
+        return (m_iterator_holder.mapping_iterator == rhs.m_iterator_holder.mapping_iterator);
     }
 
     /// @brief An not-equal-to operator of the iterator class.
@@ -395,15 +375,12 @@ public:
             throw fkyaml::exception("Cannot compare iterators of different container types.");
         }
 
-        switch (m_inner_iterator_type)
+        if (m_inner_iterator_type == iterator_t::MAPPING)
         {
-        case iterator_t::SEQUENCE:
-            return (m_iterator_holder.sequence_iterator < rhs.m_iterator_holder.sequence_iterator);
-        case iterator_t::MAPPING:
             throw fkyaml::exception("Cannot compare order of iterators of the mapping container type");
-        default:                                                         // LCOV_EXCL_LINE
-            throw fkyaml::exception("Unsupported inner iterator type."); // LCOV_EXCL_LINE
         }
+
+        return (m_iterator_holder.sequence_iterator < rhs.m_iterator_holder.sequence_iterator);
     }
 
     ///  @brief A less-than-or-equal-to operator of the iterator class.
@@ -445,20 +422,17 @@ public:
     /// @return const std::string& The key string of the YAML mapping node for the current iterator.
     const std::string& key() const
     {
-        switch (m_inner_iterator_type)
+        if (m_inner_iterator_type == iterator_t::SEQUENCE)
         {
-        case iterator_t::SEQUENCE:
             throw fkyaml::exception("Cannot retrieve key from non-mapping iterators.");
-        case iterator_t::MAPPING:
-            return m_iterator_holder.mapping_iterator->first;
-        default:                                                         // LCOV_EXCL_LINE
-            throw fkyaml::exception("Unsupported inner iterator type."); // LCOV_EXCL_LINE
         }
+
+        return m_iterator_holder.mapping_iterator->first;
     }
 
     /// @brief Get the reference of the YAML node for the current iterator.
     /// @return reference A reference to the YAML node for the current iterator.
-    reference value()
+    reference value() noexcept
     {
         return operator*();
     }

--- a/include/fkYAML/detail/node_ref_storage.hpp
+++ b/include/fkYAML/detail/node_ref_storage.hpp
@@ -39,14 +39,14 @@ class node_ref_storage
 public:
     /// @brief Construct a new node ref storage object with an rvalue basic_node object.
     /// @param n An rvalue basic_node object.
-    node_ref_storage(node_type&& n)
+    node_ref_storage(node_type&& n) noexcept(std::is_nothrow_move_constructible<node_type>::value)
         : owned_value(std::move(n))
     {
     }
 
     /// @brief Construct a new node ref storage object with an lvalue basic_node object.
     /// @param n An lvalue basic_node object.
-    node_ref_storage(const node_type& n)
+    node_ref_storage(const node_type& n) noexcept
         : value_ref(&n)
     {
     }
@@ -76,14 +76,14 @@ public:
 public:
     /// @brief An arrow operator for node_ref_storage objects.
     /// @return const node_type* A constant pointer to a basic_node object.
-    const node_type* operator->() const
+    const node_type* operator->() const noexcept
     {
         return value_ref ? value_ref : &owned_value;
     }
 
     /// @brief Releases a basic_node object internally held.
     /// @return node_type A basic_node object internally held.
-    node_type release() const
+    node_type release() const noexcept
     {
         return value_ref ? *value_ref : std::move(owned_value);
     }

--- a/include/fkYAML/detail/node_ref_storage.hpp
+++ b/include/fkYAML/detail/node_ref_storage.hpp
@@ -39,14 +39,14 @@ class node_ref_storage
 public:
     /// @brief Construct a new node ref storage object with an rvalue basic_node object.
     /// @param n An rvalue basic_node object.
-    node_ref_storage(node_type&& n) noexcept(std::is_nothrow_move_constructible<node_type>::value)
+    explicit node_ref_storage(node_type&& n) noexcept(std::is_nothrow_move_constructible<node_type>::value)
         : owned_value(std::move(n))
     {
     }
 
     /// @brief Construct a new node ref storage object with an lvalue basic_node object.
     /// @param n An lvalue basic_node object.
-    node_ref_storage(const node_type& n) noexcept
+    explicit node_ref_storage(const node_type& n) noexcept
         : value_ref(&n)
     {
     }

--- a/include/fkYAML/detail/output/serializer.hpp
+++ b/include/fkYAML/detail/output/serializer.hpp
@@ -319,15 +319,13 @@ private:
             }
             break;
         }
-        default:                                                     // LCOV_EXCL_LINE
-            throw fkyaml::exception("Unsupported node type found."); // LCOV_EXCL_LINE
         }
     }
 
     /// @brief Serialize mapping keys.
     /// @param key A key string to be serialized.
     /// @param str A string to hold serialization result.
-    void serialize_key(const std::string& key, std::string& str)
+    void serialize_key(const std::string& key, std::string& str) const noexcept
     {
         str += key + ":";
     }
@@ -335,7 +333,7 @@ private:
     /// @brief Insert indentation to the serialization result.
     /// @param cur_indent The current indent width to be inserted.
     /// @param str A string to hold serialization result.
-    void insert_indentation(const uint32_t cur_indent, std::string& str)
+    void insert_indentation(const uint32_t cur_indent, std::string& str) const noexcept
     {
         for (uint32_t i = 0; i < cur_indent; ++i)
         {

--- a/include/fkYAML/detail/types/node_t.hpp
+++ b/include/fkYAML/detail/types/node_t.hpp
@@ -35,7 +35,7 @@ enum class node_t : std::uint32_t
     STRING,       //!< string value type
 };
 
-inline std::string to_string(node_t t)
+inline std::string to_string(node_t t) noexcept
 {
     switch (t)
     {

--- a/include/fkYAML/exception.hpp
+++ b/include/fkYAML/exception.hpp
@@ -34,7 +34,7 @@ public:
     /// @brief Construct a new exception object with an error message.
     /// @param[in] msg An error message.
     /// @sa https://fktn-k.github.io/fkYAML/api/exception/constructor/
-    explicit exception(const char* msg)
+    explicit exception(const char* msg) noexcept
     {
         if (msg)
         {
@@ -62,7 +62,7 @@ class invalid_encoding : public exception
 {
 public:
     template <std::size_t N>
-    explicit invalid_encoding(const char* msg, std::array<int, N> u8)
+    explicit invalid_encoding(const char* msg, std::array<int, N> u8) noexcept
         : exception(generate_error_message(msg, u8).c_str())
     {
     }
@@ -71,7 +71,7 @@ public:
     /// @param msg An error message.
     /// @param u16_h The first UTF-16 encoded element used for the UTF-8 encoding.
     /// @param u16_l The second UTF-16 encoded element used for the UTF-8 encoding.
-    explicit invalid_encoding(const char* msg, std::array<char16_t, 2> u16)
+    explicit invalid_encoding(const char* msg, std::array<char16_t, 2> u16) noexcept
         : exception(generate_error_message(msg, u16).c_str())
     {
     }
@@ -79,14 +79,14 @@ public:
     /// @brief Construct a new invalid_encoding object for UTF-32 related errors.
     /// @param msg An error message.
     /// @param u32 The UTF-32 encoded element used for the UTF-8 encoding.
-    explicit invalid_encoding(const char* msg, char32_t u32)
+    explicit invalid_encoding(const char* msg, char32_t u32) noexcept
         : exception(generate_error_message(msg, u32).c_str())
     {
     }
 
 private:
     template <std::size_t N>
-    std::string generate_error_message(const char* msg, std::array<int, N> u8)
+    std::string generate_error_message(const char* msg, std::array<int, N> u8) const noexcept
     {
         std::stringstream ss;
         ss << "invalid_encoding: " << msg << " in=[ 0x" << std::hex << u8[0];
@@ -103,7 +103,7 @@ private:
     /// @param h The first UTF-16 encoded element used for the UTF-8 encoding.
     /// @param l The second UTF-16 encoded element used for the UTF-8 encoding.
     /// @return A generated error message.
-    std::string generate_error_message(const char* msg, std::array<char16_t, 2> u16)
+    std::string generate_error_message(const char* msg, std::array<char16_t, 2> u16) const noexcept
     {
         std::stringstream ss;
         ss << "invalid_encoding: " << msg;
@@ -116,7 +116,7 @@ private:
     /// @param msg An error message.
     /// @param u32 The UTF-32 encoded element used for the UTF-8 encoding.
     /// @return A genereated error message.
-    std::string generate_error_message(const char* msg, char32_t u32)
+    std::string generate_error_message(const char* msg, char32_t u32) const noexcept
     {
         std::stringstream ss;
         // uint32_t is large enough for UTF-32 encoded elements.
@@ -129,13 +129,13 @@ private:
 class parse_error : public exception
 {
 public:
-    explicit parse_error(const char* msg, std::size_t lines, std::size_t cols_in_line)
+    explicit parse_error(const char* msg, std::size_t lines, std::size_t cols_in_line) noexcept
         : exception(generate_error_message(msg, lines, cols_in_line).c_str())
     {
     }
 
 private:
-    std::string generate_error_message(const char* msg, std::size_t lines, std::size_t cols_in_line)
+    std::string generate_error_message(const char* msg, std::size_t lines, std::size_t cols_in_line) const noexcept
     {
         std::stringstream ss;
         ss << "parse_error: " << msg << " (at line " << lines << ", column " << cols_in_line << ")";
@@ -151,7 +151,7 @@ public:
     /// @brief Construct a new type_error object with an error message and a node type.
     /// @param[in] msg An error message.
     /// @param[in] type The type of a source node value.
-    explicit type_error(const char* msg, detail::node_t type)
+    explicit type_error(const char* msg, detail::node_t type) noexcept
         : exception(generate_error_message(msg, type).c_str())
     {
     }
@@ -161,7 +161,7 @@ private:
     /// @param msg An error message.
     /// @param type The type of a source node value.
     /// @return A generated error message.
-    std::string generate_error_message(const char* msg, detail::node_t type)
+    std::string generate_error_message(const char* msg, detail::node_t type) const noexcept
     {
         std::stringstream ss;
         ss << "type_error: " << msg << " type=" << detail::to_string(type);

--- a/include/fkYAML/node.hpp
+++ b/include/fkYAML/node.hpp
@@ -1224,6 +1224,7 @@ inline namespace yaml_literals
 /// @param s An input `char` array.
 /// @param n The size of `s`.
 /// @return The resulting `node` object deserialized from `s`.
+/// @sa https://fktn-k.github.io/fkYAML/api/operator_literal_yaml/
 inline fkyaml::node operator"" _yaml(const char* s, std::size_t n)
 {
     return fkyaml::node::deserialize((const char*)s, (const char*)s + n);
@@ -1233,6 +1234,7 @@ inline fkyaml::node operator"" _yaml(const char* s, std::size_t n)
 /// @param s An input `char16_t` array.
 /// @param n The size of `s`.
 /// @return The resulting `node` object deserialized from `s`.
+/// @sa https://fktn-k.github.io/fkYAML/api/operator_literal_yaml/
 inline fkyaml::node operator"" _yaml(const char16_t* s, std::size_t n)
 {
     return fkyaml::node::deserialize((const char16_t*)s, (const char16_t*)s + n);
@@ -1242,6 +1244,7 @@ inline fkyaml::node operator"" _yaml(const char16_t* s, std::size_t n)
 /// @param s An input `char32_t` array.
 /// @param n The size of `s`.
 /// @return The resulting `node` object deserialized from `s`.
+/// @sa https://fktn-k.github.io/fkYAML/api/operator_literal_yaml/
 inline fkyaml::node operator"" _yaml(const char32_t* s, std::size_t n)
 {
     return fkyaml::node::deserialize((const char32_t*)s, (const char32_t*)s + n);

--- a/include/fkYAML/node.hpp
+++ b/include/fkYAML/node.hpp
@@ -144,8 +144,6 @@ private:
             case node_t::STRING:
                 p_string = create_object<string_type>();
                 break;
-            default:                                                     // LCOV_EXCL_LINE
-                throw fkyaml::exception("Unsupported node value type."); // LCOV_EXCL_LINE
             }
         }
 
@@ -317,13 +315,10 @@ public:
             m_node_value.p_string = create_object<string_type>(*(rhs.m_node_value.p_string));
             FK_YAML_ASSERT(m_node_value.p_string != nullptr);
             break;
-        default:                                                       // LCOV_EXCL_LINE
-            throw fkyaml::exception("Not supported node value type."); // LCOV_EXCL_LINE
         }
 
         if (rhs.m_anchor_name)
         {
-            destroy_object<std::string>(m_anchor_name);
             m_anchor_name = create_object<std::string>(*(rhs.m_anchor_name));
             FK_YAML_ASSERT(m_anchor_name != nullptr);
         }
@@ -403,7 +398,7 @@ public:
     template <
         typename NodeRefStorageType,
         detail::enable_if_t<detail::is_node_ref_storage<NodeRefStorageType>::value, int> = 0>
-    basic_node(const NodeRefStorageType& node_ref_storage)
+    basic_node(const NodeRefStorageType& node_ref_storage) noexcept
         : basic_node(node_ref_storage.release())
     {
     }

--- a/test/unit_test/test_deserializer_class.cpp
+++ b/test/unit_test/test_deserializer_class.cpp
@@ -12,6 +12,16 @@
 #include <fkYAML/detail/input/input_adapter.hpp>
 #include <fkYAML/node.hpp>
 
+TEST_CASE("DeserializerClassTest_DeserializeEmptyInput", "[DeserializerClassTest]")
+{
+    fkyaml::detail::basic_deserializer<fkyaml::node> deserializer;
+    fkyaml::node root;
+
+    REQUIRE_NOTHROW(root = deserializer.deserialize(fkyaml::detail::input_adapter(" ")));
+    REQUIRE(root.is_mapping());
+    REQUIRE(root.empty());
+}
+
 TEST_CASE("DeserializerClassTest_DeserializeKeySeparator", "[DeserializerClassTest]")
 {
     fkyaml::detail::basic_deserializer<fkyaml::node> deserializer;


### PR DESCRIPTION
This PR has corrected the usages of the `noexcept` keyword for each fkYAML APIs (both public and private).  
Furthermore, the descriptions in the documentation have also been updated according to the latest version of the codebase.  

---

## Pull Request Checklist

Read the [CONTRIBUTING.md](https://github.com/fktn-k/fkYAML/blob/develop/CONTRIBUTING.md) file for detailed information.  

- [x] Changes are described in the pull request or in a referenced [issue](https://github.com/fktn-k/fkYAML/issues).
- [x] The test suite compiles and runs without any error.
- [x] [The code coverage](https://coveralls.io/github/fktn-k/fkYAML) on your branch is 100%.
- [x] The documentation is updated if you added/changed a feature.

## Please don't

- The C++11 support varies between different **compilers** and versions. Please note the [list of supported compilers](https://github.com/fktn-k/fkYAML/blob/develop/README.md#supported-compilers). Some compilers like GCC 4.7 (and earlier), Clang 3.3 (and earlier), or Microsoft Visual Studio 13.0 and earlier are known not to work due to missing or incomplete C++11 support. Please refrain from proposing changes that work around these compiler's limitations with `#ifdef`s or other means.
- Please refrain from proposing changes that would **break [YAML](https://yaml.org/) specifications**. If you propose a conformant extension of YAML to be supported by the library, please motivate this extension.
- Please do not open pull requests that address **multiple issues**.