### PR TITLE
Add workflow jobs with the macos-13 runner image

### DIFF
--- a/.github/workflows/macos.yml
+++ b/.github/workflows/macos.yml
@@ -27,7 +27,7 @@ concurrency:
   cancel-in-progress: true
 
 env:
-  JOBS: 4
+  JOBS: 3
 
 jobs:
   macos-latest:
@@ -76,7 +76,7 @@ jobs:
 
     - name: Test
       working-directory: ${{github.workspace}}/build
-      run: ctest -C ${{matrix.build_type}} --output-on-failure -j${{env.JOBS}}
+      run: ctest -C ${{matrix.build_type}} --output-on-failure -j ${{env.JOBS}}
 
   xcode_for_macos12:
     timeout-minutes: 10
@@ -101,4 +101,29 @@ jobs:
 
     - name: Test
       working-directory: ${{github.workspace}}/build
-      run: ctest -C ${{matrix.build_type}} --output-on-failure -j${{env.JOBS}}
+      run: ctest -C ${{matrix.build_type}} --output-on-failure -j ${{env.JOBS}}
+
+  xcode_for_macos13:
+    timeout-minutes: 10
+    runs-on: macos-13
+    strategy:
+      matrix:
+        xcode: [ '14.1', '14.2', '14.3.1', '15.0.1', '15.1', '15.2' ]
+        build_type: [ Debug, Release ]
+    env:
+      DEVELOPER_DIR: /Applications/Xcode_${{matrix.xcode}}.app/Contents/Developer
+
+    steps:
+    - uses: actions/checkout@v3
+      with:
+        submodules: recursive
+
+    - name: Configure CMake
+      run: cmake -B ${{github.workspace}}/build -DCMAKE_BUILD_TYPE=${{matrix.build_type}} -DFK_YAML_BUILD_TEST=ON
+
+    - name: Build
+      run: cmake --build ${{github.workspace}}/build --config ${{matrix.build_type}} -j ${{env.JOBS}}
+
+    - name: Test
+      working-directory: ${{github.workspace}}/build
+      run: ctest -C ${{matrix.build_type}} --output-on-failure -j ${{env.JOBS}}

--- a/README.md
+++ b/README.md
@@ -90,47 +90,51 @@ $ ctest -C Debug --test-dir build --output-on-failure
 ## Supported compilers
 Currently, the following compilers are known to work and used in GitHub Actions workflows:
 
-| Compiler                                 | Operating System   |
-| ---------------------------------------- | ------------------ |
-| AppleClang 11.0.3.11030032               | macOS 11.7.9       |
-| AppleClang 12.0.0.12000032               | macOS 11.7.9       |
-| AppleClang 12.0.5.12050022               | macOS 11.7.9       |
-| AppleClang 13.0.0.13000029               | macOS 11.7.9       |
-| AppleClang 13.0.0.13000029               | macOS 12.6.8       |
-| AppleClang 13.1.6.13160021               | macOS 12.6.8       |
-| AppleClang 14.0.0.14000029               | macOS 12.6.8       |
-| Clang 3.5.2                              | Ubuntu 22.04.3 LTS |
-| Clang 3.6.2                              | Ubuntu 22.04.3 LTS |
-| Clang 3.7.1                              | Ubuntu 22.04.3 LTS |
-| Clang 3.8.1                              | Ubuntu 22.04.3 LTS |
-| Clang 3.9.1                              | Ubuntu 22.04.3 LTS |
-| Clang 4.0.1                              | Ubuntu 22.04.3 LTS |
-| Clang 5.0.2                              | Ubuntu 22.04.3 LTS |
-| Clang 6.0.1                              | Ubuntu 22.04.3 LTS |
-| Clang 7.1.0                              | Ubuntu 22.04.3 LTS |
-| Clang 9.0.1                              | Ubuntu 22.04.3 LTS |
-| Clang 10.0.1                             | Ubuntu 22.04.3 LTS |
-| Clang 11.1.0                             | Ubuntu 22.04.3 LTS |
-| Clang 12.0.1                             | Ubuntu 22.04.3 LTS |
-| Clang 13.0.1                             | Ubuntu 22.04.3 LTS |
-| Clang 14.0.6                             | Ubuntu 22.04.3 LTS |
-| Clang 15.0.7                             | Ubuntu 22.04.3 LTS |
-| Clang 16.0.6                             | Ubuntu 22.04.3 LTS |
-| Clang 17.0.4                             | Ubuntu 22.04.3 LTS |
-| GCC 7.5.0                                | Ubuntu 22.04.3 LTS |
-| GCC 8.5.0                                | Ubuntu 22.04.3 LTS |
-| GCC 9.5.0                                | Ubuntu 22.04.3 LTS |
-| GCC 10.5.0                               | Ubuntu 22.04.3 LTS |
-| GCC 11.4.0                               | Ubuntu 22.04.3 LTS |
-| GCC 12.3.0                               | Ubuntu 22.04.3 LTS |
-| GCC 13.2.0                               | Ubuntu 22.04.3 LTS |
-| MinGW-64 8.1.0                           | Windows-10.0.17763 |
-| MinGW-64 12.2.0                          | Windows-10.0.20348 |
-| Visual Studio 16 2019 MSVC 19.29.30152.0 | Windows-10.0.17763 |
-| Visual Studio 17 2022 MSVC 19.35.32217.1 | Windows-10.0.20348 |
+| Compiler                   | Operating System                                                                                               |
+| -------------------------- | -------------------------------------------------------------------------------------------------------------- |
+| AppleClang 11.0.3.11030032 | [macOS 11](https://github.com/actions/runner-images/blob/main/images/macos/macos-11-Readme.md)                 |
+| AppleClang 12.0.0.12000032 | [macOS 11](https://github.com/actions/runner-images/blob/main/images/macos/macos-11-Readme.md)                 |
+| AppleClang 12.0.5.12050022 | [macOS 11](https://github.com/actions/runner-images/blob/main/images/macos/macos-11-Readme.md)                 |
+| AppleClang 13.0.0.13000029 | [macOS 11](https://github.com/actions/runner-images/blob/main/images/macos/macos-11-Readme.md)                 |
+| AppleClang 13.0.0.13000029 | [macOS 12](https://github.com/actions/runner-images/blob/main/images/macos/macos-12-Readme.md)                 |
+| AppleClang 13.1.6.13160021 | [macOS 12](https://github.com/actions/runner-images/blob/main/images/macos/macos-12-Readme.md)                 |
+| AppleClang 14.0.0.14000029 | [macOS 12](https://github.com/actions/runner-images/blob/main/images/macos/macos-12-Readme.md)                 |
+| AppleClang 14.0.0.14000029 | [macOS 13](https://github.com/actions/runner-images/blob/main/images/macos/macos-13-Readme.md)                 |
+| AppleClang 14.0.3.14030022 | [macOS 13](https://github.com/actions/runner-images/blob/main/images/macos/macos-13-Readme.md)                 |
+| AppleClang 15.0.0.15000040 | [macOS 13](https://github.com/actions/runner-images/blob/main/images/macos/macos-13-Readme.md)                 |
+| AppleClang 15.0.0.15000100 | [macOS 13](https://github.com/actions/runner-images/blob/main/images/macos/macos-13-Readme.md)                 |
+| Clang 3.5.2                | Ubuntu 22.04.3 LTS                                                                                             |
+| Clang 3.6.2                | Ubuntu 22.04.3 LTS                                                                                             |
+| Clang 3.7.1                | Ubuntu 22.04.3 LTS                                                                                             |
+| Clang 3.8.1                | Ubuntu 22.04.3 LTS                                                                                             |
+| Clang 3.9.1                | Ubuntu 22.04.3 LTS                                                                                             |
+| Clang 4.0.1                | Ubuntu 22.04.3 LTS                                                                                             |
+| Clang 5.0.2                | Ubuntu 22.04.3 LTS                                                                                             |
+| Clang 6.0.1                | Ubuntu 22.04.3 LTS                                                                                             |
+| Clang 7.1.0                | Ubuntu 22.04.3 LTS                                                                                             |
+| Clang 9.0.1                | Ubuntu 22.04.3 LTS                                                                                             |
+| Clang 10.0.1               | Ubuntu 22.04.3 LTS                                                                                             |
+| Clang 11.1.0               | Ubuntu 22.04.3 LTS                                                                                             |
+| Clang 12.0.1               | Ubuntu 22.04.3 LTS                                                                                             |
+| Clang 13.0.1               | Ubuntu 22.04.3 LTS                                                                                             |
+| Clang 14.0.6               | Ubuntu 22.04.3 LTS                                                                                             |
+| Clang 15.0.7               | Ubuntu 22.04.3 LTS                                                                                             |
+| Clang 16.0.6               | Ubuntu 22.04.3 LTS                                                                                             |
+| Clang 17.0.6               | Ubuntu 22.04.3 LTS                                                                                             |
+| GCC 7.5.0                  | Ubuntu 22.04.3 LTS                                                                                             |
+| GCC 8.5.0                  | Ubuntu 22.04.3 LTS                                                                                             |
+| GCC 9.5.0                  | Ubuntu 22.04.3 LTS                                                                                             |
+| GCC 10.5.0                 | Ubuntu 22.04.3 LTS                                                                                             |
+| GCC 11.4.0                 | Ubuntu 22.04.3 LTS                                                                                             |
+| GCC 12.3.0                 | Ubuntu 22.04.3 LTS                                                                                             |
+| GCC 13.2.0                 | Ubuntu 22.04.3 LTS                                                                                             |
+| MinGW-64 8.1.0             | [Windows Server 2019](https://github.com/actions/runner-images/blob/main/images/windows/Windows2019-Readme.md) |
+| MinGW-64 12.2.0            | [Windows Server 2022](https://github.com/actions/runner-images/blob/main/images/windows/Windows2022-Readme.md) |
+| Visual Studio 16 2019      | [Windows Server 2019](https://github.com/actions/runner-images/blob/main/images/windows/Windows2019-Readme.md) |
+| Visual Studio 17 2022      | [Windows Server 2022](https://github.com/actions/runner-images/blob/main/images/windows/Windows2022-Readme.md) |
 
 Requests for new compiler supports are welcome.  
-If you encounter a problem regarding compilers, please let us know by creating an issue or a PR with the information of your Operating System so that we can reproduce the same situation.  
+If you encounter a problem regarding compilers, please let us know by [creating an issue](https://github.com/fktn-k/fkYAML/issues/new?assignees=&labels=kind%3A+bug&projects=&template=bug-report.yml) or a PR with the information of your Operating System so that the same situation can be reproduced.  
 
 ## License
 

--- a/docs/mkdocs/docs/home/supported_compilers.md
+++ b/docs/mkdocs/docs/home/supported_compilers.md
@@ -1,45 +1,49 @@
 # Supported Compilers
 
-Currently, the following compilers are known to work and used in CI workflows:
+Currently, the following compilers are known to work and used in GitHub Actions workflows:
 
-| Compiler                                 | Operating System   |
-| ---------------------------------------- | ------------------ |
-| AppleClang 11.0.3.11030032               | macOS 11.7.9       |
-| AppleClang 12.0.0.12000032               | macOS 11.7.9       |
-| AppleClang 12.0.5.12050022               | macOS 11.7.9       |
-| AppleClang 13.0.0.13000029               | macOS 11.7.9       |
-| AppleClang 13.0.0.13000029               | macOS 12.6.8       |
-| AppleClang 13.1.6.13160021               | macOS 12.6.8       |
-| AppleClang 14.0.0.14000029               | macOS 12.6.8       |
-| Clang 3.5.2                              | Ubuntu 22.04.3 LTS |
-| Clang 3.6.2                              | Ubuntu 22.04.3 LTS |
-| Clang 3.7.1                              | Ubuntu 22.04.3 LTS |
-| Clang 3.8.1                              | Ubuntu 22.04.3 LTS |
-| Clang 3.9.1                              | Ubuntu 22.04.3 LTS |
-| Clang 4.0.1                              | Ubuntu 22.04.3 LTS |
-| Clang 5.0.2                              | Ubuntu 22.04.3 LTS |
-| Clang 6.0.1                              | Ubuntu 22.04.3 LTS |
-| Clang 7.1.0                              | Ubuntu 22.04.3 LTS |
-| Clang 9.0.1                              | Ubuntu 22.04.3 LTS |
-| Clang 10.0.1                             | Ubuntu 22.04.3 LTS |
-| Clang 11.1.0                             | Ubuntu 22.04.3 LTS |
-| Clang 12.0.1                             | Ubuntu 22.04.3 LTS |
-| Clang 13.0.1                             | Ubuntu 22.04.3 LTS |
-| Clang 14.0.6                             | Ubuntu 22.04.3 LTS |
-| Clang 15.0.7                             | Ubuntu 22.04.3 LTS |
-| Clang 16.0.6                             | Ubuntu 22.04.3 LTS |
-| Clang 17.0.4                             | Ubuntu 22.04.3 LTS |
-| GCC 7.5.0                                | Ubuntu 22.04.3 LTS |
-| GCC 8.5.0                                | Ubuntu 22.04.3 LTS |
-| GCC 9.5.0                                | Ubuntu 22.04.3 LTS |
-| GCC 10.5.0                               | Ubuntu 22.04.3 LTS |
-| GCC 11.4.0                               | Ubuntu 22.04.3 LTS |
-| GCC 12.3.0                               | Ubuntu 22.04.3 LTS |
-| GCC 13.2.0                               | Ubuntu 22.04.3 LTS |
-| MinGW-64 8.1.0                           | Windows-10.0.17763 |
-| MinGW-64 12.2.0                          | Windows-10.0.20348 |
-| Visual Studio 16 2019 MSVC 19.29.30152.0 | Windows-10.0.17763 |
-| Visual Studio 17 2022 MSVC 19.35.32217.1 | Windows-10.0.20348 |
+| Compiler                   | Operating System                                                                                               |
+| -------------------------- | -------------------------------------------------------------------------------------------------------------- |
+| AppleClang 11.0.3.11030032 | [macOS 11](https://github.com/actions/runner-images/blob/main/images/macos/macos-11-Readme.md)                 |
+| AppleClang 12.0.0.12000032 | [macOS 11](https://github.com/actions/runner-images/blob/main/images/macos/macos-11-Readme.md)                 |
+| AppleClang 12.0.5.12050022 | [macOS 11](https://github.com/actions/runner-images/blob/main/images/macos/macos-11-Readme.md)                 |
+| AppleClang 13.0.0.13000029 | [macOS 11](https://github.com/actions/runner-images/blob/main/images/macos/macos-11-Readme.md)                 |
+| AppleClang 13.0.0.13000029 | [macOS 12](https://github.com/actions/runner-images/blob/main/images/macos/macos-12-Readme.md)                 |
+| AppleClang 13.1.6.13160021 | [macOS 12](https://github.com/actions/runner-images/blob/main/images/macos/macos-12-Readme.md)                 |
+| AppleClang 14.0.0.14000029 | [macOS 12](https://github.com/actions/runner-images/blob/main/images/macos/macos-12-Readme.md)                 |
+| AppleClang 14.0.0.14000029 | [macOS 13](https://github.com/actions/runner-images/blob/main/images/macos/macos-13-Readme.md)                 |
+| AppleClang 14.0.3.14030022 | [macOS 13](https://github.com/actions/runner-images/blob/main/images/macos/macos-13-Readme.md)                 |
+| AppleClang 15.0.0.15000040 | [macOS 13](https://github.com/actions/runner-images/blob/main/images/macos/macos-13-Readme.md)                 |
+| AppleClang 15.0.0.15000100 | [macOS 13](https://github.com/actions/runner-images/blob/main/images/macos/macos-13-Readme.md)                 |
+| Clang 3.5.2                | Ubuntu 22.04.3 LTS                                                                                             |
+| Clang 3.6.2                | Ubuntu 22.04.3 LTS                                                                                             |
+| Clang 3.7.1                | Ubuntu 22.04.3 LTS                                                                                             |
+| Clang 3.8.1                | Ubuntu 22.04.3 LTS                                                                                             |
+| Clang 3.9.1                | Ubuntu 22.04.3 LTS                                                                                             |
+| Clang 4.0.1                | Ubuntu 22.04.3 LTS                                                                                             |
+| Clang 5.0.2                | Ubuntu 22.04.3 LTS                                                                                             |
+| Clang 6.0.1                | Ubuntu 22.04.3 LTS                                                                                             |
+| Clang 7.1.0                | Ubuntu 22.04.3 LTS                                                                                             |
+| Clang 9.0.1                | Ubuntu 22.04.3 LTS                                                                                             |
+| Clang 10.0.1               | Ubuntu 22.04.3 LTS                                                                                             |
+| Clang 11.1.0               | Ubuntu 22.04.3 LTS                                                                                             |
+| Clang 12.0.1               | Ubuntu 22.04.3 LTS                                                                                             |
+| Clang 13.0.1               | Ubuntu 22.04.3 LTS                                                                                             |
+| Clang 14.0.6               | Ubuntu 22.04.3 LTS                                                                                             |
+| Clang 15.0.7               | Ubuntu 22.04.3 LTS                                                                                             |
+| Clang 16.0.6               | Ubuntu 22.04.3 LTS                                                                                             |
+| Clang 17.0.6               | Ubuntu 22.04.3 LTS                                                                                             |
+| GCC 7.5.0                  | Ubuntu 22.04.3 LTS                                                                                             |
+| GCC 8.5.0                  | Ubuntu 22.04.3 LTS                                                                                             |
+| GCC 9.5.0                  | Ubuntu 22.04.3 LTS                                                                                             |
+| GCC 10.5.0                 | Ubuntu 22.04.3 LTS                                                                                             |
+| GCC 11.4.0                 | Ubuntu 22.04.3 LTS                                                                                             |
+| GCC 12.3.0                 | Ubuntu 22.04.3 LTS                                                                                             |
+| GCC 13.2.0                 | Ubuntu 22.04.3 LTS                                                                                             |
+| MinGW-64 8.1.0             | [Windows Server 2019](https://github.com/actions/runner-images/blob/main/images/windows/Windows2019-Readme.md) |
+| MinGW-64 12.2.0            | [Windows Server 2022](https://github.com/actions/runner-images/blob/main/images/windows/Windows2022-Readme.md) |
+| Visual Studio 16 2019      | [Windows Server 2019](https://github.com/actions/runner-images/blob/main/images/windows/Windows2019-Readme.md) |
+| Visual Studio 17 2022      | [Windows Server 2022](https://github.com/actions/runner-images/blob/main/images/windows/Windows2022-Readme.md) |
 
 Requests for new compiler supports are welcome.  
-If you encounter a problem regarding compilers, please let us know by [creating an issue](https://github.com/fktn-k/fkYAML/issues/new?assignees=&labels=kind%3A+bug&projects=&template=bug-report.yml) or a PR with the information of your Operating System so that we can reproduce the same situation.  
+If you encounter a problem regarding compilers, please let us know by [creating an issue](https://github.com/fktn-k/fkYAML/issues/new?assignees=&labels=kind%3A+bug&projects=&template=bug-report.yml) or a PR with the information of your Operating System so that the same situation can be reproduced.  


### PR DESCRIPTION
Since [the macos-13 GA runner image](https://github.com/actions/runner-images/blob/main/images/macos/macos-13-Readme.md) has been officially released, some workflow jobs which use that runner image have been added.  
Furthermore, the list of supported compilers has been updated.  

---

## Pull Request Checklist

Read the [CONTRIBUTING.md](https://github.com/fktn-k/fkYAML/blob/develop/CONTRIBUTING.md) file for detailed information.  

- [x] Changes are described in the pull request or in a referenced [issue](https://github.com/fktn-k/fkYAML/issues).
- [x] The test suite compiles and runs without any error.
- [x] [The code coverage](https://coveralls.io/github/fktn-k/fkYAML) on your branch is 100%.
- [x] The documentation is updated if you added/changed a feature.

## Please don't

- The C++11 support varies between different **compilers** and versions. Please note the [list of supported compilers](https://github.com/fktn-k/fkYAML/blob/develop/README.md#supported-compilers). Some compilers like GCC 4.7 (and earlier), Clang 3.3 (and earlier), or Microsoft Visual Studio 13.0 and earlier are known not to work due to missing or incomplete C++11 support. Please refrain from proposing changes that work around these compiler's limitations with `#ifdef`s or other means.
- Please refrain from proposing changes that would **break [YAML](https://yaml.org/) specifications**. If you propose a conformant extension of YAML to be supported by the library, please motivate this extension.
- Please do not open pull requests that address **multiple issues**.