### PR TITLE
#302 Fixed parse error on alias mapping keys

### DIFF
--- a/test/unit_test/test_deserializer_class.cpp
+++ b/test/unit_test/test_deserializer_class.cpp
@@ -1082,6 +1082,20 @@ TEST_CASE("DeserializerClassTest_DeserializeBlockMappingTest", "[DeserializerCla
         REQUIRE(root["qux"][2].is_string());
         REQUIRE(root["qux"][2].get_value_ref<std::string&>() == "b");
     }
+
+    SECTION("parse alias mapping key")
+    {
+        REQUIRE_NOTHROW(root = deserializer.deserialize(fkyaml::detail::input_adapter("&anchor foo:\n  *anchor: 123")));
+
+        REQUIRE(root.is_mapping());
+        REQUIRE(root.size() == 1);
+        REQUIRE(root.contains("foo"));
+        REQUIRE(root["foo"].is_mapping());
+        REQUIRE(root["foo"].size() == 1);
+        REQUIRE(root["foo"].contains("foo"));
+        REQUIRE(root["foo"]["foo"].is_integer());
+        REQUIRE(root["foo"]["foo"].get_value<int>() == 123);
+    }
 }
 
 TEST_CASE("DeserializerClassTest_DeserializeFlowSequenceTest", "[DeserializerClassTest]")

--- a/test/unit_test/test_lexical_analyzer_class.cpp
+++ b/test/unit_test/test_lexical_analyzer_class.cpp
@@ -1256,47 +1256,45 @@ TEST_CASE("LexicalAnalyzerClassTest_ScanAnchorTokenTest", "[LexicalAnalyzerClass
 {
     fkyaml::detail::lexical_token_t token;
 
-    SECTION("Test nothorw expected tokens with an anchor.")
+    SECTION("valid anchor name")
     {
-        lexer_t lexer(fkyaml::detail::input_adapter("test: &anchor foo"));
+        auto input = GENERATE(
+            std::string("&:anchor"),
+            std::string("&:anchor "),
+            std::string("&:anchor\t"),
+            std::string("&:anchor\r"),
+            std::string("&:anchor\n"),
+            std::string("&:anchor{"),
+            std::string("&:anchor}"),
+            std::string("&:anchor["),
+            std::string("&:anchor]"),
+            std::string("&:anchor,"),
+            std::string("&:anchor: "));
 
-        REQUIRE_NOTHROW(token = lexer.get_next_token());
-        REQUIRE(token == fkyaml::detail::lexical_token_t::STRING_VALUE);
-        REQUIRE_NOTHROW(lexer.get_string());
-        REQUIRE(lexer.get_string().compare("test") == 0);
-
-        REQUIRE_NOTHROW(token = lexer.get_next_token());
-        REQUIRE(token == fkyaml::detail::lexical_token_t::KEY_SEPARATOR);
+        lexer_t lexer(fkyaml::detail::input_adapter(input));
 
         REQUIRE_NOTHROW(token = lexer.get_next_token());
         REQUIRE(token == fkyaml::detail::lexical_token_t::ANCHOR_PREFIX);
-        REQUIRE_NOTHROW(lexer.get_string());
-        REQUIRE(lexer.get_string().compare("anchor") == 0);
-
-        REQUIRE_NOTHROW(token = lexer.get_next_token());
-        REQUIRE(token == fkyaml::detail::lexical_token_t::STRING_VALUE);
-        REQUIRE_NOTHROW(lexer.get_string());
-        REQUIRE(lexer.get_string().compare("foo") == 0);
-
-        REQUIRE_NOTHROW(token = lexer.get_next_token());
-        REQUIRE(token == fkyaml::detail::lexical_token_t::END_OF_BUFFER);
+        REQUIRE_NOTHROW(lexer.get_string() == ":anchor");
     }
 
-    SECTION("Test nothrow unexpected tokens with an anchor.")
+    SECTION("invalid anchor name")
     {
-        auto buffer =
-            GENERATE(std::string("test: &anchor"), std::string("test: &anchor\r\n"), std::string("test: &anchor\n"));
-        lexer_t lexer(fkyaml::detail::input_adapter(buffer));
+        auto input = GENERATE(
+            std::string("&"),
+            std::string("& "),
+            std::string("&\t"),
+            std::string("&\r"),
+            std::string("&\n"),
+            std::string("&{"),
+            std::string("&}"),
+            std::string("&["),
+            std::string("&]"),
+            std::string("&,"),
+            std::string("&: "));
 
-        REQUIRE_NOTHROW(token = lexer.get_next_token());
-        REQUIRE(token == fkyaml::detail::lexical_token_t::STRING_VALUE);
-        REQUIRE_NOTHROW(lexer.get_string());
-        REQUIRE(lexer.get_string().compare("test") == 0);
-
-        REQUIRE_NOTHROW(token = lexer.get_next_token());
-        REQUIRE(token == fkyaml::detail::lexical_token_t::KEY_SEPARATOR);
-
-        REQUIRE_THROWS_AS(token = lexer.get_next_token(), fkyaml::parse_error);
+        lexer_t lexer(fkyaml::detail::input_adapter(input));
+        REQUIRE_THROWS_AS(lexer.get_next_token(), fkyaml::parse_error);
     }
 }
 
@@ -1304,42 +1302,45 @@ TEST_CASE("LexicalAnalyzerClassTest_ScanAliasTokenTest", "[LexicalAnalyzerClassT
 {
     fkyaml::detail::lexical_token_t token;
 
-    SECTION("Test nothrow expected tokens with an alias.")
+    SECTION("valid anchor name")
     {
-        lexer_t lexer(fkyaml::detail::input_adapter("test: *anchor"));
+        auto input = GENERATE(
+            std::string("*:anchor"),
+            std::string("*:anchor "),
+            std::string("*:anchor\t"),
+            std::string("*:anchor\r"),
+            std::string("*:anchor\n"),
+            std::string("*:anchor{"),
+            std::string("*:anchor}"),
+            std::string("*:anchor["),
+            std::string("*:anchor]"),
+            std::string("*:anchor,"),
+            std::string("*:anchor: "));
 
-        REQUIRE_NOTHROW(token = lexer.get_next_token());
-        REQUIRE(token == fkyaml::detail::lexical_token_t::STRING_VALUE);
-        REQUIRE_NOTHROW(lexer.get_string());
-        REQUIRE(lexer.get_string().compare("test") == 0);
-
-        REQUIRE_NOTHROW(token = lexer.get_next_token());
-        REQUIRE(token == fkyaml::detail::lexical_token_t::KEY_SEPARATOR);
+        lexer_t lexer(fkyaml::detail::input_adapter(input));
 
         REQUIRE_NOTHROW(token = lexer.get_next_token());
         REQUIRE(token == fkyaml::detail::lexical_token_t::ALIAS_PREFIX);
-        REQUIRE_NOTHROW(lexer.get_string());
-        REQUIRE(lexer.get_string().compare("anchor") == 0);
-
-        REQUIRE_NOTHROW(token = lexer.get_next_token());
-        REQUIRE(token == fkyaml::detail::lexical_token_t::END_OF_BUFFER);
+        REQUIRE_NOTHROW(lexer.get_string() == ":anchor");
     }
 
-    SECTION("Test nothrow unexpected tokens with an anchor.")
+    SECTION("invalid anchor name")
     {
-        auto buffer = GENERATE(
-            std::string("test: *"), std::string("test: *\r\n"), std::string("test: *\n"), std::string("test: * "));
-        lexer_t lexer(fkyaml::detail::input_adapter(buffer));
+        auto input = GENERATE(
+            std::string("*"),
+            std::string("* "),
+            std::string("*\t"),
+            std::string("*\r"),
+            std::string("*\n"),
+            std::string("*{"),
+            std::string("*}"),
+            std::string("*["),
+            std::string("*]"),
+            std::string("*,"),
+            std::string("*: "));
 
-        REQUIRE_NOTHROW(token = lexer.get_next_token());
-        REQUIRE(token == fkyaml::detail::lexical_token_t::STRING_VALUE);
-        REQUIRE_NOTHROW(lexer.get_string());
-        REQUIRE(lexer.get_string().compare("test") == 0);
-
-        REQUIRE_NOTHROW(token = lexer.get_next_token());
-        REQUIRE(token == fkyaml::detail::lexical_token_t::KEY_SEPARATOR);
-
-        REQUIRE_THROWS_AS(token = lexer.get_next_token(), fkyaml::parse_error);
+        lexer_t lexer(fkyaml::detail::input_adapter(input));
+        REQUIRE_THROWS_AS(lexer.get_next_token(), fkyaml::parse_error);
     }
 }
 


### PR DESCRIPTION
This PR addresses the issue #302 by the following changes:
* The handling of alias nodes has been fixed in both the parser and the lexer since they didn't consider alias mapping keys.
* The deserialization of scalar nodes has been changed to correctly parse anchor/alias nodes.
* The extraction of anchor names has been changed since some invalid patterns were not correctly detected.
* The test suite has been updated to validate the above changes.

---

## Pull Request Checklist

Read the [CONTRIBUTING.md](https://github.com/fktn-k/fkYAML/blob/develop/CONTRIBUTING.md) file for detailed information.  

- [x] Changes are described in the pull request or in a referenced [issue](https://github.com/fktn-k/fkYAML/issues).
- [x] The test suite compiles and runs without any error.
- [x] [The code coverage](https://coveralls.io/github/fktn-k/fkYAML) on your branch is 100%.
- [x] The documentation is updated if you added/changed a feature.

## Please don't

- The C++11 support varies between different **compilers** and versions. Please note the [list of supported compilers](https://github.com/fktn-k/fkYAML/blob/develop/README.md#supported-compilers). Some compilers like GCC 4.7 (and earlier), Clang 3.3 (and earlier), or Microsoft Visual Studio 13.0 and earlier are known not to work due to missing or incomplete C++11 support. Please refrain from proposing changes that work around these compiler's limitations with `#ifdef`s or other means.
- Please refrain from proposing changes that would **break [YAML](https://yaml.org/) specifications**. If you propose a conformant extension of YAML to be supported by the library, please motivate this extension.
- Please do not open pull requests that address **multiple issues**.
