### PR TITLE
#237 Support char8_t in deserialization

### DIFF
--- a/include/fkYAML/detail/encodings/encode_detector.hpp
+++ b/include/fkYAML/detail/encodings/encode_detector.hpp
@@ -97,7 +97,7 @@ inline encode_t detect_encoding_and_skip_bom(ItrType& begin, const ItrType& end)
     uint8_t bytes[4] = {0xFFu, 0xFFu, 0xFFu, 0xFFu};
     switch (ElemSize)
     {
-    case sizeof(char): {
+    case sizeof(char): { // this case covers char8_t as well when compiled with C++20 features.
         for (std::size_t i = 0; i < 4 && begin + i != end; i++)
         {
             bytes[i] = uint8_t(begin[i]);

--- a/include/fkYAML/detail/input/input_adapter.hpp
+++ b/include/fkYAML/detail/input/input_adapter.hpp
@@ -39,7 +39,6 @@ template <typename IterType, typename = void>
 class iterator_input_adapter;
 
 /// @brief An input adapter for iterators of type char.
-/// @note This adapter requires at least bidirectional iterator tag.
 /// @tparam IterType An iterator type.
 template <typename IterType>
 class iterator_input_adapter<
@@ -237,8 +236,85 @@ private:
     std::size_t m_utf8_buf_size {0};
 };
 
+#ifdef FK_YAML_HAS_CHAR8_T
+
+/// @brief An input adapter for iterators of type char8_t.
+/// @tparam IterType An iterator type.
+template <typename IterType>
+class iterator_input_adapter<
+    IterType,
+    enable_if_t<std::is_same<remove_cv_t<typename std::iterator_traits<IterType>::value_type>, char8_t>::value>>
+{
+public:
+    /// A type for characters used in this input adapter.
+    using char_type = char;
+
+    /// @brief Construct a new iterator_input_adapter object.
+    iterator_input_adapter() = default;
+
+    /// @brief Construct a new iterator_input_adapter object.
+    /// @param begin The beginning of iteraters.
+    /// @param end The end of iterators.
+    /// @param encode_type The encoding type for this input adapter.
+    iterator_input_adapter(IterType begin, IterType end, encode_t encode_type) noexcept
+        : m_current(begin),
+          m_end(end),
+          m_encode_type(encode_type)
+    {
+    }
+
+    // allow only move construct/assignment like other input adapters.
+    iterator_input_adapter(const iterator_input_adapter&) = delete;
+    iterator_input_adapter(iterator_input_adapter&& rhs) = default;
+    iterator_input_adapter& operator=(const iterator_input_adapter&) = delete;
+    iterator_input_adapter& operator=(iterator_input_adapter&&) = default;
+    ~iterator_input_adapter() = default;
+
+    /// @brief Get a character at the current position and move forward.
+    /// @return std::char_traits<char_type>::int_type A character or EOF.
+    typename std::char_traits<char_type>::int_type get_character()
+    {
+        typename std::char_traits<char_type>::int_type ret = 0;
+        switch (m_encode_type)
+        {
+        case encode_t::UTF_8_N:
+        case encode_t::UTF_8_BOM:
+            ret = get_character_for_utf8();
+            break;
+        default: // LCOV_EXCL_LINE
+            // char8_t characters must be encoded in the UTF-8 format.
+            // See https://www.open-std.org/jtc1/sc22/wg21/docs/papers/2018/p0482r6.html.
+            break; // LCOV_EXCL_LINE
+        }
+        return ret;
+    }
+
+private:
+    /// @brief The concrete implementation of get_character() for UTF-8 encoded inputs.
+    /// @return A UTF-8 encoded byte at the current position, or EOF.
+    typename std::char_traits<char_type>::int_type get_character_for_utf8() noexcept
+    {
+        if (m_current != m_end)
+        {
+            auto ret = std::char_traits<char_type>::to_int_type(*m_current);
+            ++m_current;
+            return ret;
+        }
+        return std::char_traits<char_type>::eof();
+    }
+
+private:
+    /// The iterator at the current position.
+    IterType m_current {};
+    /// The iterator at the end of input.
+    IterType m_end {};
+    /// The encoding type for this input adapter.
+    encode_t m_encode_type {encode_t::UTF_8_N};
+};
+
+#endif // defined(FK_YAML_HAS_CHAR8_T)
+
 /// @brief An input adapter for iterators of type char16_t.
-/// @note This adapter requires at least bidirectional iterator tag.
 /// @tparam IterType An iterator type.
 template <typename IterType>
 class iterator_input_adapter<
@@ -345,7 +421,6 @@ private:
 };
 
 /// @brief An input adapter for iterators of type char32_t.
-/// @note This adapter requires at least bidirectional iterator tag.
 /// @tparam IterType An iterator type.
 template <typename IterType>
 class iterator_input_adapter<

--- a/include/fkYAML/detail/macros/cpp_config_macros.hpp
+++ b/include/fkYAML/detail/macros/cpp_config_macros.hpp
@@ -40,4 +40,20 @@
     #define FK_YAML_INLINE_VAR
 #endif
 
+#ifdef __has_include
+    #if __has_include(<version>)
+        // <version> is available since C++20
+        #include <version>
+    #endif
+#endif
+
+// switch usage of char8_t. char8_t has been introduced since C++20
+#if !defined(FK_YAML_HAS_CHAR8_T)
+    #if defined(FK_YAML_HAS_CXX_20)
+        #if defined(__cpp_char8_t) && __cpp_char8_t >= 201811L
+            #define FK_YAML_HAS_CHAR8_T
+        #endif
+    #endif
+#endif
+
 #endif /* FK_YAML_DETAIL_MACROS_CPP_CONFIG_MACROS_HPP_ */

--- a/include/fkYAML/node.hpp
+++ b/include/fkYAML/node.hpp
@@ -1456,15 +1456,14 @@ inline fkyaml::node operator"" _yaml(const char32_t* s, std::size_t n)
     return fkyaml::node::deserialize((const char32_t*)s, (const char32_t*)s + n);
 }
 
-#if defined(__cpp_char8_t)
+#ifdef FK_YAML_HAS_CHAR8_T
 /// @brief The user-defined string literal which deserializes a `char8_t` array into a `node` object.
 /// @param s An input `char8_t` array.
 /// @param n The size of `s`.
 /// @return The resulting `node` object deserialized from `s`.
 inline fkyaml::node operator"" _yaml(const char8_t* s, std::size_t n)
 {
-    // TODO: This is a workaround. `char8_t` string literals should be supported in `input_adapter`
-    return fkyaml::node::deserialize((const char*)s, (const char*)s + n);
+    return fkyaml::node::deserialize((const char8_t*)s, (const char8_t*)s + n);
 }
 #endif
 

--- a/test/unit_test/test_node_class.cpp
+++ b/test/unit_test/test_node_class.cpp
@@ -433,8 +433,40 @@ TEST_CASE("NodeClassTest_ExtractionOperatorTest", "[NodeClassTest]")
 
 TEST_CASE("NodeClassTest_UserDefinedLiteralYamlTest", "[NodeClassTest]")
 {
+    SECTION("char sequences literals with using fkyaml::literals")
+    {
+        using namespace fkyaml::literals;
+        fkyaml::node node = "en: hello\njp: konnichiwa"_yaml;
 
-    SECTION("char sequences with using fkyaml::literals")
+        REQUIRE(node.is_mapping());
+        REQUIRE(node.size() == 2);
+        REQUIRE(node["en"].get_value_ref<std::string&>() == "hello");
+        REQUIRE(node["jp"].get_value_ref<std::string&>() == "konnichiwa");
+    }
+
+    SECTION("char sequences literals with using fkyaml::yaml_literals")
+    {
+        using namespace fkyaml::yaml_literals;
+        fkyaml::node node = "en: hello\njp: konnichiwa"_yaml;
+
+        REQUIRE(node.is_mapping());
+        REQUIRE(node.size() == 2);
+        REQUIRE(node["en"].get_value_ref<std::string&>() == "hello");
+        REQUIRE(node["jp"].get_value_ref<std::string&>() == "konnichiwa");
+    }
+
+    SECTION("char sequences literals with using fkyaml::literals::yaml_literals")
+    {
+        using namespace fkyaml::literals::yaml_literals;
+        fkyaml::node node = "en: hello\njp: konnichiwa"_yaml;
+
+        REQUIRE(node.is_mapping());
+        REQUIRE(node.size() == 2);
+        REQUIRE(node["en"].get_value_ref<std::string&>() == "hello");
+        REQUIRE(node["jp"].get_value_ref<std::string&>() == "konnichiwa");
+    }
+
+    SECTION("char sequences of u8\"\" literals with using fkyaml::literals")
     {
         using namespace fkyaml::literals;
         fkyaml::node node = u8"en: hello\njp: こんにちは"_yaml;
@@ -445,7 +477,7 @@ TEST_CASE("NodeClassTest_UserDefinedLiteralYamlTest", "[NodeClassTest]")
         REQUIRE(node["jp"].get_value_ref<std::string&>() == reinterpret_cast<const char*>(u8"こんにちは"));
     }
 
-    SECTION("char sequences with using fkyaml::yaml_literals")
+    SECTION("char sequences of u8\"\" literals with using fkyaml::yaml_literals")
     {
         using namespace fkyaml::yaml_literals;
         fkyaml::node node = u8"en: hello\njp: こんにちは"_yaml;
@@ -456,7 +488,7 @@ TEST_CASE("NodeClassTest_UserDefinedLiteralYamlTest", "[NodeClassTest]")
         REQUIRE(node["jp"].get_value_ref<std::string&>() == reinterpret_cast<const char*>(u8"こんにちは"));
     }
 
-    SECTION("char sequences with using fkyaml::literals::yaml_literals")
+    SECTION("char sequences of u8\"\" literals with using fkyaml::literals::yaml_literals")
     {
         using namespace fkyaml::literals::yaml_literals;
         fkyaml::node node = u8"en: hello\njp: こんにちは"_yaml;


### PR DESCRIPTION
As described in #237, since C++20, the string literal `u8""` has changed to return a `char8_t[N]` object, instead of a `char[N]` object, which has broken backward compatiblity with the code compiled with C++17 or earlier.  
fkYAML is intended to work C++11 and later, and so this PR has added a workaround to resolve the issue described above.  

---

## Pull Request Checklist

Read the [CONTRIBUTING.md](https://github.com/fktn-k/fkYAML/blob/develop/CONTRIBUTING.md) file for detailed information.  

- [x] Changes are described in the pull request or in a referenced [issue](https://github.com/fktn-k/fkYAML/issues).
- [x] The test suite compiles and runs without any error.
- [x] [The code coverage](https://coveralls.io/github/fktn-k/fkYAML) on your branch is 100%.
- [x] The documentation is updated if you added/changed a feature.

## Please don't

- The C++11 support varies between different **compilers** and versions. Please note the [list of supported compilers](https://github.com/fktn-k/fkYAML/blob/develop/README.md#supported-compilers). Some compilers like GCC 4.7 (and earlier), Clang 3.3 (and earlier), or Microsoft Visual Studio 13.0 and earlier are known not to work due to missing or incomplete C++11 support. Please refrain from proposing changes that work around these compiler's limitations with `#ifdef`s or other means.
- Please refrain from proposing changes that would **break [YAML](https://yaml.org/) specifications**. If you propose a conformant extension of YAML to be supported by the library, please motivate this extension.
- Please do not open pull requests that address **multiple issues**.