### PR TITLE
#181 Serialize container tags

### DIFF
--- a/docs/mkdocs/docs/api/basic_node/serialize.md
+++ b/docs/mkdocs/docs/api/basic_node/serialize.md
@@ -7,8 +7,34 @@ static std::string serialize(const basic_node& node);
 ```
 
 Serializes YAML node values recursively.  
-Currently, the serialization result only supports block styles.  
-That means that, even if a deserialized source input is written in flow styles, the serialization result forces to convert it in block styles.  
+Currently, the serialization of mappings and sequences only supports block styles.  
+That means that, even if a deserialized source input is originally written in flow styles, the serialization result forces to convert it in block styles.   
+This function serializes the given `node` parameter in the following format.  
+```yaml
+# A scalar
+{[anchor] [tag] value | alias}
+
+# A sequence value.
+# Extra 2 spaces are inserted before the sequence indicators denoted as "- ".
+# If an anchor and/or a tag are set to the sequence, they are put on the same line as the key.
+# Sequence keys are not yet supported.
+<scalar>: [anchor] [tag]
+  - <sequence scalar value>
+  - [anchor] [tag] # A child sequence node.
+    - <child sequence value>
+
+# A mapping whose value is a scalar.
+<scalar>: <scalar>
+
+# A mapping value whose value is a container node, either a mapping or a sequence.
+# Extra 2 spaces are inserted before the value to indicate indentation.
+# If an anchor and/or a tag are set to the mapping, they are put on the same line as the key.
+# Mapping keys are not yet supported.
+<scalar>: [anchor] [tag]
+  <mapping scalar key>: <mapping scalar value>
+  <mapping scalar key>: [anchor] [tag] # A child mapping node.
+    <child mapping scalar key>: <child mapping scalar value>
+```
 
 ### **Parameters**
 

--- a/include/fkYAML/detail/output/serializer.hpp
+++ b/include/fkYAML/detail/output/serializer.hpp
@@ -133,6 +133,7 @@ private:
                 }
 
                 try_append_anchor(seq_item, true, str);
+                try_append_tag(seq_item, true, str);
 
                 bool is_scalar = seq_item.is_scalar();
                 if (is_scalar)
@@ -159,8 +160,9 @@ private:
                 bool is_appended = try_append_alias(itr.key(), false, str);
                 if (!is_appended)
                 {
-                    is_appended = try_append_anchor(itr.key(), false, str);
-                    if (is_appended)
+                    bool is_anchor_appended = try_append_anchor(itr.key(), false, str);
+                    bool is_tag_appended = try_append_tag(itr.key(), is_anchor_appended, str);
+                    if (is_anchor_appended || is_tag_appended)
                     {
                         str += " ";
                     }
@@ -177,6 +179,7 @@ private:
                 }
 
                 try_append_anchor(*itr, true, str);
+                try_append_tag(*itr, true, str);
 
                 bool is_scalar = itr->is_scalar();
                 if (is_scalar)
@@ -193,44 +196,22 @@ private:
             }
             break;
         case node_t::NULL_OBJECT:
-            if (try_append_tag(node, str))
-            {
-                str += " ";
-            }
             to_string(nullptr, m_tmp_str_buff);
             str += m_tmp_str_buff;
             break;
         case node_t::BOOLEAN:
-            if (try_append_tag(node, str))
-            {
-                str += " ";
-            }
             to_string(node.template get_value<typename BasicNodeType::boolean_type>(), m_tmp_str_buff);
             str += m_tmp_str_buff;
             break;
         case node_t::INTEGER:
-            if (try_append_tag(node, str))
-            {
-                str += " ";
-            }
             to_string(node.template get_value<typename BasicNodeType::integer_type>(), m_tmp_str_buff);
             str += m_tmp_str_buff;
             break;
         case node_t::FLOAT_NUMBER:
-            if (try_append_tag(node, str))
-            {
-                str += " ";
-            }
             to_string(node.template get_value<typename BasicNodeType::float_number_type>(), m_tmp_str_buff);
             str += m_tmp_str_buff;
             break;
         case node_t::STRING: {
-            bool is_appended = try_append_tag(node, str);
-            if (is_appended)
-            {
-                str += " ";
-            }
-
             bool is_escaped = false;
             typename BasicNodeType::string_type str_val = get_string_node_value(node, is_escaped);
 
@@ -315,10 +296,14 @@ private:
     /// @param[in] node The target node which possibly has a tag name.
     /// @param[out] str A string to hold serialization result.
     /// @return true if a tag name has been appended, false otherwise.
-    bool try_append_tag(const BasicNodeType& node, std::string& str) const
+    bool try_append_tag(const BasicNodeType& node, bool prepends_space, std::string& str) const
     {
         if (node.has_tag_name())
         {
+            if (prepends_space)
+            {
+                str += " ";
+            }
             str += node.get_tag_name();
             return true;
         }

--- a/single_include/fkYAML/node.hpp
+++ b/single_include/fkYAML/node.hpp
@@ -7521,6 +7521,7 @@ private:
                 }
 
                 try_append_anchor(seq_item, true, str);
+                try_append_tag(seq_item, true, str);
 
                 bool is_scalar = seq_item.is_scalar();
                 if (is_scalar)
@@ -7547,8 +7548,9 @@ private:
                 bool is_appended = try_append_alias(itr.key(), false, str);
                 if (!is_appended)
                 {
-                    is_appended = try_append_anchor(itr.key(), false, str);
-                    if (is_appended)
+                    bool is_anchor_appended = try_append_anchor(itr.key(), false, str);
+                    bool is_tag_appended = try_append_tag(itr.key(), is_anchor_appended, str);
+                    if (is_anchor_appended || is_tag_appended)
                     {
                         str += " ";
                     }
@@ -7565,6 +7567,7 @@ private:
                 }
 
                 try_append_anchor(*itr, true, str);
+                try_append_tag(*itr, true, str);
 
                 bool is_scalar = itr->is_scalar();
                 if (is_scalar)
@@ -7581,44 +7584,22 @@ private:
             }
             break;
         case node_t::NULL_OBJECT:
-            if (try_append_tag(node, str))
-            {
-                str += " ";
-            }
             to_string(nullptr, m_tmp_str_buff);
             str += m_tmp_str_buff;
             break;
         case node_t::BOOLEAN:
-            if (try_append_tag(node, str))
-            {
-                str += " ";
-            }
             to_string(node.template get_value<typename BasicNodeType::boolean_type>(), m_tmp_str_buff);
             str += m_tmp_str_buff;
             break;
         case node_t::INTEGER:
-            if (try_append_tag(node, str))
-            {
-                str += " ";
-            }
             to_string(node.template get_value<typename BasicNodeType::integer_type>(), m_tmp_str_buff);
             str += m_tmp_str_buff;
             break;
         case node_t::FLOAT_NUMBER:
-            if (try_append_tag(node, str))
-            {
-                str += " ";
-            }
             to_string(node.template get_value<typename BasicNodeType::float_number_type>(), m_tmp_str_buff);
             str += m_tmp_str_buff;
             break;
         case node_t::STRING: {
-            bool is_appended = try_append_tag(node, str);
-            if (is_appended)
-            {
-                str += " ";
-            }
-
             bool is_escaped = false;
             typename BasicNodeType::string_type str_val = get_string_node_value(node, is_escaped);
 
@@ -7703,10 +7684,14 @@ private:
     /// @param[in] node The target node which possibly has a tag name.
     /// @param[out] str A string to hold serialization result.
     /// @return true if a tag name has been appended, false otherwise.
-    bool try_append_tag(const BasicNodeType& node, std::string& str) const
+    bool try_append_tag(const BasicNodeType& node, bool prepends_space, std::string& str) const
     {
         if (node.has_tag_name())
         {
+            if (prepends_space)
+            {
+                str += " ";
+            }
             str += node.get_tag_name();
             return true;
         }

--- a/test/unit_test/test_serializer_class.cpp
+++ b/test/unit_test/test_serializer_class.cpp
@@ -210,15 +210,26 @@ TEST_CASE("Serializer_TaggedNode")
     int_node.add_tag_name("!!int");
     fkyaml::node float_node(3.14);
     float_node.add_tag_name("!<tag:yaml.org,2002:float>");
+    fkyaml::node map_node = {{"bar", false}};
+    map_node.add_tag_name("!!map");
+    fkyaml::node seq_node = {nullptr, 456};
+    seq_node.add_tag_name("!!seq");
 
     auto& mapping = root.get_value_ref<fkyaml::node::mapping_type&>();
     mapping.emplace(str_node, null_node);
     mapping.emplace(bool_node, int_node);
     mapping.emplace(null_node, float_node);
+    mapping.emplace("map", map_node);
+    mapping.emplace("seq", seq_node);
 
     std::string expected = "!!null null: !<tag:yaml.org,2002:float> 3.14\n"
                            "!<tag:yaml.org,2002:bool> true: !!int 123\n"
-                           "!!str foo: !!null null\n";
+                           "!!str foo: !!null null\n"
+                           "map: !!map\n"
+                           "  bar: false\n"
+                           "seq: !!seq\n"
+                           "  - null\n"
+                           "  - 456\n";
 
     fkyaml::detail::basic_serializer<fkyaml::node> serializer;
     REQUIRE(serializer.serialize(root) == expected);


### PR DESCRIPTION
This PR has added the feature of serializing container tags with related test cases (scalar tags are already supported in #305 ).  
Furthermore, the format with which the serialization feature complies are added to the documentation for the `basic_node::serialize` function.  

---

## Pull Request Checklist

Read the [CONTRIBUTING.md](https://github.com/fktn-k/fkYAML/blob/develop/CONTRIBUTING.md) file for detailed information.  

- [x] Changes are described in the pull request or in a referenced [issue](https://github.com/fktn-k/fkYAML/issues).
- [x] The test suite compiles and runs without any error.
- [x] [The code coverage](https://coveralls.io/github/fktn-k/fkYAML) on your branch is 100%.
- [x] The documentation is updated if you added/changed a feature.

## Please don't

- The C++11 support varies between different **compilers** and versions. Please note the [list of supported compilers](https://github.com/fktn-k/fkYAML/blob/develop/README.md#supported-compilers). Some compilers like GCC 4.7 (and earlier), Clang 3.3 (and earlier), or Microsoft Visual Studio 13.0 and earlier are known not to work due to missing or incomplete C++11 support. Please refrain from proposing changes that work around these compiler's limitations with `#ifdef`s or other means.
- Please refrain from proposing changes that would **break [YAML](https://yaml.org/) specifications**. If you propose a conformant extension of YAML to be supported by the library, please motivate this extension.
- Please do not open pull requests that address **multiple issues**.
