### PR TITLE
support tags for container nodes with some cleanup in test suite

### DIFF
--- a/include/fkYAML/detail/input/lexical_analyzer.hpp
+++ b/include/fkYAML/detail/input/lexical_analyzer.hpp
@@ -174,7 +174,7 @@ public:
             return m_last_token_type = lexical_token_t::TAG_PREFIX;
         case '#': // comment prefix
             scan_comment();
-            return m_last_token_type = lexical_token_t::COMMENT_PREFIX;
+            return get_next_token();
         case '%': // directive prefix
             return m_last_token_type = scan_directive();
         case '-': {
@@ -376,13 +376,10 @@ private:
     }
 
     /// @brief Skip until a newline code or a null character is found.
-    /// @return lexical_token_t The lexical token type for comments
-    lexical_token_t scan_comment()
+    void scan_comment()
     {
         FK_YAML_ASSERT(*m_cur_itr == '#');
-
         skip_until_line_end();
-        return lexical_token_t::COMMENT_PREFIX;
     }
 
     /// @brief Scan directives starting with the prefix '%'
@@ -406,7 +403,8 @@ private:
                 break;
             case '\r':
             case '\n':
-                emit_error("invalid directive is found.");
+                skip_until_line_end();
+                return lexical_token_t::INVALID_DIRECTIVE;
             default:
                 ++m_cur_itr;
                 break;
@@ -1557,22 +1555,6 @@ private:
                 }
             });
         }
-    }
-
-    /// @brief Skip white spaces and comments from the current position.
-    void skip_white_spaces_and_comments()
-    {
-        do
-        {
-            skip_white_spaces();
-
-            if (m_cur_itr == m_end_itr || *m_cur_itr != '#')
-            {
-                return;
-            }
-
-            scan_comment();
-        } while (++m_cur_itr != m_end_itr);
     }
 
     /// @brief Skip the rest in the current line.

--- a/include/fkYAML/detail/types/lexical_token_t.hpp
+++ b/include/fkYAML/detail/types/lexical_token_t.hpp
@@ -29,7 +29,6 @@ enum class lexical_token_t
     VALUE_SEPARATOR,       //!< the value separater `,`
     ANCHOR_PREFIX,         //!< the character for anchor prefix `&`
     ALIAS_PREFIX,          //!< the character for alias prefix `*`
-    COMMENT_PREFIX,        //!< the character for comment prefix `#`
     YAML_VER_DIRECTIVE,    //!< a YAML version directive found. use get_yaml_version() to get a value.
     TAG_DIRECTIVE,         //!< a TAG directive found. use GetTagInfo() to get the tag information.
     TAG_PREFIX,            //!< the character for tag prefix `!`

--- a/single_include/fkYAML/node.hpp
+++ b/single_include/fkYAML/node.hpp
@@ -262,6 +262,7 @@ FK_YAML_NAMESPACE_END
 #include <algorithm>
 #include <cstdint>
 #include <deque>
+#include <set>
 #include <unordered_map>
 
 // #include <fkYAML/detail/macros/version_macros.hpp>
@@ -1943,7 +1944,6 @@ enum class lexical_token_t
     VALUE_SEPARATOR,       //!< the value separater `,`
     ANCHOR_PREFIX,         //!< the character for anchor prefix `&`
     ALIAS_PREFIX,          //!< the character for alias prefix `*`
-    COMMENT_PREFIX,        //!< the character for comment prefix `#`
     YAML_VER_DIRECTIVE,    //!< a YAML version directive found. use get_yaml_version() to get a value.
     TAG_DIRECTIVE,         //!< a TAG directive found. use GetTagInfo() to get the tag information.
     TAG_PREFIX,            //!< the character for tag prefix `!`
@@ -2758,7 +2758,7 @@ public:
             return m_last_token_type = lexical_token_t::TAG_PREFIX;
         case '#': // comment prefix
             scan_comment();
-            return m_last_token_type = lexical_token_t::COMMENT_PREFIX;
+            return get_next_token();
         case '%': // directive prefix
             return m_last_token_type = scan_directive();
         case '-': {
@@ -2960,13 +2960,10 @@ private:
     }
 
     /// @brief Skip until a newline code or a null character is found.
-    /// @return lexical_token_t The lexical token type for comments
-    lexical_token_t scan_comment()
+    void scan_comment()
     {
         FK_YAML_ASSERT(*m_cur_itr == '#');
-
         skip_until_line_end();
-        return lexical_token_t::COMMENT_PREFIX;
     }
 
     /// @brief Scan directives starting with the prefix '%'
@@ -2990,7 +2987,8 @@ private:
                 break;
             case '\r':
             case '\n':
-                emit_error("invalid directive is found.");
+                skip_until_line_end();
+                return lexical_token_t::INVALID_DIRECTIVE;
             default:
                 ++m_cur_itr;
                 break;
@@ -4143,22 +4141,6 @@ private:
         }
     }
 
-    /// @brief Skip white spaces and comments from the current position.
-    void skip_white_spaces_and_comments()
-    {
-        do
-        {
-            skip_white_spaces();
-
-            if (m_cur_itr == m_end_itr || *m_cur_itr != '#')
-            {
-                return;
-            }
-
-            scan_comment();
-        } while (++m_cur_itr != m_end_itr);
-    }
-
     /// @brief Skip the rest in the current line.
     void skip_until_line_end()
     {
@@ -4761,14 +4743,18 @@ private:
                 std::size_t old_line = line;
 
                 type = lexer.get_next_token();
-                if (type == lexical_token_t::COMMENT_PREFIX)
+                line = lexer.get_lines_processed();
+                indent = lexer.get_last_token_begin_pos();
+
+                bool found_props = deserialize_node_properties(lexer, type, line, indent);
+                if (found_props && line == lexer.get_lines_processed())
                 {
-                    // just skip the comment and get the next token.
-                    type = lexer.get_next_token();
+                    // defer applying node properties for the subsequent node on the same line.
+                    continue;
                 }
 
-                indent = lexer.get_last_token_begin_pos();
                 line = lexer.get_lines_processed();
+                indent = lexer.get_last_token_begin_pos();
 
                 bool is_implicit_same_line =
                     (line == old_line) && (m_indent_stack.empty() || old_indent > m_indent_stack.back().indent);
@@ -4780,12 +4766,34 @@ private:
 
                 if (line > old_line)
                 {
+                    if (m_needs_tag_impl)
+                    {
+                        tag_t tag_type = tag_resolver::resolve_tag(m_tag_name, mp_directive_set);
+                        if (tag_type == tag_t::MAPPING)
+                        {
+                            // set YAML node properties here to distinguish them from those for the first key node
+                            // as shown in the following snippet:
+                            //
+                            // ```yaml
+                            // foo: !!map
+                            //   !!str 123: true
+                            //   ^
+                            //   this !!str tag overwrites the preceeding !!map tag.
+                            // ```
+                            *mp_current_node = node_type::mapping();
+                            apply_directive_set(*mp_current_node);
+                            apply_node_properties(*mp_current_node);
+                            continue;
+                        }
+                    }
+
                     switch (type)
                     {
                     case lexical_token_t::SEQUENCE_BLOCK_PREFIX:
                         // a key separator preceeding block sequence entries
                         *mp_current_node = node_type::sequence();
                         apply_directive_set(*mp_current_node);
+                        apply_node_properties(*mp_current_node);
                         break;
                     case lexical_token_t::EXPLICIT_KEY_PREFIX:
                         // a key separator for a explicit block mapping key.
@@ -4847,6 +4855,7 @@ private:
                 {
                     *mp_current_node = node_type::sequence();
                     apply_directive_set(*mp_current_node);
+                    apply_node_properties(*mp_current_node);
                 }
                 indent = lexer.get_last_token_begin_pos();
                 line = lexer.get_lines_processed();
@@ -4854,9 +4863,14 @@ private:
             }
             case lexical_token_t::VALUE_SEPARATOR:
                 break;
-            case lexical_token_t::ANCHOR_PREFIX: {
-                m_anchor_name = lexer.get_string();
-                m_needs_anchor_impl = true;
+            // just ignore directives
+            case lexical_token_t::YAML_VER_DIRECTIVE:
+            case lexical_token_t::TAG_DIRECTIVE:
+            case lexical_token_t::INVALID_DIRECTIVE:
+                break;
+            case lexical_token_t::ANCHOR_PREFIX:
+            case lexical_token_t::TAG_PREFIX:
+                deserialize_node_properties(lexer, type, line, indent);
 
                 // Skip updating the current indent to avoid stacking a wrong indentation.
                 //
@@ -4864,22 +4878,7 @@ private:
                 //   ^
                 //   the correct indent width for the "bar" node key.
 
-                type = lexer.get_next_token();
-                line = lexer.get_lines_processed();
                 continue;
-            }
-            case lexical_token_t::COMMENT_PREFIX:
-                break;
-            // just ignore directives
-            case lexical_token_t::YAML_VER_DIRECTIVE:
-            case lexical_token_t::TAG_DIRECTIVE:
-            case lexical_token_t::INVALID_DIRECTIVE:
-                break;
-            case lexical_token_t::TAG_PREFIX:
-                // TODO: implement tag name handling.
-                m_tag_name = lexer.get_string();
-                m_needs_tag_impl = true;
-                break;
             case lexical_token_t::SEQUENCE_BLOCK_PREFIX:
                 if (mp_current_node->is_sequence())
                 {
@@ -4924,6 +4923,7 @@ private:
                 ++m_flow_context_depth;
                 *mp_current_node = node_type::sequence();
                 apply_directive_set(*mp_current_node);
+                apply_node_properties(*mp_current_node);
                 break;
             case lexical_token_t::SEQUENCE_FLOW_END:
                 FK_YAML_ASSERT(m_flow_context_depth > 0);
@@ -4935,6 +4935,7 @@ private:
                 ++m_flow_context_depth;
                 *mp_current_node = node_type::mapping();
                 apply_directive_set(*mp_current_node);
+                apply_node_properties(*mp_current_node);
                 break;
             case lexical_token_t::MAPPING_FLOW_END:
                 FK_YAML_ASSERT(m_flow_context_depth > 0);
@@ -4966,6 +4967,93 @@ private:
             indent = (prev_type == lexical_token_t::ANCHOR_PREFIX) ? indent : lexer.get_last_token_begin_pos();
             line = lexer.get_lines_processed();
         } while (type != lexical_token_t::END_OF_BUFFER);
+    }
+
+    /// @brief Deserializes YAML node properties (anchor and/or tag names) if they exist
+    /// @param lexer The lexical analyzer to be used.
+    /// @param last_type The variable to store the last lexical token type.
+    /// @param line The variable to store the line of either the first property or the last non-property token.
+    /// @param indent The variable to store the indent of either the first property or the last non-property token.
+    /// @return true if any property is found, false otherwise.
+    bool deserialize_node_properties(
+        lexer_type& lexer, lexical_token_t& last_type, std::size_t& line, std::size_t& indent)
+    {
+        std::set<lexical_token_t> prop_types {lexical_token_t::ANCHOR_PREFIX, lexical_token_t::TAG_PREFIX};
+
+        lexical_token_t type = last_type;
+        bool ends_loop {false};
+        do
+        {
+            if (line < lexer.get_lines_processed())
+            {
+                break;
+            }
+
+            switch (type)
+            {
+            case lexical_token_t::ANCHOR_PREFIX: {
+                bool already_specified = prop_types.find(type) == prop_types.end();
+                if (already_specified)
+                {
+                    throw parse_error(
+                        "anchor name cannot be specified more than once to the same node.",
+                        lexer.get_lines_processed(),
+                        lexer.get_last_token_begin_pos());
+                }
+
+                prop_types.erase(type);
+                m_anchor_name = lexer.get_string();
+                m_needs_anchor_impl = true;
+
+                if (prop_types.size() == 1)
+                {
+                    line = lexer.get_lines_processed();
+                    indent = lexer.get_last_token_begin_pos();
+                }
+
+                break;
+            }
+            case lexical_token_t::TAG_PREFIX: {
+                bool already_specified = prop_types.find(type) == prop_types.end();
+                if (already_specified)
+                {
+                    throw parse_error(
+                        "tag name cannot be specified more than once to the same node.",
+                        lexer.get_lines_processed(),
+                        lexer.get_last_token_begin_pos());
+                }
+
+                prop_types.erase(type);
+                m_tag_name = lexer.get_string();
+                m_needs_tag_impl = true;
+
+                if (prop_types.size() == 1)
+                {
+                    line = lexer.get_lines_processed();
+                    indent = lexer.get_last_token_begin_pos();
+                }
+
+                break;
+            }
+            default:
+                ends_loop = true;
+                break;
+            }
+
+            if (!ends_loop)
+            {
+                type = lexer.get_next_token();
+            }
+        } while (!ends_loop);
+
+        last_type = type;
+        if (prop_types.size() == 2)
+        {
+            line = lexer.get_lines_processed();
+            indent = lexer.get_last_token_begin_pos();
+        }
+
+        return prop_types.size() < 2;
     }
 
     /// @brief Add new key string to the current YAML node.
@@ -5126,21 +5214,7 @@ private:
         }
 
         apply_directive_set(node);
-
-        if (m_needs_anchor_impl)
-        {
-            node.add_anchor_name(m_anchor_name);
-            m_anchor_table[m_anchor_name] = node;
-            m_needs_anchor_impl = false;
-            m_anchor_name.clear();
-        }
-
-        if (m_needs_tag_impl)
-        {
-            node.add_tag_name(m_tag_name);
-            m_needs_tag_impl = false;
-            m_tag_name.clear();
-        }
+        apply_node_properties(node);
 
         return node;
     }
@@ -5198,13 +5272,33 @@ private:
         return true;
     }
 
-    /// @brief Set the yaml_version_t object to the given node.
-    /// @param node A node_type object to be set the yaml_version_t object.
+    /// @brief Set YAML directive properties to the given node.
+    /// @param node A node_type object to be set YAML directive properties.
     void apply_directive_set(node_type& node) noexcept
     {
         if (mp_directive_set)
         {
             node.mp_directive_set = mp_directive_set;
+        }
+    }
+
+    /// @brief Set YAML node properties (anchor and/or tag names) to the given node.
+    /// @param node A node type object to be set YAML node properties.
+    void apply_node_properties(node_type& node)
+    {
+        if (m_needs_anchor_impl)
+        {
+            node.add_anchor_name(m_anchor_name);
+            m_anchor_table[m_anchor_name] = node;
+            m_needs_anchor_impl = false;
+            m_anchor_name.clear();
+        }
+
+        if (m_needs_tag_impl)
+        {
+            node.add_tag_name(m_tag_name);
+            m_needs_tag_impl = false;
+            m_tag_name.clear();
         }
     }
 

--- a/test/unit_test/test_deserializer_class.cpp
+++ b/test/unit_test/test_deserializer_class.cpp
@@ -289,165 +289,6 @@ TEST_CASE("DeserializerClassTest_DeserializeBlockSequenceTest", "[DeserializerCl
         REQUIRE(test_1_bar_node.get_value_ref<fkyaml::node::string_type&>().compare("two") == 0);
     }
 
-    SECTION("Input source No.3.")
-    {
-        REQUIRE_NOTHROW(
-            root = deserializer.deserialize(fkyaml::detail::input_adapter("test:\n  - &anchor true\n  - *anchor")));
-
-        REQUIRE(root.is_mapping());
-        REQUIRE_NOTHROW(root.size());
-        REQUIRE(root.size() == 1);
-
-        REQUIRE_NOTHROW(root["test"]);
-        fkyaml::node& test_node = root["test"];
-        REQUIRE(test_node.is_sequence());
-        REQUIRE_NOTHROW(test_node.size());
-        REQUIRE(test_node.size() == 2);
-
-        REQUIRE_NOTHROW(test_node[0]);
-        fkyaml::node& test_0_node = test_node[0];
-        REQUIRE(test_0_node.has_anchor_name());
-        REQUIRE(test_0_node.get_anchor_name().compare("anchor") == 0);
-        REQUIRE(test_0_node.is_boolean());
-        REQUIRE_NOTHROW(test_0_node.get_value<fkyaml::node::boolean_type>());
-        REQUIRE(test_0_node.get_value<fkyaml::node::boolean_type>() == true);
-
-        REQUIRE_NOTHROW(test_node[1]);
-        fkyaml::node& test_1_node = test_node[1];
-        REQUIRE(test_1_node.is_boolean());
-        REQUIRE_NOTHROW(test_1_node.get_value<fkyaml::node::boolean_type>());
-        REQUIRE(
-            test_1_node.get_value<fkyaml::node::boolean_type>() == test_0_node.get_value<fkyaml::node::boolean_type>());
-    }
-
-    SECTION("Input source No.4.")
-    {
-        REQUIRE_NOTHROW(
-            root = deserializer.deserialize(fkyaml::detail::input_adapter("test:\n  - &anchor -123\n  - *anchor")));
-
-        REQUIRE(root.is_mapping());
-        REQUIRE_NOTHROW(root.size());
-        REQUIRE(root.size() == 1);
-
-        REQUIRE_NOTHROW(root["test"]);
-        fkyaml::node& test_node = root["test"];
-        REQUIRE(test_node.is_sequence());
-        REQUIRE_NOTHROW(test_node.size());
-        REQUIRE(test_node.size() == 2);
-
-        REQUIRE_NOTHROW(test_node[0]);
-        fkyaml::node& test_0_node = test_node[0];
-        REQUIRE(test_0_node.has_anchor_name());
-        REQUIRE(test_0_node.get_anchor_name().compare("anchor") == 0);
-        REQUIRE(test_0_node.is_integer());
-        REQUIRE_NOTHROW(test_0_node.get_value<fkyaml::node::integer_type>());
-        REQUIRE(test_0_node.get_value<fkyaml::node::integer_type>() == -123);
-
-        REQUIRE_NOTHROW(test_node[1]);
-        fkyaml::node& test_1_node = test_node[1];
-        REQUIRE(test_1_node.is_integer());
-        REQUIRE_NOTHROW(test_1_node.get_value<fkyaml::node::integer_type>());
-        REQUIRE(
-            test_1_node.get_value<fkyaml::node::integer_type>() == test_0_node.get_value<fkyaml::node::integer_type>());
-    }
-
-    SECTION("Input source No.5.")
-    {
-        REQUIRE_NOTHROW(
-            root = deserializer.deserialize(fkyaml::detail::input_adapter("test:\n  - &anchor 567\n  - *anchor")));
-
-        REQUIRE(root.is_mapping());
-        REQUIRE_NOTHROW(root.size());
-        REQUIRE(root.size() == 1);
-
-        REQUIRE_NOTHROW(root["test"]);
-        fkyaml::node& test_node = root["test"];
-        REQUIRE(test_node.is_sequence());
-        REQUIRE_NOTHROW(test_node.size());
-        REQUIRE(test_node.size() == 2);
-
-        REQUIRE_NOTHROW(test_node[0]);
-        fkyaml::node& test_0_node = test_node[0];
-        REQUIRE(test_0_node.has_anchor_name());
-        REQUIRE(test_0_node.get_anchor_name().compare("anchor") == 0);
-        REQUIRE(test_0_node.is_integer());
-        REQUIRE_NOTHROW(test_0_node.get_value<fkyaml::node::integer_type>());
-        REQUIRE(test_0_node.get_value<fkyaml::node::integer_type>() == 567);
-
-        REQUIRE_NOTHROW(test_node[1]);
-        fkyaml::node& test_1_node = test_node[1];
-        REQUIRE(test_1_node.is_integer());
-        REQUIRE_NOTHROW(test_1_node.get_value<fkyaml::node::integer_type>());
-        REQUIRE(
-            test_1_node.get_value<fkyaml::node::integer_type>() == test_0_node.get_value<fkyaml::node::integer_type>());
-    }
-
-    SECTION("Input source No.6.")
-    {
-        REQUIRE_NOTHROW(
-            root = deserializer.deserialize(fkyaml::detail::input_adapter("test:\n  - &anchor 3.14\n  - *anchor")));
-
-        REQUIRE(root.is_mapping());
-        REQUIRE_NOTHROW(root.size());
-        REQUIRE(root.size() == 1);
-
-        REQUIRE_NOTHROW(root["test"]);
-        fkyaml::node& test_node = root["test"];
-        REQUIRE(test_node.is_sequence());
-        REQUIRE_NOTHROW(test_node.size());
-        REQUIRE(test_node.size() == 2);
-
-        REQUIRE_NOTHROW(test_node[0]);
-        fkyaml::node& test_0_node = test_node[0];
-        REQUIRE(test_0_node.has_anchor_name());
-        REQUIRE(test_0_node.get_anchor_name().compare("anchor") == 0);
-        REQUIRE(test_0_node.is_float_number());
-        REQUIRE_NOTHROW(test_0_node.get_value<fkyaml::node::float_number_type>());
-        REQUIRE(test_0_node.get_value<fkyaml::node::float_number_type>() == 3.14);
-
-        REQUIRE_NOTHROW(test_node[1]);
-        fkyaml::node& test_1_node = test_node[1];
-        REQUIRE(test_1_node.is_float_number());
-        REQUIRE_NOTHROW(test_1_node.get_value<fkyaml::node::float_number_type>());
-        REQUIRE(
-            test_1_node.get_value<fkyaml::node::float_number_type>() ==
-            test_0_node.get_value<fkyaml::node::float_number_type>());
-    }
-
-    SECTION("Input source No.7.")
-    {
-        REQUIRE_NOTHROW(
-            root = deserializer.deserialize(fkyaml::detail::input_adapter("test:\n  - &anchor foo\n  - *anchor")));
-
-        REQUIRE(root.is_mapping());
-        REQUIRE_NOTHROW(root.size());
-        REQUIRE(root.size() == 1);
-
-        REQUIRE_NOTHROW(root["test"]);
-        fkyaml::node& test_node = root["test"];
-        REQUIRE(test_node.is_sequence());
-        REQUIRE_NOTHROW(test_node.size());
-        REQUIRE(test_node.size() == 2);
-
-        REQUIRE_NOTHROW(test_node[0]);
-        fkyaml::node& test_0_node = test_node[0];
-        REQUIRE(test_0_node.has_anchor_name());
-        REQUIRE(test_0_node.get_anchor_name().compare("anchor") == 0);
-        REQUIRE(test_0_node.is_string());
-        REQUIRE_NOTHROW(test_0_node.size());
-        REQUIRE(test_0_node.size() == 3);
-        REQUIRE_NOTHROW(test_0_node.get_value_ref<fkyaml::node::string_type&>());
-        REQUIRE(test_0_node.get_value_ref<fkyaml::node::string_type&>().compare("foo") == 0);
-
-        REQUIRE_NOTHROW(test_node[1]);
-        fkyaml::node& test_1_node = test_node[1];
-        REQUIRE(test_1_node.is_string());
-        REQUIRE_NOTHROW(test_1_node.size());
-        REQUIRE(test_1_node.size() == 3);
-        REQUIRE_NOTHROW(test_1_node.get_value_ref<fkyaml::node::string_type&>());
-        REQUIRE(test_1_node.get_value_ref<fkyaml::node::string_type&>().compare("foo") == 0);
-    }
-
     SECTION("Input source No.8.")
     {
         REQUIRE_NOTHROW(
@@ -549,125 +390,6 @@ TEST_CASE("DeserializerClassTest_DeserializeBlockMappingTest", "[DeserializerCla
         REQUIRE(test_pi_node.is_float_number());
         REQUIRE_NOTHROW(test_pi_node.get_value<fkyaml::node::float_number_type>());
         REQUIRE(test_pi_node.get_value<fkyaml::node::float_number_type>() == 3.14);
-    }
-
-    SECTION("Input source No.3.")
-    {
-        REQUIRE_NOTHROW(
-            root = deserializer.deserialize(fkyaml::detail::input_adapter("foo: &anchor true\nbar: *anchor")));
-
-        REQUIRE(root.is_mapping());
-        REQUIRE(root.size() == 2);
-
-        REQUIRE_NOTHROW(root["foo"]);
-        fkyaml::node& foo_node = root["foo"];
-        REQUIRE(foo_node.has_anchor_name());
-        REQUIRE(foo_node.get_anchor_name().compare("anchor") == 0);
-        REQUIRE(foo_node.is_boolean());
-        REQUIRE_NOTHROW(foo_node.get_value<fkyaml::node::boolean_type>());
-        REQUIRE(foo_node.get_value<fkyaml::node::boolean_type>() == true);
-
-        REQUIRE_NOTHROW(root["bar"]);
-        fkyaml::node& bar_node = root["bar"];
-        REQUIRE(bar_node.is_boolean());
-        REQUIRE_NOTHROW(bar_node.get_value<fkyaml::node::boolean_type>());
-        REQUIRE(bar_node.get_value<fkyaml::node::boolean_type>() == foo_node.get_value<fkyaml::node::boolean_type>());
-    }
-
-    SECTION("Input source No.4.")
-    {
-        REQUIRE_NOTHROW(
-            root = deserializer.deserialize(fkyaml::detail::input_adapter("foo: &anchor -123\nbar: *anchor")));
-
-        REQUIRE(root.is_mapping());
-        REQUIRE(root.size() == 2);
-
-        REQUIRE_NOTHROW(root["foo"]);
-        fkyaml::node& foo_node = root["foo"];
-        REQUIRE(foo_node.has_anchor_name());
-        REQUIRE(foo_node.get_anchor_name().compare("anchor") == 0);
-        REQUIRE(foo_node.is_integer());
-        REQUIRE_NOTHROW(foo_node.get_value<fkyaml::node::integer_type>());
-        REQUIRE(foo_node.get_value<fkyaml::node::integer_type>() == -123);
-
-        REQUIRE_NOTHROW(root["bar"]);
-        fkyaml::node& bar_node = root["bar"];
-        REQUIRE(bar_node.is_integer());
-        REQUIRE_NOTHROW(bar_node.get_value<fkyaml::node::integer_type>());
-        REQUIRE(bar_node.get_value<fkyaml::node::integer_type>() == foo_node.get_value<fkyaml::node::integer_type>());
-    }
-
-    SECTION("Input source No.5.")
-    {
-        REQUIRE_NOTHROW(
-            root = deserializer.deserialize(fkyaml::detail::input_adapter("foo: &anchor 567\nbar: *anchor")));
-
-        REQUIRE(root.is_mapping());
-        REQUIRE(root.size() == 2);
-
-        REQUIRE_NOTHROW(root["foo"]);
-        fkyaml::node& foo_node = root["foo"];
-        REQUIRE(foo_node.has_anchor_name());
-        REQUIRE(foo_node.get_anchor_name().compare("anchor") == 0);
-        REQUIRE(foo_node.is_integer());
-        REQUIRE_NOTHROW(foo_node.get_value<fkyaml::node::integer_type>());
-        REQUIRE(foo_node.get_value<fkyaml::node::integer_type>() == 567);
-
-        REQUIRE_NOTHROW(root["bar"]);
-        fkyaml::node& bar_node = root["bar"];
-        REQUIRE(bar_node.is_integer());
-        REQUIRE_NOTHROW(bar_node.get_value<fkyaml::node::integer_type>());
-        REQUIRE(bar_node.get_value<fkyaml::node::integer_type>() == foo_node.get_value<fkyaml::node::integer_type>());
-    }
-
-    SECTION("Input source No.6.")
-    {
-        REQUIRE_NOTHROW(
-            root = deserializer.deserialize(fkyaml::detail::input_adapter("foo: &anchor 3.14\nbar: *anchor")));
-
-        REQUIRE(root.is_mapping());
-        REQUIRE(root.size() == 2);
-
-        REQUIRE_NOTHROW(root["foo"]);
-        fkyaml::node& foo_node = root["foo"];
-        REQUIRE(foo_node.has_anchor_name());
-        REQUIRE(foo_node.get_anchor_name().compare("anchor") == 0);
-        REQUIRE(foo_node.is_float_number());
-        REQUIRE_NOTHROW(foo_node.get_value<fkyaml::node::float_number_type>());
-        REQUIRE(foo_node.get_value<fkyaml::node::float_number_type>() == 3.14);
-
-        REQUIRE_NOTHROW(root["bar"]);
-        fkyaml::node& bar_node = root["bar"];
-        REQUIRE(bar_node.is_float_number());
-        REQUIRE_NOTHROW(bar_node.get_value<fkyaml::node::float_number_type>());
-        REQUIRE(
-            bar_node.get_value<fkyaml::node::float_number_type>() ==
-            foo_node.get_value<fkyaml::node::float_number_type>());
-    }
-
-    SECTION("Input source No.7.")
-    {
-        REQUIRE_NOTHROW(
-            root = deserializer.deserialize(fkyaml::detail::input_adapter("foo: &anchor one\nbar: *anchor")));
-
-        REQUIRE(root.is_mapping());
-        REQUIRE(root.size() == 2);
-
-        REQUIRE_NOTHROW(root["foo"]);
-        fkyaml::node& foo_node = root["foo"];
-        REQUIRE(foo_node.has_anchor_name());
-        REQUIRE(foo_node.get_anchor_name().compare("anchor") == 0);
-        REQUIRE(foo_node.is_string());
-        REQUIRE_NOTHROW(foo_node.get_value_ref<fkyaml::node::string_type&>());
-        REQUIRE(foo_node.get_value_ref<fkyaml::node::string_type&>().compare("one") == 0);
-
-        REQUIRE_NOTHROW(root["bar"]);
-        fkyaml::node& bar_node = root["bar"];
-        REQUIRE(bar_node.is_string());
-        REQUIRE_NOTHROW(bar_node.get_value_ref<fkyaml::node::string_type&>());
-        REQUIRE(
-            bar_node.get_value_ref<fkyaml::node::string_type&>() ==
-            foo_node.get_value_ref<fkyaml::node::string_type&>());
     }
 
     SECTION("Input source No.8.")
@@ -1082,26 +804,6 @@ TEST_CASE("DeserializerClassTest_DeserializeBlockMappingTest", "[DeserializerCla
         REQUIRE(root["qux"][2].is_string());
         REQUIRE(root["qux"][2].get_value_ref<std::string&>() == "b");
     }
-
-    SECTION("parse alias mapping key")
-    {
-        REQUIRE_NOTHROW(root = deserializer.deserialize(fkyaml::detail::input_adapter("&anchor foo:\n  *anchor: 123")));
-
-        REQUIRE(root.is_mapping());
-        REQUIRE(root.size() == 1);
-        REQUIRE(root.contains("foo"));
-        REQUIRE(root["foo"].is_mapping());
-        REQUIRE(root["foo"].size() == 1);
-        REQUIRE(root["foo"].contains("foo"));
-        REQUIRE(root["foo"]["foo"].is_integer());
-        REQUIRE(root["foo"]["foo"].get_value<int>() == 123);
-    }
-
-    SECTION("alias node with tag")
-    {
-        REQUIRE_THROWS_AS(
-            deserializer.deserialize(fkyaml::detail::input_adapter("&anchor foo: !!str *anchor")), fkyaml::parse_error);
-    }
 }
 
 TEST_CASE("DeserializerClassTest_DeserializeFlowSequenceTest", "[DeserializerClassTest]")
@@ -1433,64 +1135,401 @@ TEST_CASE("DeserializerClassTest_InvalidDirectiveTest", "[DeserializerClassTest]
     REQUIRE(root.empty());
 }
 
+TEST_CASE("DeserializerClassTest_DeserializeAnchorTest", "[DeserializerClassTest]")
+{
+    fkyaml::detail::basic_deserializer<fkyaml::node> deserializer;
+    fkyaml::node root;
+
+    SECTION("block sequence with anchored boolean scalar node.")
+    {
+        REQUIRE_NOTHROW(
+            root = deserializer.deserialize(fkyaml::detail::input_adapter("test:\n  - &anchor true\n  - *anchor")));
+
+        REQUIRE(root.is_mapping());
+        REQUIRE_NOTHROW(root.size());
+        REQUIRE(root.size() == 1);
+
+        REQUIRE_NOTHROW(root["test"]);
+        fkyaml::node& test_node = root["test"];
+        REQUIRE(test_node.is_sequence());
+        REQUIRE_NOTHROW(test_node.size());
+        REQUIRE(test_node.size() == 2);
+
+        REQUIRE_NOTHROW(test_node[0]);
+        fkyaml::node& test_0_node = test_node[0];
+        REQUIRE(test_0_node.has_anchor_name());
+        REQUIRE(test_0_node.get_anchor_name().compare("anchor") == 0);
+        REQUIRE(test_0_node.is_boolean());
+        REQUIRE_NOTHROW(test_0_node.get_value<fkyaml::node::boolean_type>());
+        REQUIRE(test_0_node.get_value<fkyaml::node::boolean_type>() == true);
+
+        REQUIRE_NOTHROW(test_node[1]);
+        fkyaml::node& test_1_node = test_node[1];
+        REQUIRE(test_1_node.is_boolean());
+        REQUIRE_NOTHROW(test_1_node.get_value<fkyaml::node::boolean_type>());
+        REQUIRE(
+            test_1_node.get_value<fkyaml::node::boolean_type>() == test_0_node.get_value<fkyaml::node::boolean_type>());
+    }
+
+    SECTION("block sequence with anchored integer scalar node.")
+    {
+        REQUIRE_NOTHROW(
+            root = deserializer.deserialize(fkyaml::detail::input_adapter("test:\n  - &anchor -123\n  - *anchor")));
+
+        REQUIRE(root.is_mapping());
+        REQUIRE_NOTHROW(root.size());
+        REQUIRE(root.size() == 1);
+
+        REQUIRE_NOTHROW(root["test"]);
+        fkyaml::node& test_node = root["test"];
+        REQUIRE(test_node.is_sequence());
+        REQUIRE_NOTHROW(test_node.size());
+        REQUIRE(test_node.size() == 2);
+
+        REQUIRE_NOTHROW(test_node[0]);
+        fkyaml::node& test_0_node = test_node[0];
+        REQUIRE(test_0_node.has_anchor_name());
+        REQUIRE(test_0_node.get_anchor_name().compare("anchor") == 0);
+        REQUIRE(test_0_node.is_integer());
+        REQUIRE_NOTHROW(test_0_node.get_value<fkyaml::node::integer_type>());
+        REQUIRE(test_0_node.get_value<fkyaml::node::integer_type>() == -123);
+
+        REQUIRE_NOTHROW(test_node[1]);
+        fkyaml::node& test_1_node = test_node[1];
+        REQUIRE(test_1_node.is_integer());
+        REQUIRE_NOTHROW(test_1_node.get_value<fkyaml::node::integer_type>());
+        REQUIRE(
+            test_1_node.get_value<fkyaml::node::integer_type>() == test_0_node.get_value<fkyaml::node::integer_type>());
+    }
+
+    SECTION("block sequence with anchored floating point number scalar node.")
+    {
+        REQUIRE_NOTHROW(
+            root = deserializer.deserialize(fkyaml::detail::input_adapter("test:\n  - &anchor 3.14\n  - *anchor")));
+
+        REQUIRE(root.is_mapping());
+        REQUIRE_NOTHROW(root.size());
+        REQUIRE(root.size() == 1);
+
+        REQUIRE_NOTHROW(root["test"]);
+        fkyaml::node& test_node = root["test"];
+        REQUIRE(test_node.is_sequence());
+        REQUIRE_NOTHROW(test_node.size());
+        REQUIRE(test_node.size() == 2);
+
+        REQUIRE_NOTHROW(test_node[0]);
+        fkyaml::node& test_0_node = test_node[0];
+        REQUIRE(test_0_node.has_anchor_name());
+        REQUIRE(test_0_node.get_anchor_name().compare("anchor") == 0);
+        REQUIRE(test_0_node.is_float_number());
+        REQUIRE_NOTHROW(test_0_node.get_value<fkyaml::node::float_number_type>());
+        REQUIRE(test_0_node.get_value<fkyaml::node::float_number_type>() == 3.14);
+
+        REQUIRE_NOTHROW(test_node[1]);
+        fkyaml::node& test_1_node = test_node[1];
+        REQUIRE(test_1_node.is_float_number());
+        REQUIRE_NOTHROW(test_1_node.get_value<fkyaml::node::float_number_type>());
+        REQUIRE(
+            test_1_node.get_value<fkyaml::node::float_number_type>() ==
+            test_0_node.get_value<fkyaml::node::float_number_type>());
+    }
+
+    SECTION("block sequence with anchored string scalar node.")
+    {
+        REQUIRE_NOTHROW(
+            root = deserializer.deserialize(fkyaml::detail::input_adapter("test:\n  - &anchor foo\n  - *anchor")));
+
+        REQUIRE(root.is_mapping());
+        REQUIRE_NOTHROW(root.size());
+        REQUIRE(root.size() == 1);
+
+        REQUIRE_NOTHROW(root["test"]);
+        fkyaml::node& test_node = root["test"];
+        REQUIRE(test_node.is_sequence());
+        REQUIRE_NOTHROW(test_node.size());
+        REQUIRE(test_node.size() == 2);
+
+        REQUIRE_NOTHROW(test_node[0]);
+        fkyaml::node& test_0_node = test_node[0];
+        REQUIRE(test_0_node.has_anchor_name());
+        REQUIRE(test_0_node.get_anchor_name().compare("anchor") == 0);
+        REQUIRE(test_0_node.is_string());
+        REQUIRE_NOTHROW(test_0_node.size());
+        REQUIRE(test_0_node.size() == 3);
+        REQUIRE_NOTHROW(test_0_node.get_value_ref<fkyaml::node::string_type&>());
+        REQUIRE(test_0_node.get_value_ref<fkyaml::node::string_type&>().compare("foo") == 0);
+
+        REQUIRE_NOTHROW(test_node[1]);
+        fkyaml::node& test_1_node = test_node[1];
+        REQUIRE(test_1_node.is_string());
+        REQUIRE_NOTHROW(test_1_node.size());
+        REQUIRE(test_1_node.size() == 3);
+        REQUIRE_NOTHROW(test_1_node.get_value_ref<fkyaml::node::string_type&>());
+        REQUIRE(test_1_node.get_value_ref<fkyaml::node::string_type&>().compare("foo") == 0);
+    }
+
+    SECTION("block mapping with anchored boolean scalar node.")
+    {
+        REQUIRE_NOTHROW(
+            root = deserializer.deserialize(fkyaml::detail::input_adapter("foo: &anchor true\nbar: *anchor")));
+
+        REQUIRE(root.is_mapping());
+        REQUIRE(root.size() == 2);
+
+        REQUIRE_NOTHROW(root["foo"]);
+        fkyaml::node& foo_node = root["foo"];
+        REQUIRE(foo_node.has_anchor_name());
+        REQUIRE(foo_node.get_anchor_name().compare("anchor") == 0);
+        REQUIRE(foo_node.is_boolean());
+        REQUIRE_NOTHROW(foo_node.get_value<fkyaml::node::boolean_type>());
+        REQUIRE(foo_node.get_value<fkyaml::node::boolean_type>() == true);
+
+        REQUIRE_NOTHROW(root["bar"]);
+        fkyaml::node& bar_node = root["bar"];
+        REQUIRE(bar_node.is_boolean());
+        REQUIRE_NOTHROW(bar_node.get_value<fkyaml::node::boolean_type>());
+        REQUIRE(bar_node.get_value<fkyaml::node::boolean_type>() == foo_node.get_value<fkyaml::node::boolean_type>());
+    }
+
+    SECTION("block mapping with anchored integer scalar node.")
+    {
+        REQUIRE_NOTHROW(
+            root = deserializer.deserialize(fkyaml::detail::input_adapter("foo: &anchor -123\nbar: *anchor")));
+
+        REQUIRE(root.is_mapping());
+        REQUIRE(root.size() == 2);
+
+        REQUIRE_NOTHROW(root["foo"]);
+        fkyaml::node& foo_node = root["foo"];
+        REQUIRE(foo_node.has_anchor_name());
+        REQUIRE(foo_node.get_anchor_name().compare("anchor") == 0);
+        REQUIRE(foo_node.is_integer());
+        REQUIRE_NOTHROW(foo_node.get_value<fkyaml::node::integer_type>());
+        REQUIRE(foo_node.get_value<fkyaml::node::integer_type>() == -123);
+
+        REQUIRE_NOTHROW(root["bar"]);
+        fkyaml::node& bar_node = root["bar"];
+        REQUIRE(bar_node.is_integer());
+        REQUIRE_NOTHROW(bar_node.get_value<fkyaml::node::integer_type>());
+        REQUIRE(bar_node.get_value<fkyaml::node::integer_type>() == foo_node.get_value<fkyaml::node::integer_type>());
+    }
+
+    SECTION("block mapping with anchored floating point number scalar node.")
+    {
+        REQUIRE_NOTHROW(
+            root = deserializer.deserialize(fkyaml::detail::input_adapter("foo: &anchor 3.14\nbar: *anchor")));
+
+        REQUIRE(root.is_mapping());
+        REQUIRE(root.size() == 2);
+
+        REQUIRE_NOTHROW(root["foo"]);
+        fkyaml::node& foo_node = root["foo"];
+        REQUIRE(foo_node.has_anchor_name());
+        REQUIRE(foo_node.get_anchor_name().compare("anchor") == 0);
+        REQUIRE(foo_node.is_float_number());
+        REQUIRE_NOTHROW(foo_node.get_value<fkyaml::node::float_number_type>());
+        REQUIRE(foo_node.get_value<fkyaml::node::float_number_type>() == 3.14);
+
+        REQUIRE_NOTHROW(root["bar"]);
+        fkyaml::node& bar_node = root["bar"];
+        REQUIRE(bar_node.is_float_number());
+        REQUIRE_NOTHROW(bar_node.get_value<fkyaml::node::float_number_type>());
+        REQUIRE(
+            bar_node.get_value<fkyaml::node::float_number_type>() ==
+            foo_node.get_value<fkyaml::node::float_number_type>());
+    }
+
+    SECTION("block mapping with anchored string scalar node.")
+    {
+        REQUIRE_NOTHROW(
+            root = deserializer.deserialize(fkyaml::detail::input_adapter("foo: &anchor one\nbar: *anchor")));
+
+        REQUIRE(root.is_mapping());
+        REQUIRE(root.size() == 2);
+
+        REQUIRE_NOTHROW(root["foo"]);
+        fkyaml::node& foo_node = root["foo"];
+        REQUIRE(foo_node.has_anchor_name());
+        REQUIRE(foo_node.get_anchor_name().compare("anchor") == 0);
+        REQUIRE(foo_node.is_string());
+        REQUIRE_NOTHROW(foo_node.get_value_ref<fkyaml::node::string_type&>());
+        REQUIRE(foo_node.get_value_ref<fkyaml::node::string_type&>().compare("one") == 0);
+
+        REQUIRE_NOTHROW(root["bar"]);
+        fkyaml::node& bar_node = root["bar"];
+        REQUIRE(bar_node.is_string());
+        REQUIRE_NOTHROW(bar_node.get_value_ref<fkyaml::node::string_type&>());
+        REQUIRE(
+            bar_node.get_value_ref<fkyaml::node::string_type&>() ==
+            foo_node.get_value_ref<fkyaml::node::string_type&>());
+    }
+
+    SECTION("parse alias mapping key")
+    {
+        REQUIRE_NOTHROW(root = deserializer.deserialize(fkyaml::detail::input_adapter("&anchor foo:\n  *anchor: 123")));
+
+        REQUIRE(root.is_mapping());
+        REQUIRE(root.size() == 1);
+        REQUIRE(root.contains("foo"));
+        REQUIRE(root["foo"].is_mapping());
+        REQUIRE(root["foo"].size() == 1);
+        REQUIRE(root["foo"].contains("foo"));
+        REQUIRE(root["foo"]["foo"].is_integer());
+        REQUIRE(root["foo"]["foo"].get_value<int>() == 123);
+    }
+
+    SECTION("multiple anchors specified")
+    {
+        auto input =
+            GENERATE(std::string("foo: &anchor &anchor2\n  bar: baz"), std::string("&anchor &anchor2 foo: bar"));
+        REQUIRE_THROWS_AS(root = deserializer.deserialize(fkyaml::detail::input_adapter(input)), fkyaml::parse_error);
+    }
+}
+
 TEST_CASE("DeserializerClassTest_DeserializeTagTest", "[DeserializerClassTest]")
 {
     fkyaml::detail::basic_deserializer<fkyaml::node> deserializer;
     fkyaml::node root;
 
-    std::string input = "str: !!str true\n"
-                        "int: !<tag:yaml.org,2002:int> 123\n"
-                        "nil: !!null null\n"
-                        "bool: !!bool false\n"
-                        "float: !!float 3.14\n"
-                        "non specific: ! non specific\n"
-                        "custom: !local value";
-    REQUIRE_NOTHROW(root = deserializer.deserialize(fkyaml::detail::input_adapter(input)));
+    SECTION("valid tags")
+    {
+        std::string input = "str: !!str true\n"
+                            "int: !<tag:yaml.org,2002:int> 123\n"
+                            "nil: !!null null\n"
+                            "bool: !!bool false\n"
+                            "float: !!float 3.14\n"
+                            "non specific: ! non specific\n"
+                            "custom: !local value\n"
+                            "map: !!map\n"
+                            "  !!str foo: bar\n"
+                            "map_flow: !<tag:yaml.org,2002:map> {foo: bar}\n"
+                            "seq: !<tag:yaml.org,2002:seq>\n"
+                            "  - 123\n"
+                            "  - 3.14\n"
+                            "seq_flow: !!seq [123, 3.14]";
+        REQUIRE_NOTHROW(root = deserializer.deserialize(fkyaml::detail::input_adapter(input)));
 
-    REQUIRE(root.is_mapping());
-    REQUIRE(root.size() == 7);
+        REQUIRE(root.is_mapping());
+        REQUIRE(root.size() == 11);
 
-    REQUIRE(root.contains("str"));
-    REQUIRE(root["str"].has_tag_name());
-    REQUIRE(root["str"].get_tag_name() == "!!str");
-    REQUIRE(root["str"].is_string());
-    REQUIRE(root["str"].get_value_ref<std::string&>() == "true");
+        REQUIRE(root.contains("str"));
+        REQUIRE(root["str"].has_tag_name());
+        REQUIRE(root["str"].get_tag_name() == "!!str");
+        REQUIRE(root["str"].is_string());
+        REQUIRE(root["str"].get_value_ref<std::string&>() == "true");
 
-    REQUIRE(root.contains("int"));
-    REQUIRE(root["int"].has_tag_name());
-    REQUIRE(root["int"].get_tag_name() == "!<tag:yaml.org,2002:int>");
-    REQUIRE(root["int"].is_integer());
-    REQUIRE(root["int"].get_value<int>() == 123);
+        REQUIRE(root.contains("int"));
+        REQUIRE(root["int"].has_tag_name());
+        REQUIRE(root["int"].get_tag_name() == "!<tag:yaml.org,2002:int>");
+        REQUIRE(root["int"].is_integer());
+        REQUIRE(root["int"].get_value<int>() == 123);
 
-    REQUIRE(root.contains("nil"));
-    REQUIRE(root["nil"].has_tag_name());
-    REQUIRE(root["nil"].get_tag_name() == "!!null");
-    REQUIRE(root["nil"].is_null());
-    REQUIRE(root["nil"].get_value<std::nullptr_t>() == nullptr);
+        REQUIRE(root.contains("nil"));
+        REQUIRE(root["nil"].has_tag_name());
+        REQUIRE(root["nil"].get_tag_name() == "!!null");
+        REQUIRE(root["nil"].is_null());
+        REQUIRE(root["nil"].get_value<std::nullptr_t>() == nullptr);
 
-    REQUIRE(root.contains("bool"));
-    REQUIRE(root["bool"].has_tag_name());
-    REQUIRE(root["bool"].get_tag_name() == "!!bool");
-    REQUIRE(root["bool"].is_boolean());
-    REQUIRE(root["bool"].get_value<bool>() == false);
+        REQUIRE(root.contains("bool"));
+        REQUIRE(root["bool"].has_tag_name());
+        REQUIRE(root["bool"].get_tag_name() == "!!bool");
+        REQUIRE(root["bool"].is_boolean());
+        REQUIRE(root["bool"].get_value<bool>() == false);
 
-    REQUIRE(root.contains("float"));
-    REQUIRE(root["float"].has_tag_name());
-    REQUIRE(root["float"].get_tag_name() == "!!float");
-    REQUIRE(root["float"].is_float_number());
-    REQUIRE(root["float"].get_value<double>() == 3.14);
+        REQUIRE(root.contains("float"));
+        REQUIRE(root["float"].has_tag_name());
+        REQUIRE(root["float"].get_tag_name() == "!!float");
+        REQUIRE(root["float"].is_float_number());
+        REQUIRE(root["float"].get_value<double>() == 3.14);
 
-    REQUIRE(root.contains("non specific"));
-    REQUIRE(root["non specific"].has_tag_name());
-    REQUIRE(root["non specific"].get_tag_name() == "!");
-    REQUIRE(root["non specific"].is_string());
-    REQUIRE(root["non specific"].get_value_ref<std::string&>() == "non specific");
+        REQUIRE(root.contains("non specific"));
+        REQUIRE(root["non specific"].has_tag_name());
+        REQUIRE(root["non specific"].get_tag_name() == "!");
+        REQUIRE(root["non specific"].is_string());
+        REQUIRE(root["non specific"].get_value_ref<std::string&>() == "non specific");
 
-    REQUIRE(root.contains("custom"));
-    REQUIRE(root["custom"].has_tag_name());
-    REQUIRE(root["custom"].get_tag_name() == "!local");
-    REQUIRE(root["custom"].is_string());
-    REQUIRE(root["custom"].get_value_ref<std::string&>() == "value");
+        REQUIRE(root.contains("custom"));
+        REQUIRE(root["custom"].has_tag_name());
+        REQUIRE(root["custom"].get_tag_name() == "!local");
+        REQUIRE(root["custom"].is_string());
+        REQUIRE(root["custom"].get_value_ref<std::string&>() == "value");
+
+        REQUIRE(root.contains("map"));
+        REQUIRE(root["map"].has_tag_name());
+        REQUIRE(root["map"].get_tag_name() == "!!map");
+        REQUIRE(root["map"].is_mapping());
+        REQUIRE(root["map"].size() == 1);
+        REQUIRE(root["map"].begin().key().has_tag_name());
+        REQUIRE(root["map"].begin().key().get_tag_name() == "!!str");
+        REQUIRE(root["map"].contains("foo"));
+        REQUIRE(root["map"]["foo"].get_value_ref<std::string&>() == "bar");
+
+        REQUIRE(root.contains("map_flow"));
+        REQUIRE(root["map_flow"].has_tag_name());
+        REQUIRE(root["map_flow"].get_tag_name() == "!<tag:yaml.org,2002:map>");
+        REQUIRE(root["map_flow"].is_mapping());
+        REQUIRE(root["map_flow"].size() == 1);
+        REQUIRE(root["map_flow"].contains("foo"));
+        REQUIRE(root["map_flow"]["foo"].get_value_ref<std::string&>() == "bar");
+
+        REQUIRE(root.contains("seq"));
+        REQUIRE(root["seq"].has_tag_name());
+        REQUIRE(root["seq"].get_tag_name() == "!<tag:yaml.org,2002:seq>");
+        REQUIRE(root["seq"].is_sequence());
+        REQUIRE(root["seq"].size() == 2);
+        REQUIRE(root["seq"][0].get_value<int>() == 123);
+        REQUIRE(root["seq"][1].get_value<float>() == 3.14f);
+
+        REQUIRE(root.contains("seq_flow"));
+        REQUIRE(root["seq_flow"].has_tag_name());
+        REQUIRE(root["seq_flow"].get_tag_name() == "!!seq");
+        REQUIRE(root["seq_flow"].is_sequence());
+        REQUIRE(root["seq_flow"].size() == 2);
+        REQUIRE(root["seq_flow"][0].get_value<int>() == 123);
+        REQUIRE(root["seq_flow"][1].get_value<float>() == 3.14f);
+    }
+
+    SECTION("multiple tags specified")
+    {
+        auto input = GENERATE(std::string("foo: !!map !!map\n  bar: baz"), std::string("!!str !!bool true: 123"));
+        REQUIRE_THROWS_AS(deserializer.deserialize(fkyaml::detail::input_adapter(input)), fkyaml::parse_error);
+    }
+}
+
+TEST_CASE("DeserializerClassTest_DeserializeNodeProperties", "[DeserializerClassTest]")
+{
+    fkyaml::detail::basic_deserializer<fkyaml::node> deserializer;
+    fkyaml::node root;
+
+    SECTION("both tag and anchor specified")
+    {
+        auto input = GENERATE(
+            std::string("foo: !!map &anchor\n  bar: baz"), // tag -> anchor
+            std::string("foo: &anchor !!map\n  bar: baz")  // anchor -> tag
+        );
+        REQUIRE_NOTHROW(root = deserializer.deserialize(fkyaml::detail::input_adapter(input)));
+
+        REQUIRE(root.is_mapping());
+        REQUIRE(root.size() == 1);
+
+        REQUIRE(root.contains("foo"));
+        REQUIRE(root["foo"].is_mapping());
+        REQUIRE(root["foo"].has_anchor_name());
+        REQUIRE(root["foo"].get_anchor_name() == "anchor");
+        REQUIRE(root["foo"].has_tag_name());
+        REQUIRE(root["foo"].get_tag_name() == "!!map");
+        REQUIRE(root["foo"].size() == 1);
+
+        REQUIRE(root["foo"].contains("bar"));
+        REQUIRE(root["foo"]["bar"].is_string());
+        REQUIRE(root["foo"]["bar"].get_value_ref<std::string&>() == "baz");
+    }
+
+    SECTION("alias node with tag")
+    {
+        REQUIRE_THROWS_AS(
+            deserializer.deserialize(fkyaml::detail::input_adapter("&anchor foo: !!str *anchor")), fkyaml::parse_error);
+    }
 }
 
 TEST_CASE("DeserializerClassTest_DeserializeNoMachingAnchorTest", "[DeserializerClassTest]")

--- a/test/unit_test/test_lexical_analyzer_class.cpp
+++ b/test/unit_test/test_lexical_analyzer_class.cpp
@@ -169,8 +169,7 @@ TEST_CASE("LexicalAnalyzerClassTest_ScanTagDirectiveTest", "[LexicalAnalyzerClas
 
 TEST_CASE("LexicalAnalyzerClassTest_ScanInvalidDirectiveTest", "[LexicalAnalyzerClassTest]")
 {
-    auto buffer =
-        GENERATE(std::string("%INVALID\r"), std::string("%INVALID\r"), std::string("%TAG"), std::string("%YAML"));
+    auto buffer = GENERATE(std::string("%TAG"), std::string("%YAML"));
 
     lexer_t lexer(fkyaml::detail::input_adapter(buffer));
     REQUIRE_THROWS_AS(lexer.get_next_token(), fkyaml::parse_error);
@@ -179,7 +178,7 @@ TEST_CASE("LexicalAnalyzerClassTest_ScanInvalidDirectiveTest", "[LexicalAnalyzer
 TEST_CASE("LexicalAnalyzerClassTest_ScanReservedDirectiveTest", "[LexicalAnalyzerClassTest]")
 {
     auto buffer =
-        GENERATE(std::string("%TEST"), std::string("%1984"), std::string("%TEST4LIB"), std::string("%%ERROR"));
+        GENERATE(std::string("%TEST\r\n"), std::string("%1984\r "), std::string("%TEST4LIB\n"), std::string("%%ERROR"));
 
     fkyaml::detail::lexical_token_t token;
     lexer_t lexer(fkyaml::detail::input_adapter(buffer));
@@ -1484,23 +1483,6 @@ TEST_CASE("LexicalAnalyzerClassTest_ScanTagTokenTest", "[LexicalAnalyzerClassTes
         lexer_t lexer(fkyaml::detail::input_adapter(input));
         REQUIRE_THROWS_AS(token = lexer.get_next_token(), fkyaml::parse_error);
     }
-}
-
-TEST_CASE("LexicalAnalyzerClassTest_ScanCommentTokenTest", "[LexicalAnalyzerClassTest]")
-{
-    auto buffer = GENERATE(
-        std::string("# comment\r "),
-        std::string("# comment\r\n"),
-        std::string("# comment\n"),
-        std::string("# comment"));
-    lexer_t lexer(fkyaml::detail::input_adapter(buffer));
-    fkyaml::detail::lexical_token_t token;
-
-    REQUIRE_NOTHROW(token = lexer.get_next_token());
-    REQUIRE(token == fkyaml::detail::lexical_token_t::COMMENT_PREFIX);
-
-    REQUIRE_NOTHROW(token = lexer.get_next_token());
-    REQUIRE(token == fkyaml::detail::lexical_token_t::END_OF_BUFFER);
 }
 
 TEST_CASE("LexicalAnalyzerClassTest_ScanReservedIndicatorTokenTest", "[LexicalAnalyzerClassTest]")


### PR DESCRIPTION
This PR adds support of tags for container nodes while improving the handlings of node properties in general in the deserialization feature.  
Moreover, the test cases for the `fkyaml::detail::basic_deserializer` class, especially their test case names and the way of classifying them, have been reorganized for better readability.  

---

## Pull Request Checklist

Read the [CONTRIBUTING.md](https://github.com/fktn-k/fkYAML/blob/develop/CONTRIBUTING.md) file for detailed information.  

- [x] Changes are described in the pull request or in a referenced [issue](https://github.com/fktn-k/fkYAML/issues).
- [x] The test suite compiles and runs without any error.
- [x] [The code coverage](https://coveralls.io/github/fktn-k/fkYAML) on your branch is 100%.
- [x] The documentation is updated if you added/changed a feature.

## Please don't

- The C++11 support varies between different **compilers** and versions. Please note the [list of supported compilers](https://github.com/fktn-k/fkYAML/blob/develop/README.md#supported-compilers). Some compilers like GCC 4.7 (and earlier), Clang 3.3 (and earlier), or Microsoft Visual Studio 13.0 and earlier are known not to work due to missing or incomplete C++11 support. Please refrain from proposing changes that work around these compiler's limitations with `#ifdef`s or other means.
- Please refrain from proposing changes that would **break [YAML](https://yaml.org/) specifications**. If you propose a conformant extension of YAML to be supported by the library, please motivate this extension.
- Please do not open pull requests that address **multiple issues**.
