### PR TITLE
#240 Support non-string-scalar node keys in basic_node ctor with std::initializer_list

### DIFF
--- a/include/fkYAML/node.hpp
+++ b/include/fkYAML/node.hpp
@@ -410,7 +410,7 @@ public:
     {
         bool is_mapping =
             std::all_of(init.begin(), init.end(), [](const detail::node_ref_storage<basic_node>& node_ref) {
-                return node_ref->is_sequence() && node_ref->size() == 2 && node_ref->operator[](0).is_string();
+                return node_ref->is_sequence() && node_ref->size() == 2;
             });
 
         if (is_mapping)
@@ -422,8 +422,7 @@ public:
             {
                 auto elem = elem_ref.release();
                 m_node_value.p_mapping->emplace(
-                    std::move(*((*(elem.m_node_value.p_sequence))[0].m_node_value.p_string)),
-                    std::move((*(elem.m_node_value.p_sequence))[1]));
+                    std::move((*(elem.m_node_value.p_sequence))[0]), std::move((*(elem.m_node_value.p_sequence))[1]));
             }
         }
         else

--- a/test/unit_test/test_node_class.cpp
+++ b/test/unit_test/test_node_class.cpp
@@ -344,30 +344,39 @@ TEST_CASE("NodeClassTest_InitializerListCtorTest", "[NodeClassTest]")
 {
     fkyaml::node node = {
         {"foo", 3.14},
-        {"bar", 123},
-        {"baz", {true, false}},
-        {"qux", nullptr},
-    };
+        {true, 123},
+        {567, {true, false}},
+        {{true, 1.57}, nullptr},
+        {{{"bar", nullptr}}, {{"baz", "qux"}}}};
+
+    REQUIRE(node.is_mapping());
+    REQUIRE(node.size() == 5);
 
     REQUIRE(node.contains("foo"));
     REQUIRE(node["foo"].is_float_number());
     REQUIRE(node["foo"].get_value_ref<fkyaml::node::float_number_type&>() == 3.14);
 
-    REQUIRE(node.contains("bar"));
-    REQUIRE(node["bar"].is_integer());
-    REQUIRE(node["bar"].get_value_ref<fkyaml::node::integer_type&>() == 123);
+    REQUIRE(node.contains(true));
+    REQUIRE(node[true].is_integer());
+    REQUIRE(node[true].get_value_ref<fkyaml::node::integer_type&>() == 123);
 
-    REQUIRE(node.contains("baz"));
-    REQUIRE(node["baz"].is_sequence());
-    REQUIRE(node["baz"].size() == 2);
-    auto& baz_seq = node["baz"].get_value_ref<fkyaml::node::sequence_type&>();
-    REQUIRE(baz_seq[0].is_boolean());
-    REQUIRE(baz_seq[0].get_value_ref<fkyaml::node::boolean_type&>() == true);
-    REQUIRE(baz_seq[1].is_boolean());
-    REQUIRE(baz_seq[1].get_value_ref<fkyaml::node::boolean_type&>() == false);
+    REQUIRE(node.contains(567));
+    REQUIRE(node[567].is_sequence());
+    REQUIRE(node[567].size() == 2);
+    REQUIRE(node[567][0].is_boolean());
+    REQUIRE(node[567][0].get_value_ref<fkyaml::node::boolean_type&>() == true);
+    REQUIRE(node[567][1].is_boolean());
+    REQUIRE(node[567][1].get_value_ref<fkyaml::node::boolean_type&>() == false);
 
-    REQUIRE(node.contains("qux"));
-    REQUIRE(node["qux"].is_null());
+    REQUIRE(node.contains(fkyaml::node {true, 1.57}));
+    REQUIRE(node[fkyaml::node {true, 1.57}].is_null());
+
+    REQUIRE(node.contains(fkyaml::node {{"bar", nullptr}}));
+    REQUIRE(node[fkyaml::node {{"bar", nullptr}}].is_mapping());
+    REQUIRE(node[fkyaml::node {{"bar", nullptr}}].size() == 1);
+    REQUIRE(node[fkyaml::node {{"bar", nullptr}}].contains("baz"));
+    REQUIRE(node[fkyaml::node {{"bar", nullptr}}]["baz"].is_string());
+    REQUIRE(node[fkyaml::node {{"bar", nullptr}}]["baz"].get_value_ref<fkyaml::node::string_type&>() == "qux");
 }
 
 //


### PR DESCRIPTION
In this PR, non-string-scalar nodes (like mappings or integer scalar nodes) have been supported in the `fkyaml::basic_node`'s constructor with `std::initializer_list`.  
The unit test has also been modified according to the changes above.  

---

## Pull Request Checklist

Read the [CONTRIBUTING.md](https://github.com/fktn-k/fkYAML/blob/develop/CONTRIBUTING.md) file for detailed information.  

- [x] Changes are described in the pull request or in a referenced [issue](https://github.com/fktn-k/fkYAML/issues).
- [x] The test suite compiles and runs without any error.
- [x] [The code coverage](https://coveralls.io/github/fktn-k/fkYAML) on your branch is 100%.
- [x] The documentation is updated if you added/changed a feature.

## Please don't

- The C++11 support varies between different **compilers** and versions. Please note the [list of supported compilers](https://github.com/fktn-k/fkYAML/blob/develop/README.md#supported-compilers). Some compilers like GCC 4.7 (and earlier), Clang 3.3 (and earlier), or Microsoft Visual Studio 13.0 and earlier are known not to work due to missing or incomplete C++11 support. Please refrain from proposing changes that work around these compiler's limitations with `#ifdef`s or other means.
- Please refrain from proposing changes that would **break [YAML](https://yaml.org/) specifications**. If you propose a conformant extension of YAML to be supported by the library, please motivate this extension.
- Please do not open pull requests that address **multiple issues**.