### PR TITLE
#229 Fix the documentation build errors

### DIFF
--- a/.github/workflows/publish_docs.yml
+++ b/.github/workflows/publish_docs.yml
@@ -6,6 +6,8 @@ on:
     branches:
       - develop
     paths:
+      - .github/workflows/publish_docs.yml
+      - docs/examples/**
       - docs/mkdocs/**
   workflow_dispatch:
 

--- a/docs/examples/ex_macros_versions.output
+++ b/docs/examples/ex_macros_versions.output
@@ -1,0 +1,1 @@
+fkYAML version 0.3.0

--- a/docs/mkdocs/docs/tutorials/index.md
+++ b/docs/mkdocs/docs/tutorials/index.md
@@ -76,7 +76,7 @@ Also, make sure the example.yaml file is encoded in either the UTF-8, UTF-16BE/L
 === "tutorial.cpp"
 
     ```cpp
-    --8<-- "examples/tutorial_1.yaml"
+    --8<-- "examples/tutorial_1.cpp"
     ```
 === "CMakeLists.txt"
 


### PR DESCRIPTION
This PR has fixed some errors in building the documentation, introduced in #264.  

---

## Pull Request Checklist

Read the [CONTRIBUTING.md](https://github.com/fktn-k/fkYAML/blob/develop/CONTRIBUTING.md) file for detailed information.  

- [x] Changes are described in the pull request or in a referenced [issue](https://github.com/fktn-k/fkYAML/issues).
- [x] The test suite compiles and runs without any error.
- [x] [The code coverage](https://coveralls.io/github/fktn-k/fkYAML) on your branch is 100%.
- [x] The documentation is updated if you added/changed a feature.

## Please don't

- The C++11 support varies between different **compilers** and versions. Please note the [list of supported compilers](https://github.com/fktn-k/fkYAML/blob/develop/README.md#supported-compilers). Some compilers like GCC 4.7 (and earlier), Clang 3.3 (and earlier), or Microsoft Visual Studio 13.0 and earlier are known not to work due to missing or incomplete C++11 support. Please refrain from proposing changes that work around these compiler's limitations with `#ifdef`s or other means.
- Please refrain from proposing changes that would **break [YAML](https://yaml.org/) specifications**. If you propose a conformant extension of YAML to be supported by the library, please motivate this extension.
- Please do not open pull requests that address **multiple issues**.