### PR TITLE
#288 Fixed incorrect parse results from mapping entries split across newlines

### DIFF
--- a/include/fkYAML/detail/input/deserializer.hpp
+++ b/include/fkYAML/detail/input/deserializer.hpp
@@ -152,47 +152,33 @@ public:
 
                 if (cur_line > old_line)
                 {
-                    bool should_continue = false;
                     switch (type)
                     {
                     case lexical_token_t::SEQUENCE_BLOCK_PREFIX:
                         // a key separator preceeding block sequence entries
                         *m_current_node = BasicNodeType::sequence();
                         set_yaml_version(*m_current_node);
-                        should_continue = true;
                         break;
                     case lexical_token_t::EXPLICIT_KEY_PREFIX:
                         // a key separator for a explicit block mapping key.
                         *m_current_node = BasicNodeType::mapping();
                         set_yaml_version(*m_current_node);
-                        should_continue = true;
                         break;
+                    // defer checking the existence of a key separator after the scalar until a deserialize_scalar() call.
                     case lexical_token_t::NULL_VALUE:
                     case lexical_token_t::BOOLEAN_VALUE:
                     case lexical_token_t::INTEGER_VALUE:
                     case lexical_token_t::FLOAT_NUMBER_VALUE:
                     case lexical_token_t::STRING_VALUE:
-                        // defer checking the existence of a key separator after the scalar until a deserialize_scalar()
-                        // call.
-                        should_continue = true;
-                        break;
+                    // defer handling these tokens until the next loop.
                     case lexical_token_t::MAPPING_FLOW_BEGIN:
                     case lexical_token_t::SEQUENCE_FLOW_BEGIN:
-                        // defer handling these tokens in the next loop.
-                        should_continue = true;
                         break;
-                    case lexical_token_t::KEY_SEPARATOR:
-                        // handle explicit maping key separators down below.
-                        break;
-                    default:
-                        break;
+                    default:   // LCOV_EXCL_LINE
+                        break; // LCOV_EXCL_LINE
                     }
 
-                    if (should_continue)
-                    {
-                        set_yaml_version(*m_current_node);
-                        continue;
-                    }
+                    continue;
                 }
 
                 // handle explicit mapping key separators.

--- a/include/fkYAML/detail/input/deserializer.hpp
+++ b/include/fkYAML/detail/input/deserializer.hpp
@@ -164,7 +164,8 @@ public:
                         *m_current_node = BasicNodeType::mapping();
                         set_yaml_version(*m_current_node);
                         break;
-                    // defer checking the existence of a key separator after the scalar until a deserialize_scalar() call.
+                    // defer checking the existence of a key separator after the scalar until a deserialize_scalar()
+                    // call.
                     case lexical_token_t::NULL_VALUE:
                     case lexical_token_t::BOOLEAN_VALUE:
                     case lexical_token_t::INTEGER_VALUE:

--- a/include/fkYAML/detail/input/lexical_analyzer.hpp
+++ b/include/fkYAML/detail/input/lexical_analyzer.hpp
@@ -129,6 +129,7 @@ public:
                 if (m_flow_context_depth > 0)
                 {
                     // the above characters are not "safe" to be followed in a flow context.
+                    // See https://yaml.org/spec/1.2.2/#733-plain-style for more details.
                     break;
                 }
                 m_value_buffer = ":";
@@ -594,9 +595,9 @@ private:
             m_value_buffer.push_back(char_traits_type::to_char_type(next));
             return scan_decimal_number_after_decimal_point();
         case 'o':
-            // Do not store 'o' since std::strtoull does not support "0o" but "0" as the prefix for octal numbers.
+            // Do not store 'o' since std::stoXXX does not support "0o" but "0" as the prefix for octal numbers.
             // YAML specifies octal values start with the prefix "0o".
-            // See "10.3.2 Tag Resolution" section in https://yaml.org/spec/1.2.2/
+            // See https://yaml.org/spec/1.2.2/#1032-tag-resolution for more details.
             return scan_octal_number();
         case 'x':
             m_value_buffer.push_back(char_traits_type::to_char_type(next));
@@ -820,7 +821,7 @@ private:
                 if (!needs_last_double_quote && !needs_last_single_quote)
                 {
                     // Allow a space in an unquoted string only if the space is surrounded by non-space characters.
-                    // See "7.3.3 Plain Style" section in https://yaml.org/spec/1.2.2/
+                    // See https://yaml.org/spec/1.2.2/#733-plain-style for more details.
                     current = m_input_handler.get_next();
                     switch (current)
                     {
@@ -950,7 +951,7 @@ private:
             }
 
             // Handle escaped characters.
-            // See "5.7 Escaped Characters" section in https://yaml.org/spec/1.2.2/
+            // See https://yaml.org/spec/1.2.2/#57-escaped-characters for more details.
             if (current == '\\')
             {
                 if (!needs_last_double_quote)

--- a/include/fkYAML/detail/input/lexical_analyzer.hpp
+++ b/include/fkYAML/detail/input/lexical_analyzer.hpp
@@ -91,6 +91,7 @@ public:
 
         char_int_type current = m_input_handler.get_current();
         m_last_token_begin_pos = m_input_handler.get_cur_pos_in_line();
+        m_last_token_begin_line = m_input_handler.get_lines_read();
 
         if (0x00 <= current && current <= 0x7F && isdigit(current))
         {
@@ -99,7 +100,7 @@ public:
 
         switch (current)
         {
-        case end_of_input: // end of input buffer
+        case s_end_of_input: // end of input buffer
             return m_last_token_type = lexical_token_t::END_OF_BUFFER;
         case '?':
             switch (m_input_handler.get_next())
@@ -110,37 +111,66 @@ public:
                 m_value_buffer = "?";
                 return m_last_token_type = scan_string(false);
             }
-        case ':': // key separater
-            switch (m_input_handler.get_next())
+        case ':': { // key separater
+            current = m_input_handler.get_next();
+            switch (current)
             {
-            case ' ': {
-                size_t prev_pos = m_input_handler.get_lines_read();
-                skip_white_spaces_and_comments();
-                size_t cur_pos = m_input_handler.get_lines_read();
-                if (prev_pos == cur_pos)
-                {
-                    current = m_input_handler.get_current();
-                    if (current != '\r' && current != '\n')
-                    {
-                        return m_last_token_type = lexical_token_t::KEY_SEPARATOR;
-                    }
-                }
-                return m_last_token_type = lexical_token_t::MAPPING_BLOCK_PREFIX;
-            }
-            case '\r': {
-                char_int_type next = m_input_handler.get_next();
-                if (next == '\n')
-                {
-                    m_input_handler.get_next();
-                }
-                return m_last_token_type = lexical_token_t::MAPPING_BLOCK_PREFIX;
-            }
+            case ' ':
+            case '\t':
+            case '\r':
             case '\n':
-                m_input_handler.get_next();
-                return m_last_token_type = lexical_token_t::MAPPING_BLOCK_PREFIX;
+            case s_end_of_input:
+                break;
+            case ',':
+            case '[':
+            case ']':
+            case '{':
+            case '}':
+                if (m_flow_context_depth > 0)
+                {
+                    // the above characters are not "safe" to be followed in a flow context.
+                    break;
+                }
+                m_value_buffer = ":";
+                return scan_string(false);
             default:
-                emit_error("Half-width spaces or newline codes are required after a key separater(:).");
+                m_value_buffer = ":";
+                return scan_string(false);
             }
+
+            return m_last_token_type = lexical_token_t::KEY_SEPARATOR;
+        }
+            // switch (m_input_handler.get_next())
+            // {
+            // case ' ': {
+            //     size_t prev_pos = m_input_handler.get_lines_read();
+            //     skip_white_spaces_and_comments();
+            //     size_t cur_pos = m_input_handler.get_lines_read();
+            //     if (prev_pos == cur_pos)
+            //     {
+            //         current = m_input_handler.get_current();
+            //         if (current != '\r' && current != '\n')
+            //         {
+            //             return m_last_token_type = lexical_token_t::KEY_SEPARATOR;
+            //         }
+            //     }
+            //     return m_last_token_type = lexical_token_t::MAPPING_BLOCK_PREFIX;
+            // }
+            // case '\r': {
+            //     char_int_type next = m_input_handler.get_next();
+            //     if (next == '\n')
+            //     {
+            //         m_input_handler.get_next();
+            //     }
+            //     return m_last_token_type = lexical_token_t::MAPPING_BLOCK_PREFIX;
+            // }
+            // case '\n':
+            //     m_input_handler.get_next();
+            //     return m_last_token_type = lexical_token_t::MAPPING_BLOCK_PREFIX;
+            // default:
+            //     emit_error("Half-width spaces or newline codes are required after a key separater(:).");
+            // }
+
         case ',': // value separater
             m_input_handler.get_next();
             return m_last_token_type = lexical_token_t::VALUE_SEPARATOR;
@@ -149,7 +179,7 @@ public:
             while (true)
             {
                 char_int_type next = m_input_handler.get_next();
-                if (next == end_of_input || next == '\r' || next == '\n')
+                if (next == s_end_of_input || next == '\r' || next == '\n')
                 {
                     emit_error("An anchor label must be followed by some value.");
                 }
@@ -167,7 +197,7 @@ public:
             while (true)
             {
                 char_int_type next = m_input_handler.get_next();
-                if (next == ' ' || next == '\r' || next == '\n' || next == end_of_input)
+                if (next == ' ' || next == '\r' || next == '\n' || next == s_end_of_input)
                 {
                     if (m_value_buffer.empty())
                     {
@@ -201,7 +231,7 @@ public:
             }
 
             char_int_type ret = m_input_handler.get_range(3, m_value_buffer);
-            if (ret != end_of_input)
+            if (ret != s_end_of_input)
             {
                 if (m_value_buffer == "---")
                 {
@@ -249,7 +279,7 @@ public:
             return m_last_token_type = scan_number();
         case '.': {
             char_int_type ret = m_input_handler.get_range(3, m_value_buffer);
-            if (ret != end_of_input)
+            if (ret != s_end_of_input)
             {
                 if (m_value_buffer == "...")
                 {
@@ -293,7 +323,7 @@ public:
     /// @return std::size_t The number of lines already processed.
     std::size_t get_lines_processed() const noexcept
     {
-        return m_input_handler.get_lines_read();
+        return m_last_token_begin_line;
     }
 
     /// @brief Convert from string to null and get the converted value.
@@ -406,7 +436,7 @@ private:
 
         switch (m_input_handler.get_next())
         {
-        case end_of_input:
+        case s_end_of_input:
             emit_error("invalid eof in a directive.");
         case 'T': {
             if (m_input_handler.get_next() != 'A' || m_input_handler.get_next() != 'G')
@@ -770,7 +800,7 @@ private:
         for (;; current = m_input_handler.get_next())
         {
             // Handle the end of input buffer.
-            if (current == end_of_input)
+            if (current == s_end_of_input)
             {
                 if (needs_last_double_quote)
                 {
@@ -1094,7 +1124,7 @@ private:
                 continue;
             }
 
-            if (current == end_of_input)
+            if (current == s_end_of_input)
             {
                 if (chomp != chomping_indicator_t::KEEP)
                 {
@@ -1136,7 +1166,7 @@ private:
             }
         }
 
-        for (; current != end_of_input; current = m_input_handler.get_next())
+        for (; current != s_end_of_input; current = m_input_handler.get_next())
         {
             if (current == '\r')
             {
@@ -1437,7 +1467,7 @@ private:
             default:
                 return;
             }
-        } while (m_input_handler.get_next() != end_of_input);
+        } while (m_input_handler.get_next() != s_end_of_input);
     }
 
     /// @brief Skip white spaces and newline codes (CR/LF) from the current position.
@@ -1455,7 +1485,7 @@ private:
             default:
                 return;
             }
-        } while (m_input_handler.get_next() != end_of_input);
+        } while (m_input_handler.get_next() != s_end_of_input);
     }
 
     /// @brief Skip white spaces and comments from the current position.
@@ -1474,7 +1504,7 @@ private:
             default:
                 return;
             }
-        } while (m_input_handler.get_next() != end_of_input);
+        } while (m_input_handler.get_next() != s_end_of_input);
     }
 
     /// @brief Skip the rest in the current line.
@@ -1496,7 +1526,7 @@ private:
             default:
                 break;
             }
-        } while (m_input_handler.get_next() != end_of_input);
+        } while (m_input_handler.get_next() != s_end_of_input);
     }
 
     [[noreturn]] void emit_error(const char* msg) const
@@ -1506,15 +1536,20 @@ private:
 
 private:
     /// The value of EOF for the target characters.
-    static constexpr char_int_type end_of_input = char_traits_type::eof();
+    static constexpr char_int_type s_end_of_input = char_traits_type::eof();
 
     /// An input buffer adapter to be analyzed.
     input_handler_type m_input_handler;
     /// A temporal buffer to store a string to be parsed to an actual datum.
     input_string_type m_value_buffer {};
+    /// A temporal buffer to store a UTF-8 encoded char sequence.
     std::array<char, 4> m_encode_buffer {};
+    /// The actual size of a UTF-8 encoded char sequence.
     std::size_t m_encoded_size {0};
+    /// The beginning position of the last lexical token. (zero origin)
     std::size_t m_last_token_begin_pos {0};
+    /// The beginning line of the last lexical token. (zero origin)
+    std::size_t m_last_token_begin_line {0};
     /// The current depth of flow context.
     uint32_t m_flow_context_depth {0};
     /// The last found token type.

--- a/include/fkYAML/detail/types/lexical_token_t.hpp
+++ b/include/fkYAML/detail/types/lexical_token_t.hpp
@@ -36,7 +36,6 @@ enum class lexical_token_t
     SEQUENCE_BLOCK_PREFIX, //!< the character for sequence block prefix `- `
     SEQUENCE_FLOW_BEGIN,   //!< the character for sequence flow begin `[`
     SEQUENCE_FLOW_END,     //!< the character for sequence flow end `]`
-    MAPPING_BLOCK_PREFIX,  //!< the character for mapping block prefix `:`
     MAPPING_FLOW_BEGIN,    //!< the character for mapping begin `{`
     MAPPING_FLOW_END,      //!< the character for mapping end `}`
     NULL_VALUE,            //!< a null value found. use get_null() to get a value.

--- a/single_include/fkYAML/node.hpp
+++ b/single_include/fkYAML/node.hpp
@@ -3869,47 +3869,34 @@ public:
 
                 if (cur_line > old_line)
                 {
-                    bool should_continue = false;
                     switch (type)
                     {
                     case lexical_token_t::SEQUENCE_BLOCK_PREFIX:
                         // a key separator preceeding block sequence entries
                         *m_current_node = BasicNodeType::sequence();
                         set_yaml_version(*m_current_node);
-                        should_continue = true;
                         break;
                     case lexical_token_t::EXPLICIT_KEY_PREFIX:
                         // a key separator for a explicit block mapping key.
                         *m_current_node = BasicNodeType::mapping();
                         set_yaml_version(*m_current_node);
-                        should_continue = true;
                         break;
+                    // defer checking the existence of a key separator after the scalar until a deserialize_scalar()
+                    // call.
                     case lexical_token_t::NULL_VALUE:
                     case lexical_token_t::BOOLEAN_VALUE:
                     case lexical_token_t::INTEGER_VALUE:
                     case lexical_token_t::FLOAT_NUMBER_VALUE:
                     case lexical_token_t::STRING_VALUE:
-                        // defer checking the existence of a key separator after the scalar until a deserialize_scalar()
-                        // call.
-                        should_continue = true;
-                        break;
+                    // defer handling these tokens until the next loop.
                     case lexical_token_t::MAPPING_FLOW_BEGIN:
                     case lexical_token_t::SEQUENCE_FLOW_BEGIN:
-                        // defer handling these tokens in the next loop.
-                        should_continue = true;
                         break;
-                    case lexical_token_t::KEY_SEPARATOR:
-                        // handle explicit maping key separators down below.
-                        break;
-                    default:
-                        break;
+                    default:   // LCOV_EXCL_LINE
+                        break; // LCOV_EXCL_LINE
                     }
 
-                    if (should_continue)
-                    {
-                        set_yaml_version(*m_current_node);
-                        continue;
-                    }
+                    continue;
                 }
 
                 // handle explicit mapping key separators.

--- a/single_include/fkYAML/node.hpp
+++ b/single_include/fkYAML/node.hpp
@@ -2132,7 +2132,6 @@ enum class lexical_token_t
     SEQUENCE_BLOCK_PREFIX, //!< the character for sequence block prefix `- `
     SEQUENCE_FLOW_BEGIN,   //!< the character for sequence flow begin `[`
     SEQUENCE_FLOW_END,     //!< the character for sequence flow end `]`
-    MAPPING_BLOCK_PREFIX,  //!< the character for mapping block prefix `:`
     MAPPING_FLOW_BEGIN,    //!< the character for mapping begin `{`
     MAPPING_FLOW_END,      //!< the character for mapping end `}`
     NULL_VALUE,            //!< a null value found. use get_null() to get a value.
@@ -2214,6 +2213,7 @@ public:
 
         char_int_type current = m_input_handler.get_current();
         m_last_token_begin_pos = m_input_handler.get_cur_pos_in_line();
+        m_last_token_begin_line = m_input_handler.get_lines_read();
 
         if (0x00 <= current && current <= 0x7F && isdigit(current))
         {
@@ -2222,7 +2222,7 @@ public:
 
         switch (current)
         {
-        case end_of_input: // end of input buffer
+        case s_end_of_input: // end of input buffer
             return m_last_token_type = lexical_token_t::END_OF_BUFFER;
         case '?':
             switch (m_input_handler.get_next())
@@ -2233,37 +2233,66 @@ public:
                 m_value_buffer = "?";
                 return m_last_token_type = scan_string(false);
             }
-        case ':': // key separater
-            switch (m_input_handler.get_next())
+        case ':': { // key separater
+            current = m_input_handler.get_next();
+            switch (current)
             {
-            case ' ': {
-                size_t prev_pos = m_input_handler.get_lines_read();
-                skip_white_spaces_and_comments();
-                size_t cur_pos = m_input_handler.get_lines_read();
-                if (prev_pos == cur_pos)
-                {
-                    current = m_input_handler.get_current();
-                    if (current != '\r' && current != '\n')
-                    {
-                        return m_last_token_type = lexical_token_t::KEY_SEPARATOR;
-                    }
-                }
-                return m_last_token_type = lexical_token_t::MAPPING_BLOCK_PREFIX;
-            }
-            case '\r': {
-                char_int_type next = m_input_handler.get_next();
-                if (next == '\n')
-                {
-                    m_input_handler.get_next();
-                }
-                return m_last_token_type = lexical_token_t::MAPPING_BLOCK_PREFIX;
-            }
+            case ' ':
+            case '\t':
+            case '\r':
             case '\n':
-                m_input_handler.get_next();
-                return m_last_token_type = lexical_token_t::MAPPING_BLOCK_PREFIX;
+            case s_end_of_input:
+                break;
+            case ',':
+            case '[':
+            case ']':
+            case '{':
+            case '}':
+                if (m_flow_context_depth > 0)
+                {
+                    // the above characters are not "safe" to be followed in a flow context.
+                    break;
+                }
+                m_value_buffer = ":";
+                return scan_string(false);
             default:
-                emit_error("Half-width spaces or newline codes are required after a key separater(:).");
+                m_value_buffer = ":";
+                return scan_string(false);
             }
+
+            return m_last_token_type = lexical_token_t::KEY_SEPARATOR;
+        }
+            // switch (m_input_handler.get_next())
+            // {
+            // case ' ': {
+            //     size_t prev_pos = m_input_handler.get_lines_read();
+            //     skip_white_spaces_and_comments();
+            //     size_t cur_pos = m_input_handler.get_lines_read();
+            //     if (prev_pos == cur_pos)
+            //     {
+            //         current = m_input_handler.get_current();
+            //         if (current != '\r' && current != '\n')
+            //         {
+            //             return m_last_token_type = lexical_token_t::KEY_SEPARATOR;
+            //         }
+            //     }
+            //     return m_last_token_type = lexical_token_t::MAPPING_BLOCK_PREFIX;
+            // }
+            // case '\r': {
+            //     char_int_type next = m_input_handler.get_next();
+            //     if (next == '\n')
+            //     {
+            //         m_input_handler.get_next();
+            //     }
+            //     return m_last_token_type = lexical_token_t::MAPPING_BLOCK_PREFIX;
+            // }
+            // case '\n':
+            //     m_input_handler.get_next();
+            //     return m_last_token_type = lexical_token_t::MAPPING_BLOCK_PREFIX;
+            // default:
+            //     emit_error("Half-width spaces or newline codes are required after a key separater(:).");
+            // }
+
         case ',': // value separater
             m_input_handler.get_next();
             return m_last_token_type = lexical_token_t::VALUE_SEPARATOR;
@@ -2272,7 +2301,7 @@ public:
             while (true)
             {
                 char_int_type next = m_input_handler.get_next();
-                if (next == end_of_input || next == '\r' || next == '\n')
+                if (next == s_end_of_input || next == '\r' || next == '\n')
                 {
                     emit_error("An anchor label must be followed by some value.");
                 }
@@ -2290,7 +2319,7 @@ public:
             while (true)
             {
                 char_int_type next = m_input_handler.get_next();
-                if (next == ' ' || next == '\r' || next == '\n' || next == end_of_input)
+                if (next == ' ' || next == '\r' || next == '\n' || next == s_end_of_input)
                 {
                     if (m_value_buffer.empty())
                     {
@@ -2324,7 +2353,7 @@ public:
             }
 
             char_int_type ret = m_input_handler.get_range(3, m_value_buffer);
-            if (ret != end_of_input)
+            if (ret != s_end_of_input)
             {
                 if (m_value_buffer == "---")
                 {
@@ -2372,7 +2401,7 @@ public:
             return m_last_token_type = scan_number();
         case '.': {
             char_int_type ret = m_input_handler.get_range(3, m_value_buffer);
-            if (ret != end_of_input)
+            if (ret != s_end_of_input)
             {
                 if (m_value_buffer == "...")
                 {
@@ -2416,7 +2445,7 @@ public:
     /// @return std::size_t The number of lines already processed.
     std::size_t get_lines_processed() const noexcept
     {
-        return m_input_handler.get_lines_read();
+        return m_last_token_begin_line;
     }
 
     /// @brief Convert from string to null and get the converted value.
@@ -2529,7 +2558,7 @@ private:
 
         switch (m_input_handler.get_next())
         {
-        case end_of_input:
+        case s_end_of_input:
             emit_error("invalid eof in a directive.");
         case 'T': {
             if (m_input_handler.get_next() != 'A' || m_input_handler.get_next() != 'G')
@@ -2893,7 +2922,7 @@ private:
         for (;; current = m_input_handler.get_next())
         {
             // Handle the end of input buffer.
-            if (current == end_of_input)
+            if (current == s_end_of_input)
             {
                 if (needs_last_double_quote)
                 {
@@ -3217,7 +3246,7 @@ private:
                 continue;
             }
 
-            if (current == end_of_input)
+            if (current == s_end_of_input)
             {
                 if (chomp != chomping_indicator_t::KEEP)
                 {
@@ -3259,7 +3288,7 @@ private:
             }
         }
 
-        for (; current != end_of_input; current = m_input_handler.get_next())
+        for (; current != s_end_of_input; current = m_input_handler.get_next())
         {
             if (current == '\r')
             {
@@ -3560,7 +3589,7 @@ private:
             default:
                 return;
             }
-        } while (m_input_handler.get_next() != end_of_input);
+        } while (m_input_handler.get_next() != s_end_of_input);
     }
 
     /// @brief Skip white spaces and newline codes (CR/LF) from the current position.
@@ -3578,7 +3607,7 @@ private:
             default:
                 return;
             }
-        } while (m_input_handler.get_next() != end_of_input);
+        } while (m_input_handler.get_next() != s_end_of_input);
     }
 
     /// @brief Skip white spaces and comments from the current position.
@@ -3597,7 +3626,7 @@ private:
             default:
                 return;
             }
-        } while (m_input_handler.get_next() != end_of_input);
+        } while (m_input_handler.get_next() != s_end_of_input);
     }
 
     /// @brief Skip the rest in the current line.
@@ -3619,7 +3648,7 @@ private:
             default:
                 break;
             }
-        } while (m_input_handler.get_next() != end_of_input);
+        } while (m_input_handler.get_next() != s_end_of_input);
     }
 
     [[noreturn]] void emit_error(const char* msg) const
@@ -3629,15 +3658,20 @@ private:
 
 private:
     /// The value of EOF for the target characters.
-    static constexpr char_int_type end_of_input = char_traits_type::eof();
+    static constexpr char_int_type s_end_of_input = char_traits_type::eof();
 
     /// An input buffer adapter to be analyzed.
     input_handler_type m_input_handler;
     /// A temporal buffer to store a string to be parsed to an actual datum.
     input_string_type m_value_buffer {};
+    /// A temporal buffer to store a UTF-8 encoded char sequence.
     std::array<char, 4> m_encode_buffer {};
+    /// The actual size of a UTF-8 encoded char sequence.
     std::size_t m_encoded_size {0};
+    /// The beginning position of the last lexical token. (zero origin)
     std::size_t m_last_token_begin_pos {0};
+    /// The beginning line of the last lexical token. (zero origin)
+    std::size_t m_last_token_begin_line {0};
     /// The current depth of flow context.
     uint32_t m_flow_context_depth {0};
     /// The last found token type.
@@ -3810,10 +3844,43 @@ public:
                     throw parse_error("A key separator found without key.", cur_line, cur_indent);
                 }
 
-                bool is_implicit = m_indent_stack.empty() || cur_indent > m_indent_stack.back().first;
+                // hold the line count of the key separator for later use.
+                std::size_t old_indent = cur_indent;
+                std::size_t old_line = cur_line;
+
+                type = lexer.get_next_token();
+                if (type == lexical_token_t::COMMENT_PREFIX)
+                {
+                    // just skip the comment and get the next token.
+                    type = lexer.get_next_token();
+                }
+
+                cur_indent = lexer.get_last_token_begin_pos();
+                cur_line = lexer.get_lines_processed();
+
+                bool is_implicit =
+                    (cur_line == old_line) && (m_indent_stack.empty() || old_indent > m_indent_stack.back().first);
                 if (is_implicit)
                 {
-                    break;
+                    // a key separator for an implicit key.
+                    continue;
+                }
+
+                if (cur_line > old_line)
+                {
+                    if (type == lexical_token_t::SEQUENCE_BLOCK_PREFIX)
+                    {
+                        // a key separator for a block sequence key.
+                        *m_current_node = BasicNodeType::sequence();
+                    }
+                    else
+                    {
+                        // a key separator for a block mapping key.
+                        *m_current_node = BasicNodeType::mapping();
+                    }
+
+                    set_yaml_version(*m_current_node);
+                    continue;
                 }
 
                 while (!m_indent_stack.back().second)
@@ -3847,7 +3914,6 @@ public:
                 m_node_stack.push_back(m_node_stack.back());
                 m_indent_stack.back().second = false;
 
-                type = lexer.get_next_token();
                 if (type == lexical_token_t::SEQUENCE_BLOCK_PREFIX)
                 {
                     *m_current_node = BasicNodeType::sequence();
@@ -3936,26 +4002,6 @@ public:
                 m_current_node = m_node_stack.back();
                 m_node_stack.pop_back();
                 break;
-            case lexical_token_t::MAPPING_BLOCK_PREFIX:
-                type = lexer.get_next_token();
-                if (type == lexical_token_t::COMMENT_PREFIX)
-                {
-                    type = lexer.get_next_token();
-                }
-                if (type == lexical_token_t::SEQUENCE_BLOCK_PREFIX)
-                {
-                    *m_current_node = BasicNodeType::sequence();
-                    set_yaml_version(*m_current_node);
-                    cur_indent = lexer.get_last_token_begin_pos();
-                    cur_line = lexer.get_lines_processed();
-                    continue;
-                }
-
-                *m_current_node = BasicNodeType::mapping();
-                set_yaml_version(*m_current_node);
-                cur_indent = lexer.get_last_token_begin_pos();
-                cur_line = lexer.get_lines_processed();
-                continue;
             case lexical_token_t::MAPPING_FLOW_BEGIN:
                 *m_current_node = BasicNodeType::mapping();
                 set_yaml_version(*m_current_node);
@@ -4135,7 +4181,7 @@ private:
         }
 
         type = lexer.get_next_token();
-        if (type == lexical_token_t::KEY_SEPARATOR || type == lexical_token_t::MAPPING_BLOCK_PREFIX)
+        if (type == lexical_token_t::KEY_SEPARATOR)
         {
             if (m_current_node->is_scalar())
             {

--- a/test/unit_test/test_deserializer_class.cpp
+++ b/test/unit_test/test_deserializer_class.cpp
@@ -1000,6 +1000,47 @@ TEST_CASE("DeserializerClassTest_DeserializeBlockMappingTest", "[DeserializerCla
         REQUIRE(root["baz"]["qux"].is_integer());
         REQUIRE(root["baz"]["qux"].get_value<int>() == 123);
     }
+
+    SECTION("mapping entries split across newlines")
+    {
+        REQUIRE_NOTHROW(
+            root = deserializer.deserialize(fkyaml::detail::input_adapter("foo:\n"
+                                                                          "  bar\n"
+                                                                          "baz:\n"
+                                                                          "  123\n"
+                                                                          "null:\n"
+                                                                          "  {false: 3.14}\n"
+                                                                          "qux:\n"
+                                                                          "  [r, g, b]")));
+
+        REQUIRE(root.is_mapping());
+        REQUIRE(root.size() == 4);
+        REQUIRE(root.contains("foo"));
+        REQUIRE(root.contains("baz"));
+        REQUIRE(root.contains(nullptr));
+        REQUIRE(root.contains("qux"));
+
+        REQUIRE(root["foo"].is_string());
+        REQUIRE(root["foo"].get_value_ref<std::string&>() == "bar");
+
+        REQUIRE(root["baz"].is_integer());
+        REQUIRE(root["baz"].get_value<int>() == 123);
+
+        REQUIRE(root[nullptr].is_mapping());
+        REQUIRE(root[nullptr].contains(false));
+        REQUIRE(root[nullptr][false].is_float_number());
+        REQUIRE(root[nullptr][false].get_value<double>() == 3.14);
+
+        REQUIRE(root["qux"].is_sequence());
+        REQUIRE(root["qux"].size() == 3);
+
+        REQUIRE(root["qux"][0].is_string());
+        REQUIRE(root["qux"][0].get_value_ref<std::string&>() == "r");
+        REQUIRE(root["qux"][1].is_string());
+        REQUIRE(root["qux"][1].get_value_ref<std::string&>() == "g");
+        REQUIRE(root["qux"][2].is_string());
+        REQUIRE(root["qux"][2].get_value_ref<std::string&>() == "b");
+    }
 }
 
 TEST_CASE("DeserializerClassTest_DeserializeFlowSequenceTest", "[DeserializerClassTest]")

--- a/test/unit_test/test_lexical_analyzer_class.cpp
+++ b/test/unit_test/test_lexical_analyzer_class.cpp
@@ -179,41 +179,35 @@ TEST_CASE("LexicalAnalyzerClassTest_ScanColonTest", "[LexicalAnalyzerClassTest]"
     {
         pchar_lexer_t lexer(fkyaml::detail::input_adapter(":\r"));
         REQUIRE_NOTHROW(token = lexer.get_next_token());
-        REQUIRE(token == fkyaml::detail::lexical_token_t::MAPPING_BLOCK_PREFIX);
+        REQUIRE(token == fkyaml::detail::lexical_token_t::KEY_SEPARATOR);
     }
 
     SECTION("Test colon with CRLF newline code.")
     {
         pchar_lexer_t lexer(fkyaml::detail::input_adapter(":\r\n"));
         REQUIRE_NOTHROW(token = lexer.get_next_token());
-        REQUIRE(token == fkyaml::detail::lexical_token_t::MAPPING_BLOCK_PREFIX);
+        REQUIRE(token == fkyaml::detail::lexical_token_t::KEY_SEPARATOR);
     }
 
     SECTION("Test colon with LF newline code.")
     {
         pchar_lexer_t lexer(fkyaml::detail::input_adapter(":\n"));
         REQUIRE_NOTHROW(token = lexer.get_next_token());
-        REQUIRE(token == fkyaml::detail::lexical_token_t::MAPPING_BLOCK_PREFIX);
-    }
-
-    SECTION("Test colon with non-newline-code character.")
-    {
-        pchar_lexer_t lexer(fkyaml::detail::input_adapter(":test"));
-        REQUIRE_THROWS_AS(token = lexer.get_next_token(), fkyaml::parse_error);
+        REQUIRE(token == fkyaml::detail::lexical_token_t::KEY_SEPARATOR);
     }
 
     SECTION("Test colon with a comment and a CRLF newline code.")
     {
         pchar_lexer_t lexer(fkyaml::detail::input_adapter(": # comment\r\n"));
         REQUIRE_NOTHROW(token = lexer.get_next_token());
-        REQUIRE(token == fkyaml::detail::lexical_token_t::MAPPING_BLOCK_PREFIX);
+        REQUIRE(token == fkyaml::detail::lexical_token_t::KEY_SEPARATOR);
     }
 
     SECTION("Test colon with a comment and a LF newline code.")
     {
         pchar_lexer_t lexer(fkyaml::detail::input_adapter(": # comment\n"));
         REQUIRE_NOTHROW(token = lexer.get_next_token());
-        REQUIRE(token == fkyaml::detail::lexical_token_t::MAPPING_BLOCK_PREFIX);
+        REQUIRE(token == fkyaml::detail::lexical_token_t::KEY_SEPARATOR);
     }
 
     SECTION("Test colon with a comment and no newline code")
@@ -227,19 +221,48 @@ TEST_CASE("LexicalAnalyzerClassTest_ScanColonTest", "[LexicalAnalyzerClassTest]"
     {
         pchar_lexer_t lexer(fkyaml::detail::input_adapter(":                         \r\n"));
         REQUIRE_NOTHROW(token = lexer.get_next_token());
-        REQUIRE(token == fkyaml::detail::lexical_token_t::MAPPING_BLOCK_PREFIX);
+        REQUIRE(token == fkyaml::detail::lexical_token_t::KEY_SEPARATOR);
     }
 
     SECTION("Test colon with many spaces and a LF newline code.")
     {
         pchar_lexer_t lexer(fkyaml::detail::input_adapter(":                         \n"));
         REQUIRE_NOTHROW(token = lexer.get_next_token());
-        REQUIRE(token == fkyaml::detail::lexical_token_t::MAPPING_BLOCK_PREFIX);
+        REQUIRE(token == fkyaml::detail::lexical_token_t::KEY_SEPARATOR);
     }
 
     SECTION("Test colon with many spaces and no newline code.")
     {
         pchar_lexer_t lexer(fkyaml::detail::input_adapter(":                         "));
+        REQUIRE_NOTHROW(token = lexer.get_next_token());
+        REQUIRE(token == fkyaml::detail::lexical_token_t::KEY_SEPARATOR);
+    }
+
+    SECTION("Test colon with an always-safe character.")
+    {
+        pchar_lexer_t lexer(fkyaml::detail::input_adapter(":test"));
+        REQUIRE_NOTHROW(token = lexer.get_next_token());
+        REQUIRE(token == fkyaml::detail::lexical_token_t::STRING_VALUE);
+        REQUIRE(lexer.get_string() == ":test");
+    }
+
+    SECTION("Test colon with a flow indicator in a non-flow context.")
+    {
+        auto input =
+            GENERATE(std::string(":,"), std::string(":{"), std::string(":}"), std::string(":["), std::string(":]"));
+        str_lexer_t lexer(fkyaml::detail::input_adapter(input));
+        REQUIRE_NOTHROW(token = lexer.get_next_token());
+        REQUIRE(token == fkyaml::detail::lexical_token_t::STRING_VALUE);
+        REQUIRE(lexer.get_string() == input);
+    }
+
+    SECTION("Test colon with a flow indicator in a flow context.")
+    {
+        auto input = GENERATE(
+            std::string("{:,"), std::string("{:{"), std::string("{:}"), std::string("{:["), std::string("{:]"));
+        str_lexer_t lexer(fkyaml::detail::input_adapter(input));
+        REQUIRE_NOTHROW(token = lexer.get_next_token());
+        REQUIRE(token == fkyaml::detail::lexical_token_t::MAPPING_FLOW_BEGIN);
         REQUIRE_NOTHROW(token = lexer.get_next_token());
         REQUIRE(token == fkyaml::detail::lexical_token_t::KEY_SEPARATOR);
     }
@@ -1690,7 +1713,7 @@ TEST_CASE("LexicalAnalyzerClassTest_ScanBlockSequenceTokenTest", "[LexicalAnalyz
         REQUIRE(lexer.get_string().compare("test") == 0);
 
         REQUIRE_NOTHROW(token = lexer.get_next_token());
-        REQUIRE(token == fkyaml::detail::lexical_token_t::MAPPING_BLOCK_PREFIX);
+        REQUIRE(token == fkyaml::detail::lexical_token_t::KEY_SEPARATOR);
 
         REQUIRE_NOTHROW(token = lexer.get_next_token());
         REQUIRE(token == fkyaml::detail::lexical_token_t::SEQUENCE_BLOCK_PREFIX);
@@ -1726,7 +1749,7 @@ TEST_CASE("LexicalAnalyzerClassTest_ScanBlockSequenceTokenTest", "[LexicalAnalyz
         REQUIRE(lexer.get_string().compare("test") == 0);
 
         REQUIRE_NOTHROW(token = lexer.get_next_token());
-        REQUIRE(token == fkyaml::detail::lexical_token_t::MAPPING_BLOCK_PREFIX);
+        REQUIRE(token == fkyaml::detail::lexical_token_t::KEY_SEPARATOR);
 
         REQUIRE_NOTHROW(token = lexer.get_next_token());
         REQUIRE(token == fkyaml::detail::lexical_token_t::SEQUENCE_BLOCK_PREFIX);
@@ -1805,7 +1828,7 @@ TEST_CASE("LexicalAnalyzerClassTest_ScanBlockMappingTokenTest", "[LexicalAnalyze
         REQUIRE(lexer.get_string().compare("test") == 0);
 
         REQUIRE_NOTHROW(token = lexer.get_next_token());
-        REQUIRE(token == fkyaml::detail::lexical_token_t::MAPPING_BLOCK_PREFIX);
+        REQUIRE(token == fkyaml::detail::lexical_token_t::KEY_SEPARATOR);
 
         REQUIRE_NOTHROW(token = lexer.get_next_token());
         REQUIRE(token == fkyaml::detail::lexical_token_t::STRING_VALUE);


### PR DESCRIPTION
As reported in the issue #288, the the parser & lexer implementations didn't cover mapping entries split across newlines.  
To fix that, the handling of key separators (`:`) have been moved from the lexer to the deserializer, and defer checking the existence of a key separator followed by a node associated to a block mapping key.  
To validate the above changes, the test suite has been updated with some new test cases.  

---

## Pull Request Checklist

Read the [CONTRIBUTING.md](https://github.com/fktn-k/fkYAML/blob/develop/CONTRIBUTING.md) file for detailed information.  

- [x] Changes are described in the pull request or in a referenced [issue](https://github.com/fktn-k/fkYAML/issues).
- [x] The test suite compiles and runs without any error.
- [x] [The code coverage](https://coveralls.io/github/fktn-k/fkYAML) on your branch is 100%.
- [x] The documentation is updated if you added/changed a feature.

## Please don't

- The C++11 support varies between different **compilers** and versions. Please note the [list of supported compilers](https://github.com/fktn-k/fkYAML/blob/develop/README.md#supported-compilers). Some compilers like GCC 4.7 (and earlier), Clang 3.3 (and earlier), or Microsoft Visual Studio 13.0 and earlier are known not to work due to missing or incomplete C++11 support. Please refrain from proposing changes that work around these compiler's limitations with `#ifdef`s or other means.
- Please refrain from proposing changes that would **break [YAML](https://yaml.org/) specifications**. If you propose a conformant extension of YAML to be supported by the library, please motivate this extension.
- Please do not open pull requests that address **multiple issues**.
