### PR TITLE
#256 Added specialization of from_node() for std::map with compatible key/value types

### DIFF
--- a/include/fkYAML/detail/conversions/from_node.hpp
+++ b/include/fkYAML/detail/conversions/from_node.hpp
@@ -98,12 +98,14 @@ inline void from_node(const BasicNodeType& n, typename BasicNodeType::mapping_ty
 }
 
 template <
-    typename BasicNodeType, typename CompatibleKeyType, typename CompatibleValueType, typename Compare, typename Allocator,
+    typename BasicNodeType, typename CompatibleKeyType, typename CompatibleValueType, typename Compare,
+    typename Allocator,
     enable_if_t<
         conjunction<
-            is_basic_node<BasicNodeType>, negation<is_basic_node<CompatibleKeyType>>, negation<is_basic_node<CompatibleValueType>>,
-            has_from_node<BasicNodeType, CompatibleKeyType>, has_from_node<BasicNodeType, CompatibleValueType>
-        >::value, int> = 0>
+            is_basic_node<BasicNodeType>, negation<is_basic_node<CompatibleKeyType>>,
+            negation<is_basic_node<CompatibleValueType>>, has_from_node<BasicNodeType, CompatibleKeyType>,
+            has_from_node<BasicNodeType, CompatibleValueType>>::value,
+        int> = 0>
 inline void from_node(const BasicNodeType& n, std::map<CompatibleKeyType, CompatibleValueType, Compare, Allocator>& m)
 {
     if (!n.is_mapping())
@@ -114,8 +116,7 @@ inline void from_node(const BasicNodeType& n, std::map<CompatibleKeyType, Compat
     for (auto pair : n.template get_value_ref<const typename BasicNodeType::mapping_type&>())
     {
         m.emplace(
-            pair.first.template get_value<CompatibleKeyType>(), pair.second.template get_value<CompatibleValueType>()
-        );
+            pair.first.template get_value<CompatibleKeyType>(), pair.second.template get_value<CompatibleValueType>());
     }
 }
 

--- a/include/fkYAML/detail/conversions/from_node.hpp
+++ b/include/fkYAML/detail/conversions/from_node.hpp
@@ -12,6 +12,7 @@
 #define FK_YAML_DETAIL_CONVERSIONS_FROM_NODE_HPP_
 
 #include <limits>
+#include <map>
 #include <utility>
 #include <vector>
 
@@ -93,6 +94,28 @@ inline void from_node(const BasicNodeType& n, typename BasicNodeType::mapping_ty
     for (auto pair : n.template get_value_ref<const typename BasicNodeType::mapping_type&>())
     {
         m.emplace(pair.first, pair.second);
+    }
+}
+
+template <
+    typename BasicNodeType, typename CompatibleKeyType, typename CompatibleValueType, typename Compare, typename Allocator,
+    enable_if_t<
+        conjunction<
+            is_basic_node<BasicNodeType>, negation<is_basic_node<CompatibleKeyType>>, negation<is_basic_node<CompatibleValueType>>,
+            has_from_node<BasicNodeType, CompatibleKeyType>, has_from_node<BasicNodeType, CompatibleValueType>
+        >::value, int> = 0>
+inline void from_node(const BasicNodeType& n, std::map<CompatibleKeyType, CompatibleValueType, Compare, Allocator>& m)
+{
+    if (!n.is_mapping())
+    {
+        throw type_error("The target node value type is not mapping type.", n.type());
+    }
+
+    for (auto pair : n.template get_value_ref<const typename BasicNodeType::mapping_type&>())
+    {
+        m.emplace(
+            pair.first.template get_value<CompatibleKeyType>(), pair.second.template get_value<CompatibleValueType>()
+        );
     }
 }
 

--- a/include/fkYAML/detail/input/deserializer.hpp
+++ b/include/fkYAML/detail/input/deserializer.hpp
@@ -97,17 +97,6 @@ public:
                     }
                 }
 
-                type = lexer.get_next_token();
-                if (type == lexical_token_t::SEQUENCE_BLOCK_PREFIX)
-                {
-                    m_node_stack.push_back(m_current_node);
-                    m_indent_stack.emplace_back(cur_indent, true);
-                    m_indent_stack.emplace_back(lexer.get_last_token_begin_pos(), false);
-                    m_current_node = new BasicNodeType(node_t::SEQUENCE);
-                    set_yaml_version(*m_current_node);
-                    break;
-                }
-
                 if (m_current_node->is_null())
                 {
                     *m_current_node = BasicNodeType::mapping();
@@ -115,6 +104,16 @@ public:
 
                 m_node_stack.push_back(m_current_node);
                 m_indent_stack.emplace_back(cur_indent, true);
+
+                type = lexer.get_next_token();
+                if (type == lexical_token_t::SEQUENCE_BLOCK_PREFIX)
+                {
+                    m_indent_stack.emplace_back(lexer.get_last_token_begin_pos(), false);
+                    m_current_node = new BasicNodeType(node_t::SEQUENCE);
+                    set_yaml_version(*m_current_node);
+                    break;
+                }
+
                 m_current_node = new BasicNodeType();
                 set_yaml_version(*m_current_node);
                 cur_indent = lexer.get_last_token_begin_pos();
@@ -141,6 +140,23 @@ public:
                     m_node_stack.pop_back();
                     m_indent_stack.pop_back();
                 }
+
+                if (m_node_stack.back()->is_sequence())
+                {
+                    m_current_node = m_node_stack.back();
+                    m_node_stack.pop_back();
+                }
+                if (m_node_stack.back() == m_current_node)
+                {
+                    // This path is for nested explicit mapping keys like:
+                    // ```yaml
+                    // ? ? foo
+                    //   : bar
+                    // : baz
+                    // ```
+                    m_node_stack.pop_back();
+                }
+
                 BasicNodeType* key_node = m_current_node;
                 m_node_stack.back()->template get_value_ref<mapping_type&>().emplace(*key_node, BasicNodeType());
                 m_current_node = &(m_node_stack.back()->operator[](*key_node));
@@ -446,6 +462,10 @@ private:
                 {
                     // This path is for explicit mapping key separator(:)
                     assign_node_value(std::move(node));
+                    if (!m_indent_stack.back().second)
+                    {
+                        m_indent_stack.pop_back();
+                    }
                     indent = lexer.get_last_token_begin_pos();
                     line = lexer.get_lines_processed();
                     return true;

--- a/test/unit_test/test_custom_from_node.cpp
+++ b/test/unit_test/test_custom_from_node.cpp
@@ -137,3 +137,26 @@ TEST_CASE("FromNodeTest_UserDefinedTypeMapTest", "[FromNodeTest]")
     REQUIRE(colors.at(test::color {0x586776}).g == 0x67);
     REQUIRE(colors.at(test::color {0x586776}).b == 0x76);
 }
+
+TEST_CASE("FromNodeTest_UserDefinedTypeMapErrorTest", "[FromNodeTest]")
+{
+    std::string input = "colors:\n"
+                        "  ? color: 0xFFFFFF\n"
+                        "  : r: 0xFF\n"
+                        "    g: 0xFF\n"
+                        "    b: 0xFF\n"
+                        "  ? color: 0x808080\n"
+                        "  : r: 0x80\n"
+                        "    g: 0x80\n"
+                        "    b: 0x80\n"
+                        "  ? color: 0x586776\n"
+                        "  : r: 0x58\n"
+                        "    g: 0x67\n"
+                        "    b: 0x76\n";
+    fkyaml::node node = fkyaml::node::deserialize(input);
+    using compat_map_t = std::map<test::color, test::rgb>;
+    REQUIRE_THROWS_AS(node.get_value<compat_map_t>(), fkyaml::exception);
+
+    fkyaml::node int_node = 123;
+    REQUIRE_THROWS_AS(int_node.get_value<compat_map_t>(), fkyaml::exception);
+}

--- a/test/unit_test/test_custom_from_node.cpp
+++ b/test/unit_test/test_custom_from_node.cpp
@@ -29,6 +29,34 @@ void from_node(const fkyaml::node& node, novel& novel)
     novel.author = node["author"].get_value_ref<const std::string&>();
     novel.year = node["year"].get_value<int>();
 }
+struct color
+{
+    int value;
+};
+
+bool operator<(const color& lhs, const color& rhs)
+{
+    return lhs.value < rhs.value;
+}
+
+void from_node(const fkyaml::node& node, color& color)
+{
+    color.value = node["color"].get_value<int>();
+}
+
+struct rgb
+{
+    int r;
+    int g;
+    int b;
+};
+
+void from_node(const fkyaml::node& node, rgb& rgb)
+{
+    rgb.r = node["r"].get_value<int>();
+    rgb.g = node["g"].get_value<int>();
+    rgb.b = node["b"].get_value<int>();
+}
 
 } // namespace test
 
@@ -76,4 +104,36 @@ TEST_CASE("FromNodeTest_UserDefinedTypeVectorErrorTest", "[FromNodeTest]")
                         "    year: 1818\n";
     fkyaml::node node = fkyaml::node::deserialize(input);
     REQUIRE_THROWS_AS(node.get_value<std::vector<test::novel>>(), fkyaml::exception);
+}
+
+TEST_CASE("FromNodeTest_UserDefinedTypeMapTest", "[FromNodeTest]")
+{
+    std::string input = "colors:\n"
+                        "  ? color: 0xFFFFFF\n"
+                        "  : r: 0xFF\n"
+                        "    g: 0xFF\n"
+                        "    b: 0xFF\n"
+                        "  ? color: 0x808080\n"
+                        "  : r: 0x80\n"
+                        "    g: 0x80\n"
+                        "    b: 0x80\n"
+                        "  ? color: 0x586776\n"
+                        "  : r: 0x58\n"
+                        "    g: 0x67\n"
+                        "    b: 0x76\n";
+    fkyaml::node node = fkyaml::node::deserialize(input);
+
+    auto colors = node["colors"].get_value<std::map<test::color, test::rgb>>();
+    REQUIRE(colors.find(test::color{0xFFFFFF}) != colors.end());
+    REQUIRE(colors.at(test::color{0xFFFFFF}).r == 0xFF);
+    REQUIRE(colors.at(test::color{0xFFFFFF}).g == 0xFF);
+    REQUIRE(colors.at(test::color{0xFFFFFF}).b == 0xFF);
+    REQUIRE(colors.find(test::color{0x808080}) != colors.end());
+    REQUIRE(colors.at(test::color{0x808080}).r == 0x80);
+    REQUIRE(colors.at(test::color{0x808080}).g == 0x80);
+    REQUIRE(colors.at(test::color{0x808080}).b == 0x80);
+    REQUIRE(colors.find(test::color{0x586776}) != colors.end());
+    REQUIRE(colors.at(test::color{0x586776}).r == 0x58);
+    REQUIRE(colors.at(test::color{0x586776}).g == 0x67);
+    REQUIRE(colors.at(test::color{0x586776}).b == 0x76);
 }

--- a/test/unit_test/test_custom_from_node.cpp
+++ b/test/unit_test/test_custom_from_node.cpp
@@ -124,16 +124,16 @@ TEST_CASE("FromNodeTest_UserDefinedTypeMapTest", "[FromNodeTest]")
     fkyaml::node node = fkyaml::node::deserialize(input);
 
     auto colors = node["colors"].get_value<std::map<test::color, test::rgb>>();
-    REQUIRE(colors.find(test::color{0xFFFFFF}) != colors.end());
-    REQUIRE(colors.at(test::color{0xFFFFFF}).r == 0xFF);
-    REQUIRE(colors.at(test::color{0xFFFFFF}).g == 0xFF);
-    REQUIRE(colors.at(test::color{0xFFFFFF}).b == 0xFF);
-    REQUIRE(colors.find(test::color{0x808080}) != colors.end());
-    REQUIRE(colors.at(test::color{0x808080}).r == 0x80);
-    REQUIRE(colors.at(test::color{0x808080}).g == 0x80);
-    REQUIRE(colors.at(test::color{0x808080}).b == 0x80);
-    REQUIRE(colors.find(test::color{0x586776}) != colors.end());
-    REQUIRE(colors.at(test::color{0x586776}).r == 0x58);
-    REQUIRE(colors.at(test::color{0x586776}).g == 0x67);
-    REQUIRE(colors.at(test::color{0x586776}).b == 0x76);
+    REQUIRE(colors.find(test::color {0xFFFFFF}) != colors.end());
+    REQUIRE(colors.at(test::color {0xFFFFFF}).r == 0xFF);
+    REQUIRE(colors.at(test::color {0xFFFFFF}).g == 0xFF);
+    REQUIRE(colors.at(test::color {0xFFFFFF}).b == 0xFF);
+    REQUIRE(colors.find(test::color {0x808080}) != colors.end());
+    REQUIRE(colors.at(test::color {0x808080}).r == 0x80);
+    REQUIRE(colors.at(test::color {0x808080}).g == 0x80);
+    REQUIRE(colors.at(test::color {0x808080}).b == 0x80);
+    REQUIRE(colors.find(test::color {0x586776}) != colors.end());
+    REQUIRE(colors.at(test::color {0x586776}).r == 0x58);
+    REQUIRE(colors.at(test::color {0x586776}).g == 0x67);
+    REQUIRE(colors.at(test::color {0x586776}).b == 0x76);
 }


### PR DESCRIPTION
As described in #256, specialization of `from_node()` for std::map whose key/value types are both compatible with `basic_node`.  
Test cases related to the specialization have also been added.  

---

## Pull Request Checklist

Read the [CONTRIBUTING.md](https://github.com/fktn-k/fkYAML/blob/develop/CONTRIBUTING.md) file for detailed information.  

- [x] Changes are described in the pull request or in a referenced [issue](https://github.com/fktn-k/fkYAML/issues).
- [x] The test suite compiles and runs without any error.
- [x] [The code coverage](https://coveralls.io/github/fktn-k/fkYAML) on your branch is 100%.
- [x] The documentation is updated if you added/changed a feature.

## Please don't

- The C++11 support varies between different **compilers** and versions. Please note the [list of supported compilers](https://github.com/fktn-k/fkYAML/blob/develop/README.md#supported-compilers). Some compilers like GCC 4.7 (and earlier), Clang 3.3 (and earlier), or Microsoft Visual Studio 13.0 and earlier are known not to work due to missing or incomplete C++11 support. Please refrain from proposing changes that work around these compiler's limitations with `#ifdef`s or other means.
- Please refrain from proposing changes that would **break [YAML](https://yaml.org/) specifications**. If you propose a conformant extension of YAML to be supported by the library, please motivate this extension.
- Please do not open pull requests that address **multiple issues**.