### PR TITLE
Allow double quotation marks in plain scalars

### DIFF
--- a/include/fkYAML/detail/input/lexical_analyzer.hpp
+++ b/include/fkYAML/detail/input/lexical_analyzer.hpp
@@ -852,12 +852,7 @@ private:
                     return lexical_token_t::STRING_VALUE;
                 }
 
-                if (!needs_last_single_quote)
-                {
-                    emit_error("Invalid double quotation mark found in a string token.");
-                }
-
-                // if the target is a single-quoted string token.
+                // if the target is a plain/single-quoted string token.
                 m_value_buffer.push_back(char_traits_type::to_char_type(current));
                 continue;
             }

--- a/test/unit_test/test_lexical_analyzer_class.cpp
+++ b/test/unit_test/test_lexical_analyzer_class.cpp
@@ -439,6 +439,8 @@ TEST_CASE("LexicalAnalyzerClassTest_ScanStringTokenTest", "[LexicalAnalyzerClass
         value_pair_t(std::string("foo]"), fkyaml::node::string_type("foo")),
         value_pair_t(std::string("foo:bar"), fkyaml::node::string_type("foo:bar")),
         value_pair_t(std::string("foo bar"), fkyaml::node::string_type("foo bar")),
+        value_pair_t(std::string("foo\"bar"), fkyaml::node::string_type("foo\"bar")),
+        value_pair_t(std::string("\'foo\"bar\'"), fkyaml::node::string_type("foo\"bar")),
         value_pair_t(std::string("foo\'s bar"), fkyaml::node::string_type("foo\'s bar")),
         value_pair_t(std::string("\"foo bar\""), fkyaml::node::string_type("foo bar")),
         value_pair_t(std::string("\"foo's bar\""), fkyaml::node::string_type("foo's bar")),
@@ -643,7 +645,6 @@ TEST_CASE("LexicalAnalyzerClassTest_ScanInvalidStringTokenTest", "[LexicalAnalyz
     SECTION("parse_error expected")
     {
         auto buffer = GENERATE(
-            std::string("foo\"bar"),
             std::string("foo\\tbar"),
             std::string("-.a"),
             std::string("\"test"),


### PR DESCRIPTION
According to the YAML spec, double quotation marks in a plain scalar are allowed. [link](https://yaml.org/spec/1.2.2/#733-plain-style).  
However, fkYAML mistakingly throws an exception against inputs which include such scalars like:
```yaml
foo: This is "Bar".
```
So, this PR has fixed the issue and the fix has also been tested by the modified test suite.  

---

## Pull Request Checklist

Read the [CONTRIBUTING.md](https://github.com/fktn-k/fkYAML/blob/develop/CONTRIBUTING.md) file for detailed information.  

- [x] Changes are described in the pull request or in a referenced [issue](https://github.com/fktn-k/fkYAML/issues).
- [x] The test suite compiles and runs without any error.
- [x] [The code coverage](https://coveralls.io/github/fktn-k/fkYAML) on your branch is 100%.
- [x] The documentation is updated if you added/changed a feature.

## Please don't

- The C++11 support varies between different **compilers** and versions. Please note the [list of supported compilers](https://github.com/fktn-k/fkYAML/blob/develop/README.md#supported-compilers). Some compilers like GCC 4.7 (and earlier), Clang 3.3 (and earlier), or Microsoft Visual Studio 13.0 and earlier are known not to work due to missing or incomplete C++11 support. Please refrain from proposing changes that work around these compiler's limitations with `#ifdef`s or other means.
- Please refrain from proposing changes that would **break [YAML](https://yaml.org/) specifications**. If you propose a conformant extension of YAML to be supported by the library, please motivate this extension.
- Please do not open pull requests that address **multiple issues**.