### PR TITLE
#240 implement node comparison

### DIFF
--- a/docs/mkdocs/docs/api/basic_node/index.md
+++ b/docs/mkdocs/docs/api/basic_node/index.md
@@ -101,6 +101,16 @@ This class provides features to handle YAML nodes.
 |-----------------------------|---------------------------------------------|
 | [operator[]](operator[].md) | accesses an item specified by the key/index |
 
+### Lexicographical Comparison Operators
+| Name                         | Description                       |
+| ---------------------------- | --------------------------------- |
+| [operator==](operator_eq.md) | comparison: equal                 |
+| [operator!=](operator_ne.md) | comparison: not equal             |
+| [operator<](operator_lt.md)  | comparison: less than             |
+| [operator<=](operator_le.md) | comparison: less than or equal    |
+| [operator>](operator_gt.md)  | comparison: greater than          |
+| [operator>=](operator_ge.md) | comparison: greater than or equal |
+
 ### Aliasing Nodes
 | Name                                  | Description                                              |
 | ------------------------------------- | -------------------------------------------------------- |

--- a/docs/mkdocs/docs/api/basic_node/operator_eq.md
+++ b/docs/mkdocs/docs/api/basic_node/operator_eq.md
@@ -1,0 +1,75 @@
+<small>Defined in header [`<fkYAML/node.hpp>`](https://github.com/fktn-k/fkYAML/blob/develop/include/fkYAML/node.hpp)</small>
+
+# <small>fkyaml::basic_node::</small>operator==
+
+```cpp
+bool operator==(const basic_node& rhs) const noexcept;
+```
+
+Equal-to operator.  
+Compares two `basic_node` objects for equality according to the following rules:  
+
+* Two `basic_node` objects are equal if they are of the same [`node_t`](node_t.md) type and their stored values are the same according to their respective `operator==`.
+* Two `basic_node` objects are always equal if both of them are of the [`node_t::NULL_OBJECT`](node_t.md) type.
+
+## **Parameters**
+
+***`rhs`*** [in]
+:   A `basic_node` object to be compared with `this` object.
+
+## **Return Value**
+
+`true` if both types and values are equal, `false` otherwise.
+
+???+ Example
+
+    ```cpp
+    #include <iomanip>
+    #include <iostream>
+    #include <fkYAML/node.hpp>
+
+    int main()
+    {
+        fkyaml::node seq_1 = {1, 2, 3};
+        fkyaml::node seq_2 = {1, 2, 4};
+        fkyaml::node map_1 = {{"foo", true}, {"bar", 123}};
+        fkyaml::node map_1 = {{"bar", 123}, {"foo", true}};
+        fkyaml::node null_1 = nullptr;
+        fkyaml::node null_2 = nullptr;
+        fkyaml::node bool_1 = true;
+        fkyaml::node bool_2 = false;
+        fkyaml::node integer_1 = 123;
+        fkyaml::node integer_2 = 123;
+        fkyaml::node float_1 = 3.14;
+        fkyaml::node float_2 = 3.14;
+        fkyaml::node string_1 = "foo";
+        fkyaml::node string_2 = "bar";
+
+        std::cout << std::boolalpha;
+        std::cout << seq_1 == seq_2 << std::endl;
+        std::cout << map_1 == map_2 << std::endl;
+        std::cout << null_1 == null_2 << std::endl;
+        std::cout << bool_1 == bool_2 << std::endl;
+        std::cout << integer_1 == integer_2 << std::endl;
+        std::cout << float_1 == float_2 << std::endl;
+        std::cout << string_1 == string_2 << std::endl;
+
+        return 0;
+    }
+    ```
+
+    output:
+    ```bash
+    false
+    true
+    true
+    false
+    true
+    true
+    false
+    ```
+
+## **See Also**
+
+* [basic_node](index.md)
+* [operator!=](operator_ne.md)

--- a/docs/mkdocs/docs/api/basic_node/operator_ge.md
+++ b/docs/mkdocs/docs/api/basic_node/operator_ge.md
@@ -1,0 +1,80 @@
+<small>Defined in header [`<fkYAML/node.hpp>`](https://github.com/fktn-k/fkYAML/blob/develop/include/fkYAML/node.hpp)</small>
+
+# <small>fkyaml::basic_node::</small>operator>=
+
+```cpp
+bool operator>=(const basic_node& rhs) const noexcept;
+```
+
+Greater-than-or-equal-to operator.  
+Check if `this` object is greater than or equal to `rhs`.  
+The operator returns the result of `!(*this < rhs)`. (see [`operator<`](operator_lt.md))  
+
+## **Parameters**
+
+***`rhs`*** [in]
+:   A `basic_node` object to be compared with `this` object.
+
+## **Return Value**
+
+`true` if `this` is greater than `rhs`, `false` otherwise.
+
+???+ Example
+
+    ```cpp
+    #include <iomanip>
+    #include <iostream>
+    #include <fkYAML/node.hpp>
+
+    int main()
+    {
+        fkyaml::node seq_1 = {1, 2, 3};
+        fkyaml::node seq_2 = {1, 2, 4};
+        fkyaml::node map_1 = {{"foo", true}, {"bar", 123}};
+        fkyaml::node map_1 = {{"bar", 123}, {"foo", true}};
+        fkyaml::node null_1 = nullptr;
+        fkyaml::node null_2 = nullptr;
+        fkyaml::node bool_1 = false;
+        fkyaml::node bool_2 = true;
+        fkyaml::node integer_1 = 321;
+        fkyaml::node integer_2 = 123;
+        fkyaml::node float_1 = 1.23;
+        fkyaml::node float_2 = 3.14;
+        fkyaml::node string_1 = "foo";
+        fkyaml::node string_2 = "bar";
+
+        // the same type
+        std::cout << std::boolalpha;
+        std::cout << seq_1 >= seq_2 << std::endl;
+        std::cout << map_1 >= map_2 << std::endl;
+        std::cout << null_1 >= null_2 << std::endl;
+        std::cout << bool_1 >= bool_2 << std::endl;
+        std::cout << integer_1 >= integer_2 << std::endl;
+        std::cout << float_1 >= float_2 << std::endl;
+        std::cout << string_1 >= string_2 << std::endl;
+
+        // different types
+        std::cout << bool_1 >= string_1 << std::endl;
+        std::cout << float_2 >= seq_2 << std::endl;
+
+        return 0;
+    }
+    ```
+
+    output:
+    ```bash
+    false
+    true
+    true
+    false
+    true
+    false
+    true
+    false
+    true
+    ```
+
+## **See Also**
+
+* [basic_node](index.md)
+* [operator<](operator_lt.md)

--- a/docs/mkdocs/docs/api/basic_node/operator_gt.md
+++ b/docs/mkdocs/docs/api/basic_node/operator_gt.md
@@ -1,0 +1,80 @@
+<small>Defined in header [`<fkYAML/node.hpp>`](https://github.com/fktn-k/fkYAML/blob/develop/include/fkYAML/node.hpp)</small>
+
+# <small>fkyaml::basic_node::</small>operator>
+
+```cpp
+bool operator>(const basic_node& rhs) const noexcept;
+```
+
+Greater-than operator.  
+Check if `this` object is greater than `rhs`.  
+The operator returns the result of `!(*this <= rhs)`. (see [`operator<=`](operator_le.md))  
+
+## **Parameters**
+
+***`rhs`*** [in]
+:   A `basic_node` object to be compared with `this` object.
+
+## **Return Value**
+
+`true` if `this` is greater than `rhs`, `false` otherwise.
+
+???+ Example
+
+    ```cpp
+    #include <iomanip>
+    #include <iostream>
+    #include <fkYAML/node.hpp>
+
+    int main()
+    {
+        fkyaml::node seq_1 = {1, 2, 3};
+        fkyaml::node seq_2 = {1, 2, 4};
+        fkyaml::node map_1 = {{"foo", true}, {"bar", 123}};
+        fkyaml::node map_1 = {{"bar", 123}, {"foo", true}};
+        fkyaml::node null_1 = nullptr;
+        fkyaml::node null_2 = nullptr;
+        fkyaml::node bool_1 = false;
+        fkyaml::node bool_2 = true;
+        fkyaml::node integer_1 = 321;
+        fkyaml::node integer_2 = 123;
+        fkyaml::node float_1 = 1.23;
+        fkyaml::node float_2 = 3.14;
+        fkyaml::node string_1 = "foo";
+        fkyaml::node string_2 = "bar";
+
+        // the same type
+        std::cout << std::boolalpha;
+        std::cout << seq_1 > seq_2 << std::endl;
+        std::cout << map_1 > map_2 << std::endl;
+        std::cout << null_1 > null_2 << std::endl;
+        std::cout << bool_1 > bool_2 << std::endl;
+        std::cout << integer_1 > integer_2 << std::endl;
+        std::cout << float_1 > float_2 << std::endl;
+        std::cout << string_1 > string_2 << std::endl;
+
+        // different types
+        std::cout << bool_1 > string_1 << std::endl;
+        std::cout << float_2 > seq_2 << std::endl;
+
+        return 0;
+    }
+    ```
+
+    output:
+    ```bash
+    false
+    false
+    false
+    false
+    true
+    false
+    true
+    false
+    true
+    ```
+
+## **See Also**
+
+* [basic_node](index.md)
+* [operator<=](operator_le.md)

--- a/docs/mkdocs/docs/api/basic_node/operator_le.md
+++ b/docs/mkdocs/docs/api/basic_node/operator_le.md
@@ -1,0 +1,80 @@
+<small>Defined in header [`<fkYAML/node.hpp>`](https://github.com/fktn-k/fkYAML/blob/develop/include/fkYAML/node.hpp)</small>
+
+# <small>fkyaml::basic_node::</small>operator<=
+
+```cpp
+bool operator<=(const basic_node& rhs) const noexcept;
+```
+
+Less-than-or-equal-to operator.  
+Check if `this` object is less than or equal to `rhs`.  
+The operator returns the result of `!(rhs < *this)`. (see [`operator<`](operator_lt.md))  
+
+## **Parameters**
+
+***`rhs`*** [in]
+:   A `basic_node` object to be compared with `this` object.
+
+## **Return Value**
+
+`true` if `this` is less than or equal to `rhs`, `false` otherwise.
+
+???+ Example
+
+    ```cpp
+    #include <iomanip>
+    #include <iostream>
+    #include <fkYAML/node.hpp>
+
+    int main()
+    {
+        fkyaml::node seq_1 = {1, 2, 3};
+        fkyaml::node seq_2 = {1, 2, 4};
+        fkyaml::node map_1 = {{"foo", true}, {"bar", 123}};
+        fkyaml::node map_1 = {{"bar", 123}, {"foo", true}};
+        fkyaml::node null_1 = nullptr;
+        fkyaml::node null_2 = nullptr;
+        fkyaml::node bool_1 = false;
+        fkyaml::node bool_2 = true;
+        fkyaml::node integer_1 = 321;
+        fkyaml::node integer_2 = 123;
+        fkyaml::node float_1 = 1.23;
+        fkyaml::node float_2 = 3.14;
+        fkyaml::node string_1 = "foo";
+        fkyaml::node string_2 = "bar";
+
+        // the same type
+        std::cout << std::boolalpha;
+        std::cout << seq_1 <= seq_2 << std::endl;
+        std::cout << map_1 <= map_2 << std::endl;
+        std::cout << null_1 <= null_2 << std::endl;
+        std::cout << bool_1 <= bool_2 << std::endl;
+        std::cout << integer_1 <= integer_2 << std::endl;
+        std::cout << float_1 <= float_2 << std::endl;
+        std::cout << string_1 <= string_2 << std::endl;
+
+        // different types
+        std::cout << bool_1 <= string_1 << std::endl;
+        std::cout << float_2 <= seq_2 << std::endl;
+
+        return 0;
+    }
+    ```
+
+    output:
+    ```bash
+    true
+    true
+    true
+    true
+    false
+    true
+    false
+    true
+    false
+    ```
+
+## **See Also**
+
+* [basic_node](index.md)
+* [operator==](operator_eq.md)

--- a/docs/mkdocs/docs/api/basic_node/operator_lt.md
+++ b/docs/mkdocs/docs/api/basic_node/operator_lt.md
@@ -1,0 +1,91 @@
+<small>Defined in header [`<fkYAML/node.hpp>`](https://github.com/fktn-k/fkYAML/blob/develop/include/fkYAML/node.hpp)</small>
+
+# <small>fkyaml::basic_node::</small>operator<
+
+```cpp
+bool operator<(const basic_node& rhs) const noexcept;
+```
+
+Less-than operator.  
+Check if `this` object is less than `rhs` according to the following rules:  
+
+* If the values are of the same [`node_t`](node_t.md) type, their stored values are compared according to their respective `operator<`.
+* Two `basic_node` objects are always equal if both of them are of the [`node_t::NULL_OBJECT`](node_t.md) type.
+* If the values are of different [`node_t`](node_t.md) types, the stored values are ignored and the order of the types are considered. The order of the types is as followed (top < bottom):
+    * node_t::SEQUENCE
+    * node_t::MAPPING
+    * node_t::NULL_OBJECT
+    * node_t::BOOLEAN
+    * node_t::INTEGER
+    * node_t::FLOAT_NUMBER
+    * node_t::STRING
+* If the values are of the [`node_t::BOOLEAN`](node_t.md) type, a value whose stored value is `false` is less than a value whose stored value is `true`.
+
+## **Parameters**
+
+***`rhs`*** [in]
+:   A `basic_node` object to be compared with `this` object.
+
+## **Return Value**
+
+`true` if `this` is less than `rhs`, `false` otherwise.
+
+???+ Example
+
+    ```cpp
+    #include <iomanip>
+    #include <iostream>
+    #include <fkYAML/node.hpp>
+
+    int main()
+    {
+        fkyaml::node seq_1 = {1, 2, 3};
+        fkyaml::node seq_2 = {1, 2, 4};
+        fkyaml::node map_1 = {{"foo", true}, {"bar", 123}};
+        fkyaml::node map_1 = {{"bar", 123}, {"foo", true}};
+        fkyaml::node null_1 = nullptr;
+        fkyaml::node null_2 = nullptr;
+        fkyaml::node bool_1 = false;
+        fkyaml::node bool_2 = true;
+        fkyaml::node integer_1 = 321;
+        fkyaml::node integer_2 = 123;
+        fkyaml::node float_1 = 1.23;
+        fkyaml::node float_2 = 3.14;
+        fkyaml::node string_1 = "foo";
+        fkyaml::node string_2 = "bar";
+
+        // the same type
+        std::cout << std::boolalpha;
+        std::cout << seq_1 < seq_2 << std::endl;
+        std::cout << map_1 < map_2 << std::endl;
+        std::cout << null_1 < null_2 << std::endl;
+        std::cout << bool_1 < bool_2 << std::endl;
+        std::cout << integer_1 < integer_2 << std::endl;
+        std::cout << float_1 < float_2 << std::endl;
+        std::cout << string_1 < string_2 << std::endl;
+
+        // different types
+        std::cout << bool_1 < string_1 << std::endl;
+        std::cout << float_2 < seq_2 << std::endl;
+
+        return 0;
+    }
+    ```
+
+    output:
+    ```bash
+    true
+    false
+    false
+    true
+    false
+    true
+    false
+    true
+    false
+    ```
+
+## **See Also**
+
+* [basic_node](index.md)
+* [operator==](operator_eq.md)

--- a/docs/mkdocs/docs/api/basic_node/operator_ne.md
+++ b/docs/mkdocs/docs/api/basic_node/operator_ne.md
@@ -1,0 +1,73 @@
+<small>Defined in header [`<fkYAML/node.hpp>`](https://github.com/fktn-k/fkYAML/blob/develop/include/fkYAML/node.hpp)</small>
+
+# <small>fkyaml::basic_node::</small>operator!=
+
+```cpp
+bool operator!=(const basic_node& rhs) const noexcept;
+```
+
+Not-Equal-to operator.  
+Compares two `basic_node` objects for inequality.  
+This operator returns the result of `!(*this == rhs)`. (see [`operator==`](operator_eq.md))
+
+## **Parameters**
+
+***`rhs`*** [in]
+:   A `basic_node` object to be compared with `this` object.
+
+## **Return Value**
+
+`true` if either types or values are not equal, `false` otherwise.
+
+???+ Example
+
+    ```cpp
+    #include <iomanip>
+    #include <iostream>
+    #include <fkYAML/node.hpp>
+
+    int main()
+    {
+        fkyaml::node seq_1 = {1, 2, 3};
+        fkyaml::node seq_2 = {1, 2, 4};
+        fkyaml::node map_1 = {{"foo", true}, {"bar", 123}};
+        fkyaml::node map_1 = {{"bar", 123}, {"foo", true}};
+        fkyaml::node null_1 = nullptr;
+        fkyaml::node null_2 = nullptr;
+        fkyaml::node bool_1 = true;
+        fkyaml::node bool_2 = false;
+        fkyaml::node integer_1 = 123;
+        fkyaml::node integer_2 = 123;
+        fkyaml::node float_1 = 3.14;
+        fkyaml::node float_2 = 3.14;
+        fkyaml::node string_1 = "foo";
+        fkyaml::node string_2 = "bar";
+
+        std::cout << std::boolalpha;
+        std::cout << seq_1 != seq_2 << std::endl;
+        std::cout << map_1 != map_2 << std::endl;
+        std::cout << null_1 != null_2 << std::endl;
+        std::cout << bool_1 != bool_2 << std::endl;
+        std::cout << integer_1 != integer_2 << std::endl;
+        std::cout << float_1 != float_2 << std::endl;
+        std::cout << string_1 != string_2 << std::endl;
+
+        return 0;
+    }
+    ```
+
+    output:
+    ```bash
+    true
+    false
+    false
+    true
+    false
+    false
+    true
+    ```
+
+## **See Also**
+
+* [basic_node](index.md)
+* [operator==](operator_eq.md)

--- a/docs/mkdocs/mkdocs.yml
+++ b/docs/mkdocs/mkdocs.yml
@@ -142,6 +142,12 @@ nav:
           - value_converter_type: api/basic_node/value_converter_type.md
           - yaml_version_t: api/basic_node/yaml_version_t.md
           - operator[]: api/basic_node/operator[].md
+          - operator==: api/basic_node/operator_eq.md
+          - operator!=: api/basic_node/operator_ne.md
+          - operator<: api/basic_node/operator_lt.md
+          - operator<=: api/basic_node/operator_le.md
+          - operator>: api/basic_node/operator_gt.md
+          - operator>=: api/basic_node/operator_ge.md
       - exception:
           - exception: api/exception/index.md
           - (constructor): api/exception/constructor.md

--- a/include/fkYAML/node.hpp
+++ b/include/fkYAML/node.hpp
@@ -667,7 +667,7 @@ public:
     /// @brief An equal-to operator of the basic_node class.
     /// @param rhs A basic_node object to be compared with this basic_node object.
     /// @return true if both types and values are equal, false otherwise.
-    /// @sa https://fktn-k.github.io/fkYAML/api/basic_node/operator==/
+    /// @sa https://fktn-k.github.io/fkYAML/api/basic_node/operator_eq/
     bool operator==(const basic_node& rhs) const noexcept
     {
         if (m_node_type != rhs.m_node_type)
@@ -710,6 +710,7 @@ public:
     /// @brief A not-equal-to operator of the basic_node class.
     /// @param rhs A basic_node object to be compared with this basic_node object.
     /// @return true if either types or values are different, false otherwise.
+    /// @sa https://fktn-k.github.io/fkYAML/api/basic_node/operator_ne/
     bool operator!=(const basic_node& rhs) const noexcept
     {
         return !operator==(rhs);
@@ -718,6 +719,7 @@ public:
     /// @brief A less-than operator of the basic_node class.
     /// @param rhs A basic_node object to be compared with this basic_node object.
     /// @return true this basic_node object is less than `rhs`.
+    /// @sa https://fktn-k.github.io/fkYAML/api/basic_node/operator_lt/
     bool operator<(const basic_node& rhs) const noexcept
     {
         if (operator==(rhs))
@@ -768,6 +770,7 @@ public:
     /// @brief A less-than-or-equal-to operator of the basic_node class.
     /// @param rhs A basic_node object to be compared with this basic_node object.
     /// @return true this basic_node object is less than or equal to `rhs`.
+    /// @sa https://fktn-k.github.io/fkYAML/api/basic_node/operator_le/
     bool operator<=(const basic_node& rhs) const noexcept
     {
         return !rhs.operator<(*this);
@@ -776,6 +779,7 @@ public:
     /// @brief A greater-than operator of the basic_node class.
     /// @param rhs A basic_node object to be compared with this basic_node object.
     /// @return true this basic_node object is greater than `rhs`.
+    /// @sa https://fktn-k.github.io/fkYAML/api/basic_node/operator_gt/
     bool operator>(const basic_node& rhs) const noexcept
     {
         return !operator<=(rhs);
@@ -784,6 +788,7 @@ public:
     /// @brief A greater-than-or-equal-to operator of the basic_node class.
     /// @param rhs A basic_node object to be compared with this basic_node object.
     /// @return true this basic_node object is greater than or equal to `rhs`.
+    /// @sa https://fktn-k.github.io/fkYAML/api/basic_node/operator_ge/
     bool operator>=(const basic_node& rhs) const noexcept
     {
         return !operator<(rhs);

--- a/include/fkYAML/node.hpp
+++ b/include/fkYAML/node.hpp
@@ -664,6 +664,131 @@ public:
         return m_node_value.p_mapping->operator[](std::forward<KeyType>(key));
     }
 
+    /// @brief An equal-to operator of the basic_node class.
+    /// @param rhs A basic_node object to be compared with this basic_node object.
+    /// @return true if both types and values are equal, false otherwise.
+    /// @sa https://fktn-k.github.io/fkYAML/api/basic_node/operator==/
+    bool operator==(const basic_node& rhs) const noexcept
+    {
+        if (m_node_type != rhs.m_node_type)
+        {
+            return false;
+        }
+
+        bool ret = false;
+        switch (m_node_type)
+        {
+        case node_t::SEQUENCE:
+            ret = (*(m_node_value.p_sequence) == *(rhs.m_node_value.p_sequence));
+            break;
+        case node_t::MAPPING:
+            ret = (*(m_node_value.p_mapping) == *(rhs.m_node_value.p_mapping));
+            break;
+        case node_t::NULL_OBJECT:
+            // Always true for comparisons between null nodes.
+            ret = true;
+            break;
+        case node_t::BOOLEAN:
+            ret = (m_node_value.boolean == rhs.m_node_value.boolean);
+            break;
+        case node_t::INTEGER:
+            ret = (m_node_value.integer == rhs.m_node_value.integer);
+            break;
+        case node_t::FLOAT_NUMBER:
+            ret =
+                (std::abs(m_node_value.float_val - rhs.m_node_value.float_val) <
+                 std::numeric_limits<float_number_type>::epsilon());
+            break;
+        case node_t::STRING:
+            ret = (*(m_node_value.p_string) == *(rhs.m_node_value.p_string));
+            break;
+        }
+
+        return ret;
+    }
+
+    /// @brief A not-equal-to operator of the basic_node class.
+    /// @param rhs A basic_node object to be compared with this basic_node object.
+    /// @return true if either types or values are different, false otherwise.
+    bool operator!=(const basic_node& rhs) const noexcept
+    {
+        return !operator==(rhs);
+    }
+
+    /// @brief A less-than operator of the basic_node class.
+    /// @param rhs A basic_node object to be compared with this basic_node object.
+    /// @return true this basic_node object is less than `rhs`.
+    bool operator<(const basic_node& rhs) const noexcept
+    {
+        if (operator==(rhs))
+        {
+            return false;
+        }
+
+        if (uint32_t(m_node_type) < uint32_t(rhs.m_node_type))
+        {
+            return true;
+        }
+
+        if (m_node_type != rhs.m_node_type)
+        {
+            return false;
+        }
+
+        bool ret = false;
+        switch (m_node_type)
+        {
+        case node_t::SEQUENCE:
+            ret = (*(m_node_value.p_sequence) < *(rhs.m_node_value.p_sequence));
+            break;
+        case node_t::MAPPING:
+            ret = (*(m_node_value.p_mapping) < *(rhs.m_node_value.p_mapping));
+            break;
+        case node_t::NULL_OBJECT: // LCOV_EXCL_LINE
+            // Will not come here since null nodes are alyways the same.
+            break; // LCOV_EXCL_LINE
+        case node_t::BOOLEAN:
+            // false < true
+            ret = (!m_node_value.boolean && rhs.m_node_value.boolean);
+            break;
+        case node_t::INTEGER:
+            ret = (m_node_value.integer < rhs.m_node_value.integer);
+            break;
+        case node_t::FLOAT_NUMBER:
+            ret = (m_node_value.float_val < rhs.m_node_value.float_val);
+            break;
+        case node_t::STRING:
+            ret = (*(m_node_value.p_string) < *(rhs.m_node_value.p_string));
+            break;
+        }
+
+        return ret;
+    }
+
+    /// @brief A less-than-or-equal-to operator of the basic_node class.
+    /// @param rhs A basic_node object to be compared with this basic_node object.
+    /// @return true this basic_node object is less than or equal to `rhs`.
+    bool operator<=(const basic_node& rhs) const noexcept
+    {
+        return !rhs.operator<(*this);
+    }
+
+    /// @brief A greater-than operator of the basic_node class.
+    /// @param rhs A basic_node object to be compared with this basic_node object.
+    /// @return true this basic_node object is greater than `rhs`.
+    bool operator>(const basic_node& rhs) const noexcept
+    {
+        return !operator<=(rhs);
+    }
+
+    /// @brief A greater-than-or-equal-to operator of the basic_node class.
+    /// @param rhs A basic_node object to be compared with this basic_node object.
+    /// @return true this basic_node object is greater than or equal to `rhs`.
+    bool operator>=(const basic_node& rhs) const noexcept
+    {
+        return !operator<(rhs);
+    }
+
 public:
     /// @brief Returns the type of the current basic_node value.
     /// @return The type of the YAML node value.

--- a/test/unit_test/test_node_class.cpp
+++ b/test/unit_test/test_node_class.cpp
@@ -839,6 +839,538 @@ TEST_CASE("NodeClassTest_IntegerSubscriptOperatorTest", "[NodeClassTest]")
 }
 
 //
+// test cases for operators for comparisons between nodes
+//
+
+TEST_CASE("NodeClassTest_EqualToOperatorTest", "[NodeClassTest]")
+{
+    SECTION("The same type and value.")
+    {
+        auto params = GENERATE(
+            fkyaml::node {{true, 123, "foo"}, {true, 123, "foo"}},
+            fkyaml::node {{{"foo", 123}, {"bar", true}}, {{"foo", 123}, {"bar", true}}},
+            fkyaml::node {nullptr, nullptr},
+            fkyaml::node {true, true},
+            fkyaml::node {123, 123},
+            fkyaml::node {3.14, 3.14},
+            fkyaml::node {"foo", "foo"});
+        REQUIRE(params[0] == params[1]);
+    }
+
+    SECTION("The same type but different values.")
+    {
+        auto params = GENERATE(
+            fkyaml::node {{true, 123, "foo"}, {false, 456, "bar"}},
+            fkyaml::node {{{"foo", 123}, {"bar", true}}, {{"baz", 456}, {"qux", false}}},
+            fkyaml::node {true, false},
+            fkyaml::node {123, 456},
+            fkyaml::node {3.14, 1.41},
+            fkyaml::node {"foo", "bar"});
+        REQUIRE_FALSE(params[0] == params[1]);
+    }
+
+    SECTION("Different types")
+    {
+        auto params = GENERATE(
+            fkyaml::node {{true, 123, "foo"}, {{"foo", 123}, {"bar", true}}},
+            fkyaml::node {{true, 123, "foo"}, nullptr},
+            fkyaml::node {{true, 123, "foo"}, true},
+            fkyaml::node {{true, 123, "foo"}, 123},
+            fkyaml::node {{true, 123, "foo"}, 3.14},
+            fkyaml::node {{true, 123, "foo"}, "foo"},
+            fkyaml::node {{{"foo", 123}, {"bar", true}}, {true, 123, "foo"}},
+            fkyaml::node {{{"foo", 123}, {"bar", true}}, nullptr},
+            fkyaml::node {{{"foo", 123}, {"bar", true}}, true},
+            fkyaml::node {{{"foo", 123}, {"bar", true}}, 123},
+            fkyaml::node {{{"foo", 123}, {"bar", true}}, 3.14},
+            fkyaml::node {{{"foo", 123}, {"bar", true}}, "foo"},
+            fkyaml::node {nullptr, {true, 123, "foo"}},
+            fkyaml::node {nullptr, {{"foo", 123}, {"bar", true}}},
+            fkyaml::node {nullptr, true},
+            fkyaml::node {nullptr, 123},
+            fkyaml::node {nullptr, 3.14},
+            fkyaml::node {nullptr, "foo"},
+            fkyaml::node {true, {true, 123, "foo"}},
+            fkyaml::node {true, {{"foo", 123}, {"bar", true}}},
+            fkyaml::node {true, nullptr},
+            fkyaml::node {true, 123},
+            fkyaml::node {true, 3.14},
+            fkyaml::node {true, "foo"},
+            fkyaml::node {123, {true, 123, "foo"}},
+            fkyaml::node {123, {{"foo", 123}, {"bar", true}}},
+            fkyaml::node {123, nullptr},
+            fkyaml::node {123, true},
+            fkyaml::node {123, 3.14},
+            fkyaml::node {123, "foo"},
+            fkyaml::node {3.14, {true, 123, "foo"}},
+            fkyaml::node {3.14, {{"foo", 123}, {"bar", true}}},
+            fkyaml::node {3.14, nullptr},
+            fkyaml::node {3.14, true},
+            fkyaml::node {3.14, 123},
+            fkyaml::node {3.14, "foo"},
+            fkyaml::node {"foo", {true, 123, "foo"}},
+            fkyaml::node {"foo", {{"foo", 123}, {"bar", true}}},
+            fkyaml::node {"foo", nullptr},
+            fkyaml::node {"foo", true},
+            fkyaml::node {"foo", 123},
+            fkyaml::node {"foo", 3.14});
+        REQUIRE_FALSE(params[0] == params[1]);
+    }
+}
+
+TEST_CASE("NodeClassTest_NotEqualToOperatorTest", "[NodeClassTest]")
+{
+    SECTION("The same type and value.")
+    {
+        auto params = GENERATE(
+            fkyaml::node {{true, 123, "foo"}, {true, 123, "foo"}},
+            fkyaml::node {{{"foo", 123}, {"bar", true}}, {{"foo", 123}, {"bar", true}}},
+            fkyaml::node {nullptr, nullptr},
+            fkyaml::node {true, true},
+            fkyaml::node {123, 123},
+            fkyaml::node {3.14, 3.14},
+            fkyaml::node {"foo", "foo"});
+        REQUIRE_FALSE(params[0] != params[1]);
+    }
+
+    SECTION("The same type but different values.")
+    {
+        auto params = GENERATE(
+            fkyaml::node {{true, 123, "foo"}, {false, 456, "bar"}},
+            fkyaml::node {{{"foo", 123}, {"bar", true}}, {{"baz", 456}, {"qux", false}}},
+            fkyaml::node {true, false},
+            fkyaml::node {123, 456},
+            fkyaml::node {3.14, 1.41},
+            fkyaml::node {"foo", "bar"});
+        REQUIRE(params[0] != params[1]);
+    }
+
+    SECTION("Different types")
+    {
+        auto params = GENERATE(
+            fkyaml::node {{true, 123, "foo"}, {{"foo", 123}, {"bar", true}}},
+            fkyaml::node {{true, 123, "foo"}, nullptr},
+            fkyaml::node {{true, 123, "foo"}, true},
+            fkyaml::node {{true, 123, "foo"}, 123},
+            fkyaml::node {{true, 123, "foo"}, 3.14},
+            fkyaml::node {{true, 123, "foo"}, "foo"},
+            fkyaml::node {{{"foo", 123}, {"bar", true}}, {true, 123, "foo"}},
+            fkyaml::node {{{"foo", 123}, {"bar", true}}, nullptr},
+            fkyaml::node {{{"foo", 123}, {"bar", true}}, true},
+            fkyaml::node {{{"foo", 123}, {"bar", true}}, 123},
+            fkyaml::node {{{"foo", 123}, {"bar", true}}, 3.14},
+            fkyaml::node {{{"foo", 123}, {"bar", true}}, "foo"},
+            fkyaml::node {nullptr, {true, 123, "foo"}},
+            fkyaml::node {nullptr, {{"foo", 123}, {"bar", true}}},
+            fkyaml::node {nullptr, true},
+            fkyaml::node {nullptr, 123},
+            fkyaml::node {nullptr, 3.14},
+            fkyaml::node {nullptr, "foo"},
+            fkyaml::node {true, {true, 123, "foo"}},
+            fkyaml::node {true, {{"foo", 123}, {"bar", true}}},
+            fkyaml::node {true, nullptr},
+            fkyaml::node {true, 123},
+            fkyaml::node {true, 3.14},
+            fkyaml::node {true, "foo"},
+            fkyaml::node {123, {true, 123, "foo"}},
+            fkyaml::node {123, {{"foo", 123}, {"bar", true}}},
+            fkyaml::node {123, nullptr},
+            fkyaml::node {123, true},
+            fkyaml::node {123, 3.14},
+            fkyaml::node {123, "foo"},
+            fkyaml::node {3.14, {true, 123, "foo"}},
+            fkyaml::node {3.14, {{"foo", 123}, {"bar", true}}},
+            fkyaml::node {3.14, nullptr},
+            fkyaml::node {3.14, true},
+            fkyaml::node {3.14, 123},
+            fkyaml::node {3.14, "foo"},
+            fkyaml::node {"foo", {true, 123, "foo"}},
+            fkyaml::node {"foo", {{"foo", 123}, {"bar", true}}},
+            fkyaml::node {"foo", nullptr},
+            fkyaml::node {"foo", true},
+            fkyaml::node {"foo", 123},
+            fkyaml::node {"foo", 3.14});
+        REQUIRE(params[0] != params[1]);
+    }
+}
+
+TEST_CASE("NodeClassTest_LessThanOperatorTest", "[NodeClassTest]")
+{
+    SECTION("The same type and value.")
+    {
+        auto params = GENERATE(
+            fkyaml::node {{true, 123, "foo"}, {true, 123, "foo"}},
+            fkyaml::node {{{"foo", 123}, {"bar", true}}, {{"foo", 123}, {"bar", true}}},
+            fkyaml::node {nullptr, nullptr},
+            fkyaml::node {true, true},
+            fkyaml::node {123, 123},
+            fkyaml::node {3.14, 3.14},
+            fkyaml::node {"foo", "foo"});
+        REQUIRE_FALSE(params[0] < params[1]);
+    }
+
+    SECTION("The same type and the target value is less than the compared one.")
+    {
+        auto params = GENERATE(
+            fkyaml::node {{true, 123}, {true, 123, "foo"}},
+            fkyaml::node {{{"bar", true}}, {{"foo", 123}, {"bar", true}}},
+            fkyaml::node {false, true},
+            fkyaml::node {123, 456},
+            fkyaml::node {3.14, 4.25},
+            fkyaml::node {"foo", "qux"});
+        REQUIRE(params[0] < params[1]);
+    }
+
+    SECTION("The same type but the target value is greater than the compared one.")
+    {
+        auto params = GENERATE(
+            fkyaml::node {{true, 123, "foo"}, {true, 123}},
+            fkyaml::node {{{"foo", 123}, {"bar", true}}, {{"bar", true}}},
+            fkyaml::node {true, false},
+            fkyaml::node {456, 123},
+            fkyaml::node {4.25, 3.14},
+            fkyaml::node {"qux", "foo"});
+        REQUIRE_FALSE(params[0] < params[1]);
+    }
+
+    SECTION("The numeric value of the target type is less than that of the compared one")
+    {
+        auto params = GENERATE(
+            fkyaml::node {{true, 123, "foo"}, {{"foo", 123}, {"bar", true}}},
+            fkyaml::node {{true, 123, "foo"}, nullptr},
+            fkyaml::node {{true, 123, "foo"}, true},
+            fkyaml::node {{true, 123, "foo"}, 123},
+            fkyaml::node {{true, 123, "foo"}, 3.14},
+            fkyaml::node {{true, 123, "foo"}, "foo"},
+            fkyaml::node {{{"foo", 123}, {"bar", true}}, nullptr},
+            fkyaml::node {{{"foo", 123}, {"bar", true}}, true},
+            fkyaml::node {{{"foo", 123}, {"bar", true}}, 123},
+            fkyaml::node {{{"foo", 123}, {"bar", true}}, 3.14},
+            fkyaml::node {{{"foo", 123}, {"bar", true}}, "foo"},
+            fkyaml::node {nullptr, true},
+            fkyaml::node {nullptr, 123},
+            fkyaml::node {nullptr, 3.14},
+            fkyaml::node {nullptr, "foo"},
+            fkyaml::node {true, 123},
+            fkyaml::node {true, 3.14},
+            fkyaml::node {true, "foo"},
+            fkyaml::node {123, 3.14},
+            fkyaml::node {123, "foo"},
+            fkyaml::node {3.14, "foo"});
+        REQUIRE(params[0] < params[1]);
+    }
+
+    SECTION("The numeric value of the target type is greater than that of the compared one")
+    {
+        auto params = GENERATE(
+            fkyaml::node {{{"foo", 123}, {"bar", true}}, {true, 123, "foo"}},
+            fkyaml::node {nullptr, {true, 123, "foo"}},
+            fkyaml::node {nullptr, {{"foo", 123}, {"bar", true}}},
+            fkyaml::node {true, {true, 123, "foo"}},
+            fkyaml::node {true, {{"foo", 123}, {"bar", true}}},
+            fkyaml::node {true, nullptr},
+            fkyaml::node {123, {true, 123, "foo"}},
+            fkyaml::node {123, {{"foo", 123}, {"bar", true}}},
+            fkyaml::node {123, nullptr},
+            fkyaml::node {123, true},
+            fkyaml::node {3.14, {true, 123, "foo"}},
+            fkyaml::node {3.14, {{"foo", 123}, {"bar", true}}},
+            fkyaml::node {3.14, nullptr},
+            fkyaml::node {3.14, true},
+            fkyaml::node {3.14, 123},
+            fkyaml::node {"foo", {true, 123, "foo"}},
+            fkyaml::node {"foo", {{"foo", 123}, {"bar", true}}},
+            fkyaml::node {"foo", nullptr},
+            fkyaml::node {"foo", true},
+            fkyaml::node {"foo", 123},
+            fkyaml::node {"foo", 3.14});
+        REQUIRE_FALSE(params[0] < params[1]);
+    }
+}
+
+TEST_CASE("NodeClassTest_LessThanOrEqualToOperatorTest", "[NodeClassTest]")
+{
+    SECTION("The same type and value.")
+    {
+        auto params = GENERATE(
+            fkyaml::node {{true, 123, "foo"}, {true, 123, "foo"}},
+            fkyaml::node {{{"foo", 123}, {"bar", true}}, {{"foo", 123}, {"bar", true}}},
+            fkyaml::node {nullptr, nullptr},
+            fkyaml::node {true, true},
+            fkyaml::node {123, 123},
+            fkyaml::node {3.14, 3.14},
+            fkyaml::node {"foo", "foo"});
+        REQUIRE(params[0] <= params[1]);
+    }
+
+    SECTION("The same type and the target value is less than the compared one.")
+    {
+        auto params = GENERATE(
+            fkyaml::node {{true, 123}, {true, 123, "foo"}},
+            fkyaml::node {{{"bar", true}}, {{"foo", 123}, {"bar", true}}},
+            fkyaml::node {false, true},
+            fkyaml::node {123, 456},
+            fkyaml::node {3.14, 4.25},
+            fkyaml::node {"foo", "qux"});
+        REQUIRE(params[0] <= params[1]);
+    }
+
+    SECTION("The same type but the target value is greater than the compared one.")
+    {
+        auto params = GENERATE(
+            fkyaml::node {{true, 123, "foo"}, {true, 123}},
+            fkyaml::node {{{"foo", 123}, {"bar", true}}, {{"bar", true}}},
+            fkyaml::node {true, false},
+            fkyaml::node {456, 123},
+            fkyaml::node {4.25, 3.14},
+            fkyaml::node {"qux", "foo"});
+        REQUIRE_FALSE(params[0] <= params[1]);
+    }
+
+    SECTION("The numeric value of the target type is less than that of the compared one")
+    {
+        auto params = GENERATE(
+            fkyaml::node {{true, 123, "foo"}, {{"foo", 123}, {"bar", true}}},
+            fkyaml::node {{true, 123, "foo"}, nullptr},
+            fkyaml::node {{true, 123, "foo"}, true},
+            fkyaml::node {{true, 123, "foo"}, 123},
+            fkyaml::node {{true, 123, "foo"}, 3.14},
+            fkyaml::node {{true, 123, "foo"}, "foo"},
+            fkyaml::node {{{"foo", 123}, {"bar", true}}, nullptr},
+            fkyaml::node {{{"foo", 123}, {"bar", true}}, true},
+            fkyaml::node {{{"foo", 123}, {"bar", true}}, 123},
+            fkyaml::node {{{"foo", 123}, {"bar", true}}, 3.14},
+            fkyaml::node {{{"foo", 123}, {"bar", true}}, "foo"},
+            fkyaml::node {nullptr, true},
+            fkyaml::node {nullptr, 123},
+            fkyaml::node {nullptr, 3.14},
+            fkyaml::node {nullptr, "foo"},
+            fkyaml::node {true, 123},
+            fkyaml::node {true, 3.14},
+            fkyaml::node {true, "foo"},
+            fkyaml::node {123, 3.14},
+            fkyaml::node {123, "foo"},
+            fkyaml::node {3.14, "foo"});
+        REQUIRE(params[0] <= params[1]);
+    }
+
+    SECTION("The numeric value of the target type is greater than that of the compared one")
+    {
+        auto params = GENERATE(
+            fkyaml::node {{{"foo", 123}, {"bar", true}}, {true, 123, "foo"}},
+            fkyaml::node {nullptr, {true, 123, "foo"}},
+            fkyaml::node {nullptr, {{"foo", 123}, {"bar", true}}},
+            fkyaml::node {true, {true, 123, "foo"}},
+            fkyaml::node {true, {{"foo", 123}, {"bar", true}}},
+            fkyaml::node {true, nullptr},
+            fkyaml::node {123, {true, 123, "foo"}},
+            fkyaml::node {123, {{"foo", 123}, {"bar", true}}},
+            fkyaml::node {123, nullptr},
+            fkyaml::node {123, true},
+            fkyaml::node {3.14, {true, 123, "foo"}},
+            fkyaml::node {3.14, {{"foo", 123}, {"bar", true}}},
+            fkyaml::node {3.14, nullptr},
+            fkyaml::node {3.14, true},
+            fkyaml::node {3.14, 123},
+            fkyaml::node {"foo", {true, 123, "foo"}},
+            fkyaml::node {"foo", {{"foo", 123}, {"bar", true}}},
+            fkyaml::node {"foo", nullptr},
+            fkyaml::node {"foo", true},
+            fkyaml::node {"foo", 123},
+            fkyaml::node {"foo", 3.14});
+        REQUIRE_FALSE(params[0] <= params[1]);
+    }
+}
+
+TEST_CASE("NodeClassTest_GreaterThanOperatorTest", "[NodeClassTest]")
+{
+    SECTION("The same type and value.")
+    {
+        auto params = GENERATE(
+            fkyaml::node {{true, 123, "foo"}, {true, 123, "foo"}},
+            fkyaml::node {{{"foo", 123}, {"bar", true}}, {{"foo", 123}, {"bar", true}}},
+            fkyaml::node {nullptr, nullptr},
+            fkyaml::node {true, true},
+            fkyaml::node {123, 123},
+            fkyaml::node {3.14, 3.14},
+            fkyaml::node {"foo", "foo"});
+        REQUIRE_FALSE(params[0] > params[1]);
+    }
+
+    SECTION("The same type and the target value is less than the compared one.")
+    {
+        auto params = GENERATE(
+            fkyaml::node {{true, 123}, {true, 123, "foo"}},
+            fkyaml::node {{{"bar", true}}, {{"foo", 123}, {"bar", true}}},
+            fkyaml::node {false, true},
+            fkyaml::node {123, 456},
+            fkyaml::node {3.14, 4.25},
+            fkyaml::node {"foo", "qux"});
+        REQUIRE_FALSE(params[0] > params[1]);
+    }
+
+    SECTION("The same type but the target value is greater than the compared one.")
+    {
+        auto params = GENERATE(
+            fkyaml::node {{true, 123, "foo"}, {true, 123}},
+            fkyaml::node {{{"foo", 123}, {"bar", true}}, {{"bar", true}}},
+            fkyaml::node {true, false},
+            fkyaml::node {456, 123},
+            fkyaml::node {4.25, 3.14},
+            fkyaml::node {"qux", "foo"});
+        REQUIRE(params[0] > params[1]);
+    }
+
+    SECTION("The numeric value of the target type is less than that of the compared one")
+    {
+        auto params = GENERATE(
+            fkyaml::node {{true, 123, "foo"}, {{"foo", 123}, {"bar", true}}},
+            fkyaml::node {{true, 123, "foo"}, nullptr},
+            fkyaml::node {{true, 123, "foo"}, true},
+            fkyaml::node {{true, 123, "foo"}, 123},
+            fkyaml::node {{true, 123, "foo"}, 3.14},
+            fkyaml::node {{true, 123, "foo"}, "foo"},
+            fkyaml::node {{{"foo", 123}, {"bar", true}}, nullptr},
+            fkyaml::node {{{"foo", 123}, {"bar", true}}, true},
+            fkyaml::node {{{"foo", 123}, {"bar", true}}, 123},
+            fkyaml::node {{{"foo", 123}, {"bar", true}}, 3.14},
+            fkyaml::node {{{"foo", 123}, {"bar", true}}, "foo"},
+            fkyaml::node {nullptr, true},
+            fkyaml::node {nullptr, 123},
+            fkyaml::node {nullptr, 3.14},
+            fkyaml::node {nullptr, "foo"},
+            fkyaml::node {true, 123},
+            fkyaml::node {true, 3.14},
+            fkyaml::node {true, "foo"},
+            fkyaml::node {123, 3.14},
+            fkyaml::node {123, "foo"},
+            fkyaml::node {3.14, "foo"});
+        REQUIRE_FALSE(params[0] > params[1]);
+    }
+
+    SECTION("The numeric value of the target type is greater than that of the compared one")
+    {
+        auto params = GENERATE(
+            fkyaml::node {{{"foo", 123}, {"bar", true}}, {true, 123, "foo"}},
+            fkyaml::node {nullptr, {true, 123, "foo"}},
+            fkyaml::node {nullptr, {{"foo", 123}, {"bar", true}}},
+            fkyaml::node {true, {true, 123, "foo"}},
+            fkyaml::node {true, {{"foo", 123}, {"bar", true}}},
+            fkyaml::node {true, nullptr},
+            fkyaml::node {123, {true, 123, "foo"}},
+            fkyaml::node {123, {{"foo", 123}, {"bar", true}}},
+            fkyaml::node {123, nullptr},
+            fkyaml::node {123, true},
+            fkyaml::node {3.14, {true, 123, "foo"}},
+            fkyaml::node {3.14, {{"foo", 123}, {"bar", true}}},
+            fkyaml::node {3.14, nullptr},
+            fkyaml::node {3.14, true},
+            fkyaml::node {3.14, 123},
+            fkyaml::node {"foo", {true, 123, "foo"}},
+            fkyaml::node {"foo", {{"foo", 123}, {"bar", true}}},
+            fkyaml::node {"foo", nullptr},
+            fkyaml::node {"foo", true},
+            fkyaml::node {"foo", 123},
+            fkyaml::node {"foo", 3.14});
+        REQUIRE(params[0] > params[1]);
+    }
+}
+
+TEST_CASE("NodeClassTest_GreaterThanOrEqualToOperatorTest", "[NodeClassTest]")
+{
+    SECTION("The same type and value.")
+    {
+        auto params = GENERATE(
+            fkyaml::node {{true, 123, "foo"}, {true, 123, "foo"}},
+            fkyaml::node {{{"foo", 123}, {"bar", true}}, {{"foo", 123}, {"bar", true}}},
+            fkyaml::node {nullptr, nullptr},
+            fkyaml::node {true, true},
+            fkyaml::node {123, 123},
+            fkyaml::node {3.14, 3.14},
+            fkyaml::node {"foo", "foo"});
+        REQUIRE(params[0] >= params[1]);
+    }
+
+    SECTION("The same type and the target value is less than the compared one.")
+    {
+        auto params = GENERATE(
+            fkyaml::node {{true, 123}, {true, 123, "foo"}},
+            fkyaml::node {{{"bar", true}}, {{"foo", 123}, {"bar", true}}},
+            fkyaml::node {false, true},
+            fkyaml::node {123, 456},
+            fkyaml::node {3.14, 4.25},
+            fkyaml::node {"foo", "qux"});
+        REQUIRE_FALSE(params[0] >= params[1]);
+    }
+
+    SECTION("The same type but the target value is greater than the compared one.")
+    {
+        auto params = GENERATE(
+            fkyaml::node {{true, 123, "foo"}, {true, 123}},
+            fkyaml::node {{{"foo", 123}, {"bar", true}}, {{"bar", true}}},
+            fkyaml::node {true, false},
+            fkyaml::node {456, 123},
+            fkyaml::node {4.25, 3.14},
+            fkyaml::node {"qux", "foo"});
+        REQUIRE(params[0] >= params[1]);
+    }
+
+    SECTION("The numeric value of the target type is less than that of the compared one")
+    {
+        auto params = GENERATE(
+            fkyaml::node {{true, 123, "foo"}, {{"foo", 123}, {"bar", true}}},
+            fkyaml::node {{true, 123, "foo"}, nullptr},
+            fkyaml::node {{true, 123, "foo"}, true},
+            fkyaml::node {{true, 123, "foo"}, 123},
+            fkyaml::node {{true, 123, "foo"}, 3.14},
+            fkyaml::node {{true, 123, "foo"}, "foo"},
+            fkyaml::node {{{"foo", 123}, {"bar", true}}, nullptr},
+            fkyaml::node {{{"foo", 123}, {"bar", true}}, true},
+            fkyaml::node {{{"foo", 123}, {"bar", true}}, 123},
+            fkyaml::node {{{"foo", 123}, {"bar", true}}, 3.14},
+            fkyaml::node {{{"foo", 123}, {"bar", true}}, "foo"},
+            fkyaml::node {nullptr, true},
+            fkyaml::node {nullptr, 123},
+            fkyaml::node {nullptr, 3.14},
+            fkyaml::node {nullptr, "foo"},
+            fkyaml::node {true, 123},
+            fkyaml::node {true, 3.14},
+            fkyaml::node {true, "foo"},
+            fkyaml::node {123, 3.14},
+            fkyaml::node {123, "foo"},
+            fkyaml::node {3.14, "foo"});
+        REQUIRE_FALSE(params[0] >= params[1]);
+    }
+
+    SECTION("The numeric value of the target type is greater than that of the compared one")
+    {
+        auto params = GENERATE(
+            fkyaml::node {{{"foo", 123}, {"bar", true}}, {true, 123, "foo"}},
+            fkyaml::node {nullptr, {true, 123, "foo"}},
+            fkyaml::node {nullptr, {{"foo", 123}, {"bar", true}}},
+            fkyaml::node {true, {true, 123, "foo"}},
+            fkyaml::node {true, {{"foo", 123}, {"bar", true}}},
+            fkyaml::node {true, nullptr},
+            fkyaml::node {123, {true, 123, "foo"}},
+            fkyaml::node {123, {{"foo", 123}, {"bar", true}}},
+            fkyaml::node {123, nullptr},
+            fkyaml::node {123, true},
+            fkyaml::node {3.14, {true, 123, "foo"}},
+            fkyaml::node {3.14, {{"foo", 123}, {"bar", true}}},
+            fkyaml::node {3.14, nullptr},
+            fkyaml::node {3.14, true},
+            fkyaml::node {3.14, 123},
+            fkyaml::node {"foo", {true, 123, "foo"}},
+            fkyaml::node {"foo", {{"foo", 123}, {"bar", true}}},
+            fkyaml::node {"foo", nullptr},
+            fkyaml::node {"foo", true},
+            fkyaml::node {"foo", 123},
+            fkyaml::node {"foo", 3.14});
+        REQUIRE(params[0] >= params[1]);
+    }
+}
+
+//
 // test cases for type property getter/checkers
 //
 


### PR DESCRIPTION
To prepare implementation in which non-string nodes are also supported as mapping keys, basic_node class operators for comparison have been added in this PR.  
Implementing those operator will enable basic_node class to be used as std::map::key_type.  
For detailed information about those operators, visit the API documentation pages.  
Furthermore, unit test cases and documentation have also been updated.  

---

## Pull Request Checklist

Read the [CONTRIBUTING.md](https://github.com/fktn-k/fkYAML/blob/develop/CONTRIBUTING.md) file for detailed information.  

- [x] Changes are described in the pull request or in a referenced [issue](https://github.com/fktn-k/fkYAML/issues).
- [x] The test suite compiles and runs without any error.
- [x] [The code coverage](https://coveralls.io/github/fktn-k/fkYAML) on your branch is 100%.
- [x] The documentation is updated if you added/changed a feature.

## Please don't

- The C++11 support varies between different **compilers** and versions. Please note the [list of supported compilers](https://github.com/fktn-k/fkYAML/blob/develop/README.md#supported-compilers). Some compilers like GCC 4.7 (and earlier), Clang 3.3 (and earlier), or Microsoft Visual Studio 13.0 and earlier are known not to work due to missing or incomplete C++11 support. Please refrain from proposing changes that work around these compiler's limitations with `#ifdef`s or other means.
- Please refrain from proposing changes that would **break [YAML](https://yaml.org/) specifications**. If you propose a conformant extension of YAML to be supported by the library, please motivate this extension.
- Please do not open pull requests that address **multiple issues**.