### PR TITLE
Added paths filter to regulate workflow executions

### DIFF
--- a/.github/workflows/amalgamation_check.yml
+++ b/.github/workflows/amalgamation_check.yml
@@ -5,11 +5,15 @@ on:
     branches:
       - develop
       - main
-      - release/*
     paths:
+      - .github/workflows/amalgamation_check.yml
       - include/fkYAML/**
       - single_include/fkYAML/**
   pull_request:
+    paths:
+      - .github/workflows/amalgamation_check.yml
+      - include/fkYAML/**
+      - single_include/fkYAML/**
   workflow_dispatch:
 
 concurrency:

--- a/.github/workflows/clang_format_check.yml
+++ b/.github/workflows/clang_format_check.yml
@@ -5,8 +5,17 @@ on:
     branches:
       - develop
       - main
-      - release/*
+    paths:
+      - .github/workflows/clang_format_check.yml
+      - include/**
+      - test/unit_test/**
+      - .clang-format
   pull_request:
+    paths:
+      - .github/workflows/clang_format_check.yml
+      - include/**
+      - test/unit_test/**
+      - .clang-format
   workflow_dispatch:
 
 concurrency:

--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -5,7 +5,6 @@ on:
     branches:
       - "develop"
       - "main"
-      - "release/*"
   pull_request:
   schedule:
     - cron: '00 0 * * 1'

--- a/.github/workflows/coverage.yml
+++ b/.github/workflows/coverage.yml
@@ -5,8 +5,21 @@ on:
     branches:
       - develop
       - main
-      - release/*
+    paths:
+      - .github/workflows/coverage.yml
+      - cmake/**
+      - include/**
+      - test/**
+      - CMakeLists.txt
+      - Makefile
   pull_request:
+    paths:
+      - .github/workflows/coverage.yml
+      - cmake/**
+      - include/**
+      - test/**
+      - CMakeLists.txt
+      - Makefile
   workflow_dispatch:
 
 jobs:

--- a/.github/workflows/macos.yml
+++ b/.github/workflows/macos.yml
@@ -5,8 +5,21 @@ on:
     branches:
       - develop
       - main
-      - release/*
+    paths:
+      - .github/workflows/macos.yml
+      - cmake/**
+      - include/**
+      - single_include/**
+      - test/**
+      - CMakeLists.txt
   pull_request:
+    paths:
+      - .github/workflows/macos.yml
+      - cmake/**
+      - include/**
+      - single_include/**
+      - test/**
+      - CMakeLists.txt
   workflow_dispatch:
 
 concurrency:

--- a/.github/workflows/ubuntu.yml
+++ b/.github/workflows/ubuntu.yml
@@ -5,8 +5,27 @@ on:
     branches:
       - develop
       - main
-      - release/*
+    paths:
+      - .github/workflows/ubuntu.yml
+      - cmake/**
+      - include/**
+      - single_include/**
+      - test/**
+      - tool/**
+      - .clang-tidy
+      - CMakeLists.txt
+      - Makefile
   pull_request:
+    paths:
+      - .github/workflows/ubuntu.yml
+      - cmake/**
+      - include/**
+      - single_include/**
+      - test/**
+      - tool/**
+      - .clang-tidy
+      - CMakeLists.txt
+      - Makefile
   workflow_dispatch:
 
 env:

--- a/.github/workflows/windows.yml
+++ b/.github/workflows/windows.yml
@@ -5,8 +5,21 @@ on:
     branches:
       - develop
       - main
-      - release/*
+    paths:
+      - .github/workflows/windows.yml
+      - cmake/**
+      - include/**
+      - single_include/**
+      - test/**
+      - CMakeLists.txt
   pull_request:
+    paths:
+      - .github/workflows/windows.yml
+      - cmake/**
+      - include/**
+      - single_include/**
+      - test/**
+      - CMakeLists.txt
   workflow_dispatch:
 
 concurrency:


### PR DESCRIPTION
This PR has added some filters of triggering workflows depending on what kind of files have been changed.  
For, previously, all the workflows were activated on every commit regardless of what kind of changes have been made, which forces developers (especially me) to wait for an unnecessary amount of time, for example, modifying only the README file activates the Valgrind check.  
So, after merging this PR, commits on main/develop or other branches for PRs will activate the minimum required workflows.  

---

## Pull Request Checklist

Read the [CONTRIBUTING.md](https://github.com/fktn-k/fkYAML/blob/develop/CONTRIBUTING.md) file for detailed information.  

- [x] Changes are described in the pull request or in a referenced [issue](https://github.com/fktn-k/fkYAML/issues).
- [x] The test suite compiles and runs without any error.
- [x] [The code coverage](https://coveralls.io/github/fktn-k/fkYAML) on your branch is 100%.
- [x] The documentation is updated if you added/changed a feature.

## Please don't

- The C++11 support varies between different **compilers** and versions. Please note the [list of supported compilers](https://github.com/fktn-k/fkYAML/blob/develop/README.md#supported-compilers). Some compilers like GCC 4.7 (and earlier), Clang 3.3 (and earlier), or Microsoft Visual Studio 13.0 and earlier are known not to work due to missing or incomplete C++11 support. Please refrain from proposing changes that work around these compiler's limitations with `#ifdef`s or other means.
- Please refrain from proposing changes that would **break [YAML](https://yaml.org/) specifications**. If you propose a conformant extension of YAML to be supported by the library, please motivate this extension.
- Please do not open pull requests that address **multiple issues**.