### PR TITLE
#294 Support std::basic_string_view

### DIFF
--- a/README.md
+++ b/README.md
@@ -30,7 +30,7 @@ There are a lot of YAML libraries out there, and each may have its reason to exi
 fkYAML has been developed with these design goals:  
 
 ### :briefcase: **Portable**  
-The whole code depends only on C++ standards, and is carefully designed to work on many platforms so that fkYAML can be imported into existing C++ projects written in C++11 or later.  
+The whole code depends only on C++ standards, and is carefully designed to work on many platforms so that fkYAML can be imported into existing C++ projects written in C++11 or better.  
 No external dependencies, no sub-project, or no additional compiler flags are required.  
 Although fkYAML is a library with multiple header files by default, you can use the single-header version located in the [single_include](https://github.com/fktn-k/tree/develop/single_include) directory.  
 Furthermore, the project supports [CMake](https://cmake.org/) and provides [the documentation exclusively for CMake integration](https://fktn-k.github.io/fkYAML/tutorials/cmake_integration).  

--- a/docs/mkdocs/docs/api/basic_node/deserialize.md
+++ b/docs/mkdocs/docs/api/basic_node/deserialize.md
@@ -17,6 +17,7 @@ Throws a [`fkyaml::exception`](../exception/index.md) if the deserialization pro
 
     fkYAML supports UTF-8, UTF-16 and UTF-32 encodings for input characters.  
     As the YAML specification shows [(here)](https://yaml.org/spec/1.2.2/#52-character-encodings), all input streams must begin with either a byte order mark(BOM) or an ASCII character, which will allow the encoding to be deduced by the pattern of the first few bytes of the input sequence.  
+    If an input fails to meet the above requirement, the input is interpreted as a UTF-8 encoded character sequence starting without a BOM.  
     If a stream with `char` as a character type is used (including FILE pointers), the encoding will be automatically detected in the deserialization process, while an array/container of `char16_t` and `char32_t` denotes that its contents are encoded in the UTF-16BE/LE and UTF-32BE/LE format, respectively.  
     Furthermore, a byte order mark (BOM) can be put only at the beginning of an input sequence.  
     The deserialization process internally converts input characters into the UTF-8 encoded ones if they are encoded in the UTF-16 or UTF-32 format.  
@@ -36,9 +37,9 @@ static basic_node deserialize(InputType&& input);
     * an `std::istream` object
     * a `FILE` pointer (must not be `nullptr`)
     * a C-style array of characters (`char`, `char16_t` or `char32_t`. See the "Supported Unicode Encodings" above.)
-        * char[N], char16_t[N], or char32_t[N] (N: the size of an array)
-    * a container `obj` for which `begin(obj)` and `end(obj)` produces a valid pair of iterators
-        * std::basic_string, std::array, and the likes.
+        * char[N], char16_t[N], or char32_t[N] (N is the size of an array)
+    * a container `obj` with which `begin(obj)` and `end(obj)` produces a valid pair of iterators
+        * std::basic_string, std::array, std::string_view (with C++17 or better) and the likes.
 
 ### **Parameters**
 
@@ -61,7 +62,7 @@ static basic_node deserialize(ItrType&& begin, ItrType&& end);
 ***`ItrType`***
 :   Type of a compatible iterator, for instance:
 
-    * a pair of `std::string::iterator`
+    * a pair of iterators such as return values of `std::string::begin()` and `std::string::end()`
     * a pair of pointers such as `ptr` and `ptr + len`
 
 ### **Parameters**

--- a/docs/mkdocs/docs/api/basic_node/get_value.md
+++ b/docs/mkdocs/docs/api/basic_node/get_value.md
@@ -25,7 +25,8 @@ If the copying costs a lot, or if you need an address of the original value, the
 
 ***ValueType***
 :   A compatible value type.  
-    This is, by default, a result of [std::remove_cvref_t<T>](https://en.cppreference.com/w/cpp/types/remove_cvref).  
+    This is, by default, a type of [std::remove_cvref_t<T>](https://en.cppreference.com/w/cpp/types/remove_cvref).  
+    If fkYAML is compiled with C++11, C++14 or C++17, fkYAML uses its own implementation.  
 
 ## **Return Value**
 

--- a/docs/mkdocs/docs/api/node_value_converter/from_node.md
+++ b/docs/mkdocs/docs/api/node_value_converter/from_node.md
@@ -16,8 +16,9 @@ Note that the `TargetType` must be default-constructible.
 !!! Tips
 
     This function can be used for user-defined types by implementing (partial) specialization for `from_node()` function which is called internally by this function.  
-    Note that the specialization **must be implemented in the same namespace as the user-defined types** so that the specialization can successfully be found by ADL (Argument Dependent Lookup).  
-    See the example below for more information.  
+    Note that the specialization **must be implemented in the same namespace as the user-defined types (including the global namespace)** so that the specialization can successfully be found by ADL (Argument Dependent Lookup).  
+    You can find a detailed explanation of how this customization point works at [this link](https://www.open-std.org/jtc1/sc22/wg21/docs/papers/2015/n4381.html).  
+    Also, see the example below for the feel of how it can be achieved.  
 
 ## **Template Parameters**
 

--- a/docs/mkdocs/docs/api/operator_literal_yaml.md
+++ b/docs/mkdocs/docs/api/operator_literal_yaml.md
@@ -4,9 +4,9 @@
 
 ```cpp
 inline node operator"" _yaml(const char* s, std::size_t n);
+inline node operator"" _yaml(const char8_t* s, std::size_t n); // for C++20 or better
 inline node operator"" _yaml(const char16_t* s, std::size_t n);
 inline node operator"" _yaml(const char32_t* s, std::size_t n);
-inline node operator"" _yaml(const char8_t* s, std::size_t n); // for C++20 or later
 ```
 
 This operator implements a user-defined string literal for YAML node objects.  
@@ -24,7 +24,7 @@ Access to this operator can be gained with:
 
 ***`s`*** [in]
 :   A string representation of a YAML node object.  
-    `char` or `char8_t`(for C++20 or later), `char16_t` and `char32_t` are interpreted as the UTF-8, UTF-16 and UTF-32 encodings, respectively.
+    `char` or `char8_t`(for C++20 or better), `char16_t` and `char32_t` are interpreted as the UTF-8, UTF-16 and UTF-32 encodings, respectively.
 
 ***`n`*** [in]
 :   The length of the string `s`.

--- a/docs/mkdocs/docs/index.md
+++ b/docs/mkdocs/docs/index.md
@@ -9,7 +9,7 @@ There are a lot of YAML libraries out there, and each may have its reason to exi
 fkYAML has been developed with these design goals:  
 
 ### :briefcase: **Portable**  
-:   The whole code depends only on C++ standards, and is carefully designed to work on many platforms so that fkYAML can be imported into existing C++ projects written in C++11 or later.  
+:   The whole code depends only on C++ standards, and is carefully designed to work on many platforms so that fkYAML can be imported into existing C++ projects written in C++11 or better.  
     No external dependencies, no sub-project, or no additional compiler flags are required.  
     Although fkYAML is a library with multiple header files by default, you can use the single-header version located in the [single_include](https://github.com/fktn-k/tree/develop/single_include) directory.  
     Furthermore, the project supports [CMake](https://cmake.org/) and provides [the documentation exclusively for CMake integration](https://fktn-k.github.io/fkYAML/tutorials/cmake_integration).  

--- a/include/fkYAML/detail/conversions/from_node.hpp
+++ b/include/fkYAML/detail/conversions/from_node.hpp
@@ -257,6 +257,28 @@ inline void from_node(const BasicNodeType& n, typename BasicNodeType::string_typ
     s = n.template get_value_ref<const typename BasicNodeType::string_type&>();
 }
 
+/// @brief from_node function for compatible string type.
+/// @tparam BasicNodeType A basic_node template instance type.
+/// @tparam CompatibleStringType A compatible string type.
+/// @param n A basic_node object.
+/// @param s A compatible string object.
+template <
+    typename BasicNodeType, typename CompatibleStringType,
+    enable_if_t<
+        conjunction<
+            is_basic_node<BasicNodeType>,
+            negation<std::is_same<CompatibleStringType, typename BasicNodeType::string_type>>,
+            std::is_constructible<CompatibleStringType, const typename BasicNodeType::string_type&>>::value,
+        int> = 0>
+inline void from_node(const BasicNodeType& n, CompatibleStringType& s)
+{
+    if (!n.is_string())
+    {
+        throw type_error("The target node value type is not string type.", n.type());
+    }
+    s = n.template get_value_ref<const typename BasicNodeType::string_type&>();
+}
+
 /// @brief A function object to call from_node functions.
 /// @note User-defined specialization is available by providing implementation **OUTSIDE** fkyaml namespace.
 struct from_node_fn

--- a/include/fkYAML/detail/conversions/from_node.hpp
+++ b/include/fkYAML/detail/conversions/from_node.hpp
@@ -268,7 +268,9 @@ template <
         conjunction<
             is_basic_node<BasicNodeType>,
             negation<std::is_same<CompatibleStringType, typename BasicNodeType::string_type>>,
-            std::is_constructible<CompatibleStringType, const typename BasicNodeType::string_type&>>::value,
+            disjunction<
+                std::is_constructible<CompatibleStringType, const typename BasicNodeType::string_type&>,
+                std::is_assignable<CompatibleStringType, const typename BasicNodeType::string_type&>>>::value,
         int> = 0>
 inline void from_node(const BasicNodeType& n, CompatibleStringType& s)
 {

--- a/include/fkYAML/detail/meta/stl_supplement.hpp
+++ b/include/fkYAML/detail/meta/stl_supplement.hpp
@@ -29,7 +29,7 @@ namespace detail
 /////////////////////////////////////////////////////////////////////////////////////////////////////////
 //   For contributors:
 //     This file is for supplementing future C++ STL implementations to utilize some useful features
-//     implemented in C++14 or later.
+//     implemented in C++14 or better.
 //     This file is needed to keep the fkYAML library requirement to C++11.
 //     **DO NOT** implement features which are not included any version of STL in this file.
 //     Such implementations must be in the type_traits.hpp file.

--- a/single_include/fkYAML/node.hpp
+++ b/single_include/fkYAML/node.hpp
@@ -350,7 +350,7 @@ namespace detail
 /////////////////////////////////////////////////////////////////////////////////////////////////////////
 //   For contributors:
 //     This file is for supplementing future C++ STL implementations to utilize some useful features
-//     implemented in C++14 or later.
+//     implemented in C++14 or better.
 //     This file is needed to keep the fkYAML library requirement to C++11.
 //     **DO NOT** implement features which are not included any version of STL in this file.
 //     Such implementations must be in the type_traits.hpp file.

--- a/single_include/fkYAML/node.hpp
+++ b/single_include/fkYAML/node.hpp
@@ -8201,6 +8201,28 @@ inline void from_node(const BasicNodeType& n, typename BasicNodeType::string_typ
     s = n.template get_value_ref<const typename BasicNodeType::string_type&>();
 }
 
+/// @brief from_node function for compatible string type.
+/// @tparam BasicNodeType A basic_node template instance type.
+/// @tparam CompatibleStringType A compatible string type.
+/// @param n A basic_node object.
+/// @param s A compatible string object.
+template <
+    typename BasicNodeType, typename CompatibleStringType,
+    enable_if_t<
+        conjunction<
+            is_basic_node<BasicNodeType>,
+            negation<std::is_same<CompatibleStringType, typename BasicNodeType::string_type>>,
+            std::is_constructible<CompatibleStringType, const typename BasicNodeType::string_type&>>::value,
+        int> = 0>
+inline void from_node(const BasicNodeType& n, CompatibleStringType& s)
+{
+    if (!n.is_string())
+    {
+        throw type_error("The target node value type is not string type.", n.type());
+    }
+    s = n.template get_value_ref<const typename BasicNodeType::string_type&>();
+}
+
 /// @brief A function object to call from_node functions.
 /// @note User-defined specialization is available by providing implementation **OUTSIDE** fkyaml namespace.
 struct from_node_fn

--- a/single_include/fkYAML/node.hpp
+++ b/single_include/fkYAML/node.hpp
@@ -8212,7 +8212,9 @@ template <
         conjunction<
             is_basic_node<BasicNodeType>,
             negation<std::is_same<CompatibleStringType, typename BasicNodeType::string_type>>,
-            std::is_constructible<CompatibleStringType, const typename BasicNodeType::string_type&>>::value,
+            disjunction<
+                std::is_constructible<CompatibleStringType, const typename BasicNodeType::string_type&>,
+                std::is_assignable<CompatibleStringType, const typename BasicNodeType::string_type&>>>::value,
         int> = 0>
 inline void from_node(const BasicNodeType& n, CompatibleStringType& s)
 {

--- a/test/unit_test/test_input_adapter.cpp
+++ b/test/unit_test/test_input_adapter.cpp
@@ -17,6 +17,10 @@
 // generated in test/unit_test/CMakeLists.txt
 #include <test_data.hpp>
 
+#ifdef FK_YAML_HAS_CXX_17
+    #include <string_view>
+#endif
+
 #ifdef _MSC_VER
     #define DISABLE_C4996 __pragma(warning(push)) __pragma(warning(disable : 4996))
     #define ENABLE_C4996 __pragma(warning(pop))
@@ -69,6 +73,69 @@ TEST_CASE("InputAdapter_IteratorInputAdapterProvider")
         using iterator_type = typename std::string::iterator;
         REQUIRE(std::is_same<decltype(input_adapter), fkyaml::detail::iterator_input_adapter<iterator_type>>::value);
     }
+
+    SECTION("std::u16string")
+    {
+        std::u16string input_str(u"test");
+        auto input_adapter = fkyaml::detail::input_adapter(input_str);
+        using iterator_type = typename std::u16string::iterator;
+        REQUIRE(std::is_same<decltype(input_adapter), fkyaml::detail::iterator_input_adapter<iterator_type>>::value);
+    }
+
+    SECTION("std::u32string")
+    {
+        std::u32string input_str(U"test");
+        auto input_adapter = fkyaml::detail::input_adapter(input_str);
+        using iterator_type = typename std::u32string::iterator;
+        REQUIRE(std::is_same<decltype(input_adapter), fkyaml::detail::iterator_input_adapter<iterator_type>>::value);
+    }
+
+#ifdef FK_YAML_HAS_CXX_17
+    SECTION("std::string_view")
+    {
+        std::string_view input_str_view(input);
+        auto input_adapter = fkyaml::detail::input_adapter(input_str_view);
+        using iterator_type = typename std::string_view::iterator;
+        REQUIRE(std::is_same<decltype(input_adapter), fkyaml::detail::iterator_input_adapter<iterator_type>>::value);
+    }
+
+    SECTION("std::u16string_view")
+    {
+        using namespace std::string_view_literals;
+        std::u16string_view input_str_view = u"test"sv;
+        auto input_adapter = fkyaml::detail::input_adapter(input_str_view);
+        using iterator_type = typename std::u16string_view::iterator;
+        REQUIRE(std::is_same<decltype(input_adapter), fkyaml::detail::iterator_input_adapter<iterator_type>>::value);
+    }
+
+    SECTION("std::u32string_view")
+    {
+        using namespace std::string_view_literals;
+        std::u32string_view input_str_view = U"test"sv;
+        auto input_adapter = fkyaml::detail::input_adapter(input_str_view);
+        using iterator_type = typename std::u32string_view::iterator;
+        REQUIRE(std::is_same<decltype(input_adapter), fkyaml::detail::iterator_input_adapter<iterator_type>>::value);
+    }
+#endif
+
+#ifdef FK_YAML_HAS_CXX_20
+    SECTION("std::u32string")
+    {
+        std::u8string input_str(u8"test");
+        auto input_adapter = fkyaml::detail::input_adapter(input_str);
+        using iterator_type = typename std::u8string::iterator;
+        REQUIRE(std::is_same<decltype(input_adapter), fkyaml::detail::iterator_input_adapter<iterator_type>>::value);
+    }
+
+    SECTION("std::u8string_view")
+    {
+        using namespace std::string_view_literals;
+        std::u8string_view input_str_view = u8"test"sv;
+        auto input_adapter = fkyaml::detail::input_adapter(input_str_view);
+        using iterator_type = typename std::u8string_view::iterator;
+        REQUIRE(std::is_same<decltype(input_adapter), fkyaml::detail::iterator_input_adapter<iterator_type>>::value);
+    }
+#endif
 }
 
 TEST_CASE("InputAdapter_FileInputAdapterProvider")

--- a/test/unit_test/test_node_class.cpp
+++ b/test/unit_test/test_node_class.cpp
@@ -19,6 +19,10 @@
 // generated in test/unit_test/CMakeLists.txt
 #include <test_data.hpp>
 
+#ifdef FK_YAML_HAS_CXX_17
+    #include <string_view>
+#endif
+
 //
 // test cases for constructors
 //
@@ -2651,6 +2655,15 @@ TEST_CASE("Node_GetValue")
             REQUIRE(str.size() == 4);
             REQUIRE(str == "test");
         }
+
+#ifdef FK_YAML_HAS_CXX_17
+        SECTION("string view")
+        {
+            auto str_view = node.get_value<std::string_view>();
+            REQUIRE(str_view.size() == 4);
+            REQUIRE(str_view == "test");
+        }
+#endif
 
         SECTION("non-string values")
         {

--- a/test/unit_test/test_node_class.cpp
+++ b/test/unit_test/test_node_class.cpp
@@ -158,6 +158,18 @@ TEST_CASE("Node_StringCtor")
     REQUIRE(node.get_value_ref<fkyaml::node::string_type&>() == "test");
 }
 
+#ifdef FK_YAML_HAS_CXX_17
+TEST_CASE("Node_StringViewCtor")
+{
+    using namespace std::string_view_literals;
+    auto node = fkyaml::node("test"sv);
+    REQUIRE(node.type() == fkyaml::node::node_t::STRING);
+    REQUIRE(node.is_string());
+    REQUIRE(node.size() == 4);
+    REQUIRE(node.get_value_ref<fkyaml::node::string_type&>() == "test");
+}
+#endif
+
 TEST_CASE("Node_SequenceCopyCtor")
 {
     fkyaml::node n = "test";
@@ -776,6 +788,14 @@ TEST_CASE("Node_SubscriptOperator")
                 REQUIRE_NOTHROW(node["test"]);
             }
         }
+
+#ifdef FK_YAML_HAS_CXX_17
+        SECTION("string view value")
+        {
+            std::string_view key = "test";
+            REQUIRE(map[key].is_null());
+        }
+#endif
 
         SECTION("non-const string node")
         {
@@ -1904,6 +1924,14 @@ TEST_CASE("Node_Contains")
             REQUIRE(node.contains("test"));
         }
 
+#ifdef FK_YAML_HAS_CXX_17
+        SECTION("mapping node with a string view key")
+        {
+            using namespace std::string_view_literals;
+            REQUIRE(node.contains("test"sv));
+        }
+#endif
+
         SECTION("mapping node with a string node key")
         {
             fkyaml::node node_key = "test";
@@ -2036,7 +2064,7 @@ TEST_CASE("Node_At")
             }
         }
 
-        SECTION("const string node")
+        SECTION("const string value")
         {
             const fkyaml::node node = fkyaml::node::mapping(map);
             std::string key = "test";
@@ -2051,6 +2079,14 @@ TEST_CASE("Node_At")
                 REQUIRE_NOTHROW(node.at("test"));
             }
         }
+
+#ifdef FK_YAML_HAS_CXX_17
+        SECTION("string view value")
+        {
+            std::string_view key = "test";
+            REQUIRE(map.at(key).is_null());
+        }
+#endif
 
         SECTION("non-const string node")
         {

--- a/test/unit_test/test_node_class.cpp
+++ b/test/unit_test/test_node_class.cpp
@@ -2501,8 +2501,20 @@ TEST_CASE("Node_AddTagName")
 // test cases for value getters (copy)
 //
 
+struct string_wrap
+{
+    string_wrap() = default;
+    string_wrap& operator=(const std::string& _str)
+    {
+        str = _str;
+        return *this;
+    }
+    std::string str;
+};
+
 TEST_CASE("Node_GetValue")
 {
+
     SECTION("sequence")
     {
         fkyaml::node node(fkyaml::node::sequence_type {fkyaml::node(true), fkyaml::node(false)});
@@ -2525,6 +2537,7 @@ TEST_CASE("Node_GetValue")
             REQUIRE_THROWS_AS(node.get_value<fkyaml::node::integer_type>(), fkyaml::type_error);
             REQUIRE_THROWS_AS(node.get_value<fkyaml::node::float_number_type>(), fkyaml::type_error);
             REQUIRE_THROWS_AS(node.get_value<fkyaml::node::string_type>(), fkyaml::type_error);
+            REQUIRE_THROWS_AS(node.get_value<string_wrap>(), fkyaml::type_error);
         }
     }
 
@@ -2552,6 +2565,7 @@ TEST_CASE("Node_GetValue")
             REQUIRE_THROWS_AS(node.get_value<fkyaml::node::integer_type>(), fkyaml::type_error);
             REQUIRE_THROWS_AS(node.get_value<fkyaml::node::float_number_type>(), fkyaml::type_error);
             REQUIRE_THROWS_AS(node.get_value<fkyaml::node::string_type>(), fkyaml::type_error);
+            REQUIRE_THROWS_AS(node.get_value<string_wrap>(), fkyaml::type_error);
         }
     }
 
@@ -2573,6 +2587,7 @@ TEST_CASE("Node_GetValue")
             REQUIRE_THROWS_AS(node.get_value<fkyaml::node::integer_type>(), fkyaml::type_error);
             REQUIRE_THROWS_AS(node.get_value<fkyaml::node::float_number_type>(), fkyaml::type_error);
             REQUIRE_THROWS_AS(node.get_value<fkyaml::node::string_type>(), fkyaml::type_error);
+            REQUIRE_THROWS_AS(node.get_value<string_wrap>(), fkyaml::type_error);
         }
     }
 
@@ -2593,6 +2608,7 @@ TEST_CASE("Node_GetValue")
             REQUIRE_THROWS_AS(node.get_value<fkyaml::node::integer_type>(), fkyaml::type_error);
             REQUIRE_THROWS_AS(node.get_value<fkyaml::node::float_number_type>(), fkyaml::type_error);
             REQUIRE_THROWS_AS(node.get_value<fkyaml::node::string_type>(), fkyaml::type_error);
+            REQUIRE_THROWS_AS(node.get_value<string_wrap>(), fkyaml::type_error);
         }
     }
 
@@ -2620,6 +2636,7 @@ TEST_CASE("Node_GetValue")
             REQUIRE_THROWS_AS(node.get_value<fkyaml::node::boolean_type>(), fkyaml::type_error);
             REQUIRE_THROWS_AS(node.get_value<fkyaml::node::float_number_type>(), fkyaml::type_error);
             REQUIRE_THROWS_AS(node.get_value<fkyaml::node::string_type>(), fkyaml::type_error);
+            REQUIRE_THROWS_AS(node.get_value<string_wrap>(), fkyaml::type_error);
         }
 
         SECTION("non-integer node value")
@@ -2660,6 +2677,7 @@ TEST_CASE("Node_GetValue")
             REQUIRE_THROWS_AS(node.get_value<fkyaml::node::boolean_type>(), fkyaml::type_error);
             REQUIRE_THROWS_AS(node.get_value<fkyaml::node::integer_type>(), fkyaml::type_error);
             REQUIRE_THROWS_AS(node.get_value<fkyaml::node::string_type>(), fkyaml::type_error);
+            REQUIRE_THROWS_AS(node.get_value<string_wrap>(), fkyaml::type_error);
         }
 
         SECTION("non-float-number node value")
@@ -2690,6 +2708,13 @@ TEST_CASE("Node_GetValue")
             auto str = node.get_value<fkyaml::node::string_type>();
             REQUIRE(str.size() == 4);
             REQUIRE(str == "test");
+        }
+
+        SECTION("compatible string value")
+        {
+            auto str_wrap = node.get_value<string_wrap>();
+            REQUIRE(str_wrap.str.size() == 4);
+            REQUIRE(str_wrap.str == "test");
         }
 
 #ifdef FK_YAML_HAS_CXX_17


### PR DESCRIPTION
This PR has added the `std::basic_string_view` support in the conversion from a string node to a native string value only when compiled with C++17 or better.  
Also, test cases for the deserialization feature have been added for the explicit support for the `std::basic_string_view<CharT>` types.  
The documentation has also been updated according to the above changes.  

---

## Pull Request Checklist

Read the [CONTRIBUTING.md](https://github.com/fktn-k/fkYAML/blob/develop/CONTRIBUTING.md) file for detailed information.  

- [x] Changes are described in the pull request or in a referenced [issue](https://github.com/fktn-k/fkYAML/issues).
- [x] The test suite compiles and runs without any error.
- [x] [The code coverage](https://coveralls.io/github/fktn-k/fkYAML) on your branch is 100%.
- [x] The documentation is updated if you added/changed a feature.

## Please don't

- The C++11 support varies between different **compilers** and versions. Please note the [list of supported compilers](https://github.com/fktn-k/fkYAML/blob/develop/README.md#supported-compilers). Some compilers like GCC 4.7 (and earlier), Clang 3.3 (and earlier), or Microsoft Visual Studio 13.0 and earlier are known not to work due to missing or incomplete C++11 support. Please refrain from proposing changes that work around these compiler's limitations with `#ifdef`s or other means.
- Please refrain from proposing changes that would **break [YAML](https://yaml.org/) specifications**. If you propose a conformant extension of YAML to be supported by the library, please motivate this extension.
- Please do not open pull requests that address **multiple issues**.
