### PR TITLE
Fix Valgrind error in the test suite

### DIFF
--- a/test/unit_test/test_input_adapter.cpp
+++ b/test/unit_test/test_input_adapter.cpp
@@ -1424,6 +1424,8 @@ TEST_CASE("InputAdapterTest_FillBufferUTF8CharsValidationTest", "[InputAdapterTe
 
         std::string buffer {};
         REQUIRE_THROWS_AS(input_adapter.fill_buffer(buffer), fkyaml::invalid_encoding);
+
+        std::fclose(p_file);
     }
 
     SECTION("stream_input_adapter with valid 1-byte UTF-8 encodings")
@@ -1487,6 +1489,8 @@ TEST_CASE("InputAdapterTest_FillBufferUTF8CharsValidationTest", "[InputAdapterTe
 
         std::string buffer {};
         REQUIRE_THROWS_AS(input_adapter.fill_buffer(buffer), fkyaml::invalid_encoding);
+
+        std::fclose(p_file);
     }
 
     SECTION("stream_input_adapter with valid 2-byte UTF-8 encodings")
@@ -1553,6 +1557,8 @@ TEST_CASE("InputAdapterTest_FillBufferUTF8CharsValidationTest", "[InputAdapterTe
 
         std::string buffer {};
         REQUIRE_THROWS_AS(input_adapter.fill_buffer(buffer), fkyaml::invalid_encoding);
+
+        std::fclose(p_file);
     }
 
     SECTION("stream_input_adapter with valid 3-byte UTF-8 encodings")
@@ -1623,6 +1629,8 @@ TEST_CASE("InputAdapterTest_FillBufferUTF8CharsValidationTest", "[InputAdapterTe
 
         std::string buffer {};
         REQUIRE_THROWS_AS(input_adapter.fill_buffer(buffer), fkyaml::invalid_encoding);
+
+        std::fclose(p_file);
     }
 
     SECTION("stream_input_adapter with valid 4-byte UTF-8 encodings")


### PR DESCRIPTION
This PR has fixed errors reported by Valgrind.  
The errors were due to missing `std::fclose()` calls after opening a test data file in the input_adapter class test cases.  
So no changes have been made to the library source codes.  

---

## Pull Request Checklist

Read the [CONTRIBUTING.md](https://github.com/fktn-k/fkYAML/blob/develop/CONTRIBUTING.md) file for detailed information.  

- [x] Changes are described in the pull request or in a referenced [issue](https://github.com/fktn-k/fkYAML/issues).
- [x] The test suite compiles and runs without any error.
- [x] [The code coverage](https://coveralls.io/github/fktn-k/fkYAML) on your branch is 100%.
- [x] The documentation is updated if you added/changed a feature.

## Please don't

- The C++11 support varies between different **compilers** and versions. Please note the [list of supported compilers](https://github.com/fktn-k/fkYAML/blob/develop/README.md#supported-compilers). Some compilers like GCC 4.7 (and earlier), Clang 3.3 (and earlier), or Microsoft Visual Studio 13.0 and earlier are known not to work due to missing or incomplete C++11 support. Please refrain from proposing changes that work around these compiler's limitations with `#ifdef`s or other means.
- Please refrain from proposing changes that would **break [YAML](https://yaml.org/) specifications**. If you propose a conformant extension of YAML to be supported by the library, please motivate this extension.
- Please do not open pull requests that address **multiple issues**.
