### PR TITLE
#282 Don't traverse up to the parent node immediately after parsing a flow-mapping value

### DIFF
--- a/include/fkYAML/detail/input/deserializer.hpp
+++ b/include/fkYAML/detail/input/deserializer.hpp
@@ -280,7 +280,6 @@ public:
                 break;
             case lexical_token_t::MAPPING_FLOW_END:
                 m_current_node = m_node_stack.back();
-                m_node_stack.pop_back();
                 break;
             case lexical_token_t::NULL_VALUE: {
                 bool do_continue =

--- a/single_include/fkYAML/node.hpp
+++ b/single_include/fkYAML/node.hpp
@@ -3913,7 +3913,6 @@ public:
                 break;
             case lexical_token_t::MAPPING_FLOW_END:
                 m_current_node = m_node_stack.back();
-                m_node_stack.pop_back();
                 break;
             case lexical_token_t::NULL_VALUE: {
                 bool do_continue =

--- a/test/unit_test/test_deserializer_class.cpp
+++ b/test/unit_test/test_deserializer_class.cpp
@@ -1046,7 +1046,32 @@ TEST_CASE("DeserializerClassTest_DeserializeFlowMappingTest", "[DeserializerClas
         REQUIRE_NOTHROW(test_pi_node.get_value<fkyaml::node::float_number_type>());
         REQUIRE(test_pi_node.get_value<fkyaml::node::float_number_type>() == 3.14);
     }
+    SECTION("Correct traversal after deserializing flow mapping value")
+    {
+        REQUIRE_NOTHROW(root = deserializer.deserialize(fkyaml::detail::input_adapter(  "test: { foo: bar }\n"
+                                                                                        "sibling: a_string_val")));
+		REQUIRE(root.is_mapping());
+        REQUIRE_NOTHROW(root.size());
+        REQUIRE(root.size() == 2);
 
+        REQUIRE_NOTHROW(root["test"]);
+        fkyaml::node& test_node = root["test"];
+        REQUIRE(test_node.is_mapping());
+        REQUIRE_NOTHROW(test_node.size());
+        REQUIRE(test_node.size() == 1);
+
+        REQUIRE_NOTHROW(test_node["foo"]);
+        fkyaml::node& test_foo_node = test_node["foo"];
+        REQUIRE(test_foo_node.is_string());
+        REQUIRE_NOTHROW(test_foo_node.get_value_ref<fkyaml::node::string_type&>());
+        REQUIRE(test_foo_node.get_value_ref<fkyaml::node::string_type&>().compare("bar") == 0);
+
+        REQUIRE_NOTHROW(root["sibling"]);
+        fkyaml::node& sibling_node = root["sibling"];
+        REQUIRE(sibling_node.is_string());
+        REQUIRE_NOTHROW(sibling_node.get_value_ref<fkyaml::node::string_type&>());
+        REQUIRE(sibling_node.get_value_ref<fkyaml::node::string_type&>().compare("a_string_val") == 0);
+    }
     SECTION("Input source No.2. (invalid)")
     {
         REQUIRE_THROWS_AS(deserializer.deserialize(fkyaml::detail::input_adapter("test: }")), fkyaml::parse_error);

--- a/test/unit_test/test_deserializer_class.cpp
+++ b/test/unit_test/test_deserializer_class.cpp
@@ -1048,9 +1048,10 @@ TEST_CASE("DeserializerClassTest_DeserializeFlowMappingTest", "[DeserializerClas
     }
     SECTION("Correct traversal after deserializing flow mapping value")
     {
-        REQUIRE_NOTHROW(root = deserializer.deserialize(fkyaml::detail::input_adapter(  "test: { foo: bar }\n"
-                                                                                        "sibling: a_string_val")));
-		REQUIRE(root.is_mapping());
+        REQUIRE_NOTHROW(
+            root = deserializer.deserialize(fkyaml::detail::input_adapter("test: { foo: bar }\n"
+                                                                          "sibling: a_string_val")));
+        REQUIRE(root.is_mapping());
         REQUIRE_NOTHROW(root.size());
         REQUIRE(root.size() == 2);
 


### PR DESCRIPTION
Fixes #282 by not traversing up to the parent node immediately after parsing flow-mapping values, as code elsewhere in the deserializer implementation was also traversing to the parent node, meaning either a crash occurred if there was only one parent, or a double-traversal occurred and sibling values were appended to the grandparent instead.

---

## Pull Request Checklist

Read the [CONTRIBUTING.md](https://github.com/fktn-k/fkYAML/blob/develop/CONTRIBUTING.md) file for detailed information.  

- [x] Changes are described in the pull request or in a referenced [issue](https://github.com/fktn-k/fkYAML/issues).
- [x] The test suite compiles and runs without any error.
- [x] [The code coverage](https://coveralls.io/github/fktn-k/fkYAML) on your branch is 100%.
- [x] The documentation is updated if you added/changed a feature.

## Please don't

- The C++11 support varies between different **compilers** and versions. Please note the [list of supported compilers](https://github.com/fktn-k/fkYAML/blob/develop/README.md#supported-compilers). Some compilers like GCC 4.7 (and earlier), Clang 3.3 (and earlier), or Microsoft Visual Studio 13.0 and earlier are known not to work due to missing or incomplete C++11 support. Please refrain from proposing changes that work around these compiler's limitations with `#ifdef`s or other means.
- Please refrain from proposing changes that would **break [YAML](https://yaml.org/) specifications**. If you propose a conformant extension of YAML to be supported by the library, please motivate this extension.
- Please do not open pull requests that address **multiple issues**.