### PR TITLE
fixed typos which needs to be target_link_libraries() in tutorials

### DIFF
--- a/docs/mkdocs/docs/tutorials/cmake_integration.md
+++ b/docs/mkdocs/docs/tutorials/cmake_integration.md
@@ -23,7 +23,7 @@ The package configuration file, `fkYAMLConfig.cmake`, can be used either from an
     find_package(fkYAML 0.1.3 REQUIRED)
 
     add_executable(example example.cpp)
-    target_link_library(example PRIVATE fkYAML::fkYAML)
+    target_link_libraries(example PRIVATE fkYAML::fkYAML)
     ```
 
 ### With `add_subdirectory()`
@@ -62,5 +62,5 @@ Since CMake v3.11, [`FetchContent`](https://cmake.org/cmake/help/latest/module/F
     FetchContent_MakeAvailable(fkYAML)
 
     add_executable(example example.cpp)
-    target_link_library(example PRIVATE fkYAML::fkYAML)
+    target_link_libraries(example PRIVATE fkYAML::fkYAML)
     ```

--- a/docs/mkdocs/docs/tutorials/index.md
+++ b/docs/mkdocs/docs/tutorials/index.md
@@ -90,7 +90,7 @@ Also, make sure the example.yaml file is encoded in either the UTF-8, UTF-16BE/L
     add_executable(tutorial tutorial.cpp)
 
     # This exported CMake target sets the necessary configurations for the project.
-    target_link_library(tutorial PUBLIC fkYAML::fkYAML)
+    target_link_libraries(tutorial PUBLIC fkYAML::fkYAML)
     ```
 
 After creating a tutorial project with the above files, execute the following commands to build the project with CMake.  


### PR DESCRIPTION
As reported in #262, this PR has fixed typos which needs to be `target_link_libraries()` in the CMakeLists.txt files in tutorials.  
No other changes have been made.  

---

## Pull Request Checklist

Read the [CONTRIBUTING.md](https://github.com/fktn-k/fkYAML/blob/develop/CONTRIBUTING.md) file for detailed information.  

- [x] Changes are described in the pull request or in a referenced [issue](https://github.com/fktn-k/fkYAML/issues).
- [x] The test suite compiles and runs without any error.
- [x] [The code coverage](https://coveralls.io/github/fktn-k/fkYAML) on your branch is 100%.
- [x] The documentation is updated if you added/changed a feature.

## Please don't

- The C++11 support varies between different **compilers** and versions. Please note the [list of supported compilers](https://github.com/fktn-k/fkYAML/blob/develop/README.md#supported-compilers). Some compilers like GCC 4.7 (and earlier), Clang 3.3 (and earlier), or Microsoft Visual Studio 13.0 and earlier are known not to work due to missing or incomplete C++11 support. Please refrain from proposing changes that work around these compiler's limitations with `#ifdef`s or other means.
- Please refrain from proposing changes that would **break [YAML](https://yaml.org/) specifications**. If you propose a conformant extension of YAML to be supported by the library, please motivate this extension.
- Please do not open pull requests that address **multiple issues**.