### PR TITLE
#275 Fixed parse error on plain scalars containing flow indicators

### DIFF
--- a/.github/workflows/ubuntu.yml
+++ b/.github/workflows/ubuntu.yml
@@ -138,7 +138,7 @@ jobs:
         apt-get update
         apt-get install -y git unzip
         git --version
-      
+
     - uses: actions/checkout@v3
       with:
         submodules: recursive

--- a/.github/workflows/ubuntu.yml
+++ b/.github/workflows/ubuntu.yml
@@ -108,21 +108,25 @@ jobs:
 
   ci_test_clang_sanitizers:
     runs-on: ubuntu-latest
+    container: silkeh/clang:latest
     timeout-minutes: 10
 
     steps:
-    - uses: actions/checkout@v3
-      with:
-        submodules: recursive
+      - name: Install git and unzip
+        run: |
+          apt-get update
+          apt-get install -y git unzip
+          git --version
 
-    - name: Install Clang
-      run: |
-        sudo apt-get update
-        sudo apt-get install -y clang
-        clang++ --version
+      - uses: actions/checkout@v3
+        with:
+          submodules: recursive
 
-    - name: Run Clang Sanitizers
-      run: make clang-sanitizers
+      - name: Get latest CMake
+        uses: lukka/get-cmake@latest
+
+      - name: Run Clang Sanitizers
+        run: make clang-sanitizers
 
   ci_test_clang_cxx_standards:
     runs-on: ubuntu-latest

--- a/include/fkYAML/detail/input/deserializer.hpp
+++ b/include/fkYAML/detail/input/deserializer.hpp
@@ -279,10 +279,6 @@ public:
                 set_yaml_version(*m_current_node);
                 break;
             case lexical_token_t::MAPPING_FLOW_END:
-                if (!m_current_node->is_mapping())
-                {
-                    throw parse_error("Invalid mapping flow ending found.", cur_line, cur_indent);
-                }
                 m_current_node = m_node_stack.back();
                 m_node_stack.pop_back();
                 break;

--- a/include/fkYAML/detail/input/lexical_analyzer.hpp
+++ b/include/fkYAML/detail/input/lexical_analyzer.hpp
@@ -222,15 +222,27 @@ public:
             return m_last_token_type = scan_string(false);
         }
         case '[': // sequence flow begin
+            m_flow_context_depth++;
             m_input_handler.get_next();
             return m_last_token_type = lexical_token_t::SEQUENCE_FLOW_BEGIN;
         case ']': // sequence flow end
+            if (m_flow_context_depth == 0)
+            {
+                emit_error("An invalid flow sequence ending.");
+            }
+            m_flow_context_depth--;
             m_input_handler.get_next();
             return m_last_token_type = lexical_token_t::SEQUENCE_FLOW_END;
         case '{': // mapping flow begin
+            m_flow_context_depth++;
             m_input_handler.get_next();
             return m_last_token_type = lexical_token_t::MAPPING_FLOW_BEGIN;
         case '}': // mapping flow end
+            if (m_flow_context_depth == 0)
+            {
+                emit_error("An invalid flow mapping ending.");
+            }
+            m_flow_context_depth--;
             m_input_handler.get_next();
             return m_last_token_type = lexical_token_t::MAPPING_FLOW_END;
         case '@':
@@ -899,43 +911,43 @@ private:
                 return lexical_token_t::STRING_VALUE;
             }
 
-            // Handle commas.
-            if (current == ',')
+            // Handle flow indicators.
             {
-                // Just regard a comma as a character if surrounded by quotation marks.
-                if (needs_last_double_quote || needs_last_single_quote)
+                bool flow_indicator_appended = false;
+                switch (current)
                 {
-                    m_value_buffer.push_back(char_traits_type::to_char_type(current));
-                    continue;
+                case '{':
+                case '}':
+                case '[':
+                case ']':
+                case ',':
+                    // just regard the flow indicators as a normal character:
+                    // - if single or double quotated,
+                    // - or if not inside flow context.
+
+                    if (needs_last_single_quote || needs_last_double_quote)
+                    {
+                        m_value_buffer.push_back(char_traits_type::to_char_type(current));
+                    }
+                    else if (m_flow_context_depth == 0)
+                    {
+                        m_value_buffer.push_back(char_traits_type::to_char_type(current));
+                    }
+                    else
+                    {
+                        return lexical_token_t::STRING_VALUE;
+                    }
+
+                    flow_indicator_appended = true;
+                    break;
+                default:
+                    break;
                 }
 
-                return lexical_token_t::STRING_VALUE;
-            }
-
-            // Handle right square brackets.
-            if (current == ']')
-            {
-                // just regard a right square bracket as a character if surrounded by quotation marks.
-                if (needs_last_double_quote || needs_last_single_quote)
+                if (flow_indicator_appended)
                 {
-                    m_value_buffer.push_back(char_traits_type::to_char_type(current));
                     continue;
                 }
-
-                return lexical_token_t::STRING_VALUE;
-            }
-
-            // Handle right curly braces.
-            if (current == '}')
-            {
-                // just regard a right curly brace as a character if surrounded by quotation marks.
-                if (needs_last_double_quote || needs_last_single_quote)
-                {
-                    m_value_buffer.push_back(char_traits_type::to_char_type(current));
-                    continue;
-                }
-
-                return lexical_token_t::STRING_VALUE;
             }
 
             // Handle newline codes.
@@ -1515,6 +1527,8 @@ private:
     std::array<char, 4> m_encode_buffer {};
     std::size_t m_encoded_size {0};
     std::size_t m_last_token_begin_pos {0};
+    /// The current depth of flow context.
+    uint32_t m_flow_context_depth {0};
     /// The last found token type.
     lexical_token_t m_last_token_type {lexical_token_t::END_OF_BUFFER};
     /// A temporal bool holder.

--- a/test/unit_test/CMakeLists.txt
+++ b/test/unit_test/CMakeLists.txt
@@ -102,7 +102,7 @@ target_compile_options(unit_test_config INTERFACE
 if(FK_YAML_RUN_CLANG_SANITIZERS)
   target_compile_options(
     unit_test_config
-    INTERFACE -O1
+    INTERFACE -O0
               -g
               -fno-omit-frame-pointer
               -fsanitize=address,undefined,bounds,integer,nullability

--- a/test/unit_test/test_deserializer_class.cpp
+++ b/test/unit_test/test_deserializer_class.cpp
@@ -953,6 +953,21 @@ TEST_CASE("DeserializerClassTest_DeserializeBlockMappingTest", "[DeserializerCla
         REQUIRE(root[key][1].is_string());
         REQUIRE(root[key][1].get_value_ref<std::string&>() == "qux");
     }
+
+    SECTION("Input source No.16.")
+    {
+        REQUIRE_NOTHROW(
+            root = deserializer.deserialize(fkyaml::detail::input_adapter("Foo,Bar: true\nBaz[123]: 3.14")));
+
+        REQUIRE(root.is_mapping());
+        REQUIRE(root.size() == 2);
+
+        REQUIRE(root.contains("Foo,Bar"));
+        REQUIRE(root["Foo,Bar"].get_value<bool>() == true);
+
+        REQUIRE(root.contains("Baz[123]"));
+        REQUIRE(root["Baz[123]"].get_value<double>() == 3.14);
+    }
 }
 
 TEST_CASE("DeserializerClassTest_DeserializeFlowSequenceTest", "[DeserializerClassTest]")
@@ -985,6 +1000,11 @@ TEST_CASE("DeserializerClassTest_DeserializeFlowSequenceTest", "[DeserializerCla
         REQUIRE(test_1_node.is_string());
         REQUIRE_NOTHROW(test_1_node.get_value_ref<fkyaml::node::string_type&>());
         REQUIRE(test_1_node.get_value_ref<fkyaml::node::string_type&>().compare("bar") == 0);
+    }
+
+    SECTION("Input source No.2. (invalid)")
+    {
+        REQUIRE_THROWS_AS(deserializer.deserialize(fkyaml::detail::input_adapter("test: ]")), fkyaml::parse_error);
     }
 }
 

--- a/test/unit_test/test_lexical_analyzer_class.cpp
+++ b/test/unit_test/test_lexical_analyzer_class.cpp
@@ -418,12 +418,6 @@ TEST_CASE("LexicalAnalyzerClassTest_ScanNaNTokenTest", "[LexicalAnalyzerClassTes
     }
 }
 
-// TEST_CASE("LexicalAnalyzerClassTest_ScanInvalidNumberTokenTest", "[LexicalAnalyzerClassTest]")
-// {
-//     pchar_lexer_t lexer(fkyaml::detail::input_adapter("-.test"));
-//     REQUIRE_THROWS_AS(lexer.get_next_token(), fkyaml::parse_error);
-// }
-
 TEST_CASE("LexicalAnalyzerClassTest_ScanStringTokenTest", "[LexicalAnalyzerClassTest]")
 {
     using value_pair_t = std::pair<std::string, fkyaml::node::string_type>;
@@ -441,7 +435,11 @@ TEST_CASE("LexicalAnalyzerClassTest_ScanStringTokenTest", "[LexicalAnalyzerClass
         value_pair_t(std::string("-foo"), fkyaml::node::string_type("-foo")),
         value_pair_t(std::string("-.test"), fkyaml::node::string_type("-.test")),
         value_pair_t(std::string("1.2.3"), fkyaml::node::string_type("1.2.3")),
-        value_pair_t(std::string("foo]"), fkyaml::node::string_type("foo")),
+        value_pair_t(std::string("foo,bar"), fkyaml::node::string_type("foo,bar")),
+        value_pair_t(std::string("foo[bar"), fkyaml::node::string_type("foo[bar")),
+        value_pair_t(std::string("foo]bar"), fkyaml::node::string_type("foo]bar")),
+        value_pair_t(std::string("foo{bar"), fkyaml::node::string_type("foo{bar")),
+        value_pair_t(std::string("foo}bar"), fkyaml::node::string_type("foo}bar")),
         value_pair_t(std::string("foo:bar"), fkyaml::node::string_type("foo:bar")),
         value_pair_t(std::string("foo bar"), fkyaml::node::string_type("foo bar")),
         value_pair_t(std::string("foo\"bar"), fkyaml::node::string_type("foo\"bar")),


### PR DESCRIPTION
As reported in #275, plain scalars containing flow indicators (`[]`, `{}`, and `,`) caused either incorrect parse result or parse errors.  
That was because fkYAML couldn't handle context (whether a current node is within flow context or not).  
This PR has fixed the reported issues, and now fkYAML can successfully parse such plain scalars.  

---

## Pull Request Checklist

Read the [CONTRIBUTING.md](https://github.com/fktn-k/fkYAML/blob/develop/CONTRIBUTING.md) file for detailed information.  

- [x] Changes are described in the pull request or in a referenced [issue](https://github.com/fktn-k/fkYAML/issues).
- [x] The test suite compiles and runs without any error.
- [x] [The code coverage](https://coveralls.io/github/fktn-k/fkYAML) on your branch is 100%.
- [x] The documentation is updated if you added/changed a feature.

## Please don't

- The C++11 support varies between different **compilers** and versions. Please note the [list of supported compilers](https://github.com/fktn-k/fkYAML/blob/develop/README.md#supported-compilers). Some compilers like GCC 4.7 (and earlier), Clang 3.3 (and earlier), or Microsoft Visual Studio 13.0 and earlier are known not to work due to missing or incomplete C++11 support. Please refrain from proposing changes that work around these compiler's limitations with `#ifdef`s or other means.
- Please refrain from proposing changes that would **break [YAML](https://yaml.org/) specifications**. If you propose a conformant extension of YAML to be supported by the library, please motivate this extension.
- Please do not open pull requests that address **multiple issues**.