### PR TITLE
#240 Support non-string scalar nodes as mapping keys

### DIFF
--- a/docs/mkdocs/docs/api/basic_node/contains.md
+++ b/docs/mkdocs/docs/api/basic_node/contains.md
@@ -5,19 +5,25 @@
 ```cpp
 template <
     typename KeyType, detail::enable_if_t<
-                            detail::is_usable_as_key_type<
-                                typename mapping_type::key_compare, typename mapping_type::key_type, KeyType>::value,
+                            detail::conjunction<
+                                detail::negation<detail::is_basic_node<detail::remove_cvref_t<KeyType>>>,
+                                detail::is_node_compatible_type<basic_node, detail::remove_cvref_t<KeyType>>>::value,
                             int> = 0>
-bool contains(KeyType&& key) const;
+bool contains(KeyType&& key) const; // (1) A compatible key object with basic_node type
+
+template <
+    typename KeyType, detail::enable_if_t<detail::is_basic_node<detail::remove_cvref_t<KeyType>>::value, int> = 0>
+bool contains(KeyType&& key) const; // (2) A basic_node object
 ```
 
 Checks if the YAML node has the given key.  
-If the node value is not a mapping, this API will throw an [`fkyaml::exception`](../exception/index.md).  
+If the node value is not a mapping, this API will throw an [`fkyaml::type_error`](../exception/type_error.md).  
+The `KeyType` can be a compatible type with [`fkyaml::basic_node`](index.md) or a kind of [`fkyaml::basic_node`](index.md) template class.
 
 ## **Template Parameters**
 
 ***KeyType***
-:   A type compatible with the key type of mapping node values.
+:   A type which is compatible with or a kind of [`fkyaml::basic_node`](index.md).
 
 ## **Parameters**
 
@@ -43,7 +49,7 @@ If the node value is not a mapping, this API will throw an [`fkyaml::exception`]
         // check if the node has the following keys.
         std::cout << std::boolalpha;
         std::cout << n.contains("foo") << std::endl;
-        std::cout << n.contains("baz") << std::endl;
+        std::cout << n.contains(fkyaml::node("baz")) << std::endl;
 
         // create a YAML node. (not mapping)
         fkyaml::node n2 = "qux";
@@ -66,3 +72,4 @@ If the node value is not a mapping, this API will throw an [`fkyaml::exception`]
 
 * [basic_node](index.md)
 * [mapping_type](mapping_type.md)
+* [type_error](../exception/type_error.md)

--- a/docs/mkdocs/docs/api/basic_node/operator[].md
+++ b/docs/mkdocs/docs/api/basic_node/operator[].md
@@ -3,51 +3,77 @@
 # <small>fkyaml::basic_node::</small>operator[]
 
 ```cpp
-basic_node& operator[](std::size_t index); // (1)
-
-const basic_node& operator[](std::size_t index) const; // (2)
+template <
+    typename KeyType, detail::enable_if_t<
+                            detail::conjunction<
+                                detail::negation<detail::is_basic_node<KeyType>>,
+                                detail::is_node_compatible_type<basic_node, KeyType>>::value,
+                            int> = 0>
+basic_node& operator[](KeyType&& key); // (1)
 
 template <
     typename KeyType, detail::enable_if_t<
-                            detail::is_usable_as_key_type<
-                                typename mapping_type::key_compare, typename mapping_type::key_type, KeyType>::value,
+                            detail::conjunction<
+                                detail::negation<detail::is_basic_node<KeyType>>,
+                                detail::is_node_compatible_type<basic_node, KeyType>>::value,
                             int> = 0>
+const basic_node& operator[](KeyType&& key) const; // (2)
+
+template <
+    typename KeyType, detail::enable_if_t<detail::is_basic_node<detail::remove_cvref_t<KeyType>>::value, int> = 0>
 basic_node& operator[](KeyType&& key); // (3)
 
 template <
-    typename KeyType, detail::enable_if_t<
-                            detail::is_usable_as_key_type<
-                                typename mapping_type::key_compare, typename mapping_type::key_type, KeyType>::value,
-                            int> = 0>
+    typename KeyType, detail::enable_if_t<detail::is_basic_node<detail::remove_cvref_t<KeyType>>::value, int> = 0>
 const basic_node& operator[](KeyType&& key) const; // (4)
 ```
 
 Access to a YAML node element with either a key or an index.  
-If the node is neither a mapping nor a sequence, a [`fkyaml::exception`](../exception/index.md) will be thrown.  
-
-## Overload (1), (2)  
-
-```cpp
-basic_node& operator[](std::size_t index); // (1)
-const basic_node& operator[](std::size_t index) const; // (2)
-```
-
-Accesses to an element in the YAML sequence node with the given index.  
-If the node is not a sequence, a [`fkyaml::exception`](../exception/index.md) will be thrown.  
+If the node is neither a mapping nor a sequence, a [`fkyaml::type_error`](../exception/type_error.md) will be thrown.  
 
 !!! Danger
 
     This API does not check the size of a sequence node before accessing the element.  
-    To avoid undefined behaviors, please make sure the argument `index` is smaller than the actual sequence size with a return value of [`size()`](size.md).  
+    To avoid undefined behaviors, please make sure the argument `index` is smaller than the actual sequence size with a return value of the [`basic_node::size()`](size.md) function.  
+
+!!! Warning
+
+    This API does not check the existence of the given key in the YAML mapping node.  
+    If the given key does not exist, a default [basic_node](index.md) object will be created.  
+    Please make sure that the node has the given key in advance by calling the [`basic_node::contains()`](contains.md) function.  
+
+## Overload (1), (2)  
+
+```cpp
+template <
+    typename KeyType, detail::enable_if_t<
+                            detail::conjunction<
+                                detail::negation<detail::is_basic_node<KeyType>>,
+                                detail::is_node_compatible_type<basic_node, KeyType>>::value,
+                            int> = 0>
+basic_node& operator[](KeyType&& key); // (1)
+
+template <
+    typename KeyType, detail::enable_if_t<
+                            detail::conjunction<
+                                detail::negation<detail::is_basic_node<KeyType>>,
+                                detail::is_node_compatible_type<basic_node, KeyType>>::value,
+                            int> = 0>
+const basic_node& operator[](KeyType&& key) const; // (2)
+```
+
+Accesses to an element in the YAML sequence/mapping node with the given key object of a compatible type with the [`basic_node`](index.md) class, i.e., a type with which a [`basic_node`](index.md) object is constructible.  
+These overloads internally construct a [`basic_node`](index.md) object with `key`.  
+If the node is a scalar, or if it is a sequence but the key is not an integer, a [`fkyaml::type_error`](../exception/type_error.md) will be thrown.  
 
 ### **Parameters**
 
 ***`index`*** [in]
-:   An index for an element in the YAML sequence node.  
+:   An index/key for an element in the YAML sequence/mapping node.  
 
 ### **Return Value**
 
-Reference, or constant reference, to the YAML node at the given index.  
+Reference, or constant reference, to the YAML node object associated with the given index/key.  
 
 ???+ Example
 
@@ -58,58 +84,63 @@ Reference, or constant reference, to the YAML node at the given index.
     int main()
     {
         // create a YAML sequence node.
-        fkyaml::node n = {123, 234, 345, 456};
+        fkyaml::node n1 = {123, 234, 345, 456};
 
         // print YAML nodes at the following indexes.
-        std::cout << n[0] << std::endl;
-        std::cout << n[1] << std::endl;
-        std::cout << n[2] << std::endl;
-        std::cout << n[3] << std::endl;
+        std::cout << n1[0] << std::endl;
+        std::cout << n1[1] << std::endl;
+        std::cout << n1[2] << std::endl;
+        std::cout << n1[3] << std::endl;
+
+        // create a YAML mapping node.
+        fkyaml::node n2 = {{"foo", true}, {"bar", 123}};
+
+        // print YAML nodes associated with the following keys.
+        std::cout << std::boolalpha << n2["foo"] << std::endl;
+        std::cout << n2["bar"] << std::endl;
         return 0;
     }
+    ```
+    output:
+    ```bash
+    123
+    234
+    345
+    456
+    true
+    123
     ```
 
 ## Overload (3), (4)
 
 ```cpp
 template <
-    typename KeyType, detail::enable_if_t<
-                            detail::is_usable_as_key_type<
-                                typename mapping_type::key_compare, typename mapping_type::key_type, KeyType>::value,
-                            int> = 0>
+    typename KeyType, detail::enable_if_t<detail::is_basic_node<detail::remove_cvref_t<KeyType>>::value, int> = 0>
 basic_node& operator[](KeyType&& key); // (3)
 
 template <
-    typename KeyType, detail::enable_if_t<
-                            detail::is_usable_as_key_type<
-                                typename mapping_type::key_compare, typename mapping_type::key_type, KeyType>::value,
-                            int> = 0>
+    typename KeyType, detail::enable_if_t<detail::is_basic_node<detail::remove_cvref_t<KeyType>>::value, int> = 0>
 const basic_node& operator[](KeyType&& key) const; // (4)
 ```
 
-Accesses to an element in the YAML mapping node with the given key.  
-The given key must be of a compatible type with [`fkyaml::string_type`](string_type.md), i.e., a [`fkyaml::string_type`](string_type.md) object can be constructible with the given key.  
-If the node is not a mapping, a [`fkyaml::exception`](../exception/index.md) will be thrown.  
-
-!!! Warning
-
-    This API does not check the existence of the given key in the YAML mapping node.  
-    If the given key does not exist, a default [basic_node](index.md) object will be created.  
-    Please make sure that the node has the given key beforehand by calling the [`contains`](contains.md) API.  
+Accesses to an element in the YAML sequence/mapping node with the given [`basic_node`](index.md) key object.  
+Unlike the overloads (1) and (2) above, these overloads do not internally construct a [`basic_node`](index.md) object.  
+So, these overloads works more effectively when some key objects are used multiple times, for instance, in a for-loop.  
+If the node is a scalar, or if it is a sequence but the key is not an integer, a [`fkyaml::type_error`](../exception/type_error.md) will be thrown.  
 
 ### **Template Parameters**
 
 ***KeyType***
-:   A type compatible with the key type of mapping node values.
+:   A key type which is a kind of the [`basic_node`](index.md) template class.
 
 ### **Parameters**
 
 ***`key`*** [in]
-:   A key to the target value in the YAML mapping node.
+:   An index/key for an element in the YAML sequence/mapping node.
 
 ### **Return Value**
 
-Reference, or constant reference, to the YAML node associated with the given key.  
+Reference, or constant reference, to the YAML node object associated with the given index/key.  
 
 ???+ Example
 
@@ -119,15 +150,33 @@ Reference, or constant reference, to the YAML node associated with the given key
 
     int main()
     {
+        // create a YAML sequence node.
+        fkyaml::node n1 = {123, 234, 345, 456};
+
+        // print YAML nodes at the following indexes.
+        std::cout << n1[0] << std::endl;
+        std::cout << n1[1] << std::endl;
+        std::cout << n1[2] << std::endl;
+        std::cout << n1[3] << std::endl;
+
         // create a YAML node.
-        fkyaml::node n = {{"foo", true}, {"bar", 123}};
+        fkyaml::node n2 = {{"foo", true}, {"bar", 123}};
 
         // print YAML nodes associated with the following keys.
-        std::cout << std::boolalpha << n["foo"] << std::endl;
-        std::cout << n["bar"] << std::endl;
+        std::cout << std::boolalpha << n2[fkyaml::node("foo")] << std::endl;
+        std::cout << n2[fkyaml::node("bar")] << std::endl;
 
         return 0;
     }
+    ```
+    output:
+    ```bash
+    123
+    234
+    345
+    456
+    true
+    123
     ```
 
 ## **See Also**
@@ -136,3 +185,4 @@ Reference, or constant reference, to the YAML node associated with the given key
 * [size](size.md)
 * [contains](contains.md)
 * [operator<<](insertion_operator.md)
+* [type_error](../exception/type_error.md)

--- a/include/fkYAML/detail/conversions/to_node.hpp
+++ b/include/fkYAML/detail/conversions/to_node.hpp
@@ -286,10 +286,7 @@ inline void to_node(BasicNodeType& n, T b) noexcept
 /// @param i An integer object.
 template <
     typename BasicNodeType, typename T,
-    enable_if_t<
-        conjunction<
-            is_basic_node<BasicNodeType>, is_compatible_integer_type<typename BasicNodeType::integer_type, T>>::value,
-        int> = 0>
+    enable_if_t<conjunction<is_basic_node<BasicNodeType>, is_non_bool_integral<T>>::value, int> = 0>
 inline void to_node(BasicNodeType& n, T i) noexcept
 {
     external_node_constructor<node_t::INTEGER>::construct(n, i);

--- a/include/fkYAML/detail/input/deserializer.hpp
+++ b/include/fkYAML/detail/input/deserializer.hpp
@@ -370,7 +370,7 @@ public:
 private:
     /// @brief Add new key string to the current YAML node.
     /// @param key a key string to be added to the current YAML node.
-    void add_new_key(const string_type& key, const std::size_t indent, const std::size_t line)
+    void add_new_key(const BasicNodeType& key, const std::size_t indent, const std::size_t line)
     {
         if (!m_indent_stack.empty() && indent < m_indent_stack.back())
         {

--- a/include/fkYAML/detail/input/deserializer.hpp
+++ b/include/fkYAML/detail/input/deserializer.hpp
@@ -196,19 +196,18 @@ public:
             case lexical_token_t::NULL_VALUE: {
                 if (m_current_node->is_mapping())
                 {
-                    add_new_key(lexer.get_string(), cur_indent, cur_line);
+                    add_new_key(BasicNodeType(), cur_indent, cur_line);
                     break;
                 }
 
                 if (m_current_node->is_sequence())
                 {
-                    string_type str = lexer.get_string();
                     type = lexer.get_next_token();
 
                     // check if the current target token is a key or not.
                     if (type == lexical_token_t::KEY_SEPARATOR || type == lexical_token_t::MAPPING_BLOCK_PREFIX)
                     {
-                        add_new_key(str, cur_indent, cur_line);
+                        add_new_key(BasicNodeType(), cur_indent, cur_line);
                         cur_indent = lexer.get_last_token_begin_pos();
                         cur_line = lexer.get_lines_processed();
                         continue;
@@ -226,20 +225,19 @@ public:
             case lexical_token_t::BOOLEAN_VALUE: {
                 if (m_current_node->is_mapping())
                 {
-                    add_new_key(lexer.get_string(), cur_indent, cur_line);
+                    add_new_key(lexer.get_boolean(), cur_indent, cur_line);
                     break;
                 }
 
                 if (m_current_node->is_sequence())
                 {
                     boolean_type boolean = lexer.get_boolean();
-                    string_type str = lexer.get_string();
                     type = lexer.get_next_token();
 
                     // check if the current target token is a key or not.
                     if (type == lexical_token_t::KEY_SEPARATOR || type == lexical_token_t::MAPPING_BLOCK_PREFIX)
                     {
-                        add_new_key(str, cur_indent, cur_line);
+                        add_new_key(boolean, cur_indent, cur_line);
                         cur_indent = lexer.get_last_token_begin_pos();
                         cur_line = lexer.get_lines_processed();
                         continue;
@@ -257,20 +255,19 @@ public:
             case lexical_token_t::INTEGER_VALUE: {
                 if (m_current_node->is_mapping())
                 {
-                    add_new_key(lexer.get_string(), cur_indent, cur_line);
+                    add_new_key(lexer.get_integer(), cur_indent, cur_line);
                     break;
                 }
 
                 if (m_current_node->is_sequence())
                 {
                     integer_type integer = lexer.get_integer();
-                    string_type str = lexer.get_string();
                     type = lexer.get_next_token();
 
                     // check if the current target token is a key or not.
                     if (type == lexical_token_t::KEY_SEPARATOR || type == lexical_token_t::MAPPING_BLOCK_PREFIX)
                     {
-                        add_new_key(str, cur_indent, cur_line);
+                        add_new_key(integer, cur_indent, cur_line);
                         cur_indent = lexer.get_last_token_begin_pos();
                         cur_line = lexer.get_lines_processed();
                         continue;
@@ -288,20 +285,19 @@ public:
             case lexical_token_t::FLOAT_NUMBER_VALUE: {
                 if (m_current_node->is_mapping())
                 {
-                    add_new_key(lexer.get_string(), cur_indent, cur_line);
+                    add_new_key(lexer.get_float_number(), cur_indent, cur_line);
                     break;
                 }
 
                 if (m_current_node->is_sequence())
                 {
                     float_number_type float_val = lexer.get_float_number();
-                    string_type str = lexer.get_string();
                     type = lexer.get_next_token();
 
                     // check if the current target token is a key or not.
                     if (type == lexical_token_t::KEY_SEPARATOR || type == lexical_token_t::MAPPING_BLOCK_PREFIX)
                     {
-                        add_new_key(str, cur_indent, cur_line);
+                        add_new_key(float_val, cur_indent, cur_line);
                         cur_indent = lexer.get_last_token_begin_pos();
                         cur_line = lexer.get_lines_processed();
                         continue;

--- a/include/fkYAML/detail/iterator.hpp
+++ b/include/fkYAML/detail/iterator.hpp
@@ -420,7 +420,7 @@ public:
 
     /// @brief Get the key string of the YAML mapping node for the current iterator.
     /// @return const std::string& The key string of the YAML mapping node for the current iterator.
-    const std::string& key() const
+    const typename ValueType::mapping_type::key_type& key() const
     {
         if (m_inner_iterator_type == iterator_t::SEQUENCE)
         {

--- a/include/fkYAML/detail/meta/type_traits.hpp
+++ b/include/fkYAML/detail/meta/type_traits.hpp
@@ -100,13 +100,8 @@ struct is_compatible_integer_type_impl : std::false_type
 /// @tparam CompatibleIntegerType A compatible integer type.
 template <typename TargetIntegerType, typename CompatibleIntegerType>
 struct is_compatible_integer_type_impl<
-    TargetIntegerType, CompatibleIntegerType,
-    enable_if_t<conjunction<
-        std::is_integral<TargetIntegerType>, is_non_bool_integral<CompatibleIntegerType>,
-        std::is_constructible<TargetIntegerType, CompatibleIntegerType>,
-        disjunction<
-            is_all_signed<TargetIntegerType, CompatibleIntegerType>,
-            is_all_unsigned<TargetIntegerType, CompatibleIntegerType>>>::value>> : std::true_type
+    TargetIntegerType, CompatibleIntegerType, enable_if_t<is_non_bool_integral<CompatibleIntegerType>::value>>
+    : std::true_type
 {
 };
 

--- a/include/fkYAML/detail/output/serializer.hpp
+++ b/include/fkYAML/detail/output/serializer.hpp
@@ -82,7 +82,8 @@ private:
             for (auto itr = node.begin(); itr != node.end(); ++itr)
             {
                 insert_indentation(cur_indent, str);
-                serialize_key(itr.key().template get_value_ref<const std::string&>(), str);
+                serialize_node(itr.key(), cur_indent, str);
+                str += ":";
                 bool is_scalar = itr->is_scalar();
                 if (is_scalar)
                 {
@@ -320,14 +321,6 @@ private:
             break;
         }
         }
-    }
-
-    /// @brief Serialize mapping keys.
-    /// @param key A key string to be serialized.
-    /// @param str A string to hold serialization result.
-    void serialize_key(const std::string& key, std::string& str) const noexcept
-    {
-        str += key + ":";
     }
 
     /// @brief Insert indentation to the serialization result.

--- a/include/fkYAML/detail/output/serializer.hpp
+++ b/include/fkYAML/detail/output/serializer.hpp
@@ -82,7 +82,7 @@ private:
             for (auto itr = node.begin(); itr != node.end(); ++itr)
             {
                 insert_indentation(cur_indent, str);
-                serialize_key(itr.key(), str);
+                serialize_key(itr.key().template get_value_ref<const std::string&>(), str);
                 bool is_scalar = itr->is_scalar();
                 if (is_scalar)
                 {

--- a/include/fkYAML/node.hpp
+++ b/include/fkYAML/node.hpp
@@ -590,6 +590,11 @@ public:
         return *this;
     }
 
+    /// @brief A subscript operator of the basic_node class with a key of a compatible type with basic_node.
+    /// @tparam KeyType A key type compatible with basic_node
+    /// @param key A key to the target value in a sequence/mapping node.
+    /// @return The value associated with the given key, or a default basic_node object associated with the given key.
+    /// @sa https://fktn-k.github.io/fkYAML/api/basic_node/operator[]/
     template <
         typename KeyType, detail::enable_if_t<
                               detail::conjunction<
@@ -620,6 +625,11 @@ public:
         return m_node_value.p_mapping->operator[](std::move(n));
     }
 
+    /// @brief A subscript operator of the basic_node class with a key of a compatible type with basic_node.
+    /// @tparam KeyType A key type compatible with basic_node
+    /// @param key A key to the target value in a sequence/mapping node.
+    /// @return The value associated with the given key, or a default basic_node object associated with the given key.
+    /// @sa https://fktn-k.github.io/fkYAML/api/basic_node/operator[]/
     template <
         typename KeyType, detail::enable_if_t<
                               detail::conjunction<
@@ -650,6 +660,11 @@ public:
         return m_node_value.p_mapping->operator[](std::move(node_key));
     }
 
+    /// @brief A subscript operator of the basic_node class with a basic_node key object.
+    /// @tparam KeyType A key type which is a kind of the basic_node template class.
+    /// @param key A key to the target value in a sequence/mapping node.
+    /// @return The value associated with the given key, or a default basic_node object associated with the given key.
+    /// @sa https://fktn-k.github.io/fkYAML/api/basic_node/operator[]/
     template <
         typename KeyType, detail::enable_if_t<detail::is_basic_node<detail::remove_cvref_t<KeyType>>::value, int> = 0>
     basic_node& operator[](KeyType&& key)
@@ -674,6 +689,11 @@ public:
         return m_node_value.p_mapping->operator[](std::forward<KeyType>(key));
     }
 
+    /// @brief A subscript operator of the basic_node class with a basic_node key object.
+    /// @tparam KeyType A key type which is a kind of the basic_node template class.
+    /// @param key A key to the target value in a sequence/mapping node.
+    /// @return The value associated with the given key, or a default basic_node object associated with the given key.
+    /// @sa https://fktn-k.github.io/fkYAML/api/basic_node/operator[]/
     template <
         typename KeyType, detail::enable_if_t<detail::is_basic_node<detail::remove_cvref_t<KeyType>>::value, int> = 0>
     const basic_node& operator[](KeyType&& key) const
@@ -943,6 +963,11 @@ public:
         }
     }
 
+    /// @brief Check whether or not this basic_node object has a given key in its inner mapping node value.
+    /// @tparam KeyType A key type compatible with basic_node.
+    /// @param key A key to the target value in the mapping node value.
+    /// @return true if the target node is a mapping and has the given key, false otherwise.
+    /// @sa https://fktn-k.github.io/fkYAML/api/basic_node/contains/
     template <
         typename KeyType, detail::enable_if_t<
                               detail::conjunction<
@@ -965,7 +990,7 @@ public:
     }
 
     /// @brief Check whether or not this basic_node object has a given key in its inner mapping Node value.
-    /// @tparam KeyType A type compatible with the key type of mapping node values.
+    /// @tparam KeyType A key type which is a kind of basic_node template class.
     /// @param[in] key A key to the target value in the YAML mapping node value.
     /// @return true if the YAML node is a mapping and has the given key, false otherwise.
     /// @sa https://fktn-k.github.io/fkYAML/api/basic_node/contains/

--- a/include/fkYAML/node.hpp
+++ b/include/fkYAML/node.hpp
@@ -943,16 +943,34 @@ public:
         }
     }
 
+    template <
+        typename KeyType, detail::enable_if_t<
+                              detail::conjunction<
+                                  detail::negation<detail::is_basic_node<detail::remove_cvref_t<KeyType>>>,
+                                  detail::is_node_compatible_type<basic_node, detail::remove_cvref_t<KeyType>>>::value,
+                              int> = 0>
+    bool contains(KeyType&& key) const
+    {
+        switch (m_node_type)
+        {
+        case node_t::MAPPING: {
+            FK_YAML_ASSERT(m_node_value.p_mapping != nullptr);
+            mapping_type& map = *m_node_value.p_mapping;
+            basic_node node_key = std::forward<KeyType>(key);
+            return map.find(node_key) != map.end();
+        }
+        default:
+            return false;
+        }
+    }
+
     /// @brief Check whether or not this basic_node object has a given key in its inner mapping Node value.
     /// @tparam KeyType A type compatible with the key type of mapping node values.
     /// @param[in] key A key to the target value in the YAML mapping node value.
     /// @return true if the YAML node is a mapping and has the given key, false otherwise.
     /// @sa https://fktn-k.github.io/fkYAML/api/basic_node/contains/
     template <
-        typename KeyType, detail::enable_if_t<
-                              detail::is_usable_as_key_type<
-                                  typename mapping_type::key_compare, typename mapping_type::key_type, KeyType>::value,
-                              int> = 0>
+        typename KeyType, detail::enable_if_t<detail::is_basic_node<detail::remove_cvref_t<KeyType>>::value, int> = 0>
     bool contains(KeyType&& key) const
     {
         switch (m_node_type)

--- a/test/unit_test/test_deserializer_class.cpp
+++ b/test/unit_test/test_deserializer_class.cpp
@@ -63,14 +63,14 @@ TEST_CASE("DeserializerClassTest_DeserializeNullValue", "[DeserializerClassTes]"
     SECTION("key not in a sequence.")
     {
         REQUIRE_NOTHROW(root = deserializer.deserialize(fkyaml::detail::input_adapter("Null: test")));
-        REQUIRE(root.contains("Null"));
+        REQUIRE(root.contains(nullptr));
     }
 
     SECTION("key in a sequence.")
     {
         auto input = GENERATE(std::string("test:\n  - null: foo"), std::string("test:\n  - null:\n      - true"));
         REQUIRE_NOTHROW(root = deserializer.deserialize(fkyaml::detail::input_adapter(input)));
-        REQUIRE(root["test"][0].contains("null"));
+        REQUIRE(root["test"][0].contains(nullptr));
     }
 
     SECTION("mapping value.")
@@ -94,14 +94,14 @@ TEST_CASE("DeserializerClassTest_DeserializeBooleanValue", "[DeserializerClassTe
     SECTION("key not in a sequence.")
     {
         REQUIRE_NOTHROW(root = deserializer.deserialize(fkyaml::detail::input_adapter("true: test")));
-        REQUIRE(root.contains("true"));
+        REQUIRE(root.contains(true));
     }
 
     SECTION("key in a sequence.")
     {
         auto input = GENERATE(std::string("test:\n  - false: foo"), std::string("test:\n  - false:\n      - null"));
         REQUIRE_NOTHROW(root = deserializer.deserialize(fkyaml::detail::input_adapter(input)));
-        REQUIRE(root["test"][0].contains("false"));
+        REQUIRE(root["test"][0].contains(false));
     }
 
     SECTION("mapping value.")
@@ -125,14 +125,14 @@ TEST_CASE("DeserializerClassTest_DeserializeIntegerKey", "[DeserializerClassTest
     SECTION("key not in a sequence.")
     {
         REQUIRE_NOTHROW(root = deserializer.deserialize(fkyaml::detail::input_adapter("123: test")));
-        REQUIRE(root.contains("123"));
+        REQUIRE(root.contains(123));
     }
 
     SECTION("key in a sequence.")
     {
         auto input = GENERATE(std::string("test:\n  - 123: foo"), std::string("test:\n  - 123:\n      - true"));
         REQUIRE_NOTHROW(root = deserializer.deserialize(fkyaml::detail::input_adapter(input)));
-        REQUIRE(root["test"][0].contains("123"));
+        REQUIRE(root["test"][0].contains(123));
     }
 
     SECTION("mapping value.")
@@ -156,14 +156,14 @@ TEST_CASE("DeserializerClassTest_DeserializeFloatingPointNumberKey", "[Deseriali
     SECTION("key not in a sequence.")
     {
         REQUIRE_NOTHROW(root = deserializer.deserialize(fkyaml::detail::input_adapter("3.14: test")));
-        REQUIRE(root.contains("3.14"));
+        REQUIRE(root.contains(3.14));
     }
 
     SECTION("key in a sequence.")
     {
         auto input = GENERATE(std::string("test:\n  - .inf: foo"), std::string("test:\n  - .inf:\n      - true"));
         REQUIRE_NOTHROW(root = deserializer.deserialize(fkyaml::detail::input_adapter(input)));
-        REQUIRE(root["test"][0].contains(".inf"));
+        REQUIRE(root["test"][0].contains(std::numeric_limits<fkyaml::node::float_number_type>::infinity()));
     }
 
     SECTION("mapping value.")

--- a/test/unit_test/test_iterator_class.cpp
+++ b/test/unit_test/test_iterator_class.cpp
@@ -44,7 +44,7 @@ TEST_CASE("IteratorClassTest_MappingCopyCtorTest", "[IteratorClassTest]")
         fkyaml::detail::mapping_iterator_tag {}, mapping.get_value_ref<fkyaml::node::mapping_type&>().begin());
     fkyaml::detail::iterator<fkyaml::node> iterator(copied);
     REQUIRE(iterator.type() == fkyaml::detail::iterator_t::MAPPING);
-    REQUIRE(iterator.key().compare("test") == 0);
+    REQUIRE(iterator.key().get_value_ref<const std::string&>() == "test");
     REQUIRE(iterator.value().is_null());
 }
 
@@ -66,7 +66,7 @@ TEST_CASE("IteratorClassTest_MappingMoveCtorTest", "[IteratorClassTest]")
         fkyaml::detail::mapping_iterator_tag {}, mapping.get_value_ref<fkyaml::node::mapping_type&>().begin());
     fkyaml::detail::iterator<fkyaml::node> iterator(std::move(moved));
     REQUIRE(iterator.type() == fkyaml::detail::iterator_t::MAPPING);
-    REQUIRE(iterator.key().compare("test") == 0);
+    REQUIRE(iterator.key().get_value_ref<const std::string&>() == "test");
     REQUIRE(iterator.value().is_null());
 }
 
@@ -132,7 +132,7 @@ TEST_CASE("IteratorClassTest_AssignmentOperatorTest", "[IteratorClassTest]")
         {
             iterator = copied_itr;
             REQUIRE(iterator.type() == fkyaml::detail::iterator_t::MAPPING);
-            REQUIRE(iterator.key().compare("key") == 0);
+            REQUIRE(iterator.key().get_value_ref<const std::string&>() == "key");
             REQUIRE(iterator.value().is_string());
             REQUIRE(iterator.value().get_value_ref<fkyaml::node::string_type&>().compare("test") == 0);
         }
@@ -141,7 +141,7 @@ TEST_CASE("IteratorClassTest_AssignmentOperatorTest", "[IteratorClassTest]")
         {
             iterator = std::move(copied_itr);
             REQUIRE(iterator.type() == fkyaml::detail::iterator_t::MAPPING);
-            REQUIRE(iterator.key().compare("key") == 0);
+            REQUIRE(iterator.key().get_value_ref<const std::string&>() == "key");
             REQUIRE(iterator.value().is_string());
             REQUIRE(iterator.value().get_value_ref<fkyaml::node::string_type&>().compare("test") == 0);
         }
@@ -204,7 +204,7 @@ TEST_CASE("IteratorClassTest_CompoundAssignmentOperatorBySumTest", "[IteratorCla
         fkyaml::detail::iterator<fkyaml::node> iterator(
             fkyaml::detail::mapping_iterator_tag {}, mapping.get_value_ref<fkyaml::node::mapping_type&>().begin());
         iterator += 1;
-        REQUIRE(iterator.key().compare("test1") == 0);
+        REQUIRE(iterator.key().get_value_ref<const std::string&>() == "test1");
         REQUIRE(iterator.value().is_boolean());
         REQUIRE(iterator.value().get_value<fkyaml::node::boolean_type>() == true);
     }
@@ -228,7 +228,7 @@ TEST_CASE("IteratorClassTest_PlusOperatorTest", "[IteratorClassTest]")
         fkyaml::detail::iterator<fkyaml::node> iterator(
             fkyaml::detail::mapping_iterator_tag {}, mapping.get_value_ref<fkyaml::node::mapping_type&>().begin());
         fkyaml::detail::iterator<fkyaml::node> after_plus_itr = iterator + 1;
-        REQUIRE(after_plus_itr.key().compare("test1") == 0);
+        REQUIRE(after_plus_itr.key().get_value_ref<const std::string&>() == "test1");
         REQUIRE(after_plus_itr.value().is_boolean());
         REQUIRE(after_plus_itr.value().get_value<fkyaml::node::boolean_type>() == true);
     }
@@ -252,7 +252,7 @@ TEST_CASE("IteratorClassTest_PreIncrementOperatorTest", "[IteratorClassTest]")
         fkyaml::detail::iterator<fkyaml::node> iterator(
             fkyaml::detail::mapping_iterator_tag {}, mapping.get_value_ref<fkyaml::node::mapping_type&>().begin());
         ++iterator;
-        REQUIRE(iterator.key().compare("test1") == 0);
+        REQUIRE(iterator.key().get_value_ref<const std::string&>() == "test1");
         REQUIRE(iterator.value().is_boolean());
         REQUIRE(iterator.value().get_value<fkyaml::node::boolean_type>() == true);
     }
@@ -276,7 +276,7 @@ TEST_CASE("IteratorClassTest_PostIncrementOperatorTest", "[IteratorClassTest]")
         fkyaml::detail::iterator<fkyaml::node> iterator(
             fkyaml::detail::mapping_iterator_tag {}, mapping.get_value_ref<fkyaml::node::mapping_type&>().begin());
         iterator++;
-        REQUIRE(iterator.key().compare("test1") == 0);
+        REQUIRE(iterator.key().get_value_ref<const std::string&>() == "test1");
         REQUIRE(iterator.value().is_boolean());
         REQUIRE(iterator.value().get_value<fkyaml::node::boolean_type>() == true);
     }
@@ -300,7 +300,7 @@ TEST_CASE("IteratorClassTest_CompoundAssignmentOperatorByDifferenceTest", "[Iter
         fkyaml::detail::iterator<fkyaml::node> iterator(
             fkyaml::detail::mapping_iterator_tag {}, mapping.get_value_ref<fkyaml::node::mapping_type&>().end());
         iterator -= 1;
-        REQUIRE(iterator.key().compare("test1") == 0);
+        REQUIRE(iterator.key().get_value_ref<const std::string&>() == "test1");
         REQUIRE(iterator.value().is_boolean());
         REQUIRE(iterator.value().get_value<fkyaml::node::boolean_type>() == true);
     }
@@ -324,7 +324,7 @@ TEST_CASE("IteratorClassTest_MinusOperatorTest", "[IteratorClassTest]")
         fkyaml::detail::iterator<fkyaml::node> iterator(
             fkyaml::detail::mapping_iterator_tag {}, mapping.get_value_ref<fkyaml::node::mapping_type&>().end());
         fkyaml::detail::iterator<fkyaml::node> after_minus_itr = iterator - 1;
-        REQUIRE(after_minus_itr.key().compare("test1") == 0);
+        REQUIRE(after_minus_itr.key().get_value_ref<const std::string&>() == "test1");
         REQUIRE(after_minus_itr.value().is_boolean());
         REQUIRE(after_minus_itr.value().get_value<fkyaml::node::boolean_type>() == true);
     }
@@ -348,7 +348,7 @@ TEST_CASE("IteratorClassTest_PreDecrementOperatorTest", "[IteratorClassTest]")
         fkyaml::detail::iterator<fkyaml::node> iterator(
             fkyaml::detail::mapping_iterator_tag {}, mapping.get_value_ref<fkyaml::node::mapping_type&>().end());
         --iterator;
-        REQUIRE(iterator.key().compare("test1") == 0);
+        REQUIRE(iterator.key().get_value_ref<const std::string&>() == "test1");
         REQUIRE(iterator.value().is_boolean());
         REQUIRE(iterator.value().get_value<fkyaml::node::boolean_type>() == true);
     }
@@ -372,7 +372,7 @@ TEST_CASE("IteratorClassTest_PostDecrementOperatorTest", "[IteratorClassTest]")
         fkyaml::detail::iterator<fkyaml::node> iterator(
             fkyaml::detail::mapping_iterator_tag {}, mapping.get_value_ref<fkyaml::node::mapping_type&>().end());
         iterator--;
-        REQUIRE(iterator.key().compare("test1") == 0);
+        REQUIRE(iterator.key().get_value_ref<const std::string&>() == "test1");
         REQUIRE(iterator.value().is_boolean());
         REQUIRE(iterator.value().get_value<fkyaml::node::boolean_type>() == true);
     }
@@ -633,7 +633,7 @@ TEST_CASE("IteratorClassTest_KeyGetterTest", "[IteratorClassTest]")
         fkyaml::detail::iterator<fkyaml::node> iterator(
             fkyaml::detail::mapping_iterator_tag {}, mapping.get_value_ref<fkyaml::node::mapping_type&>().begin());
         REQUIRE_NOTHROW(iterator.key());
-        REQUIRE(iterator.key().compare("test0") == 0);
+        REQUIRE(iterator.key().get_value_ref<const std::string&>() == "test0");
     }
 }
 

--- a/test/unit_test/test_node_class.cpp
+++ b/test/unit_test/test_node_class.cpp
@@ -1863,30 +1863,16 @@ TEST_CASE("NodeClassTest_ContainsTest", "[NodeClassTest]")
     SECTION("Test mapping node.")
     {
         fkyaml::node node = fkyaml::node::mapping({{"test", fkyaml::node()}});
-        std::string key = "test";
 
-        SECTION("Test non-alias mapping node with lvalue key.")
+        SECTION("Test mapping node with a string key.")
         {
-            REQUIRE(node.contains(key));
+            REQUIRE(node.contains("test"));
         }
 
-        SECTION("Test alias mapping node with lvalue key.")
+        SECTION("Test mapping node with a string node key.")
         {
-            node.add_anchor_name("anchor_name");
-            fkyaml::node alias = fkyaml::node::alias_of(node);
-            REQUIRE(node.contains(key));
-        }
-
-        SECTION("Test non-alias mapping node with rvalue key.")
-        {
-            REQUIRE(node.contains(std::move(key)));
-        }
-
-        SECTION("Test alias mapping node with rvalue key.")
-        {
-            node.add_anchor_name("anchor_name");
-            fkyaml::node alias = fkyaml::node::alias_of(node);
-            REQUIRE(node.contains(std::move(key)));
+            fkyaml::node node_key = "test";
+            REQUIRE(node.contains(node_key));
         }
     }
 
@@ -1899,30 +1885,16 @@ TEST_CASE("NodeClassTest_ContainsTest", "[NodeClassTest]")
             fkyaml::node(0),
             fkyaml::node(0.0),
             fkyaml::node(""));
-        std::string key = "test";
 
-        SECTION("Test non-alias non-mapping node with lvalue key.")
+        SECTION("Test non-mapping node with a key.")
         {
-            REQUIRE_FALSE(node.contains(key));
+            REQUIRE_FALSE(node.contains("test"));
         }
 
-        SECTION("Test alias non-mapping node with lvalue key.")
+        SECTION("Test non-mapping node with a node key.")
         {
-            node.add_anchor_name("anchor_name");
-            fkyaml::node alias = fkyaml::node::alias_of(node);
-            REQUIRE_FALSE(alias.contains(key));
-        }
-
-        SECTION("Test non-alias non-mapping node with rvalue key.")
-        {
-            REQUIRE_FALSE(node.contains(std::move(key)));
-        }
-
-        SECTION("Test alias non-mapping node with rvalue key.")
-        {
-            node.add_anchor_name("anchor_name");
-            fkyaml::node alias = fkyaml::node::alias_of(node);
-            REQUIRE_FALSE(alias.contains(std::move(key)));
+            fkyaml::node node_key = "test";
+            REQUIRE_FALSE(node.contains(node_key));
         }
     }
 }

--- a/test/unit_test/test_node_class.cpp
+++ b/test/unit_test/test_node_class.cpp
@@ -685,9 +685,9 @@ TEST_CASE("NodeClassTest_AliasNodeFactoryTest", "[NodeClassTest]")
 // test cases for subscript operators
 //
 
-TEST_CASE("NodeClassTest_StringSubscriptOperatorTest", "[NodeClassTest]")
+TEST_CASE("NodeClassTest_SubscriptOperatorTest", "[NodeClassTest]")
 {
-    SECTION("Test nothrow expected string subscript operators.")
+    SECTION("Test nothrow expected subscript operators for mapping nodes.")
     {
         fkyaml::node::mapping_type map {{"test", fkyaml::node()}};
 
@@ -702,28 +702,10 @@ TEST_CASE("NodeClassTest_StringSubscriptOperatorTest", "[NodeClassTest]")
                 REQUIRE(node[key].is_null());
             }
 
-            SECTION("Test the non-const alias lvalue string subscript operator.")
-            {
-                std::string key = "test";
-                node.add_anchor_name("anchor_name");
-                fkyaml::node alias = fkyaml::node::alias_of(node);
-                REQUIRE_NOTHROW(alias[key]);
-                REQUIRE(alias[key].is_null());
-            }
-
             SECTION("Test the non-const rvalue string subscript operator.")
             {
                 REQUIRE_NOTHROW(node["test"]);
                 REQUIRE(node["test"].is_null());
-            }
-
-            SECTION("Test the const alias lvalue string subscript operator.")
-            {
-                std::string key = "test";
-                node.add_anchor_name("anchor_name");
-                const fkyaml::node alias = fkyaml::node::alias_of(node);
-                REQUIRE_NOTHROW(alias[key]);
-                REQUIRE(alias[key].is_null());
             }
         }
 
@@ -735,105 +717,141 @@ TEST_CASE("NodeClassTest_StringSubscriptOperatorTest", "[NodeClassTest]")
             SECTION("Test the const lvalue string subscript operator.")
             {
                 REQUIRE_NOTHROW(node[key]);
-                REQUIRE(node[key].is_null());
             }
 
             SECTION("Test the const rvalue string subscript operator.")
             {
                 REQUIRE_NOTHROW(node["test"]);
-                REQUIRE(node["test"].is_null());
+            }
+        }
+
+        SECTION("Test the non-const string node subscript operators.")
+        {
+            fkyaml::node node = fkyaml::node::mapping(map);
+            fkyaml::node node_key = "test";
+
+            SECTION("Test the non-const lvalue string subscript operator.")
+            {
+                REQUIRE_NOTHROW(node[node_key]);
+            }
+
+            SECTION("Test the non-const rvalue string subscript operator.")
+            {
+                REQUIRE_NOTHROW(node[std::move(node_key)]);
+            }
+        }
+
+        SECTION("Test the const string node subscript operators.")
+        {
+            const fkyaml::node node = fkyaml::node::mapping(map);
+            fkyaml::node node_key = "test";
+
+            SECTION("Test the non-const lvalue string subscript operator.")
+            {
+                REQUIRE_NOTHROW(node[node_key]);
+            }
+
+            SECTION("Test the non-const rvalue string subscript operator.")
+            {
+                REQUIRE_NOTHROW(node[std::move(node_key)]);
             }
         }
     }
 
-    SECTION("Test throwing expected string subscript operator.")
-    {
-        auto node = GENERATE(
-            fkyaml::node::sequence(),
-            fkyaml::node(),
-            fkyaml::node(false),
-            fkyaml::node(0),
-            fkyaml::node(0.0),
-            fkyaml::node(""));
-
-        SECTION("Test non-const lvalue throwing invocation.")
-        {
-            std::string key = "test";
-            REQUIRE_THROWS_AS(node[key], fkyaml::type_error);
-        }
-
-        SECTION("Test const lvalue throwing invocation.")
-        {
-            std::string key = "test";
-            const fkyaml::node const_node = node;
-            REQUIRE_THROWS_AS(const_node[key], fkyaml::type_error);
-        }
-
-        SECTION("Test non-const rvalue throwing invocation.")
-        {
-            REQUIRE_THROWS_AS(node["test"], fkyaml::type_error);
-        }
-
-        SECTION("Test const rvalue throwing invocation.")
-        {
-            const fkyaml::node const_node = node;
-            REQUIRE_THROWS_AS(const_node["test"], fkyaml::type_error);
-        }
-    }
-}
-
-TEST_CASE("NodeClassTest_IntegerSubscriptOperatorTest", "[NodeClassTest]")
-{
-    SECTION("Test nothrow expected integer subscript operators.")
+    SECTION("Test nothrow expected subscript operators for sequence nodes.")
     {
         fkyaml::node node = fkyaml::node::sequence();
         node.get_value_ref<fkyaml::node::sequence_type&>().emplace_back();
 
-        SECTION("Test non-const non-alias integer subscript operators")
+        SECTION("Test non-const integer subscript operators")
         {
             REQUIRE_NOTHROW(node[0]);
         }
 
-        SECTION("Test non-const alias integer subscript operators")
-        {
-            node.add_anchor_name("anchor_name");
-            fkyaml::node alias = fkyaml::node::alias_of(node);
-            REQUIRE_NOTHROW(alias[0]);
-        }
-
-        SECTION("Test const non-alias integer subscript operators")
+        SECTION("Test const integer subscript operators")
         {
             const fkyaml::node const_node = node;
             REQUIRE_NOTHROW(const_node[0]);
         }
 
-        SECTION("Test const alias integer subscript operators")
+        SECTION("Test non-const integer subscript operators")
         {
-            node.add_anchor_name("anchor_name");
-            const fkyaml::node alias = fkyaml::node::alias_of(node);
-            REQUIRE_NOTHROW(alias[0]);
+            REQUIRE_NOTHROW(node[fkyaml::node(0)]);
+        }
+
+        SECTION("Test const integer subscript operators")
+        {
+            const fkyaml::node const_node = node;
+            REQUIRE_NOTHROW(const_node[fkyaml::node(0)]);
         }
     }
 
-    SECTION("Test throwing expected integer subscript operator.")
+    SECTION("Test throwing expected subscript operator for sequence nodes.")
     {
-        auto node = GENERATE(
-            fkyaml::node::mapping(),
-            fkyaml::node(),
-            fkyaml::node(false),
-            fkyaml::node(0),
-            fkyaml::node(0.0),
-            fkyaml::node(""));
+        fkyaml::node node = fkyaml::node::sequence();
+        node.get_value_ref<fkyaml::node::sequence_type&>().emplace_back();
 
-        SECTION("Test non-const non-sequence nodes.")
+        SECTION("Test non-const node with a non-integer value.")
+        {
+            REQUIRE_THROWS_AS(node[fkyaml::node::sequence_type()], fkyaml::type_error);
+            REQUIRE_THROWS_AS(node[fkyaml::node::mapping_type()], fkyaml::type_error);
+            REQUIRE_THROWS_AS(node[nullptr], fkyaml::type_error);
+            REQUIRE_THROWS_AS(node[false], fkyaml::type_error);
+            REQUIRE_THROWS_AS(node[0.0], fkyaml::type_error);
+            REQUIRE_THROWS_AS(node[""], fkyaml::type_error);
+        }
+
+        SECTION("Test const node with a non-integer value.")
+        {
+            const fkyaml::node const_node = node;
+            REQUIRE_THROWS_AS(const_node[fkyaml::node::sequence_type()], fkyaml::type_error);
+            REQUIRE_THROWS_AS(const_node[fkyaml::node::mapping_type()], fkyaml::type_error);
+            REQUIRE_THROWS_AS(const_node[nullptr], fkyaml::type_error);
+            REQUIRE_THROWS_AS(const_node[false], fkyaml::type_error);
+            REQUIRE_THROWS_AS(const_node[0.0], fkyaml::type_error);
+            REQUIRE_THROWS_AS(const_node[""], fkyaml::type_error);
+        }
+
+        fkyaml::node node_key =
+            GENERATE(fkyaml::node::mapping(), fkyaml::node(), fkyaml::node(false), fkyaml::node(0.0), fkyaml::node(""));
+
+        SECTION("Test non-const node with a non-integer node.")
+        {
+            REQUIRE_THROWS_AS(node[node_key], fkyaml::type_error);
+        }
+
+        SECTION("Test const node with a non-integer node.")
+        {
+            const fkyaml::node const_node = node;
+            REQUIRE_THROWS_AS(const_node[node_key], fkyaml::type_error);
+        }
+    }
+
+    SECTION("Test throwing expected subscript operator for scalar nodes.")
+    {
+        auto node = GENERATE(fkyaml::node(), fkyaml::node(false), fkyaml::node(0), fkyaml::node(0.0), fkyaml::node(""));
+        fkyaml::node node_key = 0;
+
+        SECTION("Test non-const node with an integer.")
         {
             REQUIRE_THROWS_AS(node[0], fkyaml::type_error);
         }
 
-        SECTION("Test const non-sequence nodes.")
+        SECTION("Test const node with an integer.")
         {
             const fkyaml::node const_node = node;
             REQUIRE_THROWS_AS(const_node[0], fkyaml::type_error);
+        }
+
+        SECTION("Test non-const node with an integer node.")
+        {
+            REQUIRE_THROWS_AS(node[node_key], fkyaml::type_error);
+        }
+
+        SECTION("Test const node with an integer node.")
+        {
+            const fkyaml::node const_node = node;
+            REQUIRE_THROWS_AS(const_node[node_key], fkyaml::type_error);
         }
     }
 }


### PR DESCRIPTION
In this PR, non-string scalar nodes have become acceptable as mapping keys.  
Sequence/mapping nodes are still unavailable. (Those will also be supported soon.)  
Along with the implementation above, `basic_node::operator[]` has been expanded to access an inner `basic_node` element within sequence/mapping nodes.  
See the documentation for more detailed information.  

---

## Pull Request Checklist

Read the [CONTRIBUTING.md](https://github.com/fktn-k/fkYAML/blob/develop/CONTRIBUTING.md) file for detailed information.  

- [x] Changes are described in the pull request or in a referenced [issue](https://github.com/fktn-k/fkYAML/issues).
- [x] The test suite compiles and runs without any error.
- [x] [The code coverage](https://coveralls.io/github/fktn-k/fkYAML) on your branch is 100%.
- [x] The documentation is updated if you added/changed a feature.

## Please don't

- The C++11 support varies between different **compilers** and versions. Please note the [list of supported compilers](https://github.com/fktn-k/fkYAML/blob/develop/README.md#supported-compilers). Some compilers like GCC 4.7 (and earlier), Clang 3.3 (and earlier), or Microsoft Visual Studio 13.0 and earlier are known not to work due to missing or incomplete C++11 support. Please refrain from proposing changes that work around these compiler's limitations with `#ifdef`s or other means.
- Please refrain from proposing changes that would **break [YAML](https://yaml.org/) specifications**. If you propose a conformant extension of YAML to be supported by the library, please motivate this extension.
- Please do not open pull requests that address **multiple issues**.