### PR TITLE
#277 Fixed incorrect parse result from plain scalars starting with special values

### DIFF
--- a/include/fkYAML/detail/input/lexical_analyzer.hpp
+++ b/include/fkYAML/detail/input/lexical_analyzer.hpp
@@ -200,26 +200,9 @@ public:
                 }
 
                 m_input_handler.unget_range(2);
-                ret = m_input_handler.get_range(5, m_value_buffer);
-                if (ret != end_of_input)
-                {
-                    try
-                    {
-                        // try convert to the negative infinite value.
-                        m_float_val = from_string(m_value_buffer, type_tag<float_number_type> {});
-                        m_input_handler.get_next();
-                        return m_last_token_type = lexical_token_t::FLOAT_NUMBER_VALUE;
-                    }
-                    catch (const fkyaml::exception& /*unused*/)
-                    {
-                        m_input_handler.unget_range(4);
-                    }
-                }
             }
 
-            m_input_handler.get_next();
-            m_value_buffer = "-";
-            return m_last_token_type = scan_string(false);
+            return m_last_token_type = scan_string();
         }
         case '[': // sequence flow begin
             m_flow_context_depth++;
@@ -252,31 +235,10 @@ public:
         case '\"':
         case '\'':
             return m_last_token_type = scan_string();
-        case '~':
-            m_value_buffer = char_traits_type::to_char_type(current);
-            return m_last_token_type = lexical_token_t::NULL_VALUE;
         case '+':
             return m_last_token_type = scan_number();
         case '.': {
-            char_int_type ret = m_input_handler.get_range(4, m_value_buffer);
-            if (ret != end_of_input)
-            {
-                try
-                {
-                    // try convert to an infinite/nan value.
-                    m_float_val = from_string(m_value_buffer, type_tag<float_number_type> {});
-                    m_input_handler.get_next();
-                    return m_last_token_type = lexical_token_t::FLOAT_NUMBER_VALUE;
-                }
-                catch (const fkyaml::exception& /*unused*/)
-                {
-                    // revert change in the position to the one before comparison above.
-                    m_input_handler.unget_range(3);
-                    return m_last_token_type = scan_string();
-                }
-            }
-
-            ret = m_input_handler.get_range(3, m_value_buffer);
+            char_int_type ret = m_input_handler.get_range(3, m_value_buffer);
             if (ret != end_of_input)
             {
                 if (m_value_buffer == "...")
@@ -304,79 +266,6 @@ public:
             get_block_style_metadata(chomp_type, indent);
             return m_last_token_type =
                        scan_block_style_string_token(block_style_indicator_t::FOLDED, chomp_type, indent);
-        }
-        case 'F':
-        case 'f': {
-            // YAML specifies that only these words represent the boolean value `false`.
-            // See "10.3.2 Tag Resolution" section in https://yaml.org/spec/1.2.2/
-            char_int_type ret = m_input_handler.get_range(5, m_value_buffer);
-            if (ret == end_of_input)
-            {
-                return m_last_token_type = scan_string();
-            }
-
-            try
-            {
-                // try convert to a boolean false value.
-                m_boolean_val = from_string(m_value_buffer, type_tag<boolean_type> {});
-                m_input_handler.get_next();
-                return m_last_token_type = lexical_token_t::BOOLEAN_VALUE;
-            }
-            catch (const fkyaml::exception& /*unused*/)
-            {
-                // revert change in the position to the one before comparison above.
-                m_input_handler.unget_range(4);
-                return m_last_token_type = scan_string();
-            }
-        }
-        case 'N':
-        case 'n': {
-            // YAML specifies that these words and a tilde represent a null value.
-            // Tildes are already checked above, so no check is needed here.
-            // See "10.3.2 Tag Resolution" section in https://yaml.org/spec/1.2.2/
-            char_int_type ret = m_input_handler.get_range(4, m_value_buffer);
-            if (ret == end_of_input)
-            {
-                return m_last_token_type = scan_string();
-            }
-
-            try
-            {
-                // try convert to a null value.
-                from_string(m_value_buffer, type_tag<std::nullptr_t> {});
-                m_input_handler.get_next();
-                return m_last_token_type = lexical_token_t::NULL_VALUE;
-            }
-            catch (const fkyaml::exception& /*unused*/)
-            {
-                // revert change in the position to the one before comparison above.
-                m_input_handler.unget_range(3);
-                return m_last_token_type = scan_string();
-            }
-        }
-        case 'T':
-        case 't': {
-            // YAML specifies that only these words represent the boolean value `true`.
-            // See "10.3.2 Tag Resolution" section in https://yaml.org/spec/1.2.2/
-            char_int_type ret = m_input_handler.get_range(4, m_value_buffer);
-            if (ret == end_of_input)
-            {
-                return m_last_token_type = scan_string();
-            }
-
-            try
-            {
-                // try convert to a boolean true value.
-                m_boolean_val = from_string(m_value_buffer, type_tag<boolean_type> {});
-                m_input_handler.get_next();
-                return m_last_token_type = lexical_token_t::BOOLEAN_VALUE;
-            }
-            catch (const fkyaml::exception& /*unused*/)
-            {
-                // revert change in the position to the one before comparison above.
-                m_input_handler.unget_range(3);
-                return m_last_token_type = scan_string();
-            }
         }
         default:
             return m_last_token_type = scan_string();
@@ -790,25 +679,83 @@ private:
     }
 
     /// @brief Scan a string token(unquoted/single-quoted/double-quoted).
-    /// @note Multibyte characters(including escaped ones) are currently unsupported.
     /// @return lexical_token_t The lexical token type for strings.
     lexical_token_t scan_string(bool needs_clear = true)
     {
-        char_int_type current = m_input_handler.get_current();
-        bool needs_last_double_quote = false;
         bool needs_last_single_quote = false;
+        bool needs_last_double_quote = false;
 
         if (needs_clear)
         {
             m_value_buffer.clear();
 
-            needs_last_double_quote = (m_input_handler.get_current() == '\"');
             needs_last_single_quote = (m_input_handler.get_current() == '\'');
+            needs_last_double_quote = (m_input_handler.get_current() == '\"');
             if (needs_last_double_quote || needs_last_single_quote)
             {
-                current = m_input_handler.get_next();
+                m_input_handler.get_next();
             }
         }
+
+        lexical_token_t type = extract_string_token(needs_last_single_quote, needs_last_double_quote);
+        FK_YAML_ASSERT(type == lexical_token_t::STRING_VALUE);
+
+        if (needs_last_single_quote || needs_last_double_quote)
+        {
+            // just returned the extracted string value if quoted.
+            return type;
+        }
+
+        if (m_value_buffer == "~")
+        {
+            return lexical_token_t::NULL_VALUE;
+        }
+
+        size_t val_size = m_value_buffer.size();
+        if (val_size == 4)
+        {
+            if (m_value_buffer == "null" || m_value_buffer == "Null" || m_value_buffer == "NULL")
+            {
+                from_string(m_value_buffer, type_tag<std::nullptr_t> {});
+                return lexical_token_t::NULL_VALUE;
+            }
+
+            if (m_value_buffer == "true" || m_value_buffer == "True" || m_value_buffer == "TRUE")
+            {
+                m_boolean_val = from_string(m_value_buffer, type_tag<boolean_type> {});
+                return lexical_token_t::BOOLEAN_VALUE;
+            }
+
+            if (m_value_buffer == ".inf" || m_value_buffer == ".Inf" || m_value_buffer == ".INF" ||
+                m_value_buffer == ".nan" || m_value_buffer == ".NaN" || m_value_buffer == ".NAN")
+            {
+                m_float_val = from_string(m_value_buffer, type_tag<float_number_type> {});
+                return lexical_token_t::FLOAT_NUMBER_VALUE;
+            }
+        }
+        else if (val_size == 5)
+        {
+            if (m_value_buffer == "false" || m_value_buffer == "False" || m_value_buffer == "FALSE")
+            {
+                m_boolean_val = from_string(m_value_buffer, type_tag<boolean_type> {});
+                return lexical_token_t::BOOLEAN_VALUE;
+            }
+
+            if (m_value_buffer == "-.inf" || m_value_buffer == "-.Inf" || m_value_buffer == "-.INF")
+            {
+                m_float_val = from_string(m_value_buffer, type_tag<float_number_type> {});
+                return lexical_token_t::FLOAT_NUMBER_VALUE;
+            }
+        }
+
+        return type;
+    }
+
+    /// @brief Scan a string token(unquoted/single-quoted/double-quoted).
+    /// @return lexical_token_t The lexical token type for strings.
+    lexical_token_t extract_string_token(bool needs_last_single_quote, bool needs_last_double_quote)
+    {
+        char_int_type current = m_input_handler.get_current();
 
         for (;; current = m_input_handler.get_next())
         {

--- a/test/unit_test/test_lexical_analyzer_class.cpp
+++ b/test/unit_test/test_lexical_analyzer_class.cpp
@@ -424,6 +424,7 @@ TEST_CASE("LexicalAnalyzerClassTest_ScanStringTokenTest", "[LexicalAnalyzerClass
     auto value_pair = GENERATE(
         value_pair_t(std::string("\"\""), fkyaml::node::string_type("")),
         value_pair_t(std::string("\'\'"), fkyaml::node::string_type("")),
+
         value_pair_t(std::string("test"), fkyaml::node::string_type("test")),
         value_pair_t(std::string("nop"), fkyaml::node::string_type("nop")),
         value_pair_t(std::string("none"), fkyaml::node::string_type("none")),
@@ -443,8 +444,36 @@ TEST_CASE("LexicalAnalyzerClassTest_ScanStringTokenTest", "[LexicalAnalyzerClass
         value_pair_t(std::string("foo:bar"), fkyaml::node::string_type("foo:bar")),
         value_pair_t(std::string("foo bar"), fkyaml::node::string_type("foo bar")),
         value_pair_t(std::string("foo\"bar"), fkyaml::node::string_type("foo\"bar")),
-        value_pair_t(std::string("\'foo\"bar\'"), fkyaml::node::string_type("foo\"bar")),
         value_pair_t(std::string("foo\'s bar"), fkyaml::node::string_type("foo\'s bar")),
+        value_pair_t(std::string("nullValue"), fkyaml::node::string_type("nullValue")),
+        value_pair_t(std::string("NullValue"), fkyaml::node::string_type("NullValue")),
+        value_pair_t(std::string("NULL_VALUE"), fkyaml::node::string_type("NULL_VALUE")),
+        value_pair_t(std::string("~Value"), fkyaml::node::string_type("~Value")),
+        value_pair_t(std::string("trueValue"), fkyaml::node::string_type("trueValue")),
+        value_pair_t(std::string("TrueValue"), fkyaml::node::string_type("TrueValue")),
+        value_pair_t(std::string("TRUE_VALUE"), fkyaml::node::string_type("TRUE_VALUE")),
+        value_pair_t(std::string("falseValue"), fkyaml::node::string_type("falseValue")),
+        value_pair_t(std::string("FalseValue"), fkyaml::node::string_type("FalseValue")),
+        value_pair_t(std::string("FALSE_VALUE"), fkyaml::node::string_type("FALSE_VALUE")),
+        value_pair_t(std::string(".infValue"), fkyaml::node::string_type(".infValue")),
+        value_pair_t(std::string(".InfValue"), fkyaml::node::string_type(".InfValue")),
+        value_pair_t(std::string(".INF_VALUE"), fkyaml::node::string_type(".INF_VALUE")),
+        value_pair_t(std::string("-.infValue"), fkyaml::node::string_type("-.infValue")),
+        value_pair_t(std::string("-.InfValue"), fkyaml::node::string_type("-.InfValue")),
+        value_pair_t(std::string("-.INF_VALUE"), fkyaml::node::string_type("-.INF_VALUE")),
+        value_pair_t(std::string(".nanValue"), fkyaml::node::string_type(".nanValue")),
+        value_pair_t(std::string(".NaNValue"), fkyaml::node::string_type(".NaNValue")),
+        value_pair_t(std::string(".NAN_VALUE"), fkyaml::node::string_type(".NAN_VALUE")),
+
+        value_pair_t(std::string("\'foo\"bar\'"), fkyaml::node::string_type("foo\"bar")),
+        value_pair_t(std::string("\'foo bar\'"), fkyaml::node::string_type("foo bar")),
+        value_pair_t(std::string("\'foo\'\'bar\'"), fkyaml::node::string_type("foo\'bar")),
+        value_pair_t(std::string("\'foo,bar\'"), fkyaml::node::string_type("foo,bar")),
+        value_pair_t(std::string("\'foo]bar\'"), fkyaml::node::string_type("foo]bar")),
+        value_pair_t(std::string("\'foo}bar\'"), fkyaml::node::string_type("foo}bar")),
+        value_pair_t(std::string("\'foo\"bar\'"), fkyaml::node::string_type("foo\"bar")),
+        value_pair_t(std::string("\'foo:bar\'"), fkyaml::node::string_type("foo:bar")),
+
         value_pair_t(std::string("\"foo bar\""), fkyaml::node::string_type("foo bar")),
         value_pair_t(std::string("\"foo's bar\""), fkyaml::node::string_type("foo's bar")),
         value_pair_t(std::string("\"foo:bar\""), fkyaml::node::string_type("foo:bar")),
@@ -468,14 +497,7 @@ TEST_CASE("LexicalAnalyzerClassTest_ScanStringTokenTest", "[LexicalAnalyzerClass
         value_pair_t(std::string("\"foo\\_bar\""), fkyaml::node::string_type("foo\u00A0bar")),
         value_pair_t(std::string("\"foo\\Lbar\""), fkyaml::node::string_type("foo\u2028bar")),
         value_pair_t(std::string("\"foo\\Pbar\""), fkyaml::node::string_type("foo\u2029bar")),
-        value_pair_t(std::string("\"\\x30\\x2B\\x6d\""), fkyaml::node::string_type("0+m")),
-        value_pair_t(std::string("\'foo bar\'"), fkyaml::node::string_type("foo bar")),
-        value_pair_t(std::string("\'foo\'\'bar\'"), fkyaml::node::string_type("foo\'bar")),
-        value_pair_t(std::string("\'foo,bar\'"), fkyaml::node::string_type("foo,bar")),
-        value_pair_t(std::string("\'foo]bar\'"), fkyaml::node::string_type("foo]bar")),
-        value_pair_t(std::string("\'foo}bar\'"), fkyaml::node::string_type("foo}bar")),
-        value_pair_t(std::string("\'foo\"bar\'"), fkyaml::node::string_type("foo\"bar")),
-        value_pair_t(std::string("\'foo:bar\'"), fkyaml::node::string_type("foo:bar")));
+        value_pair_t(std::string("\"\\x30\\x2B\\x6d\""), fkyaml::node::string_type("0+m")));
 
     str_lexer_t lexer(fkyaml::detail::input_adapter(value_pair.first));
     fkyaml::detail::lexical_token_t token;


### PR DESCRIPTION
As reported in #277, the parser generate a incorrect YAML node tree from plain scalars which start with special string values (such as `null` or `True`).  
This PR has fixed the issue by changing the timing where such special values are detected.  

---

## Pull Request Checklist

Read the [CONTRIBUTING.md](https://github.com/fktn-k/fkYAML/blob/develop/CONTRIBUTING.md) file for detailed information.  

- [x] Changes are described in the pull request or in a referenced [issue](https://github.com/fktn-k/fkYAML/issues).
- [x] The test suite compiles and runs without any error.
- [x] [The code coverage](https://coveralls.io/github/fktn-k/fkYAML) on your branch is 100%.
- [x] The documentation is updated if you added/changed a feature.

## Please don't

- The C++11 support varies between different **compilers** and versions. Please note the [list of supported compilers](https://github.com/fktn-k/fkYAML/blob/develop/README.md#supported-compilers). Some compilers like GCC 4.7 (and earlier), Clang 3.3 (and earlier), or Microsoft Visual Studio 13.0 and earlier are known not to work due to missing or incomplete C++11 support. Please refrain from proposing changes that work around these compiler's limitations with `#ifdef`s or other means.
- Please refrain from proposing changes that would **break [YAML](https://yaml.org/) specifications**. If you propose a conformant extension of YAML to be supported by the library, please motivate this extension.
- Please do not open pull requests that address **multiple issues**.