### PR TITLE
Fixed missing callings of `fclose()` in the unit tests

### DIFF
--- a/test/unit_test/test_encode_detector.cpp
+++ b/test/unit_test/test_encode_detector.cpp
@@ -318,6 +318,8 @@ TEST_CASE("EncodeDetectorTest_DetectEncodingAndSkipBomTest", "[EncodeDetectorTes
         fkyaml::detail::encode_t ret = fkyaml::detail::detect_encoding_and_skip_bom(p_file);
         REQUIRE(ret == fkyaml::detail::encode_t::UTF_8_N);
         REQUIRE(std::ftell(p_file) == 0);
+
+        std::fclose(p_file);
     }
 
     SECTION("FILE* object with UTF-8(BOM) encoding")
@@ -330,6 +332,8 @@ TEST_CASE("EncodeDetectorTest_DetectEncodingAndSkipBomTest", "[EncodeDetectorTes
         fkyaml::detail::encode_t ret = fkyaml::detail::detect_encoding_and_skip_bom(p_file);
         REQUIRE(ret == fkyaml::detail::encode_t::UTF_8_BOM);
         REQUIRE(std::ftell(p_file) == 3);
+
+        std::fclose(p_file);
     }
 
     SECTION("FILE* object with UTF-16BE encoding")
@@ -342,6 +346,8 @@ TEST_CASE("EncodeDetectorTest_DetectEncodingAndSkipBomTest", "[EncodeDetectorTes
         fkyaml::detail::encode_t ret = fkyaml::detail::detect_encoding_and_skip_bom(p_file);
         REQUIRE(ret == fkyaml::detail::encode_t::UTF_16BE_N);
         REQUIRE(std::ftell(p_file) == 0);
+
+        std::fclose(p_file);
     }
 
     SECTION("FILE* object with UTF-16BE(BOM) encoding")
@@ -354,6 +360,8 @@ TEST_CASE("EncodeDetectorTest_DetectEncodingAndSkipBomTest", "[EncodeDetectorTes
         fkyaml::detail::encode_t ret = fkyaml::detail::detect_encoding_and_skip_bom(p_file);
         REQUIRE(ret == fkyaml::detail::encode_t::UTF_16BE_BOM);
         REQUIRE(std::ftell(p_file) == 2);
+
+        std::fclose(p_file);
     }
 
     SECTION("FILE* object with UTF-16LE encoding")
@@ -366,6 +374,8 @@ TEST_CASE("EncodeDetectorTest_DetectEncodingAndSkipBomTest", "[EncodeDetectorTes
         fkyaml::detail::encode_t ret = fkyaml::detail::detect_encoding_and_skip_bom(p_file);
         REQUIRE(ret == fkyaml::detail::encode_t::UTF_16LE_N);
         REQUIRE(std::ftell(p_file) == 0);
+
+        std::fclose(p_file);
     }
 
     SECTION("FILE* object with UTF-16LE(BOM) encoding")
@@ -378,6 +388,8 @@ TEST_CASE("EncodeDetectorTest_DetectEncodingAndSkipBomTest", "[EncodeDetectorTes
         fkyaml::detail::encode_t ret = fkyaml::detail::detect_encoding_and_skip_bom(p_file);
         REQUIRE(ret == fkyaml::detail::encode_t::UTF_16LE_BOM);
         REQUIRE(std::ftell(p_file) == 2);
+
+        std::fclose(p_file);
     }
 
     SECTION("FILE* object with UTF-32BE encoding")
@@ -390,6 +402,8 @@ TEST_CASE("EncodeDetectorTest_DetectEncodingAndSkipBomTest", "[EncodeDetectorTes
         fkyaml::detail::encode_t ret = fkyaml::detail::detect_encoding_and_skip_bom(p_file);
         REQUIRE(ret == fkyaml::detail::encode_t::UTF_32BE_N);
         REQUIRE(std::ftell(p_file) == 0);
+
+        std::fclose(p_file);
     }
 
     SECTION("FILE* object with UTF-32BE(BOM) encoding")
@@ -402,6 +416,8 @@ TEST_CASE("EncodeDetectorTest_DetectEncodingAndSkipBomTest", "[EncodeDetectorTes
         fkyaml::detail::encode_t ret = fkyaml::detail::detect_encoding_and_skip_bom(p_file);
         REQUIRE(ret == fkyaml::detail::encode_t::UTF_32BE_BOM);
         REQUIRE(std::ftell(p_file) == 4);
+
+        std::fclose(p_file);
     }
 
     SECTION("FILE* object with UTF-32LE encoding")
@@ -414,6 +430,8 @@ TEST_CASE("EncodeDetectorTest_DetectEncodingAndSkipBomTest", "[EncodeDetectorTes
         fkyaml::detail::encode_t ret = fkyaml::detail::detect_encoding_and_skip_bom(p_file);
         REQUIRE(ret == fkyaml::detail::encode_t::UTF_32LE_N);
         REQUIRE(std::ftell(p_file) == 0);
+
+        std::fclose(p_file);
     }
 
     SECTION("FILE* object with UTF-32LE(BOM) encoding")
@@ -426,6 +444,8 @@ TEST_CASE("EncodeDetectorTest_DetectEncodingAndSkipBomTest", "[EncodeDetectorTes
         fkyaml::detail::encode_t ret = fkyaml::detail::detect_encoding_and_skip_bom(p_file);
         REQUIRE(ret == fkyaml::detail::encode_t::UTF_32LE_BOM);
         REQUIRE(std::ftell(p_file) == 4);
+
+        std::fclose(p_file);
     }
 
     SECTION("FILE* object with an empty input file")
@@ -438,6 +458,8 @@ TEST_CASE("EncodeDetectorTest_DetectEncodingAndSkipBomTest", "[EncodeDetectorTes
         fkyaml::detail::encode_t ret = fkyaml::detail::detect_encoding_and_skip_bom(p_file);
         REQUIRE(ret == fkyaml::detail::encode_t::UTF_8_N);
         REQUIRE(std::ftell(p_file) == 0);
+
+        std::fclose(p_file);
     }
 
     /////////////////////////////


### PR DESCRIPTION
I've noticed that the test with Valgrind emits warnings about possible memory leaks.  
Although it's turned out missing callings of the `std::fclose()` function in the unit tests for encode detector is the cause and that doesn't affect the fkYAML library itself, it should be better to fix them.  
No other fixes are included in this PR.  

---

## Pull Request Checklist

Read the [CONTRIBUTING.md](https://github.com/fktn-k/fkYAML/blob/develop/CONTRIBUTING.md) file for detailed information.  

- [x] Changes are described in the pull request or in a referenced [issue](https://github.com/fktn-k/fkYAML/issues).
- [x] The test suite compiles and runs without any error.
- [x] [The code coverage](https://coveralls.io/github/fktn-k/fkYAML) on your branch is 100%.
- [x] The documentation is updated if you added/changed a feature.

## Please don't

- The C++11 support varies between different **compilers** and versions. Please note the [list of supported compilers](https://github.com/fktn-k/fkYAML/blob/develop/README.md#supported-compilers). Some compilers like GCC 4.7 (and earlier), Clang 3.3 (and earlier), or Microsoft Visual Studio 13.0 and earlier are known not to work due to missing or incomplete C++11 support. Please refrain from proposing changes that work around these compiler's limitations with `#ifdef`s or other means.
- Please refrain from proposing changes that would **break [YAML](https://yaml.org/) specifications**. If you propose a conformant extension of YAML to be supported by the library, please motivate this extension.
- Please do not open pull requests that address **multiple issues**.