### PR TITLE
Avoid using unintended C++14 features

### DIFF
--- a/.github/workflows/macos.yml
+++ b/.github/workflows/macos.yml
@@ -50,7 +50,7 @@ jobs:
       run: cmake --build ${{github.workspace}}/build --config ${{matrix.build_type}} -j ${{env.JOBS}}
 
     - name: Test
-      working-directory: ${{github.workspace}}
+      working-directory: ${{github.workspace}}/build
       run: ctest -C ${{matrix.build_type}} --output-on-failure -j ${{env.JOBS}}
 
   xcode_for_macos11:

--- a/include/fkYAML/detail/encodings/utf8_encoding.hpp
+++ b/include/fkYAML/detail/encodings/utf8_encoding.hpp
@@ -214,7 +214,7 @@ public:
         }
         else if (utf16[0] <= char16_t(0x7FFu))
         {
-            uint16_t utf8_encoded = 0b1100000010000000;
+            uint16_t utf8_encoded = 0xC080u;
             utf8_encoded |= static_cast<uint16_t>((utf16[0] & 0x07C0u) << 2);
             utf8_encoded |= static_cast<uint16_t>(utf16[0] & 0x003Fu);
             utf8_bytes[0] = static_cast<char>((utf8_encoded & 0xFF00u) >> 8);
@@ -225,7 +225,7 @@ public:
         }
         else if (utf16[0] < char16_t(0xD800u) || char16_t(0xE000u) <= utf16[0])
         {
-            uint32_t utf8_encoded = 0b111000001000000010000000;
+            uint32_t utf8_encoded = 0xE08080u;
             utf8_encoded |= static_cast<uint32_t>((utf16[0] & 0xF000u) << 4);
             utf8_encoded |= static_cast<uint32_t>((utf16[0] & 0x0FC0u) << 2);
             utf8_encoded |= static_cast<uint32_t>(utf16[0] & 0x003Fu);
@@ -240,7 +240,7 @@ public:
         {
             // for surrogate pairs
             uint32_t code_point = 0x10000u + ((utf16[0] & 0x03FFu) << 10) + (utf16[1] & 0x03FFu);
-            uint32_t utf8_encoded = 0b11110000100000001000000010000000;
+            uint32_t utf8_encoded = 0xF0808080u;
             utf8_encoded |= static_cast<uint32_t>((code_point & 0x1C0000u) << 6);
             utf8_encoded |= static_cast<uint32_t>((code_point & 0x03F000u) << 4);
             utf8_encoded |= static_cast<uint32_t>((code_point & 0x000FC0u) << 2);
@@ -278,7 +278,7 @@ public:
         }
         else if (utf32 <= char32_t(0x7FFu))
         {
-            uint16_t utf8_encoded = 0b1100000010000000;
+            uint16_t utf8_encoded = 0xC080u;
             utf8_encoded |= static_cast<uint16_t>((utf32 & 0x07C0u) << 2);
             utf8_encoded |= static_cast<uint16_t>(utf32 & 0x003Fu);
             utf8_bytes[0] = static_cast<char>((utf8_encoded & 0xFF00u) >> 8);
@@ -288,7 +288,7 @@ public:
         }
         else if (utf32 <= char32_t(0xFFFFu))
         {
-            uint32_t utf8_encoded = 0b111000001000000010000000;
+            uint32_t utf8_encoded = 0xE08080u;
             utf8_encoded |= static_cast<uint32_t>((utf32 & 0xF000u) << 4);
             utf8_encoded |= static_cast<uint32_t>((utf32 & 0x0FC0u) << 2);
             utf8_encoded |= static_cast<uint32_t>(utf32 & 0x003F);
@@ -300,7 +300,7 @@ public:
         }
         else if (utf32 <= char32_t(0x10FFFFu))
         {
-            uint32_t utf8_encoded = 0b11110000100000001000000010000000;
+            uint32_t utf8_encoded = 0xF0808080u;
             utf8_encoded |= static_cast<uint32_t>((utf32 & 0x1C0000u) << 6);
             utf8_encoded |= static_cast<uint32_t>((utf32 & 0x03F000u) << 4);
             utf8_encoded |= static_cast<uint32_t>((utf32 & 0x000FC0u) << 2);

--- a/include/fkYAML/node.hpp
+++ b/include/fkYAML/node.hpp
@@ -1222,7 +1222,7 @@ private:
     /// @brief Returns constant reference to the sequence node value.
     /// @throw fkyaml::exception The node value is not a sequence.
     /// @return Constant reference to the sequence node value.
-    constexpr const sequence_type& get_value_ref_impl(const sequence_type* /*unused*/) const
+    const sequence_type& get_value_ref_impl(const sequence_type* /*unused*/) const
     {
         if (!is_sequence())
         {
@@ -1246,7 +1246,7 @@ private:
     /// @brief Returns constant reference to the mapping node value.
     /// @throw fkyaml::exception The node value is not a mapping.
     /// @return Constant reference to the mapping node value.
-    constexpr const mapping_type& get_value_ref_impl(const mapping_type* /*unused*/) const
+    const mapping_type& get_value_ref_impl(const mapping_type* /*unused*/) const
     {
         if (!is_mapping())
         {
@@ -1269,8 +1269,8 @@ private:
 
     /// @brief Returns reference to the boolean node value.
     /// @throw fkyaml::exception The node value is not a boolean.
-    /// @return Reference to the boolean node value.
-    constexpr const boolean_type& get_value_ref_impl(const boolean_type* /*unused*/) const
+    /// @return Constant reference to the boolean node value.
+    const boolean_type& get_value_ref_impl(const boolean_type* /*unused*/) const
     {
         if (!is_boolean())
         {
@@ -1293,8 +1293,8 @@ private:
 
     /// @brief Returns reference to the integer node value.
     /// @throw fkyaml::exception The node value is not an integer.
-    /// @return Reference to the integer node value.
-    constexpr const integer_type& get_value_ref_impl(const integer_type* /*unused*/) const
+    /// @return Constant reference to the integer node value.
+    const integer_type& get_value_ref_impl(const integer_type* /*unused*/) const
     {
         if (!is_integer())
         {
@@ -1317,8 +1317,8 @@ private:
 
     /// @brief Returns reference to the floating point number node value.
     /// @throw fkyaml::exception The node value is not a floating point number.
-    /// @return Reference to the floating point number node value.
-    constexpr const float_number_type& get_value_ref_impl(const float_number_type* /*unused*/) const
+    /// @return Constant reference to the floating point number node value.
+    const float_number_type& get_value_ref_impl(const float_number_type* /*unused*/) const
     {
         if (!is_float_number())
         {
@@ -1341,8 +1341,8 @@ private:
 
     /// @brief Returns reference to the string node value.
     /// @throw fkyaml::exception The node value is not a string.
-    /// @return Reference to the string node value.
-    constexpr const string_type& get_value_ref_impl(const string_type* /*unused*/) const
+    /// @return Constant reference to the string node value.
+    const string_type& get_value_ref_impl(const string_type* /*unused*/) const
     {
         if (!is_string())
         {

--- a/single_include/fkYAML/node.hpp
+++ b/single_include/fkYAML/node.hpp
@@ -1425,7 +1425,7 @@ public:
         }
         else if (utf16[0] <= char16_t(0x7FFu))
         {
-            uint16_t utf8_encoded = 0b1100000010000000;
+            uint16_t utf8_encoded = 0xC080u;
             utf8_encoded |= static_cast<uint16_t>((utf16[0] & 0x07C0u) << 2);
             utf8_encoded |= static_cast<uint16_t>(utf16[0] & 0x003Fu);
             utf8_bytes[0] = static_cast<char>((utf8_encoded & 0xFF00u) >> 8);
@@ -1436,7 +1436,7 @@ public:
         }
         else if (utf16[0] < char16_t(0xD800u) || char16_t(0xE000u) <= utf16[0])
         {
-            uint32_t utf8_encoded = 0b111000001000000010000000;
+            uint32_t utf8_encoded = 0xE08080u;
             utf8_encoded |= static_cast<uint32_t>((utf16[0] & 0xF000u) << 4);
             utf8_encoded |= static_cast<uint32_t>((utf16[0] & 0x0FC0u) << 2);
             utf8_encoded |= static_cast<uint32_t>(utf16[0] & 0x003Fu);
@@ -1451,7 +1451,7 @@ public:
         {
             // for surrogate pairs
             uint32_t code_point = 0x10000u + ((utf16[0] & 0x03FFu) << 10) + (utf16[1] & 0x03FFu);
-            uint32_t utf8_encoded = 0b11110000100000001000000010000000;
+            uint32_t utf8_encoded = 0xF0808080u;
             utf8_encoded |= static_cast<uint32_t>((code_point & 0x1C0000u) << 6);
             utf8_encoded |= static_cast<uint32_t>((code_point & 0x03F000u) << 4);
             utf8_encoded |= static_cast<uint32_t>((code_point & 0x000FC0u) << 2);
@@ -1489,7 +1489,7 @@ public:
         }
         else if (utf32 <= char32_t(0x7FFu))
         {
-            uint16_t utf8_encoded = 0b1100000010000000;
+            uint16_t utf8_encoded = 0xC080u;
             utf8_encoded |= static_cast<uint16_t>((utf32 & 0x07C0u) << 2);
             utf8_encoded |= static_cast<uint16_t>(utf32 & 0x003Fu);
             utf8_bytes[0] = static_cast<char>((utf8_encoded & 0xFF00u) >> 8);
@@ -1499,7 +1499,7 @@ public:
         }
         else if (utf32 <= char32_t(0xFFFFu))
         {
-            uint32_t utf8_encoded = 0b111000001000000010000000;
+            uint32_t utf8_encoded = 0xE08080u;
             utf8_encoded |= static_cast<uint32_t>((utf32 & 0xF000u) << 4);
             utf8_encoded |= static_cast<uint32_t>((utf32 & 0x0FC0u) << 2);
             utf8_encoded |= static_cast<uint32_t>(utf32 & 0x003F);
@@ -1511,7 +1511,7 @@ public:
         }
         else if (utf32 <= char32_t(0x10FFFFu))
         {
-            uint32_t utf8_encoded = 0b11110000100000001000000010000000;
+            uint32_t utf8_encoded = 0xF0808080u;
             utf8_encoded |= static_cast<uint32_t>((utf32 & 0x1C0000u) << 6);
             utf8_encoded |= static_cast<uint32_t>((utf32 & 0x03F000u) << 4);
             utf8_encoded |= static_cast<uint32_t>((utf32 & 0x000FC0u) << 2);
@@ -8570,7 +8570,7 @@ private:
     /// @brief Returns constant reference to the sequence node value.
     /// @throw fkyaml::exception The node value is not a sequence.
     /// @return Constant reference to the sequence node value.
-    constexpr const sequence_type& get_value_ref_impl(const sequence_type* /*unused*/) const
+    const sequence_type& get_value_ref_impl(const sequence_type* /*unused*/) const
     {
         if (!is_sequence())
         {
@@ -8594,7 +8594,7 @@ private:
     /// @brief Returns constant reference to the mapping node value.
     /// @throw fkyaml::exception The node value is not a mapping.
     /// @return Constant reference to the mapping node value.
-    constexpr const mapping_type& get_value_ref_impl(const mapping_type* /*unused*/) const
+    const mapping_type& get_value_ref_impl(const mapping_type* /*unused*/) const
     {
         if (!is_mapping())
         {
@@ -8617,8 +8617,8 @@ private:
 
     /// @brief Returns reference to the boolean node value.
     /// @throw fkyaml::exception The node value is not a boolean.
-    /// @return Reference to the boolean node value.
-    constexpr const boolean_type& get_value_ref_impl(const boolean_type* /*unused*/) const
+    /// @return Constant reference to the boolean node value.
+    const boolean_type& get_value_ref_impl(const boolean_type* /*unused*/) const
     {
         if (!is_boolean())
         {
@@ -8641,8 +8641,8 @@ private:
 
     /// @brief Returns reference to the integer node value.
     /// @throw fkyaml::exception The node value is not an integer.
-    /// @return Reference to the integer node value.
-    constexpr const integer_type& get_value_ref_impl(const integer_type* /*unused*/) const
+    /// @return Constant reference to the integer node value.
+    const integer_type& get_value_ref_impl(const integer_type* /*unused*/) const
     {
         if (!is_integer())
         {
@@ -8665,8 +8665,8 @@ private:
 
     /// @brief Returns reference to the floating point number node value.
     /// @throw fkyaml::exception The node value is not a floating point number.
-    /// @return Reference to the floating point number node value.
-    constexpr const float_number_type& get_value_ref_impl(const float_number_type* /*unused*/) const
+    /// @return Constant reference to the floating point number node value.
+    const float_number_type& get_value_ref_impl(const float_number_type* /*unused*/) const
     {
         if (!is_float_number())
         {
@@ -8689,8 +8689,8 @@ private:
 
     /// @brief Returns reference to the string node value.
     /// @throw fkyaml::exception The node value is not a string.
-    /// @return Reference to the string node value.
-    constexpr const string_type& get_value_ref_impl(const string_type* /*unused*/) const
+    /// @return Constant reference to the string node value.
+    const string_type& get_value_ref_impl(const string_type* /*unused*/) const
     {
         if (!is_string())
         {


### PR DESCRIPTION
As reported in #262, some jobs on GitHub Actions are not running unit tests since fkYAML unintendedly use C++14 features like binary integer literals and constexpr method with if statements.  
To keep fkYAML compatible with C++11, this PR has removed those keywords for now.  
What "for now" means is that fkYAML might introduce compile-time features in the future.  

---

## Pull Request Checklist

Read the [CONTRIBUTING.md](https://github.com/fktn-k/fkYAML/blob/develop/CONTRIBUTING.md) file for detailed information.  

- [x] Changes are described in the pull request or in a referenced [issue](https://github.com/fktn-k/fkYAML/issues).
- [x] The test suite compiles and runs without any error.
- [x] [The code coverage](https://coveralls.io/github/fktn-k/fkYAML) on your branch is 100%.
- [x] The documentation is updated if you added/changed a feature.

## Please don't

- The C++11 support varies between different **compilers** and versions. Please note the [list of supported compilers](https://github.com/fktn-k/fkYAML/blob/develop/README.md#supported-compilers). Some compilers like GCC 4.7 (and earlier), Clang 3.3 (and earlier), or Microsoft Visual Studio 13.0 and earlier are known not to work due to missing or incomplete C++11 support. Please refrain from proposing changes that work around these compiler's limitations with `#ifdef`s or other means.
- Please refrain from proposing changes that would **break [YAML](https://yaml.org/) specifications**. If you propose a conformant extension of YAML to be supported by the library, please motivate this extension.
- Please do not open pull requests that address **multiple issues**.