### PR TITLE
Add GCC compiler versions tested in GA workflows

### DIFF
--- a/.github/workflows/ubuntu.yml
+++ b/.github/workflows/ubuntu.yml
@@ -213,11 +213,17 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        compiler: [ "9", "10", "11", "12", "13", latest ]
+        compiler: [ "7", "8", "9", "10", "11", "12", "13", latest ]
         build_type: [ Debug, Release ]
     container: gcc:${{matrix.compiler}}
 
     steps:
+    - name: Install git and unzip
+      run: |
+        apt-get update
+        apt-get install -y git unzip
+        git --version
+
     - uses: actions/checkout@v3
       with:
         submodules: recursive

--- a/README.md
+++ b/README.md
@@ -115,6 +115,9 @@ Currently, the following compilers are known to work and used in GitHub Actions 
 | Clang 14.0.6                             | Ubuntu 22.04.3 LTS |
 | Clang 15.0.7                             | Ubuntu 22.04.3 LTS |
 | Clang 16.0.6                             | Ubuntu 22.04.3 LTS |
+| Clang 17.0.4                             | Ubuntu 22.04.3 LTS |
+| GCC 7.5.0                                | Ubuntu 22.04.3 LTS |
+| GCC 8.5.0                                | Ubuntu 22.04.3 LTS |
 | GCC 9.5.0                                | Ubuntu 22.04.3 LTS |
 | GCC 10.5.0                               | Ubuntu 22.04.3 LTS |
 | GCC 11.4.0                               | Ubuntu 22.04.3 LTS |

--- a/docs/mkdocs/docs/home/supported_compilers.md
+++ b/docs/mkdocs/docs/home/supported_compilers.md
@@ -28,6 +28,9 @@ Currently, the following compilers are known to work and used in CI workflows:
 | Clang 14.0.6                             | Ubuntu 22.04.3 LTS |
 | Clang 15.0.7                             | Ubuntu 22.04.3 LTS |
 | Clang 16.0.6                             | Ubuntu 22.04.3 LTS |
+| Clang 17.0.4                             | Ubuntu 22.04.3 LTS |
+| GCC 7.5.0                                | Ubuntu 22.04.3 LTS |
+| GCC 8.5.0                                | Ubuntu 22.04.3 LTS |
 | GCC 9.5.0                                | Ubuntu 22.04.3 LTS |
 | GCC 10.5.0                               | Ubuntu 22.04.3 LTS |
 | GCC 11.4.0                               | Ubuntu 22.04.3 LTS |


### PR DESCRIPTION
In this PR, GCC compiler versions have been added with which fkYAML is built/tested in GitHub Actions workflows.  
The list of supported compilers have also been updated both in README.md and the documentation hosted by the GitHub Pages.  
The compilers which are added to the list are as follows:

| Compiler                                 | Operating System   |
| ---------------------------------------- | ------------------ |
| Clang 17.0.4                             | Ubuntu 22.04.3 LTS |
| GCC 7.5.0                                | Ubuntu 22.04.3 LTS |
| GCC 8.5.0                                | Ubuntu 22.04.3 LTS |

---

## Pull Request Checklist

Read the [CONTRIBUTING.md](https://github.com/fktn-k/fkYAML/blob/develop/CONTRIBUTING.md) file for detailed information.  

- [x] Changes are described in the pull request or in a referenced [issue](https://github.com/fktn-k/fkYAML/issues).
- [x] The test suite compiles and runs without any error.
- [x] [The code coverage](https://coveralls.io/github/fktn-k/fkYAML) on your branch is 100%.
- [x] The documentation is updated if you added/changed a feature.

## Please don't

- The C++11 support varies between different **compilers** and versions. Please note the [list of supported compilers](https://github.com/fktn-k/fkYAML/blob/develop/README.md#supported-compilers). Some compilers like GCC 4.7 (and earlier), Clang 3.3 (and earlier), or Microsoft Visual Studio 13.0 and earlier are known not to work due to missing or incomplete C++11 support. Please refrain from proposing changes that work around these compiler's limitations with `#ifdef`s or other means.
- Please refrain from proposing changes that would **break [YAML](https://yaml.org/) specifications**. If you propose a conformant extension of YAML to be supported by the library, please motivate this extension.
- Please do not open pull requests that address **multiple issues**.