### PR TITLE
Modify handling node properties

### DIFF
--- a/docs/examples/ex_basic_node_is_alias.cpp
+++ b/docs/examples/ex_basic_node_is_alias.cpp
@@ -1,0 +1,20 @@
+#include <iomanip>
+#include <iostream>
+#include <fkYAML/node.hpp>
+
+int main()
+{
+    // create YAML nodes (both anchor/non-anchor)
+    fkyaml::node anchor = true;
+    anchor.add_anchor_name("anchor");
+    fkyaml::node alias = fkyaml::node::alias_of(anchor);
+    fkyaml::node non_alias = 123;
+
+    // print the result of testing whether they are an anchor node or not.
+    std::cout << std::boolalpha;
+    std::cout << anchor.is_alias() << std::endl;
+    std::cout << alias.is_alias() << std::endl;
+    std::cout << non_alias.is_alias() << std::endl;
+
+    return 0;
+}

--- a/docs/examples/ex_basic_node_is_alias.output
+++ b/docs/examples/ex_basic_node_is_alias.output
@@ -1,0 +1,3 @@
+false
+true
+false

--- a/docs/examples/ex_basic_node_is_anchor.cpp
+++ b/docs/examples/ex_basic_node_is_anchor.cpp
@@ -1,0 +1,17 @@
+#include <iomanip>
+#include <iostream>
+#include <fkYAML/node.hpp>
+
+int main()
+{
+    // create YAML nodes (both anchor/non-anchor)
+    fkyaml::node anchor = true;
+    anchor.add_anchor_name("anchor");
+    fkyaml::node non_anchor = 123;
+
+    // print the result of testing whether they are an anchor node or not.
+    std::cout << std::boolalpha << anchor.is_anchor() << std::endl;
+    std::cout << non_anchor.is_anchor() << std::endl;
+
+    return 0;
+}

--- a/docs/examples/ex_basic_node_is_anchor.output
+++ b/docs/examples/ex_basic_node_is_anchor.output
@@ -1,0 +1,2 @@
+true
+false

--- a/docs/examples/ex_macros_versions.output
+++ b/docs/examples/ex_macros_versions.output
@@ -1,1 +1,1 @@
-fkYAML version 0.3.0
+fkYAML version 0.3.1

--- a/docs/mkdocs/docs/api/basic_node/index.md
+++ b/docs/mkdocs/docs/api/basic_node/index.md
@@ -114,6 +114,8 @@ This class provides features to handle YAML nodes.
 ### Aliasing Nodes
 | Name                                  | Description                                              |
 | ------------------------------------- | -------------------------------------------------------- |
+| [is_alias](is_alias.md)               | checks if a basic_node is an alias node.                 |
+| [is_anchor](is_anchor.md)             | checks if a basic_node is an anchor node.                |
 | [add_anchor_name](add_anchor_name.md) | registers an anchor name to a basic_node object.         |
 | [get_anchor_name](get_anchor_name.md) | gets an anchor name associated with a basic_node object. |
 | [has_anchor_name](has_anchor_name.md) | checks if a basic_node has any anchor name.              |

--- a/docs/mkdocs/docs/api/basic_node/is_alias.md
+++ b/docs/mkdocs/docs/api/basic_node/is_alias.md
@@ -1,0 +1,29 @@
+<small>Defined in header [`<fkYAML/node.hpp>`](https://github.com/fktn-k/fkYAML/blob/develop/include/fkYAML/node.hpp)</small>
+
+# <small>fkyaml::basic_node::</small>is_alias
+
+```cpp
+bool is_alias() const noexcept;
+```
+
+Tests whether the node is an alias node.  
+
+### **Return Value**
+
+`true` if the node is an alias node, `false` otherwise.  
+
+???+ Example
+
+    ```cpp
+    --8<-- "examples/ex_basic_node_is_alias.cpp"
+    ```
+
+    output:
+    ```bash
+    --8<-- "examples/ex_basic_node_is_alias.output"
+    ```
+
+### **See Also**
+
+* [add_anchor_name](add_anchor_name.md)
+* [alias_of](alias_of.md)

--- a/docs/mkdocs/docs/api/basic_node/is_anchor.md
+++ b/docs/mkdocs/docs/api/basic_node/is_anchor.md
@@ -1,0 +1,28 @@
+<small>Defined in header [`<fkYAML/node.hpp>`](https://github.com/fktn-k/fkYAML/blob/develop/include/fkYAML/node.hpp)</small>
+
+# <small>fkyaml::basic_node::</small>is_anchor
+
+```cpp
+bool is_anchor() const noexcept;
+```
+
+Tests whether the node is an anchor node.  
+
+### **Return Value**
+
+`true` if the node is an anchor node, `false` otherwise.  
+
+???+ Example
+
+    ```cpp
+    --8<-- "examples/ex_basic_node_is_anchor.cpp"
+    ```
+
+    output:
+    ```bash
+    --8<-- "examples/ex_basic_node_is_anchor.output"
+    ```
+
+### **See Also**
+
+* [add_anchor_name](add_anchor_name.md)

--- a/docs/mkdocs/mkdocs.yml
+++ b/docs/mkdocs/mkdocs.yml
@@ -121,6 +121,8 @@ nav:
           - get_yaml_version: api/basic_node/get_yaml_version.md
           - has_anchor_name: api/basic_node/has_anchor_name.md
           - integer_type: api/basic_node/integer_type.md
+          - is_alias: api/basic_node/is_alias.md
+          - is_anchor: api/basic_node/is_anchor.md
           - is_boolean: api/basic_node/is_boolean.md
           - is_float_number: api/basic_node/is_float_number.md
           - is_integer: api/basic_node/is_integer.md

--- a/include/fkYAML/detail/conversions/to_string.hpp
+++ b/include/fkYAML/detail/conversions/to_string.hpp
@@ -34,13 +34,13 @@ namespace detail
 /// @param s A resulting output string.
 /// @param v A source value.
 template <typename ValueType, typename CharType>
-inline void to_string(std::basic_string<CharType>& s, ValueType v) noexcept;
+inline void to_string(ValueType v, std::basic_string<CharType>& s) noexcept;
 
 /// @brief Specialization of to_string() for null values.
 /// @param s A resulting string YAML token.
 /// @param (unused) nullptr
 template <>
-inline void to_string(std::string& s, std::nullptr_t /*unused*/) noexcept
+inline void to_string(std::nullptr_t /*unused*/, std::string& s) noexcept
 {
     s = "null";
 }
@@ -49,7 +49,7 @@ inline void to_string(std::string& s, std::nullptr_t /*unused*/) noexcept
 /// @param s A resulting string YAML token.
 /// @param b A boolean source value.
 template <>
-inline void to_string(std::string& s, bool b) noexcept
+inline void to_string(bool b, std::string& s) noexcept
 {
     s = b ? "true" : "false";
 }
@@ -59,7 +59,7 @@ inline void to_string(std::string& s, bool b) noexcept
 /// @param s A resulting string YAML token.
 /// @param i An integer source value.
 template <typename IntegerType>
-inline enable_if_t<is_non_bool_integral<IntegerType>::value> to_string(std::string& s, IntegerType i) noexcept
+inline enable_if_t<is_non_bool_integral<IntegerType>::value> to_string(IntegerType i, std::string& s) noexcept
 {
     s = std::to_string(i);
 }
@@ -69,7 +69,7 @@ inline enable_if_t<is_non_bool_integral<IntegerType>::value> to_string(std::stri
 /// @param s A resulting string YAML token.
 /// @param f A floating point number source value.
 template <typename FloatType>
-inline enable_if_t<std::is_floating_point<FloatType>::value> to_string(std::string& s, FloatType f) noexcept
+inline enable_if_t<std::is_floating_point<FloatType>::value> to_string(FloatType f, std::string& s) noexcept
 {
     if (std::isnan(f))
     {

--- a/include/fkYAML/detail/node_property.hpp
+++ b/include/fkYAML/detail/node_property.hpp
@@ -1,0 +1,44 @@
+///  _______   __ __   __  _____   __  __  __
+/// |   __| |_/  |  \_/  |/  _  \ /  \/  \|  |     fkYAML: A C++ header-only YAML library
+/// |   __|  _  < \_   _/|  ___  |    _   |  |___  version 0.3.1
+/// |__|  |_| \__|  |_|  |_|   |_|___||___|______| https://github.com/fktn-k/fkYAML
+///
+/// SPDX-FileCopyrightText: 2023 Kensuke Fukutani <fktn.dev@gmail.com>
+/// SPDX-License-Identifier: MIT
+///
+/// @file
+
+#ifndef FK_YAML_DETAIL_NODE_PROPERTY_HPP_
+#define FK_YAML_DETAIL_NODE_PROPERTY_HPP_
+
+#include <string>
+
+#include <fkYAML/detail/macros/version_macros.hpp>
+
+/// @brief namespace for fkYAML library.
+FK_YAML_NAMESPACE_BEGIN
+
+/// @brief namespace for internal implementations of fkYAML library.
+namespace detail
+{
+
+enum class anchor_status_t
+{
+    NONE,
+    ANCHOR,
+    ALIAS,
+};
+
+struct node_property
+{
+    std::string tag {};
+    anchor_status_t anchor_status {anchor_status_t::NONE};
+    std::string anchor {};
+};
+
+
+} // namespace detail
+
+FK_YAML_NAMESPACE_END
+
+#endif /* FK_YAML_DETAIL_NODE_PROPERTY_HPP_ */

--- a/include/fkYAML/detail/node_property.hpp
+++ b/include/fkYAML/detail/node_property.hpp
@@ -36,7 +36,6 @@ struct node_property
     std::string anchor {};
 };
 
-
 } // namespace detail
 
 FK_YAML_NAMESPACE_END

--- a/include/fkYAML/detail/output/serializer.hpp
+++ b/include/fkYAML/detail/output/serializer.hpp
@@ -62,8 +62,21 @@ private:
         case node_t::SEQUENCE:
             for (const auto& seq_item : node)
             {
-                insert_indentation(cur_indent, str);
+                if (cur_indent > 0)
+                {
+                    insert_indentation(cur_indent, str);
+                }
                 str += "-";
+
+                bool is_appended = try_append_alias(seq_item, true, str);
+                if (is_appended)
+                {
+                    str += "\n";
+                    continue;
+                }
+
+                try_append_anchor(seq_item, true, str);
+
                 bool is_scalar = seq_item.is_scalar();
                 if (is_scalar)
                 {
@@ -81,9 +94,33 @@ private:
         case node_t::MAPPING:
             for (auto itr = node.begin(); itr != node.end(); ++itr)
             {
-                insert_indentation(cur_indent, str);
-                serialize_node(itr.key(), cur_indent, str);
+                if (cur_indent > 0)
+                {
+                    insert_indentation(cur_indent, str);
+                }
+
+                bool is_appended = try_append_alias(itr.key(), false, str);
+                if (!is_appended)
+                {
+                    is_appended = try_append_anchor(itr.key(), false, str);
+                    if (is_appended)
+                    {
+                        str += " ";
+                    }
+                    serialize_node(itr.key(), cur_indent, str);
+                }
+
                 str += ":";
+
+                is_appended = try_append_alias(*itr, true, str);
+                if (is_appended)
+                {
+                    str += "\n";
+                    continue;
+                }
+
+                try_append_anchor(*itr, true, str);
+
                 bool is_scalar = itr->is_scalar();
                 if (is_scalar)
                 {
@@ -328,10 +365,45 @@ private:
     /// @param str A string to hold serialization result.
     void insert_indentation(const uint32_t cur_indent, std::string& str) const noexcept
     {
-        for (uint32_t i = 0; i < cur_indent; ++i)
+        str.append(cur_indent, ' ');
+    }
+
+    /// @brief Append an anchor property if it's available. Do nothing otherwise.
+    /// @param node The target node which is possibly an anchor node.
+    /// @param prepends_space Whether or not to prepend a space before an anchor property.
+    /// @param str A string to hold serialization result.
+    /// @return true if an anchor property has been appended, false otherwise.
+    bool try_append_anchor(const BasicNodeType& node, bool prepends_space, std::string& str) const
+    {
+        if (node.is_anchor())
         {
-            str += " ";
+            if (prepends_space)
+            {
+                str += " ";
+            }
+            str += "&" + node.get_anchor_name();
+            return true;
         }
+        return false;
+    }
+
+    /// @brief Append an alias property if it's available. Do nothing otherwise.
+    /// @param node The target node which is possibly an alias node.
+    /// @param prepends_space Whether or not to prepend a space before an alias property.
+    /// @param str A string to hold serialization result.
+    /// @return true if an alias property has been appended, false otherwise.
+    bool try_append_alias(const BasicNodeType& node, bool prepends_space, std::string& str) const
+    {
+        if (node.is_alias())
+        {
+            if (prepends_space)
+            {
+                str += " ";
+            }
+            str += "*" + node.get_anchor_name();
+            return true;
+        }
+        return false;
     }
 
 private:

--- a/include/fkYAML/detail/output/serializer.hpp
+++ b/include/fkYAML/detail/output/serializer.hpp
@@ -99,19 +99,19 @@ private:
             }
             break;
         case node_t::NULL_OBJECT:
-            to_string(m_tmp_str_buff, nullptr);
+            to_string(nullptr, m_tmp_str_buff);
             str += m_tmp_str_buff;
             break;
         case node_t::BOOLEAN:
-            to_string(m_tmp_str_buff, node.template get_value<typename BasicNodeType::boolean_type>());
+            to_string(node.template get_value<typename BasicNodeType::boolean_type>(), m_tmp_str_buff);
             str += m_tmp_str_buff;
             break;
         case node_t::INTEGER:
-            to_string(m_tmp_str_buff, node.template get_value<typename BasicNodeType::integer_type>());
+            to_string(node.template get_value<typename BasicNodeType::integer_type>(), m_tmp_str_buff);
             str += m_tmp_str_buff;
             break;
         case node_t::FLOAT_NUMBER:
-            to_string(m_tmp_str_buff, node.template get_value<typename BasicNodeType::float_number_type>());
+            to_string(node.template get_value<typename BasicNodeType::float_number_type>(), m_tmp_str_buff);
             str += m_tmp_str_buff;
             break;
         case node_t::STRING: {

--- a/include/fkYAML/node.hpp
+++ b/include/fkYAML/node.hpp
@@ -254,16 +254,13 @@ private:
     }
 
     /// @brief Destroys and deallocates an object with specified type.
+    /// @warning Make sure the `obj` parameter is not nullptr before calling this function.
     /// @tparam ObjType The target object type.
     /// @param[in] obj A pointer to the target object to be destroyed.
     template <typename ObjType>
     static void destroy_object(ObjType* obj)
     {
-        if (!obj)
-        {
-            return;
-        }
-
+        FK_YAML_ASSERT(obj != nullptr);
         std::allocator<ObjType> alloc;
         std::allocator_traits<decltype(alloc)>::destroy(alloc, obj);
         std::allocator_traits<decltype(alloc)>::deallocate(alloc, obj, 1);
@@ -562,7 +559,7 @@ public:
         node.m_prop.anchor_status = detail::anchor_status_t::ALIAS;
         node.m_prop.anchor = anchor_node.m_prop.anchor;
         return node;
-    }
+    } // LCOV_EXCL_LINE
 
 public:
     /// @brief A copy assignment operator of the basic_node class.
@@ -914,6 +911,22 @@ public:
     bool is_scalar() const noexcept
     {
         return !is_sequence() && !is_mapping();
+    }
+
+    /// @brief Tests whether the current basic_node is an anchor node.
+    /// @return true if the current basic_node is an anchor node, false otherwise.
+    /// @sa https://fktn-k.github.io/fkYAML/api/basic_node/is_anchor/
+    bool is_anchor() const noexcept
+    {
+        return m_prop.anchor_status == detail::anchor_status_t::ANCHOR;
+    }
+
+    /// @brief Tests whether the current basic_node is an alias node.
+    /// @return true if the current basic_node is an alias node, false otherwise.
+    /// @sa https://fktn-k.github.io/fkYAML/api/basic_node/is_alias/
+    bool is_alias() const noexcept
+    {
+        return m_prop.anchor_status == detail::anchor_status_t::ALIAS;
     }
 
     /// @brief Tests whether the current basic_node value (sequence, mapping, string) is empty.

--- a/include/fkYAML/node.hpp
+++ b/include/fkYAML/node.hpp
@@ -29,6 +29,7 @@
 #include <fkYAML/detail/meta/node_traits.hpp>
 #include <fkYAML/detail/meta/stl_supplement.hpp>
 #include <fkYAML/detail/meta/type_traits.hpp>
+#include <fkYAML/detail/node_property.hpp>
 #include <fkYAML/detail/node_ref_storage.hpp>
 #include <fkYAML/detail/output/serializer.hpp>
 #include <fkYAML/detail/types/node_t.hpp>
@@ -287,7 +288,8 @@ public:
     /// @sa https://fktn-k.github.io/fkYAML/api/basic_node/constructor/
     basic_node(const basic_node& rhs)
         : m_node_type(rhs.m_node_type),
-          m_yaml_version_type(rhs.m_yaml_version_type)
+          m_yaml_version_type(rhs.m_yaml_version_type),
+          m_prop(rhs.m_prop)
     {
         switch (m_node_type)
         {
@@ -316,12 +318,6 @@ public:
             FK_YAML_ASSERT(m_node_value.p_string != nullptr);
             break;
         }
-
-        if (rhs.m_anchor_name)
-        {
-            m_anchor_name = create_object<std::string>(*(rhs.m_anchor_name));
-            FK_YAML_ASSERT(m_anchor_name != nullptr);
-        }
     }
 
     /// @brief Move constructor of the basic_node class.
@@ -330,7 +326,7 @@ public:
     basic_node(basic_node&& rhs) noexcept
         : m_node_type(rhs.m_node_type),
           m_yaml_version_type(rhs.m_yaml_version_type),
-          m_anchor_name(rhs.m_anchor_name)
+          m_prop(std::move(rhs.m_prop))
     {
         switch (m_node_type)
         {
@@ -370,7 +366,7 @@ public:
         rhs.m_node_type = node_t::NULL_OBJECT;
         rhs.m_yaml_version_type = yaml_version_t::VER_1_2;
         rhs.m_node_value.p_mapping = nullptr;
-        rhs.m_anchor_name = nullptr;
+        rhs.m_prop.anchor_status = detail::anchor_status_t::NONE;
     }
 
     /// @brief Construct a new basic_node object from a value of compatible types.
@@ -436,8 +432,6 @@ public:
     /// @sa https://fktn-k.github.io/fkYAML/api/basic_node/destructor/
     ~basic_node() noexcept // NOLINT(bugprone-exception-escape)
     {
-        destroy_object<std::string>(m_anchor_name);
-        m_anchor_name = nullptr;
         m_node_value.destroy(m_node_type);
         m_node_type = node_t::NULL_OBJECT;
     }
@@ -559,12 +553,14 @@ public:
     /// @sa https://fktn-k.github.io/fkYAML/api/basic_node/alias_of/
     static basic_node alias_of(const basic_node& anchor_node)
     {
-        if (!anchor_node.m_anchor_name || anchor_node.m_anchor_name->empty())
+        if (!anchor_node.has_anchor_name() || anchor_node.m_prop.anchor_status != detail::anchor_status_t::ANCHOR)
         {
             throw fkyaml::exception("Cannot create an alias without anchor name.");
         }
 
         basic_node node = anchor_node;
+        node.m_prop.anchor_status = detail::anchor_status_t::ALIAS;
+        node.m_prop.anchor = anchor_node.m_prop.anchor;
         return node;
     }
 
@@ -1030,7 +1026,7 @@ public:
     /// @sa https://fktn-k.github.io/fkYAML/api/basic_node/has_anchor_name/
     bool has_anchor_name() const noexcept
     {
-        return m_anchor_name != nullptr;
+        return m_prop.anchor_status != detail::anchor_status_t::NONE && !m_prop.anchor.empty();
     }
 
     /// @brief Get the anchor name associated to this basic_node object.
@@ -1040,11 +1036,11 @@ public:
     /// @sa https://fktn-k.github.io/fkYAML/api/basic_node/get_anchor_name/
     const std::string& get_anchor_name() const
     {
-        if (!m_anchor_name)
+        if (!has_anchor_name())
         {
             throw fkyaml::exception("No anchor name has been set.");
         }
-        return *m_anchor_name;
+        return m_prop.anchor;
     }
 
     /// @brief Add an anchor name to this basic_node object.
@@ -1052,9 +1048,8 @@ public:
     /// @sa https://fktn-k.github.io/fkYAML/api/basic_node/add_anchor_name/
     void add_anchor_name(const std::string& anchor_name)
     {
-        destroy_object<std::string>(m_anchor_name);
-        m_anchor_name = create_object<std::string>(anchor_name);
-        FK_YAML_ASSERT(m_anchor_name != nullptr);
+        m_prop.anchor_status = detail::anchor_status_t::ANCHOR;
+        m_prop.anchor = anchor_name;
     }
 
     /// @brief Add an anchor name to this basic_node object.
@@ -1063,9 +1058,8 @@ public:
     /// @sa https://fktn-k.github.io/fkYAML/api/basic_node/add_anchor_name/
     void add_anchor_name(std::string&& anchor_name)
     {
-        destroy_object<std::string>(m_anchor_name);
-        m_anchor_name = create_object<std::string>(std::move(anchor_name));
-        FK_YAML_ASSERT(m_anchor_name != nullptr);
+        m_prop.anchor_status = detail::anchor_status_t::ANCHOR;
+        m_prop.anchor = std::move(anchor_name);
     }
 
     /// @brief Get the node value object converted into a given type.
@@ -1127,7 +1121,9 @@ public:
         std::memcpy(&m_node_value, &rhs.m_node_value, sizeof(node_value));
         std::memcpy(&rhs.m_node_value, &tmp, sizeof(node_value));
 
-        swap(m_anchor_name, rhs.m_anchor_name);
+        swap(m_prop.tag, rhs.m_prop.tag);
+        swap(m_prop.anchor_status, rhs.m_prop.anchor_status);
+        swap(m_prop.anchor, rhs.m_prop.anchor);
     }
 
     /// @brief Returns the first iterator of basic_node values of container types (sequence or mapping) from a non-const
@@ -1357,8 +1353,8 @@ private:
     yaml_version_t m_yaml_version_type {yaml_version_t::VER_1_2};
     /// The current node value.
     node_value m_node_value {};
-    /// The anchor name for this node.
-    std::string* m_anchor_name {nullptr};
+    /// The property set of this node.
+    detail::node_property m_prop {};
 };
 
 /// @brief Swap function for basic_node objects.

--- a/test/unit_test/test_serializer_class.cpp
+++ b/test/unit_test/test_serializer_class.cpp
@@ -157,10 +157,7 @@ TEST_CASE("SerializerClassTest_SerializeStringNode", "[SerializerClassTest]")
 
 TEST_CASE("SerializerClassTest_SerializeAnchorNode", "[SerializerClassTest]")
 {
-    fkyaml::node node = {
-        { "foo", 123 },
-        { nullptr, { true, "bar", 3.14 } }
-    };
+    fkyaml::node node = {{"foo", 123}, {nullptr, {true, "bar", 3.14}}};
     node[nullptr].add_anchor_name("A");
     node[nullptr][2].add_anchor_name("B");
     fkyaml::node key = "baz";
@@ -180,13 +177,11 @@ TEST_CASE("SerializerClassTest_SerializeAnchorNode", "[SerializerClassTest]")
 
 TEST_CASE("SerializerClassTest_SerializeAliasNode", "[SerializerClassTest]")
 {
-    fkyaml::node node = {
-        { "foo", 123 }
-    };
+    fkyaml::node node = {{"foo", 123}};
     node["foo"].add_anchor_name("A");
     node.get_value_ref<fkyaml::node::mapping_type&>().emplace(true, fkyaml::node::alias_of(node["foo"]));
     node.get_value_ref<fkyaml::node::mapping_type&>().emplace(fkyaml::node::alias_of(node["foo"]), 3.14);
-    node[nullptr] = { "bar", fkyaml::node::alias_of(node["foo"]) };
+    node[nullptr] = {"bar", fkyaml::node::alias_of(node["foo"])};
 
     // FIXME: Semantic equality between the input & the output is not guranteed
     //        when anchors/aliases are contained in a YAML document.

--- a/test/unit_test/test_serializer_class.cpp
+++ b/test/unit_test/test_serializer_class.cpp
@@ -154,3 +154,53 @@ TEST_CASE("SerializerClassTest_SerializeStringNode", "[SerializerClassTest]")
     fkyaml::detail::basic_serializer<fkyaml::node> serializer;
     REQUIRE(serializer.serialize(node_str_pair.first) == node_str_pair.second);
 }
+
+TEST_CASE("SerializerClassTest_SerializeAnchorNode", "[SerializerClassTest]")
+{
+    fkyaml::node node = {
+        { "foo", 123 },
+        { nullptr, { true, "bar", 3.14 } }
+    };
+    node[nullptr].add_anchor_name("A");
+    node[nullptr][2].add_anchor_name("B");
+    fkyaml::node key = "baz";
+    key.add_anchor_name("C");
+    node.get_value_ref<fkyaml::node::mapping_type&>().emplace(key, "qux");
+
+    std::string expected = "null: &A\n"
+                           "  - true\n"
+                           "  - bar\n"
+                           "  - &B 3.14\n"
+                           "&C baz: qux\n"
+                           "foo: 123\n";
+
+    fkyaml::detail::basic_serializer<fkyaml::node> serializer;
+    REQUIRE(serializer.serialize(node) == expected);
+}
+
+TEST_CASE("SerializerClassTest_SerializeAliasNode", "[SerializerClassTest]")
+{
+    fkyaml::node node = {
+        { "foo", 123 }
+    };
+    node["foo"].add_anchor_name("A");
+    node.get_value_ref<fkyaml::node::mapping_type&>().emplace(true, fkyaml::node::alias_of(node["foo"]));
+    node.get_value_ref<fkyaml::node::mapping_type&>().emplace(fkyaml::node::alias_of(node["foo"]), 3.14);
+    node[nullptr] = { "bar", fkyaml::node::alias_of(node["foo"]) };
+
+    // FIXME: Semantic equality between the input & the output is not guranteed
+    //        when anchors/aliases are contained in a YAML document.
+    //        This is because mappings have no information to correctly revoke
+    //        the original relations between anchors & aliases.
+    //        Using fkyaml::ordered_map as the type of mappings should solve the
+    //        issue.
+    std::string expected = "null:\n"
+                           "  - bar\n"
+                           "  - *A\n"
+                           "true: *A\n"
+                           "*A: 3.14\n"
+                           "foo: &A 123\n";
+
+    fkyaml::detail::basic_serializer<fkyaml::node> serializer;
+    REQUIRE(serializer.serialize(node) == expected);
+}


### PR DESCRIPTION
This PR improved the way of handling anchors/aliases by classifying them as node properties.  
Along the way, new basic_node APIs, `is_anchor()` and `is_alias()`, have been added with descriptions in the documentation.  

---

## Pull Request Checklist

Read the [CONTRIBUTING.md](https://github.com/fktn-k/fkYAML/blob/develop/CONTRIBUTING.md) file for detailed information.  

- [x] Changes are described in the pull request or in a referenced [issue](https://github.com/fktn-k/fkYAML/issues).
- [x] The test suite compiles and runs without any error.
- [x] [The code coverage](https://coveralls.io/github/fktn-k/fkYAML) on your branch is 100%.
- [x] The documentation is updated if you added/changed a feature.

## Please don't

- The C++11 support varies between different **compilers** and versions. Please note the [list of supported compilers](https://github.com/fktn-k/fkYAML/blob/develop/README.md#supported-compilers). Some compilers like GCC 4.7 (and earlier), Clang 3.3 (and earlier), or Microsoft Visual Studio 13.0 and earlier are known not to work due to missing or incomplete C++11 support. Please refrain from proposing changes that work around these compiler's limitations with `#ifdef`s or other means.
- Please refrain from proposing changes that would **break [YAML](https://yaml.org/) specifications**. If you propose a conformant extension of YAML to be supported by the library, please motivate this extension.
- Please do not open pull requests that address **multiple issues**.