### PR TITLE
modied the way of formatting error messages for exception objects

### DIFF
--- a/include/fkYAML/detail/encodings/encode_detector.hpp
+++ b/include/fkYAML/detail/encodings/encode_detector.hpp
@@ -12,6 +12,7 @@
 #define FK_YAML_DETAIL_ENCODINGS_ENCODE_DETECTOR_HPP_
 
 #include <cstdint>
+#include <istream>
 
 #include <fkYAML/detail/macros/version_macros.hpp>
 #include <fkYAML/detail/encodings/encode_t.hpp>

--- a/include/fkYAML/detail/string_formatter.hpp
+++ b/include/fkYAML/detail/string_formatter.hpp
@@ -1,0 +1,45 @@
+#ifndef FK_YAML_DETAIL_STRING_FORMATTER_HPP_
+#define FK_YAML_DETAIL_STRING_FORMATTER_HPP_
+
+#include <cstdarg>
+#include <cstdio>
+#include <memory>
+#include <string>
+
+#include <fkYAML/detail/macros/version_macros.hpp>
+
+/// @namespace namespace for fkYAML library.
+FK_YAML_NAMESPACE_BEGIN
+
+/// @namespace namespace for internal implementation of fkYAML library.
+namespace detail
+{
+
+inline std::string format(const char* fmt, ...)
+{
+    va_list vl;
+    va_start(vl, fmt);
+    int size = std::vsnprintf(nullptr, 0, fmt, vl);
+    va_end(vl);
+
+    // LCOV_EXCL_START
+    if (size < 0)
+    {
+        return "";
+    }
+    // LCOV_EXCL_STOP
+
+    std::unique_ptr<char[]> buffer {new char[size + 1] {}};
+
+    va_start(vl, fmt);
+    size = std::vsnprintf(buffer.get(), size + 1, fmt, vl);
+    va_end(vl);
+
+    return std::string(buffer.get(), size);
+}
+
+}; // namespace detail
+
+FK_YAML_NAMESPACE_END
+
+#endif /* FK_YAML_DETAIL_STRING_FORMATTER_HPP_ */

--- a/include/fkYAML/detail/types/node_t.hpp
+++ b/include/fkYAML/detail/types/node_t.hpp
@@ -35,7 +35,7 @@ enum class node_t : std::uint32_t
     STRING,       //!< string value type
 };
 
-inline std::string to_string(node_t t) noexcept
+inline const char* to_string(node_t t) noexcept
 {
     switch (t)
     {

--- a/include/fkYAML/exception.hpp
+++ b/include/fkYAML/exception.hpp
@@ -14,9 +14,9 @@
 #include <array>
 #include <stdexcept>
 #include <string>
-#include <sstream>
 
 #include <fkYAML/detail/macros/version_macros.hpp>
+#include <fkYAML/detail/string_formatter.hpp>
 #include <fkYAML/detail/types/node_t.hpp>
 
 /// @brief namespace for fkYAML library.
@@ -88,14 +88,13 @@ private:
     template <std::size_t N>
     std::string generate_error_message(const char* msg, std::array<int, N> u8) const noexcept
     {
-        std::stringstream ss;
-        ss << "invalid_encoding: " << msg << " in=[ 0x" << std::hex << u8[0];
+        std::string formatted = detail::format("invalid_encoding: %s in=[ 0x%02x", msg, u8[0]);
         for (std::size_t i = 1; i < N; i++)
         {
-            ss << ", 0x" << std::hex << u8[i];
+            formatted += detail::format(", 0x%02x", u8[i]);
         }
-        ss << " ]";
-        return ss.str();
+        formatted += " ]";
+        return formatted;
     }
 
     /// @brief Generate an error message from the given parameters for the UTF-16 encoding.
@@ -105,11 +104,8 @@ private:
     /// @return A generated error message.
     std::string generate_error_message(const char* msg, std::array<char16_t, 2> u16) const noexcept
     {
-        std::stringstream ss;
-        ss << "invalid_encoding: " << msg;
         // uint16_t is large enough for UTF-16 encoded elements.
-        ss << " in=[ 0x" << std::hex << uint16_t(u16[0]) << ", 0x" << std::hex << uint16_t(u16[1]) << " ]";
-        return ss.str();
+        return detail::format("invalid_encoding: %s in=[ 0x%04x, 0x%04x ]", msg, uint16_t(u16[0]), uint16_t(u16[1]));
     }
 
     /// @brief Generate an error message from the given parameters for the UTF-32 encoding.
@@ -118,10 +114,8 @@ private:
     /// @return A genereated error message.
     std::string generate_error_message(const char* msg, char32_t u32) const noexcept
     {
-        std::stringstream ss;
         // uint32_t is large enough for UTF-32 encoded elements.
-        ss << "invalid_encoding: " << msg << " in=0x" << std::hex << uint32_t(u32);
-        return ss.str();
+        return detail::format("invalid_encoding: %s in=0x%08x", msg, uint32_t(u32));
     }
 };
 
@@ -137,9 +131,7 @@ public:
 private:
     std::string generate_error_message(const char* msg, std::size_t lines, std::size_t cols_in_line) const noexcept
     {
-        std::stringstream ss;
-        ss << "parse_error: " << msg << " (at line " << lines << ", column " << cols_in_line << ")";
-        return ss.str();
+        return detail::format("parse_error: %s (at line %zu, column %zu)", msg, lines, cols_in_line);
     }
 };
 
@@ -163,9 +155,7 @@ private:
     /// @return A generated error message.
     std::string generate_error_message(const char* msg, detail::node_t type) const noexcept
     {
-        std::stringstream ss;
-        ss << "type_error: " << msg << " type=" << detail::to_string(type);
-        return ss.str();
+        return detail::format("type_error: %s type=%s", msg, detail::to_string(type));
     }
 };
 

--- a/single_include/fkYAML/node.hpp
+++ b/single_include/fkYAML/node.hpp
@@ -4345,6 +4345,7 @@ FK_YAML_NAMESPACE_END
 #define FK_YAML_DETAIL_ENCODINGS_ENCODE_DETECTOR_HPP_
 
 #include <cstdint>
+#include <istream>
 
 // #include <fkYAML/detail/macros/version_macros.hpp>
 

--- a/test/unit_test/CMakeLists.txt
+++ b/test/unit_test/CMakeLists.txt
@@ -207,6 +207,7 @@ add_executable(
   test_node_ref_storage_class.cpp
   test_ordered_map_class.cpp
   test_serializer_class.cpp
+  test_string_formatter.cpp
   test_utf8_encoding_class.cpp
   main.cpp
 )

--- a/test/unit_test/test_string_formatter.cpp
+++ b/test/unit_test/test_string_formatter.cpp
@@ -1,0 +1,23 @@
+//  _______   __ __   __  _____   __  __  __
+// |   __| |_/  |  \_/  |/  _  \ /  \/  \|  |     fkYAML: A C++ header-only YAML library (supporting code)
+// |   __|  _  < \_   _/|  ___  |    _   |  |___  version 0.3.2
+// |__|  |_| \__|  |_|  |_|   |_|___||___|______| https://github.com/fktn-k/fkYAML
+//
+// SPDX-FileCopyrightText: 2023-2024 Kensuke Fukutani <fktn.dev@gmail.com>
+// SPDX-License-Identifier: MIT
+
+#include <catch2/catch.hpp>
+
+#ifdef FK_YAML_TEST_USE_SINGLE_HEADER
+    #include <fkYAML/node.hpp>
+#else
+    #include <fkYAML/detail/string_formatter.hpp>
+#endif
+
+TEST_CASE("StringFormatterTest_ValidMessageFormat", "[StringFormatterTest]")
+{
+    const char* p_label = "foo_label";
+    int result = 0;
+    std::string formatted = fkyaml::detail::format("%s: ret=%d", p_label, result);
+    REQUIRE(formatted == "foo_label: ret=0");
+}


### PR DESCRIPTION
This PR has made small changes in the way of formatting error messages for the `fkyaml::exception` 
 and its derived class objects from using `std::stringstream` to the C-style formatting using `std::vsnprintf()`.  
(I honestly wanted to use std::format, but it's been available since C++20 and I don't want to add any external dependencies, other than C++ standards, to the library itself.)  
The error message contents themselves are not changed.  

---

## Pull Request Checklist

Read the [CONTRIBUTING.md](https://github.com/fktn-k/fkYAML/blob/develop/CONTRIBUTING.md) file for detailed information.  

- [x] Changes are described in the pull request or in a referenced [issue](https://github.com/fktn-k/fkYAML/issues).
- [x] The test suite compiles and runs without any error.
- [x] [The code coverage](https://coveralls.io/github/fktn-k/fkYAML) on your branch is 100%.
- [x] The documentation is updated if you added/changed a feature.

## Please don't

- The C++11 support varies between different **compilers** and versions. Please note the [list of supported compilers](https://github.com/fktn-k/fkYAML/blob/develop/README.md#supported-compilers). Some compilers like GCC 4.7 (and earlier), Clang 3.3 (and earlier), or Microsoft Visual Studio 13.0 and earlier are known not to work due to missing or incomplete C++11 support. Please refrain from proposing changes that work around these compiler's limitations with `#ifdef`s or other means.
- Please refrain from proposing changes that would **break [YAML](https://yaml.org/) specifications**. If you propose a conformant extension of YAML to be supported by the library, please motivate this extension.
- Please do not open pull requests that address **multiple issues**.
