### PR TITLE
#240 Support explicit block mappings & non-scalar nodes as mapping keys

### DIFF
--- a/include/fkYAML/detail/input/deserializer.hpp
+++ b/include/fkYAML/detail/input/deserializer.hpp
@@ -267,215 +267,49 @@ public:
                 m_node_stack.pop_back();
                 break;
             case lexical_token_t::NULL_VALUE: {
-                if (m_current_node->is_mapping())
+                bool do_continue =
+                    deserialize_scalar(lexer, BasicNodeType(lexer.get_null()), cur_indent, cur_line, type);
+                if (do_continue)
                 {
-                    add_new_key(BasicNodeType(), cur_indent, cur_line);
-                    break;
-                }
-
-                type = lexer.get_next_token();
-                if (m_current_node->is_sequence())
-                {
-                    // check if the current target token is a key or not.
-                    if (type == lexical_token_t::KEY_SEPARATOR || type == lexical_token_t::MAPPING_BLOCK_PREFIX)
-                    {
-                        add_new_key(BasicNodeType(), cur_indent, cur_line);
-                        cur_indent = lexer.get_last_token_begin_pos();
-                        cur_line = lexer.get_lines_processed();
-                        continue;
-                    }
-
-                    assign_node_value(BasicNodeType());
-                    cur_indent = lexer.get_last_token_begin_pos();
-                    cur_line = lexer.get_lines_processed();
                     continue;
                 }
-
-                if (type == lexical_token_t::KEY_SEPARATOR || type == lexical_token_t::MAPPING_BLOCK_PREFIX)
-                {
-                    if (cur_line == lexer.get_lines_processed())
-                    {
-                        *m_current_node = BasicNodeType::mapping();
-                        add_new_key(BasicNodeType(), cur_indent, cur_line);
-                        cur_indent = lexer.get_last_token_begin_pos();
-                        cur_line = lexer.get_lines_processed();
-                        continue;
-                    }
-                }
-                assign_node_value(BasicNodeType());
-                cur_indent = lexer.get_last_token_begin_pos();
-                cur_line = lexer.get_lines_processed();
-                continue;
+                break;
             }
             case lexical_token_t::BOOLEAN_VALUE: {
-                if (m_current_node->is_mapping())
+                bool do_continue =
+                    deserialize_scalar(lexer, BasicNodeType(lexer.get_boolean()), cur_indent, cur_line, type);
+                if (do_continue)
                 {
-                    add_new_key(lexer.get_boolean(), cur_indent, cur_line);
-                    break;
-                }
-
-                boolean_type boolean = lexer.get_boolean();
-                type = lexer.get_next_token();
-                if (m_current_node->is_sequence())
-                {
-                    // check if the current target token is a key or not.
-                    if (type == lexical_token_t::KEY_SEPARATOR || type == lexical_token_t::MAPPING_BLOCK_PREFIX)
-                    {
-                        add_new_key(boolean, cur_indent, cur_line);
-                        cur_indent = lexer.get_last_token_begin_pos();
-                        cur_line = lexer.get_lines_processed();
-                        continue;
-                    }
-
-                    assign_node_value(BasicNodeType(boolean));
-                    cur_indent = lexer.get_last_token_begin_pos();
-                    cur_line = lexer.get_lines_processed();
                     continue;
                 }
-
-                if (type == lexical_token_t::KEY_SEPARATOR || type == lexical_token_t::MAPPING_BLOCK_PREFIX)
-                {
-                    if (cur_line == lexer.get_lines_processed())
-                    {
-                        *m_current_node = BasicNodeType::mapping();
-                        add_new_key(boolean, cur_indent, cur_line);
-                        cur_indent = lexer.get_last_token_begin_pos();
-                        cur_line = lexer.get_lines_processed();
-                        continue;
-                    }
-                }
-                assign_node_value(BasicNodeType(boolean));
-                cur_indent = lexer.get_last_token_begin_pos();
-                cur_line = lexer.get_lines_processed();
-                continue;
+                break;
             }
             case lexical_token_t::INTEGER_VALUE: {
-                if (m_current_node->is_mapping())
+                bool do_continue =
+                    deserialize_scalar(lexer, BasicNodeType(lexer.get_integer()), cur_indent, cur_line, type);
+                if (do_continue)
                 {
-                    add_new_key(lexer.get_integer(), cur_indent, cur_line);
-                    break;
-                }
-
-                integer_type integer = lexer.get_integer();
-                type = lexer.get_next_token();
-                if (m_current_node->is_sequence())
-                {
-                    // check if the current target token is a key or not.
-                    if (type == lexical_token_t::KEY_SEPARATOR || type == lexical_token_t::MAPPING_BLOCK_PREFIX)
-                    {
-                        add_new_key(integer, cur_indent, cur_line);
-                        cur_indent = lexer.get_last_token_begin_pos();
-                        cur_line = lexer.get_lines_processed();
-                        continue;
-                    }
-
-                    assign_node_value(BasicNodeType(integer));
-                    cur_indent = lexer.get_last_token_begin_pos();
-                    cur_line = lexer.get_lines_processed();
                     continue;
                 }
-
-                if (type == lexical_token_t::KEY_SEPARATOR || type == lexical_token_t::MAPPING_BLOCK_PREFIX)
-                {
-                    if (cur_line == lexer.get_lines_processed())
-                    {
-                        *m_current_node = BasicNodeType::mapping();
-                        add_new_key(integer, cur_indent, cur_line);
-                        cur_indent = lexer.get_last_token_begin_pos();
-                        cur_line = lexer.get_lines_processed();
-                        continue;
-                    }
-                }
-                assign_node_value(BasicNodeType(integer));
-                cur_indent = lexer.get_last_token_begin_pos();
-                cur_line = lexer.get_lines_processed();
-                continue;
+                break;
             }
             case lexical_token_t::FLOAT_NUMBER_VALUE: {
-                if (m_current_node->is_mapping())
+                bool do_continue =
+                    deserialize_scalar(lexer, BasicNodeType(lexer.get_float_number()), cur_indent, cur_line, type);
+                if (do_continue)
                 {
-                    add_new_key(lexer.get_float_number(), cur_indent, cur_line);
-                    break;
-                }
-
-                float_number_type float_val = lexer.get_float_number();
-                type = lexer.get_next_token();
-                if (m_current_node->is_sequence())
-                {
-
-                    // check if the current target token is a key or not.
-                    if (type == lexical_token_t::KEY_SEPARATOR || type == lexical_token_t::MAPPING_BLOCK_PREFIX)
-                    {
-                        add_new_key(float_val, cur_indent, cur_line);
-                        cur_indent = lexer.get_last_token_begin_pos();
-                        cur_line = lexer.get_lines_processed();
-                        continue;
-                    }
-
-                    assign_node_value(BasicNodeType(float_val));
-                    cur_indent = lexer.get_last_token_begin_pos();
-                    cur_line = lexer.get_lines_processed();
                     continue;
                 }
-
-                if (type == lexical_token_t::KEY_SEPARATOR || type == lexical_token_t::MAPPING_BLOCK_PREFIX)
-                {
-                    if (cur_line == lexer.get_lines_processed())
-                    {
-                        *m_current_node = BasicNodeType::mapping();
-                        add_new_key(float_val, cur_indent, cur_line);
-                        cur_indent = lexer.get_last_token_begin_pos();
-                        cur_line = lexer.get_lines_processed();
-                        continue;
-                    }
-                }
-                assign_node_value(BasicNodeType(float_val));
-                cur_indent = lexer.get_last_token_begin_pos();
-                cur_line = lexer.get_lines_processed();
-                continue;
+                break;
             }
             case lexical_token_t::STRING_VALUE: {
-                if (m_current_node->is_mapping())
+                bool do_continue =
+                    deserialize_scalar(lexer, BasicNodeType(lexer.get_string()), cur_indent, cur_line, type);
+                if (do_continue)
                 {
-                    add_new_key(lexer.get_string(), cur_indent, cur_line);
-                    break;
-                }
-
-                string_type str = lexer.get_string();
-                type = lexer.get_next_token();
-                if (m_current_node->is_sequence())
-                {
-
-                    // check if the current target token is a key or not.
-                    if (type == lexical_token_t::KEY_SEPARATOR || type == lexical_token_t::MAPPING_BLOCK_PREFIX)
-                    {
-                        add_new_key(str, cur_indent, cur_line);
-                        cur_indent = lexer.get_last_token_begin_pos();
-                        cur_line = lexer.get_lines_processed();
-                        continue;
-                    }
-
-                    assign_node_value(BasicNodeType(str));
-                    cur_indent = lexer.get_last_token_begin_pos();
-                    cur_line = lexer.get_lines_processed();
                     continue;
                 }
-
-                if (type == lexical_token_t::KEY_SEPARATOR || type == lexical_token_t::MAPPING_BLOCK_PREFIX)
-                {
-                    if (cur_line == lexer.get_lines_processed())
-                    {
-                        *m_current_node = BasicNodeType::mapping();
-                        add_new_key(str, cur_indent, cur_line);
-                        cur_indent = lexer.get_last_token_begin_pos();
-                        cur_line = lexer.get_lines_processed();
-                        continue;
-                    }
-                }
-                assign_node_value(BasicNodeType(str));
-                cur_indent = lexer.get_last_token_begin_pos();
-                cur_line = lexer.get_lines_processed();
-                continue;
+                break;
             }
             case lexical_token_t::END_OF_DIRECTIVES:
                 break;
@@ -586,6 +420,47 @@ private:
             m_current_node = m_node_stack.back();
             m_node_stack.pop_back();
         }
+    }
+
+    /// @brief Deserialize a detected scalar node.
+    /// @param node A detected scalar node by a lexer.
+    /// @param indent The current indentation width. Can be updated in this function.
+    /// @param line The number of processed lines. Can be updated in this function.
+    /// @return true if next token has already been got, false otherwise.
+    template <typename LexerType>
+    bool deserialize_scalar(
+        LexerType& lexer, BasicNodeType&& node, std::size_t& indent, std::size_t& line, lexical_token_t& type)
+    {
+        if (m_current_node->is_mapping())
+        {
+            add_new_key(node, indent, line);
+            return false;
+        }
+
+        type = lexer.get_next_token();
+        if (type == lexical_token_t::KEY_SEPARATOR || type == lexical_token_t::MAPPING_BLOCK_PREFIX)
+        {
+            if (m_current_node->is_scalar())
+            {
+                if (line != lexer.get_lines_processed())
+                {
+                    // This path is for explicit mapping key separator(:)
+                    assign_node_value(std::move(node));
+                    indent = lexer.get_last_token_begin_pos();
+                    line = lexer.get_lines_processed();
+                    return true;
+                }
+                *m_current_node = BasicNodeType::mapping();
+            }
+            add_new_key(node, indent, line);
+        }
+        else
+        {
+            assign_node_value(std::move(node));
+        }
+        indent = lexer.get_last_token_begin_pos();
+        line = lexer.get_lines_processed();
+        return true;
     }
 
     /// @brief Set the yaml_version_t object to the given node.

--- a/include/fkYAML/detail/input/deserializer.hpp
+++ b/include/fkYAML/detail/input/deserializer.hpp
@@ -101,7 +101,8 @@ public:
                 if (type == lexical_token_t::SEQUENCE_BLOCK_PREFIX)
                 {
                     m_node_stack.push_back(m_current_node);
-                    m_indent_stack.emplace_back(lexer.get_last_token_begin_pos(), true);
+                    m_indent_stack.emplace_back(cur_indent, true);
+                    m_indent_stack.emplace_back(lexer.get_last_token_begin_pos(), false);
                     m_current_node = new BasicNodeType(node_t::SEQUENCE);
                     set_yaml_version(*m_current_node);
                     break;

--- a/include/fkYAML/detail/input/deserializer.hpp
+++ b/include/fkYAML/detail/input/deserializer.hpp
@@ -148,7 +148,16 @@ public:
                 key_node = nullptr;
                 m_node_stack.push_back(m_node_stack.back());
                 m_indent_stack.back().second = false;
-                break;
+
+                type = lexer.get_next_token();
+                if (type == lexical_token_t::SEQUENCE_BLOCK_PREFIX)
+                {
+                    *m_current_node = BasicNodeType::sequence();
+                    set_yaml_version(*m_current_node);
+                }
+                cur_indent = lexer.get_last_token_begin_pos();
+                cur_line = lexer.get_lines_processed();
+                continue;
             }
             case lexical_token_t::VALUE_SEPARATOR:
                 break;
@@ -264,10 +273,9 @@ public:
                     break;
                 }
 
+                type = lexer.get_next_token();
                 if (m_current_node->is_sequence())
                 {
-                    type = lexer.get_next_token();
-
                     // check if the current target token is a key or not.
                     if (type == lexical_token_t::KEY_SEPARATOR || type == lexical_token_t::MAPPING_BLOCK_PREFIX)
                     {
@@ -283,8 +291,21 @@ public:
                     continue;
                 }
 
+                if (type == lexical_token_t::KEY_SEPARATOR || type == lexical_token_t::MAPPING_BLOCK_PREFIX)
+                {
+                    if (cur_line == lexer.get_lines_processed())
+                    {
+                        *m_current_node = BasicNodeType::mapping();
+                        add_new_key(BasicNodeType(), cur_indent, cur_line);
+                        cur_indent = lexer.get_last_token_begin_pos();
+                        cur_line = lexer.get_lines_processed();
+                        continue;
+                    }
+                }
                 assign_node_value(BasicNodeType());
-                break;
+                cur_indent = lexer.get_last_token_begin_pos();
+                cur_line = lexer.get_lines_processed();
+                continue;
             }
             case lexical_token_t::BOOLEAN_VALUE: {
                 if (m_current_node->is_mapping())
@@ -293,11 +314,10 @@ public:
                     break;
                 }
 
+                boolean_type boolean = lexer.get_boolean();
+                type = lexer.get_next_token();
                 if (m_current_node->is_sequence())
                 {
-                    boolean_type boolean = lexer.get_boolean();
-                    type = lexer.get_next_token();
-
                     // check if the current target token is a key or not.
                     if (type == lexical_token_t::KEY_SEPARATOR || type == lexical_token_t::MAPPING_BLOCK_PREFIX)
                     {
@@ -313,8 +333,21 @@ public:
                     continue;
                 }
 
-                assign_node_value(BasicNodeType(lexer.get_boolean()));
-                break;
+                if (type == lexical_token_t::KEY_SEPARATOR || type == lexical_token_t::MAPPING_BLOCK_PREFIX)
+                {
+                    if (cur_line == lexer.get_lines_processed())
+                    {
+                        *m_current_node = BasicNodeType::mapping();
+                        add_new_key(boolean, cur_indent, cur_line);
+                        cur_indent = lexer.get_last_token_begin_pos();
+                        cur_line = lexer.get_lines_processed();
+                        continue;
+                    }
+                }
+                assign_node_value(BasicNodeType(boolean));
+                cur_indent = lexer.get_last_token_begin_pos();
+                cur_line = lexer.get_lines_processed();
+                continue;
             }
             case lexical_token_t::INTEGER_VALUE: {
                 if (m_current_node->is_mapping())
@@ -323,11 +356,10 @@ public:
                     break;
                 }
 
+                integer_type integer = lexer.get_integer();
+                type = lexer.get_next_token();
                 if (m_current_node->is_sequence())
                 {
-                    integer_type integer = lexer.get_integer();
-                    type = lexer.get_next_token();
-
                     // check if the current target token is a key or not.
                     if (type == lexical_token_t::KEY_SEPARATOR || type == lexical_token_t::MAPPING_BLOCK_PREFIX)
                     {
@@ -343,8 +375,21 @@ public:
                     continue;
                 }
 
-                assign_node_value(BasicNodeType(lexer.get_integer()));
-                break;
+                if (type == lexical_token_t::KEY_SEPARATOR || type == lexical_token_t::MAPPING_BLOCK_PREFIX)
+                {
+                    if (cur_line == lexer.get_lines_processed())
+                    {
+                        *m_current_node = BasicNodeType::mapping();
+                        add_new_key(integer, cur_indent, cur_line);
+                        cur_indent = lexer.get_last_token_begin_pos();
+                        cur_line = lexer.get_lines_processed();
+                        continue;
+                    }
+                }
+                assign_node_value(BasicNodeType(integer));
+                cur_indent = lexer.get_last_token_begin_pos();
+                cur_line = lexer.get_lines_processed();
+                continue;
             }
             case lexical_token_t::FLOAT_NUMBER_VALUE: {
                 if (m_current_node->is_mapping())
@@ -353,10 +398,10 @@ public:
                     break;
                 }
 
+                float_number_type float_val = lexer.get_float_number();
+                type = lexer.get_next_token();
                 if (m_current_node->is_sequence())
                 {
-                    float_number_type float_val = lexer.get_float_number();
-                    type = lexer.get_next_token();
 
                     // check if the current target token is a key or not.
                     if (type == lexical_token_t::KEY_SEPARATOR || type == lexical_token_t::MAPPING_BLOCK_PREFIX)
@@ -373,8 +418,21 @@ public:
                     continue;
                 }
 
-                assign_node_value(BasicNodeType(lexer.get_float_number()));
-                break;
+                if (type == lexical_token_t::KEY_SEPARATOR || type == lexical_token_t::MAPPING_BLOCK_PREFIX)
+                {
+                    if (cur_line == lexer.get_lines_processed())
+                    {
+                        *m_current_node = BasicNodeType::mapping();
+                        add_new_key(float_val, cur_indent, cur_line);
+                        cur_indent = lexer.get_last_token_begin_pos();
+                        cur_line = lexer.get_lines_processed();
+                        continue;
+                    }
+                }
+                assign_node_value(BasicNodeType(float_val));
+                cur_indent = lexer.get_last_token_begin_pos();
+                cur_line = lexer.get_lines_processed();
+                continue;
             }
             case lexical_token_t::STRING_VALUE: {
                 if (m_current_node->is_mapping())
@@ -384,9 +442,9 @@ public:
                 }
 
                 string_type str = lexer.get_string();
+                type = lexer.get_next_token();
                 if (m_current_node->is_sequence())
                 {
-                    type = lexer.get_next_token();
 
                     // check if the current target token is a key or not.
                     if (type == lexical_token_t::KEY_SEPARATOR || type == lexical_token_t::MAPPING_BLOCK_PREFIX)
@@ -403,8 +461,21 @@ public:
                     continue;
                 }
 
+                if (type == lexical_token_t::KEY_SEPARATOR || type == lexical_token_t::MAPPING_BLOCK_PREFIX)
+                {
+                    if (cur_line == lexer.get_lines_processed())
+                    {
+                        *m_current_node = BasicNodeType::mapping();
+                        add_new_key(str, cur_indent, cur_line);
+                        cur_indent = lexer.get_last_token_begin_pos();
+                        cur_line = lexer.get_lines_processed();
+                        continue;
+                    }
+                }
                 assign_node_value(BasicNodeType(str));
-                break;
+                cur_indent = lexer.get_last_token_begin_pos();
+                cur_line = lexer.get_lines_processed();
+                continue;
             }
             case lexical_token_t::END_OF_DIRECTIVES:
                 break;

--- a/include/fkYAML/detail/input/lexical_analyzer.hpp
+++ b/include/fkYAML/detail/input/lexical_analyzer.hpp
@@ -100,7 +100,16 @@ public:
         switch (current)
         {
         case end_of_input: // end of input buffer
-            return lexical_token_t::END_OF_BUFFER;
+            return m_last_token_type = lexical_token_t::END_OF_BUFFER;
+        case '?':
+            switch (m_input_handler.get_next())
+            {
+            case ' ':
+                return m_last_token_type = lexical_token_t::EXPLICIT_KEY_PREFIX;
+            default:
+                m_input_handler.unget();
+                return m_last_token_type = scan_string();
+            }
         case ':': // key separater
             switch (m_input_handler.get_next())
             {

--- a/include/fkYAML/detail/types/lexical_token_t.hpp
+++ b/include/fkYAML/detail/types/lexical_token_t.hpp
@@ -24,6 +24,7 @@ namespace detail
 enum class lexical_token_t
 {
     END_OF_BUFFER,         //!< the end of input buffer.
+    EXPLICIT_KEY_PREFIX,   //!< the character for explicit mapping key prefix `?`.
     KEY_SEPARATOR,         //!< the key separater `:`
     VALUE_SEPARATOR,       //!< the value separater `,`
     ANCHOR_PREFIX,         //!< the character for anchor prefix `&`

--- a/test/unit_test/test_deserializer_class.cpp
+++ b/test/unit_test/test_deserializer_class.cpp
@@ -888,12 +888,13 @@ TEST_CASE("DeserializerClassTest_DeserializeBlockMappingTest", "[DeserializerCla
                                                            "  : baz\n"
                                                            "? ? foo\n"
                                                            "  : bar\n"
-                                                           ": baz\n"
+                                                           ": - baz\n"
+                                                           "  - qux\n"
                                                            "? - 123\n"
                                                            "  - foo:\n"
                                                            "      ? bar\n"
                                                            "      : baz\n"
-                                                           ": true");
+                                                           ": one: true");
 
         REQUIRE_NOTHROW(root = deserializer.deserialize(std::move(input_adapter)));
 
@@ -914,13 +915,21 @@ TEST_CASE("DeserializerClassTest_DeserializeBlockMappingTest", "[DeserializerCla
 
         fkyaml::node key = {{"foo", "bar"}};
         REQUIRE(root.contains(key));
-        REQUIRE(root[key].is_string());
-        REQUIRE(root[key].get_value_ref<std::string&>() == "baz");
+        REQUIRE(root[key].is_sequence());
+        REQUIRE(root[key].size() == 2);
+        REQUIRE(root[key][0].is_string());
+        REQUIRE(root[key][0].get_value_ref<std::string&>() == "baz");
+        REQUIRE(root[key][1].is_string());
+        REQUIRE(root[key][1].get_value_ref<std::string&>() == "qux");
 
         key = {123, {{"foo", {{"bar", "baz"}}}}};
         REQUIRE(root.contains(key));
-        REQUIRE(root[key].is_boolean());
-        REQUIRE(root[key].get_value<bool>() == true);
+        REQUIRE(root[key].is_mapping());
+        REQUIRE(root[key].size() == 1);
+
+        REQUIRE(root[key].contains("one"));
+        REQUIRE(root[key]["one"].is_boolean());
+        REQUIRE(root[key]["one"].get_value<bool>() == true);
     }
 }
 

--- a/test/unit_test/test_deserializer_class.cpp
+++ b/test/unit_test/test_deserializer_class.cpp
@@ -891,7 +891,8 @@ TEST_CASE("DeserializerClassTest_DeserializeBlockMappingTest", "[DeserializerCla
                                                            ": baz\n"
                                                            "? - 123\n"
                                                            "  - foo:\n"
-                                                           "      bar: baz\n"
+                                                           "      ? bar\n"
+                                                           "      : baz\n"
                                                            ": true");
 
         REQUIRE_NOTHROW(root = deserializer.deserialize(std::move(input_adapter)));

--- a/test/unit_test/test_deserializer_class.cpp
+++ b/test/unit_test/test_deserializer_class.cpp
@@ -886,15 +886,15 @@ TEST_CASE("DeserializerClassTest_DeserializeBlockMappingTest", "[DeserializerCla
                                                            "foo:\n"
                                                            "  ? bar\n"
                                                            "  : baz\n"
-                                                           "? ? foo\n"
-                                                           "  : bar\n"
-                                                           ": - baz\n"
-                                                           "  - qux\n"
                                                            "? - 123\n"
                                                            "  - foo:\n"
                                                            "      ? bar\n"
                                                            "      : baz\n"
-                                                           ": one: true");
+                                                           ": one: true\n"
+                                                           "? ? foo\n"
+                                                           "  : bar\n"
+                                                           ": - baz\n"
+                                                           "  - qux\n");
 
         REQUIRE_NOTHROW(root = deserializer.deserialize(std::move(input_adapter)));
 
@@ -913,16 +913,7 @@ TEST_CASE("DeserializerClassTest_DeserializeBlockMappingTest", "[DeserializerCla
         REQUIRE(root["foo"]["bar"].is_string());
         REQUIRE(root["foo"]["bar"].get_value_ref<std::string&>() == "baz");
 
-        fkyaml::node key = {{"foo", "bar"}};
-        REQUIRE(root.contains(key));
-        REQUIRE(root[key].is_sequence());
-        REQUIRE(root[key].size() == 2);
-        REQUIRE(root[key][0].is_string());
-        REQUIRE(root[key][0].get_value_ref<std::string&>() == "baz");
-        REQUIRE(root[key][1].is_string());
-        REQUIRE(root[key][1].get_value_ref<std::string&>() == "qux");
-
-        key = {123, {{"foo", {{"bar", "baz"}}}}};
+        fkyaml::node key = {123, {{"foo", {{"bar", "baz"}}}}};
         REQUIRE(root.contains(key));
         REQUIRE(root[key].is_mapping());
         REQUIRE(root[key].size() == 1);
@@ -930,6 +921,15 @@ TEST_CASE("DeserializerClassTest_DeserializeBlockMappingTest", "[DeserializerCla
         REQUIRE(root[key].contains("one"));
         REQUIRE(root[key]["one"].is_boolean());
         REQUIRE(root[key]["one"].get_value<bool>() == true);
+
+        key = {{"foo", "bar"}};
+        REQUIRE(root.contains(key));
+        REQUIRE(root[key].is_sequence());
+        REQUIRE(root[key].size() == 2);
+        REQUIRE(root[key][0].is_string());
+        REQUIRE(root[key][0].get_value_ref<std::string&>() == "baz");
+        REQUIRE(root[key][1].is_string());
+        REQUIRE(root[key][1].get_value_ref<std::string&>() == "qux");
     }
 }
 

--- a/test/unit_test/test_lexical_analyzer_class.cpp
+++ b/test/unit_test/test_lexical_analyzer_class.cpp
@@ -432,6 +432,7 @@ TEST_CASE("LexicalAnalyzerClassTest_ScanStringTokenTest", "[LexicalAnalyzerClass
         value_pair_t(std::string("test"), fkyaml::node::string_type("test")),
         value_pair_t(std::string("nop"), fkyaml::node::string_type("nop")),
         value_pair_t(std::string("none"), fkyaml::node::string_type("none")),
+        value_pair_t(std::string("?test"), fkyaml::node::string_type("?test")),
         value_pair_t(std::string(".NET"), fkyaml::node::string_type(".NET")),
         value_pair_t(std::string(".on"), fkyaml::node::string_type(".on")),
         value_pair_t(std::string(".n"), fkyaml::node::string_type(".n")),


### PR DESCRIPTION
In this PR, explicit block mappings and sequence/mapping keys have been supported in the deserialization feature.  
Also, new unit test cases have been added to ensure the newly supported features work as expected.  

---

## Pull Request Checklist

Read the [CONTRIBUTING.md](https://github.com/fktn-k/fkYAML/blob/develop/CONTRIBUTING.md) file for detailed information.  

- [x] Changes are described in the pull request or in a referenced [issue](https://github.com/fktn-k/fkYAML/issues).
- [x] The test suite compiles and runs without any error.
- [x] [The code coverage](https://coveralls.io/github/fktn-k/fkYAML) on your branch is 100%.
- [x] The documentation is updated if you added/changed a feature.

## Please don't

- The C++11 support varies between different **compilers** and versions. Please note the [list of supported compilers](https://github.com/fktn-k/fkYAML/blob/develop/README.md#supported-compilers). Some compilers like GCC 4.7 (and earlier), Clang 3.3 (and earlier), or Microsoft Visual Studio 13.0 and earlier are known not to work due to missing or incomplete C++11 support. Please refrain from proposing changes that work around these compiler's limitations with `#ifdef`s or other means.
- Please refrain from proposing changes that would **break [YAML](https://yaml.org/) specifications**. If you propose a conformant extension of YAML to be supported by the library, please motivate this extension.
- Please do not open pull requests that address **multiple issues**.