### PR TITLE
#281 Fixed the parser crash due to comments right after a sequence block key

### DIFF
--- a/include/fkYAML/detail/input/lexical_analyzer.hpp
+++ b/include/fkYAML/detail/input/lexical_analyzer.hpp
@@ -87,7 +87,7 @@ public:
     /// @return lexical_token_t The next lexical token type.
     lexical_token_t get_next_token()
     {
-        skip_white_spaces();
+        skip_white_spaces_and_newline_codes();
 
         char_int_type current = m_input_handler.get_current();
         m_last_token_begin_pos = m_input_handler.get_cur_pos_in_line();
@@ -113,8 +113,20 @@ public:
         case ':': // key separater
             switch (m_input_handler.get_next())
             {
-            case ' ':
-                break;
+            case ' ': {
+                size_t prev_pos = m_input_handler.get_lines_read();
+                skip_white_spaces_and_comments();
+                size_t cur_pos = m_input_handler.get_lines_read();
+                if (prev_pos == cur_pos)
+                {
+                    current = m_input_handler.get_current();
+                    if (current != '\r' && current != '\n')
+                    {
+                        return m_last_token_type = lexical_token_t::KEY_SEPARATOR;
+                    }
+                }
+                return m_last_token_type = lexical_token_t::MAPPING_BLOCK_PREFIX;
+            }
             case '\r': {
                 char_int_type next = m_input_handler.get_next();
                 if (next == '\n')
@@ -129,8 +141,6 @@ public:
             default:
                 emit_error("Half-width spaces or newline codes are required after a key separater(:).");
             }
-            m_input_handler.get_next();
-            return m_last_token_type = lexical_token_t::KEY_SEPARATOR;
         case ',': // value separater
             m_input_handler.get_next();
             return m_last_token_type = lexical_token_t::VALUE_SEPARATOR;
@@ -1414,34 +1424,66 @@ private:
         skip_until_line_end();
     }
 
-    /// @brief Skip white spaces, tabs and newline codes until any other kind of character is found.
+    /// @brief Skip white spaces (half-width spaces and tabs) from the current position.
     void skip_white_spaces()
     {
-        while (true)
+        do
         {
             switch (m_input_handler.get_current())
             {
             case ' ':
             case '\t':
+                break;
+            default:
+                return;
+            }
+        } while (m_input_handler.get_next() != end_of_input);
+    }
+
+    /// @brief Skip white spaces and newline codes (CR/LF) from the current position.
+    void skip_white_spaces_and_newline_codes()
+    {
+        do
+        {
+            skip_white_spaces();
+
+            switch (m_input_handler.get_current())
+            {
             case '\n':
             case '\r':
                 break;
             default:
                 return;
             }
-            m_input_handler.get_next();
-        }
+        } while (m_input_handler.get_next() != end_of_input);
     }
 
-    /// @brief Skip reading in the current line.
+    /// @brief Skip white spaces and comments from the current position.
+    void skip_white_spaces_and_comments()
+    {
+        do
+        {
+            skip_white_spaces();
+
+            switch (m_input_handler.get_current())
+            {
+            case '#': {
+                scan_comment();
+                break;
+            }
+            default:
+                return;
+            }
+        } while (m_input_handler.get_next() != end_of_input);
+    }
+
+    /// @brief Skip the rest in the current line.
     void skip_until_line_end()
     {
-        while (true)
+        do
         {
             switch (m_input_handler.get_current())
             {
-            case end_of_input:
-                return;
             case '\r':
                 if (m_input_handler.get_next() == '\n')
                 {
@@ -1454,8 +1496,7 @@ private:
             default:
                 break;
             }
-            m_input_handler.get_next();
-        }
+        } while (m_input_handler.get_next() != end_of_input);
     }
 
     [[noreturn]] void emit_error(const char* msg) const

--- a/test/unit_test/test_deserializer_class.cpp
+++ b/test/unit_test/test_deserializer_class.cpp
@@ -467,6 +467,21 @@ TEST_CASE("DeserializerClassTest_DeserializeBlockSequenceTest", "[DeserializerCl
         REQUIRE(root["test"][0]["item"].is_integer());
         REQUIRE(root["test"][0]["item"].get_value<int>() == 123);
     }
+
+    SECTION("Input source No.9.")
+    {
+        REQUIRE_NOTHROW(root = deserializer.deserialize(fkyaml::detail::input_adapter("foo: # comment\n  - bar\n")));
+
+        REQUIRE(root.is_mapping());
+        REQUIRE(root.size() == 1);
+        REQUIRE(root.contains("foo"));
+
+        REQUIRE(root["foo"].is_sequence());
+        REQUIRE(root["foo"].size() == 1);
+
+        REQUIRE(root["foo"][0].is_string());
+        REQUIRE(root["foo"][0].get_value_ref<std::string&>() == "bar");
+    }
 }
 
 TEST_CASE("DeserializerClassTest_DeserializeBlockMappingTest", "[DeserializerClassTest]")
@@ -968,6 +983,23 @@ TEST_CASE("DeserializerClassTest_DeserializeBlockMappingTest", "[DeserializerCla
         REQUIRE(root.contains("Baz[123]"));
         REQUIRE(root["Baz[123]"].get_value<double>() == 3.14);
     }
+
+    SECTION("a comment right after a block mapping key.")
+    {
+        REQUIRE_NOTHROW(
+            root = deserializer.deserialize(fkyaml::detail::input_adapter("baz: # comment2\n  qux: 123\n")));
+
+        REQUIRE(root.is_mapping());
+        REQUIRE(root.size() == 1);
+        REQUIRE(root.contains("baz"));
+
+        REQUIRE(root["baz"].is_mapping());
+        REQUIRE(root["baz"].size() == 1);
+        REQUIRE(root["baz"].contains("qux"));
+
+        REQUIRE(root["baz"]["qux"].is_integer());
+        REQUIRE(root["baz"]["qux"].get_value<int>() == 123);
+    }
 }
 
 TEST_CASE("DeserializerClassTest_DeserializeFlowSequenceTest", "[DeserializerClassTest]")
@@ -1046,6 +1078,7 @@ TEST_CASE("DeserializerClassTest_DeserializeFlowMappingTest", "[DeserializerClas
         REQUIRE_NOTHROW(test_pi_node.get_value<fkyaml::node::float_number_type>());
         REQUIRE(test_pi_node.get_value<fkyaml::node::float_number_type>() == 3.14);
     }
+
     SECTION("Correct traversal after deserializing flow mapping value")
     {
         REQUIRE_NOTHROW(
@@ -1073,6 +1106,7 @@ TEST_CASE("DeserializerClassTest_DeserializeFlowMappingTest", "[DeserializerClas
         REQUIRE_NOTHROW(sibling_node.get_value_ref<fkyaml::node::string_type&>());
         REQUIRE(sibling_node.get_value_ref<fkyaml::node::string_type&>().compare("a_string_val") == 0);
     }
+
     SECTION("Input source No.2. (invalid)")
     {
         REQUIRE_THROWS_AS(deserializer.deserialize(fkyaml::detail::input_adapter("test: }")), fkyaml::parse_error);

--- a/test/unit_test/test_lexical_analyzer_class.cpp
+++ b/test/unit_test/test_lexical_analyzer_class.cpp
@@ -201,6 +201,48 @@ TEST_CASE("LexicalAnalyzerClassTest_ScanColonTest", "[LexicalAnalyzerClassTest]"
         pchar_lexer_t lexer(fkyaml::detail::input_adapter(":test"));
         REQUIRE_THROWS_AS(token = lexer.get_next_token(), fkyaml::parse_error);
     }
+
+    SECTION("Test colon with a comment and a CRLF newline code.")
+    {
+        pchar_lexer_t lexer(fkyaml::detail::input_adapter(": # comment\r\n"));
+        REQUIRE_NOTHROW(token = lexer.get_next_token());
+        REQUIRE(token == fkyaml::detail::lexical_token_t::MAPPING_BLOCK_PREFIX);
+    }
+
+    SECTION("Test colon with a comment and a LF newline code.")
+    {
+        pchar_lexer_t lexer(fkyaml::detail::input_adapter(": # comment\n"));
+        REQUIRE_NOTHROW(token = lexer.get_next_token());
+        REQUIRE(token == fkyaml::detail::lexical_token_t::MAPPING_BLOCK_PREFIX);
+    }
+
+    SECTION("Test colon with a comment and no newline code")
+    {
+        pchar_lexer_t lexer(fkyaml::detail::input_adapter(": # comment"));
+        REQUIRE_NOTHROW(token = lexer.get_next_token());
+        REQUIRE(token == fkyaml::detail::lexical_token_t::KEY_SEPARATOR);
+    }
+
+    SECTION("Test colon with many spaces and a CRLF newline code.")
+    {
+        pchar_lexer_t lexer(fkyaml::detail::input_adapter(":                         \r\n"));
+        REQUIRE_NOTHROW(token = lexer.get_next_token());
+        REQUIRE(token == fkyaml::detail::lexical_token_t::MAPPING_BLOCK_PREFIX);
+    }
+
+    SECTION("Test colon with many spaces and a LF newline code.")
+    {
+        pchar_lexer_t lexer(fkyaml::detail::input_adapter(":                         \n"));
+        REQUIRE_NOTHROW(token = lexer.get_next_token());
+        REQUIRE(token == fkyaml::detail::lexical_token_t::MAPPING_BLOCK_PREFIX);
+    }
+
+    SECTION("Test colon with many spaces and no newline code.")
+    {
+        pchar_lexer_t lexer(fkyaml::detail::input_adapter(":                         "));
+        REQUIRE_NOTHROW(token = lexer.get_next_token());
+        REQUIRE(token == fkyaml::detail::lexical_token_t::KEY_SEPARATOR);
+    }
 }
 
 TEST_CASE("LexicalAnalyzerClassTest_ScanNullTokenTest", "[LexicalAnalyzerClassTest]")


### PR DESCRIPTION
This PR has fixed the parser crash reported in #281.  
The root cause was that the parser didn't handle white spaces and comments after a block sequence/mapping key.  
Now the parser handles those characters correctly and doesn't crash nor generate incorrect YAML node tree, which is confirmed with the updated test suite.  

---

## Pull Request Checklist

Read the [CONTRIBUTING.md](https://github.com/fktn-k/fkYAML/blob/develop/CONTRIBUTING.md) file for detailed information.  

- [x] Changes are described in the pull request or in a referenced [issue](https://github.com/fktn-k/fkYAML/issues).
- [x] The test suite compiles and runs without any error.
- [x] [The code coverage](https://coveralls.io/github/fktn-k/fkYAML) on your branch is 100%.
- [x] The documentation is updated if you added/changed a feature.

## Please don't

- The C++11 support varies between different **compilers** and versions. Please note the [list of supported compilers](https://github.com/fktn-k/fkYAML/blob/develop/README.md#supported-compilers). Some compilers like GCC 4.7 (and earlier), Clang 3.3 (and earlier), or Microsoft Visual Studio 13.0 and earlier are known not to work due to missing or incomplete C++11 support. Please refrain from proposing changes that work around these compiler's limitations with `#ifdef`s or other means.
- Please refrain from proposing changes that would **break [YAML](https://yaml.org/) specifications**. If you propose a conformant extension of YAML to be supported by the library, please motivate this extension.
- Please do not open pull requests that address **multiple issues**.