### PR TITLE
Allow a dash(-) at the first character of a plain scalar

### DIFF
--- a/test/unit_test/test_lexical_analyzer_class.cpp
+++ b/test/unit_test/test_lexical_analyzer_class.cpp
@@ -390,7 +390,7 @@ TEST_CASE("LexicalAnalyzerClassTest_ScanInfinityTokenTest", "[LexicalAnalyzerCla
         REQUIRE_NOTHROW(lexer.get_next_token());
     }
 
-    SECTION("Test result of positive infinity literal tokens.")
+    SECTION("Test result of infinity literal tokens.")
     {
         REQUIRE(lexer.get_next_token() == fkyaml::detail::lexical_token_t::FLOAT_NUMBER_VALUE);
         REQUIRE_NOTHROW(lexer.get_float_number());
@@ -416,11 +416,11 @@ TEST_CASE("LexicalAnalyzerClassTest_ScanNaNTokenTest", "[LexicalAnalyzerClassTes
     }
 }
 
-TEST_CASE("LexicalAnalyzerClassTest_ScanInvalidNumberTokenTest", "[LexicalAnalyzerClassTest]")
-{
-    pchar_lexer_t lexer(fkyaml::detail::input_adapter("-.test"));
-    REQUIRE_THROWS_AS(lexer.get_next_token(), fkyaml::parse_error);
-}
+// TEST_CASE("LexicalAnalyzerClassTest_ScanInvalidNumberTokenTest", "[LexicalAnalyzerClassTest]")
+// {
+//     pchar_lexer_t lexer(fkyaml::detail::input_adapter("-.test"));
+//     REQUIRE_THROWS_AS(lexer.get_next_token(), fkyaml::parse_error);
+// }
 
 TEST_CASE("LexicalAnalyzerClassTest_ScanStringTokenTest", "[LexicalAnalyzerClassTest]")
 {
@@ -435,6 +435,9 @@ TEST_CASE("LexicalAnalyzerClassTest_ScanStringTokenTest", "[LexicalAnalyzerClass
         value_pair_t(std::string(".NET"), fkyaml::node::string_type(".NET")),
         value_pair_t(std::string(".on"), fkyaml::node::string_type(".on")),
         value_pair_t(std::string(".n"), fkyaml::node::string_type(".n")),
+        value_pair_t(std::string("-t"), fkyaml::node::string_type("-t")),
+        value_pair_t(std::string("-foo"), fkyaml::node::string_type("-foo")),
+        value_pair_t(std::string("-.test"), fkyaml::node::string_type("-.test")),
         value_pair_t(std::string("1.2.3"), fkyaml::node::string_type("1.2.3")),
         value_pair_t(std::string("foo]"), fkyaml::node::string_type("foo")),
         value_pair_t(std::string("foo:bar"), fkyaml::node::string_type("foo:bar")),
@@ -646,7 +649,6 @@ TEST_CASE("LexicalAnalyzerClassTest_ScanInvalidStringTokenTest", "[LexicalAnalyz
     {
         auto buffer = GENERATE(
             std::string("foo\\tbar"),
-            std::string("-.a"),
             std::string("\"test"),
             std::string("\'test"),
             std::string("\'test\n\'"),


### PR DESCRIPTION
According to the YAML spec, a dash(-) at the first character of a scalar is allowed. [link](https://yaml.org/spec/1.2.2/#733-plain-style)  
However, fkYAML didn't support such cases and threw an exception, e.g., with the following input:
```yaml
foo: -bar
```
So, this PR has fixed the issue and the fix has also been tested by the added test cases.  

---

## Pull Request Checklist

Read the [CONTRIBUTING.md](https://github.com/fktn-k/fkYAML/blob/develop/CONTRIBUTING.md) file for detailed information.  

- [x] Changes are described in the pull request or in a referenced [issue](https://github.com/fktn-k/fkYAML/issues).
- [x] The test suite compiles and runs without any error.
- [x] [The code coverage](https://coveralls.io/github/fktn-k/fkYAML) on your branch is 100%.
- [x] The documentation is updated if you added/changed a feature.

## Please don't

- The C++11 support varies between different **compilers** and versions. Please note the [list of supported compilers](https://github.com/fktn-k/fkYAML/blob/develop/README.md#supported-compilers). Some compilers like GCC 4.7 (and earlier), Clang 3.3 (and earlier), or Microsoft Visual Studio 13.0 and earlier are known not to work due to missing or incomplete C++11 support. Please refrain from proposing changes that work around these compiler's limitations with `#ifdef`s or other means.
- Please refrain from proposing changes that would **break [YAML](https://yaml.org/) specifications**. If you propose a conformant extension of YAML to be supported by the library, please motivate this extension.
- Please do not open pull requests that address **multiple issues**.