### PR TITLE
#292 Better handling for flow indicators in permitted scalar contexts

### DIFF
--- a/include/fkYAML/detail/input/lexical_analyzer.hpp
+++ b/include/fkYAML/detail/input/lexical_analyzer.hpp
@@ -823,17 +823,33 @@ private:
                     // Allow a space in an unquoted string only if the space is surrounded by non-space characters.
                     // See https://yaml.org/spec/1.2.2/#733-plain-style for more details.
                     current = m_input_handler.get_next();
+
+                    // These characters are permitted when not inside a flow collection, and not inside an implicit key.
+                    // TODO: Support detection of implicit key context for this check.
+                    if (m_flow_context_depth > 0)
+                    {
+                        switch (current)
+                        {
+                        case '{':
+                        case '}':
+                        case '[':
+                        case ']':
+                        case ',':
+                            return lexical_token_t::STRING_VALUE;
+                        }
+                    }
+
                     switch (current)
                     {
                     case ' ':
                     case '\r':
                     case '\n':
-                    case '{':
-                    case '}':
-                    case '[':
-                    case ']':
-                    case ',':
                     case ':':
+                        // " :" is permitted in a plain style string token, but not when followed by a space.
+                        if (!m_input_handler.test_next_char(' '))
+                        {
+                            break;
+                        }
                     case '#':
                     case '\\':
                         return lexical_token_t::STRING_VALUE;

--- a/include/fkYAML/detail/input/lexical_analyzer.hpp
+++ b/include/fkYAML/detail/input/lexical_analyzer.hpp
@@ -841,15 +841,15 @@ private:
 
                     switch (current)
                     {
-                    case ' ':
-                    case '\r':
-                    case '\n':
                     case ':':
                         // " :" is permitted in a plain style string token, but not when followed by a space.
                         if (!m_input_handler.test_next_char(' '))
                         {
                             break;
                         }
+                    case ' ':
+                    case '\r':
+                    case '\n':
                     case '#':
                     case '\\':
                         return lexical_token_t::STRING_VALUE;

--- a/include/fkYAML/detail/input/lexical_analyzer.hpp
+++ b/include/fkYAML/detail/input/lexical_analyzer.hpp
@@ -839,14 +839,19 @@ private:
                         }
                     }
 
+                    // " :" is permitted in a plain style string token, but not when followed by a space.
+                    if (current == ':')
+                    {
+                        char_int_type next = m_input_handler.get_next();
+                        m_input_handler.unget();
+                        if (next == ' ')
+                        {
+                            return lexical_token_t::STRING_VALUE;
+                        }
+                    }
+
                     switch (current)
                     {
-                    case ':':
-                        // " :" is permitted in a plain style string token, but not when followed by a space.
-                        if (!m_input_handler.test_next_char(' '))
-                        {
-                            break;
-                        }
                     case ' ':
                     case '\r':
                     case '\n':

--- a/single_include/fkYAML/node.hpp
+++ b/single_include/fkYAML/node.hpp
@@ -2998,14 +2998,19 @@ private:
                         }
                     }
 
+                    // " :" is permitted in a plain style string token, but not when followed by a space.
+                    if (current == ':')
+                    {
+                        char_int_type next = m_input_handler.get_next();
+                        m_input_handler.unget();
+                        if (next == ' ')
+                        {
+                            return lexical_token_t::STRING_VALUE;
+                        }
+                    }
+
                     switch (current)
                     {
-                    case ':':
-                        // " :" is permitted in a plain style string token, but not when followed by a space.
-                        if (!m_input_handler.test_next_char(' '))
-                        {
-                            break;
-                        }
                     case ' ':
                     case '\r':
                     case '\n':

--- a/single_include/fkYAML/node.hpp
+++ b/single_include/fkYAML/node.hpp
@@ -3000,15 +3000,15 @@ private:
 
                     switch (current)
                     {
-                    case ' ':
-                    case '\r':
-                    case '\n':
                     case ':':
                         // " :" is permitted in a plain style string token, but not when followed by a space.
                         if (!m_input_handler.test_next_char(' '))
                         {
                             break;
                         }
+                    case ' ':
+                    case '\r':
+                    case '\n':
                     case '#':
                     case '\\':
                         return lexical_token_t::STRING_VALUE;

--- a/test/unit_test/test_deserializer_class.cpp
+++ b/test/unit_test/test_deserializer_class.cpp
@@ -986,12 +986,15 @@ TEST_CASE("DeserializerClassTest_DeserializeBlockMappingTest", "[DeserializerCla
 
     SECTION("Flow indicators inside unquoted plain scalar values")
     {
-        REQUIRE_NOTHROW(root = deserializer.deserialize(fkyaml::detail::input_adapter("Foo: Bar {[123] 3.14}")));
+        REQUIRE_NOTHROW(root = deserializer.deserialize(fkyaml::detail::input_adapter("Foo: Bar, {[123] :3.14}")));
         REQUIRE(root.is_mapping());
         REQUIRE(root.size() == 1);
         REQUIRE(root.contains("Foo"));
         REQUIRE(root["Foo"].is_string());
-        REQUIRE(root["Foo"].get_value_ref<std::string&>() == "Bar {[123] 3.14}");
+        REQUIRE(root["Foo"].get_value_ref<std::string&>() == "Bar, {[123] :3.14}");
+        REQUIRE_THROWS_AS(
+            root = deserializer.deserialize(fkyaml::detail::input_adapter("Foo: Bar, {[123] : 3.14}")),
+            fkyaml::parse_error);
     }
 
     SECTION("a comment right after a block mapping key.")

--- a/test/unit_test/test_deserializer_class.cpp
+++ b/test/unit_test/test_deserializer_class.cpp
@@ -984,6 +984,16 @@ TEST_CASE("DeserializerClassTest_DeserializeBlockMappingTest", "[DeserializerCla
         REQUIRE(root["Baz[123]"].get_value<double>() == 3.14);
     }
 
+    SECTION("Flow indicators inside unquoted plain scalar values")
+    {
+        REQUIRE_NOTHROW(root = deserializer.deserialize(fkyaml::detail::input_adapter("Foo: Bar {[123] 3.14}")));
+        REQUIRE(root.is_mapping());
+        REQUIRE(root.size() == 1);
+        REQUIRE(root.contains("Foo"));
+        REQUIRE(root["Foo"].is_string());
+        REQUIRE(root["Foo"].get_value_ref<std::string&>() == "Bar {[123] 3.14}");
+    }
+
     SECTION("a comment right after a block mapping key.")
     {
         REQUIRE_NOTHROW(

--- a/test/unit_test/test_deserializer_class.cpp
+++ b/test/unit_test/test_deserializer_class.cpp
@@ -986,6 +986,34 @@ TEST_CASE("DeserializerClassTest_DeserializeBlockMappingTest", "[DeserializerCla
 
     SECTION("Flow indicators inside unquoted plain scalar values")
     {
+        REQUIRE_NOTHROW(root = deserializer.deserialize(fkyaml::detail::input_adapter("Foo: Bar, abc{abc")));
+        REQUIRE(root.is_mapping());
+        REQUIRE(root.size() == 1);
+        REQUIRE(root.contains("Foo"));
+        REQUIRE(root["Foo"].is_string());
+        REQUIRE(root["Foo"].get_value_ref<std::string&>() == "Bar, abc{abc");
+
+        REQUIRE_NOTHROW(root = deserializer.deserialize(fkyaml::detail::input_adapter("Foo: Bar, abc}abc")));
+        REQUIRE(root.is_mapping());
+        REQUIRE(root.size() == 1);
+        REQUIRE(root.contains("Foo"));
+        REQUIRE(root["Foo"].is_string());
+        REQUIRE(root["Foo"].get_value_ref<std::string&>() == "Bar, abc}abc");
+
+        REQUIRE_NOTHROW(root = deserializer.deserialize(fkyaml::detail::input_adapter("Foo: Bar, abc[abc")));
+        REQUIRE(root.is_mapping());
+        REQUIRE(root.size() == 1);
+        REQUIRE(root.contains("Foo"));
+        REQUIRE(root["Foo"].is_string());
+        REQUIRE(root["Foo"].get_value_ref<std::string&>() == "Bar, abc[abc");
+
+        REQUIRE_NOTHROW(root = deserializer.deserialize(fkyaml::detail::input_adapter("Foo: Bar, abc]abc")));
+        REQUIRE(root.is_mapping());
+        REQUIRE(root.size() == 1);
+        REQUIRE(root.contains("Foo"));
+        REQUIRE(root["Foo"].is_string());
+        REQUIRE(root["Foo"].get_value_ref<std::string&>() == "Bar, abc]abc");
+
         REQUIRE_NOTHROW(root = deserializer.deserialize(fkyaml::detail::input_adapter("Foo: Bar, {[123] :3.14}")));
         REQUIRE(root.is_mapping());
         REQUIRE(root.size() == 1);


### PR DESCRIPTION
This PR addresses #292 by checking if the lexer is in a flow context before treating flow indicators, commas, or colons as terminating plain unquoted strings.
---

## Pull Request Checklist

Read the [CONTRIBUTING.md](https://github.com/fktn-k/fkYAML/blob/develop/CONTRIBUTING.md) file for detailed information.  

- [x] Changes are described in the pull request or in a referenced [issue](https://github.com/fktn-k/fkYAML/issues).
- [x] The test suite compiles and runs without any error.
- [x] [The code coverage](https://coveralls.io/github/fktn-k/fkYAML) on your branch is 100%.
- [x] The documentation is updated if you added/changed a feature.

## Please don't

- The C++11 support varies between different **compilers** and versions. Please note the [list of supported compilers](https://github.com/fktn-k/fkYAML/blob/develop/README.md#supported-compilers). Some compilers like GCC 4.7 (and earlier), Clang 3.3 (and earlier), or Microsoft Visual Studio 13.0 and earlier are known not to work due to missing or incomplete C++11 support. Please refrain from proposing changes that work around these compiler's limitations with `#ifdef`s or other means.
- Please refrain from proposing changes that would **break [YAML](https://yaml.org/) specifications**. If you propose a conformant extension of YAML to be supported by the library, please motivate this extension.
- Please do not open pull requests that address **multiple issues**.
