### PR TITLE
Query the count of UTF-8 character bytes

### DIFF
--- a/include/fkYAML/detail/encodings/utf8_encoding.hpp
+++ b/include/fkYAML/detail/encodings/utf8_encoding.hpp
@@ -62,163 +62,168 @@ public:
         }
 
         // The first byte starts with 0b10XX'XXXX or 0b1111'1XXX -> invalid
-        std::array<int, 1> bytes {{first_byte}};
-        throw fkyaml::invalid_encoding("Invalid UTF-8 encoding.", bytes);
+        throw fkyaml::invalid_encoding("Invalid UTF-8 encoding.", {first_byte});
     }
 
     /// @brief Validates the encoding of a given byte array whose length is 1.
     /// @param[in] byte_array The byte array to be validated.
     /// @return true if a given byte array is valid, false otherwise.
-    static bool validate(std::array<int, 1> byte_array) noexcept
+    static bool validate(const std::initializer_list<uint8_t>& byte_array) noexcept
     {
-        // U+0000..U+007F
-        return (0x00 <= byte_array[0] && byte_array[0] <= 0x7F);
-    }
-
-    /// @brief Validates the encoding of a given byte array whose length is 2.
-    /// @param[in] byte_array The byte array to be validated.
-    /// @return true if a given byte array is valid, false otherwise.
-    static bool validate(std::array<int, 2> byte_array) noexcept
-    {
-        // U+0080..U+07FF
-        //   1st Byte: 0xC2..0xDF
-        //   2nd Byte: 0x80..0xBF
-        if (0xC2 <= byte_array[0] && byte_array[0] <= 0xDF)
+        switch (byte_array.size())
         {
-            if (0x80 <= byte_array[1] && byte_array[1] <= 0xBF)
-            {
-                return true;
-            }
-        }
+        case 1:
+            // U+0000..U+007F
+            return uint8_t(*(byte_array.begin())) <= uint8_t(0x7Fu);
+        case 2: {
+            auto itr = byte_array.begin();
+            uint8_t first = *itr++;
+            uint8_t second = *itr;
 
-        // The rest of byte combinations are invalid.
-        return false;
-    }
-
-    /// @brief Validates the encoding of a given byte array whose length is 3.
-    /// @param[in] byte_array The byte array to be validated.
-    /// @return true if a given byte array is valid, false otherwise.
-    static bool validate(std::array<int, 3> byte_array) noexcept
-    {
-        // U+1000..U+CFFF:
-        //   1st Byte: 0xE0..0xEC
-        //   2nd Byte: 0x80..0xBF
-        //   3rd Byte: 0x80..0xBF
-        if (0xE0 <= byte_array[0] && byte_array[0] <= 0xEC)
-        {
-            if (0x80 <= byte_array[1] && byte_array[1] <= 0xBF)
+            // U+0080..U+07FF
+            //   1st Byte: 0xC2..0xDF
+            //   2nd Byte: 0x80..0xBF
+            if (uint8_t(0xC2u) <= first && first <= uint8_t(0xDFu))
             {
-                if (0x80 <= byte_array[2] && byte_array[2] <= 0xBF)
+                if (0x80 <= second && second <= 0xBF)
                 {
                     return true;
                 }
             }
+
+            // The rest of byte combinations are invalid.
             return false;
         }
+        case 3: {
+            auto itr = byte_array.begin();
+            uint8_t first = *itr++;
+            uint8_t second = *itr++;
+            uint8_t third = *itr;
 
-        // U+D000..U+D7FF:
-        //   1st Byte: 0xED
-        //   2nd Byte: 0x80..0x9F
-        //   3rd Byte: 0x80..0xBF
-        if (byte_array[0] == 0xED)
-        {
-            if (0x80 <= byte_array[1] && byte_array[1] <= 0x9F)
+            // U+1000..U+CFFF:
+            //   1st Byte: 0xE0..0xEC
+            //   2nd Byte: 0x80..0xBF
+            //   3rd Byte: 0x80..0xBF
+            if (0xE0 <= first && first <= 0xEC)
             {
-                if (0x80 <= byte_array[2] && byte_array[2] <= 0xBF)
+                if (0x80 <= second && second <= 0xBF)
                 {
-                    return true;
-                }
-            }
-            return false;
-        }
-
-        // U+E000..U+FFFF:
-        //   1st Byte: 0xEE..0xEF
-        //   2nd Byte: 0x80..0xBF
-        //   3rd Byte: 0x80..0xBF
-        if (byte_array[0] == 0xEE || byte_array[0] == 0xEF)
-        {
-            if (0x80 <= byte_array[1] && byte_array[1] <= 0xBF)
-            {
-                if (0x80 <= byte_array[2] && byte_array[2] <= 0xBF)
-                {
-                    return true;
-                }
-            }
-            return false;
-        }
-
-        // The rest of byte combinations are invalid.
-        return false;
-    }
-
-    /// @brief Validates the encoding of a given byte array whose length is 4.
-    /// @param[in] byte_array The byte array to be validated.
-    /// @return true if a given byte array is valid, false otherwise.
-    static bool validate(std::array<int, 4> byte_array) noexcept
-    {
-        // U+10000..U+3FFFF:
-        //   1st Byte: 0xF0
-        //   2nd Byte: 0x90..0xBF
-        //   3rd Byte: 0x80..0xBF
-        //   4th Byte: 0x80..0xBF
-        if (byte_array[0] == 0xF0)
-        {
-            if (0x90 <= byte_array[1] && byte_array[1] <= 0xBF)
-            {
-                if (0x80 <= byte_array[2] && byte_array[2] <= 0xBF)
-                {
-                    if (0x80 <= byte_array[3] && byte_array[3] <= 0xBF)
+                    if (0x80 <= third && third <= 0xBF)
                     {
                         return true;
                     }
                 }
+                return false;
             }
-            return false;
-        }
 
-        // U+40000..U+FFFFF:
-        //   1st Byte: 0xF1..0xF3
-        //   2nd Byte: 0x80..0xBF
-        //   3rd Byte: 0x80..0xBF
-        //   4th Byte: 0x80..0xBF
-        if (0xF1 <= byte_array[0] && byte_array[0] <= 0xF3)
-        {
-            if (0x80 <= byte_array[1] && byte_array[1] <= 0xBF)
+            // U+D000..U+D7FF:
+            //   1st Byte: 0xED
+            //   2nd Byte: 0x80..0x9F
+            //   3rd Byte: 0x80..0xBF
+            if (first == 0xED)
             {
-                if (0x80 <= byte_array[2] && byte_array[2] <= 0xBF)
+                if (0x80 <= second && second <= 0x9F)
                 {
-                    if (0x80 <= byte_array[3] && byte_array[3] <= 0xBF)
+                    if (0x80 <= third && third <= 0xBF)
                     {
                         return true;
                     }
                 }
+                return false;
             }
-            return false;
-        }
 
-        // U+100000..U+10FFFF:
-        //   1st Byte: 0xF4
-        //   2nd Byte: 0x80..0x8F
-        //   3rd Byte: 0x80..0xBF
-        //   4th Byte: 0x80..0xBF
-        if (byte_array[0] == 0xF4)
-        {
-            if (0x80 <= byte_array[1] && byte_array[1] <= 0x8F)
+            // U+E000..U+FFFF:
+            //   1st Byte: 0xEE..0xEF
+            //   2nd Byte: 0x80..0xBF
+            //   3rd Byte: 0x80..0xBF
+            if (first == 0xEE || first == 0xEF)
             {
-                if (0x80 <= byte_array[2] && byte_array[2] <= 0xBF)
+                if (0x80 <= second && second <= 0xBF)
                 {
-                    if (0x80 <= byte_array[3] && byte_array[3] <= 0xBF)
+                    if (0x80 <= third && third <= 0xBF)
                     {
                         return true;
                     }
                 }
+                return false;
             }
+
+            // The rest of byte combinations are invalid.
             return false;
         }
+        case 4: {
+            auto itr = byte_array.begin();
+            uint8_t first = *itr++;
+            uint8_t second = *itr++;
+            uint8_t third = *itr++;
+            uint8_t fourth = *itr;
 
-        // The rest of byte combinations are invalid.
-        return false;
+            // U+10000..U+3FFFF:
+            //   1st Byte: 0xF0
+            //   2nd Byte: 0x90..0xBF
+            //   3rd Byte: 0x80..0xBF
+            //   4th Byte: 0x80..0xBF
+            if (first == 0xF0)
+            {
+                if (0x90 <= second && second <= 0xBF)
+                {
+                    if (0x80 <= third && third <= 0xBF)
+                    {
+                        if (0x80 <= fourth && fourth <= 0xBF)
+                        {
+                            return true;
+                        }
+                    }
+                }
+                return false;
+            }
+
+            // U+40000..U+FFFFF:
+            //   1st Byte: 0xF1..0xF3
+            //   2nd Byte: 0x80..0xBF
+            //   3rd Byte: 0x80..0xBF
+            //   4th Byte: 0x80..0xBF
+            if (0xF1 <= first && first <= 0xF3)
+            {
+                if (0x80 <= second && second <= 0xBF)
+                {
+                    if (0x80 <= third && third <= 0xBF)
+                    {
+                        if (0x80 <= fourth && fourth <= 0xBF)
+                        {
+                            return true;
+                        }
+                    }
+                }
+                return false;
+            }
+
+            // U+100000..U+10FFFF:
+            //   1st Byte: 0xF4
+            //   2nd Byte: 0x80..0x8F
+            //   3rd Byte: 0x80..0xBF
+            //   4th Byte: 0x80..0xBF
+            if (first == 0xF4)
+            {
+                if (0x80 <= second && second <= 0x8F)
+                {
+                    if (0x80 <= third && third <= 0xBF)
+                    {
+                        if (0x80 <= fourth && fourth <= 0xBF)
+                        {
+                            return true;
+                        }
+                    }
+                }
+                return false;
+            }
+
+            // The rest of byte combinations are invalid.
+            return false;
+        }
+        default:          // LCOV_EXCL_LINE
+            return false; // LCOV_EXCL_LINE
+        }
     }
 
     /// @brief Converts UTF-16 encoded characters to UTF-8 encoded bytes.

--- a/include/fkYAML/detail/input/input_adapter.hpp
+++ b/include/fkYAML/detail/input/input_adapter.hpp
@@ -106,7 +106,7 @@ private:
             switch (num_bytes)
             {
             case 2: {
-                std::array<int, 2> bytes {{first, uint8_t(*current++)}};
+                std::initializer_list<uint8_t> bytes {first, uint8_t(*current++)};
                 bool is_valid = utf8_encoding::validate(bytes);
                 if (!is_valid)
                 {
@@ -115,7 +115,7 @@ private:
                 break;
             }
             case 3: {
-                std::array<int, 3> bytes {{first, uint8_t(*current++), uint8_t(*current++)}};
+                std::initializer_list<uint8_t> bytes {first, uint8_t(*current++), uint8_t(*current++)};
                 bool is_valid = utf8_encoding::validate(bytes);
                 if (!is_valid)
                 {
@@ -124,7 +124,8 @@ private:
                 break;
             }
             case 4: {
-                std::array<int, 4> bytes {{first, uint8_t(*current++), uint8_t(*current++), uint8_t(*current++)}};
+                std::initializer_list<uint8_t> bytes {
+                    first, uint8_t(*current++), uint8_t(*current++), uint8_t(*current++)};
                 bool is_valid = utf8_encoding::validate(bytes);
                 if (!is_valid)
                 {
@@ -270,45 +271,42 @@ public:
         IterType current = m_current;
         while (current != m_end)
         {
-            char first = *current++;
+            uint8_t first = static_cast<uint8_t>(*current++);
+            uint32_t num_bytes = utf8_encoding::get_num_bytes(first);
 
-            // The first byte starts with 0b0XXX'XXXX -> 1-byte character
-            if ((first & 0xC0) == 0x80)
+            switch (num_bytes)
             {
-                // The first byte must not start with 0b10XX'XXXX
-                std::array<int, 1> bytes {{first}};
-                throw fkyaml::invalid_encoding("Invalid UTF-8 encoding.", bytes);
-            }
-            // The first byte starts with 0b110X'XXXX -> 2-byte character
-            else if ((first & 0xE0) == 0xC0)
-            {
-                std::array<int, 2> bytes {{uint8_t(first), uint8_t(*current++)}};
+            case 2: {
+                std::initializer_list<uint8_t> bytes {first, uint8_t(*current++)};
                 bool is_valid = utf8_encoding::validate(bytes);
                 if (!is_valid)
                 {
                     throw fkyaml::invalid_encoding("Invalid UTF-8 encoding.", bytes);
                 }
+                break;
             }
-            // The first byte starts with 0b1110'XXXX -> 3-byte character
-            else if ((first & 0xF0) == 0xE0)
-            {
-                std::array<int, 3> bytes {{uint8_t(first), uint8_t(*current++), uint8_t(*current++)}};
+            case 3: {
+                std::initializer_list<uint8_t> bytes {first, uint8_t(*current++), uint8_t(*current++)};
                 bool is_valid = utf8_encoding::validate(bytes);
                 if (!is_valid)
                 {
                     throw fkyaml::invalid_encoding("Invalid UTF-8 encoding.", bytes);
                 }
+                break;
             }
-            // The first byte starts with 0x1111'0XXX -> 4-byte character
-            else if ((first & 0xF8) == 0xF0)
-            {
-                std::array<int, 4> bytes {
-                    {uint8_t(first), uint8_t(*current++), uint8_t(*current++), uint8_t(*current++)}};
+            case 4: {
+                std::initializer_list<uint8_t> bytes {
+                    first, uint8_t(*current++), uint8_t(*current++), uint8_t(*current++)};
                 bool is_valid = utf8_encoding::validate(bytes);
                 if (!is_valid)
                 {
                     throw fkyaml::invalid_encoding("Invalid UTF-8 encoding.", bytes);
                 }
+                break;
+            }
+            case 1:
+            default:
+                break;
             }
         }
 
@@ -535,45 +533,42 @@ private:
         auto end = buffer.end();
         while (current != end)
         {
-            char first = *current++;
+            uint8_t first = static_cast<uint8_t>(*current++);
+            uint32_t num_bytes = utf8_encoding::get_num_bytes(first);
 
-            // The first byte starts with 0b0XXX'XXXX -> 1-byte character
-            if ((first & 0xC0) == 0x80)
+            switch (num_bytes)
             {
-                // The first byte must not start with 0b10XX'XXXX
-                std::array<int, 1> bytes {{first}};
-                throw fkyaml::invalid_encoding("Invalid UTF-8 encoding.", bytes);
-            }
-            // The first byte starts with 0b110X'XXXX -> 2-byte character
-            else if ((first & 0xE0) == 0xC0)
-            {
-                std::array<int, 2> bytes {{uint8_t(first), uint8_t(*current++)}};
+            case 2: {
+                std::initializer_list<uint8_t> bytes {first, uint8_t(*current++)};
                 bool is_valid = utf8_encoding::validate(bytes);
                 if (!is_valid)
                 {
                     throw fkyaml::invalid_encoding("Invalid UTF-8 encoding.", bytes);
                 }
+                break;
             }
-            // The first byte starts with 0b1110'XXXX -> 3-byte character
-            else if ((first & 0xF0) == 0xE0)
-            {
-                std::array<int, 3> bytes {{uint8_t(first), uint8_t(*current++), uint8_t(*current++)}};
+            case 3: {
+                std::initializer_list<uint8_t> bytes {first, uint8_t(*current++), uint8_t(*current++)};
                 bool is_valid = utf8_encoding::validate(bytes);
                 if (!is_valid)
                 {
                     throw fkyaml::invalid_encoding("Invalid UTF-8 encoding.", bytes);
                 }
+                break;
             }
-            // The first byte starts with 0x1111'0XXX -> 4-byte character
-            else if ((first & 0xF8) == 0xF0)
-            {
-                std::array<int, 4> bytes {
-                    {uint8_t(first), uint8_t(*current++), uint8_t(*current++), uint8_t(*current++)}};
+            case 4: {
+                std::initializer_list<uint8_t> bytes {
+                    first, uint8_t(*current++), uint8_t(*current++), uint8_t(*current++)};
                 bool is_valid = utf8_encoding::validate(bytes);
                 if (!is_valid)
                 {
                     throw fkyaml::invalid_encoding("Invalid UTF-8 encoding.", bytes);
                 }
+                break;
+            }
+            case 1:
+            default:
+                break;
             }
         }
     }
@@ -733,45 +728,42 @@ private:
         auto end = buffer.end();
         while (current != end)
         {
-            char first = *current++;
+            uint8_t first = static_cast<uint8_t>(*current++);
+            uint32_t num_bytes = utf8_encoding::get_num_bytes(first);
 
-            // The first byte starts with 0b0XXX'XXXX -> 1-byte character
-            if ((first & 0xC0) == 0x80)
+            switch (num_bytes)
             {
-                // The first byte must not start with 0b10XX'XXXX
-                std::array<int, 1> bytes {{first}};
-                throw fkyaml::invalid_encoding("Invalid UTF-8 encoding.", bytes);
-            }
-            // The first byte starts with 0b110X'XXXX -> 2-byte character
-            else if ((first & 0xE0) == 0xC0)
-            {
-                std::array<int, 2> bytes {{uint8_t(first), uint8_t(*current++)}};
+            case 2: {
+                std::initializer_list<uint8_t> bytes {first, uint8_t(*current++)};
                 bool is_valid = utf8_encoding::validate(bytes);
                 if (!is_valid)
                 {
                     throw fkyaml::invalid_encoding("Invalid UTF-8 encoding.", bytes);
                 }
+                break;
             }
-            // The first byte starts with 0b1110'XXXX -> 3-byte character
-            else if ((first & 0xF0) == 0xE0)
-            {
-                std::array<int, 3> bytes {{uint8_t(first), uint8_t(*current++), uint8_t(*current++)}};
+            case 3: {
+                std::initializer_list<uint8_t> bytes {first, uint8_t(*current++), uint8_t(*current++)};
                 bool is_valid = utf8_encoding::validate(bytes);
                 if (!is_valid)
                 {
                     throw fkyaml::invalid_encoding("Invalid UTF-8 encoding.", bytes);
                 }
+                break;
             }
-            // The first byte starts with 0x1111'0XXX -> 4-byte character
-            else if ((first & 0xF8) == 0xF0)
-            {
-                std::array<int, 4> bytes {
-                    {uint8_t(first), uint8_t(*current++), uint8_t(*current++), uint8_t(*current++)}};
+            case 4: {
+                std::initializer_list<uint8_t> bytes {
+                    first, uint8_t(*current++), uint8_t(*current++), uint8_t(*current++)};
                 bool is_valid = utf8_encoding::validate(bytes);
                 if (!is_valid)
                 {
                     throw fkyaml::invalid_encoding("Invalid UTF-8 encoding.", bytes);
                 }
+                break;
+            }
+            case 1:
+            default:
+                break;
             }
         }
     }

--- a/include/fkYAML/detail/input/input_adapter.hpp
+++ b/include/fkYAML/detail/input/input_adapter.hpp
@@ -100,45 +100,41 @@ private:
         IterType current = m_current;
         while (current != m_end)
         {
-            char first = *current++;
+            uint8_t first = uint8_t(*current++);
+            uint32_t num_bytes = utf8_encoding::get_num_bytes(first);
 
-            // The first byte starts with 0b0XXX'XXXX -> 1-byte character
-            if ((first & 0xC0) == 0x80)
+            switch (num_bytes)
             {
-                // The first byte must not start with 0b10XX'XXXX
-                std::array<int, 1> bytes {{first}};
-                throw fkyaml::invalid_encoding("Invalid UTF-8 encoding.", bytes);
-            }
-            // The first byte starts with 0b110X'XXXX -> 2-byte character
-            else if ((first & 0xE0) == 0xC0)
-            {
-                std::array<int, 2> bytes {{uint8_t(first), uint8_t(*current++)}};
+            case 2: {
+                std::array<int, 2> bytes {{first, uint8_t(*current++)}};
                 bool is_valid = utf8_encoding::validate(bytes);
                 if (!is_valid)
                 {
                     throw fkyaml::invalid_encoding("Invalid UTF-8 encoding.", bytes);
                 }
+                break;
             }
-            // The first byte starts with 0b1110'XXXX -> 3-byte character
-            else if ((first & 0xF0) == 0xE0)
-            {
-                std::array<int, 3> bytes {{uint8_t(first), uint8_t(*current++), uint8_t(*current++)}};
+            case 3: {
+                std::array<int, 3> bytes {{first, uint8_t(*current++), uint8_t(*current++)}};
                 bool is_valid = utf8_encoding::validate(bytes);
                 if (!is_valid)
                 {
                     throw fkyaml::invalid_encoding("Invalid UTF-8 encoding.", bytes);
                 }
+                break;
             }
-            // The first byte starts with 0x1111'0XXX -> 4-byte character
-            else if ((first & 0xF8) == 0xF0)
-            {
-                std::array<int, 4> bytes {
-                    {uint8_t(first), uint8_t(*current++), uint8_t(*current++), uint8_t(*current++)}};
+            case 4: {
+                std::array<int, 4> bytes {{first, uint8_t(*current++), uint8_t(*current++), uint8_t(*current++)}};
                 bool is_valid = utf8_encoding::validate(bytes);
                 if (!is_valid)
                 {
                     throw fkyaml::invalid_encoding("Invalid UTF-8 encoding.", bytes);
                 }
+                break;
+            }
+            case 1:
+            default:
+                break;
             }
         }
 

--- a/include/fkYAML/exception.hpp
+++ b/include/fkYAML/exception.hpp
@@ -12,6 +12,7 @@
 #define FK_YAML_EXCEPTION_HPP_
 
 #include <array>
+#include <initializer_list>
 #include <stdexcept>
 #include <string>
 
@@ -61,8 +62,10 @@ private:
 class invalid_encoding : public exception
 {
 public:
-    template <std::size_t N>
-    explicit invalid_encoding(const char* msg, std::array<int, N> u8) noexcept
+    /// @brief Construct a new invalid_encoding object for UTF-8 related errors.
+    /// @param msg An error message.
+    /// @param u8 The UTF-8 character bytes.
+    explicit invalid_encoding(const char* msg, const std::initializer_list<uint8_t>& u8) noexcept
         : exception(generate_error_message(msg, u8).c_str())
     {
     }
@@ -85,13 +88,14 @@ public:
     }
 
 private:
-    template <std::size_t N>
-    std::string generate_error_message(const char* msg, std::array<int, N> u8) const noexcept
+    std::string generate_error_message(const char* msg, const std::initializer_list<uint8_t>& u8) const noexcept
     {
-        std::string formatted = detail::format("invalid_encoding: %s in=[ 0x%02x", msg, u8[0]);
-        for (std::size_t i = 1; i < N; i++)
+        auto itr = u8.begin();
+        auto end_itr = u8.end();
+        std::string formatted = detail::format("invalid_encoding: %s in=[ 0x%02x", msg, *itr++);
+        while (itr != end_itr)
         {
-            formatted += detail::format(", 0x%02x", u8[i]);
+            formatted += detail::format(", 0x%02x", *itr++);
         }
         formatted += " ]";
         return formatted;

--- a/single_include/fkYAML/node.hpp
+++ b/single_include/fkYAML/node.hpp
@@ -828,6 +828,7 @@ FK_YAML_NAMESPACE_END
 #define FK_YAML_EXCEPTION_HPP_
 
 #include <array>
+#include <initializer_list>
 #include <stdexcept>
 #include <string>
 
@@ -1002,8 +1003,10 @@ private:
 class invalid_encoding : public exception
 {
 public:
-    template <std::size_t N>
-    explicit invalid_encoding(const char* msg, std::array<int, N> u8) noexcept
+    /// @brief Construct a new invalid_encoding object for UTF-8 related errors.
+    /// @param msg An error message.
+    /// @param u8 The UTF-8 character bytes.
+    explicit invalid_encoding(const char* msg, const std::initializer_list<uint8_t>& u8) noexcept
         : exception(generate_error_message(msg, u8).c_str())
     {
     }
@@ -1026,13 +1029,14 @@ public:
     }
 
 private:
-    template <std::size_t N>
-    std::string generate_error_message(const char* msg, std::array<int, N> u8) const noexcept
+    std::string generate_error_message(const char* msg, const std::initializer_list<uint8_t>& u8) const noexcept
     {
-        std::string formatted = detail::format("invalid_encoding: %s in=[ 0x%02x", msg, u8[0]);
-        for (std::size_t i = 1; i < N; i++)
+        auto itr = u8.begin();
+        auto end_itr = u8.end();
+        std::string formatted = detail::format("invalid_encoding: %s in=[ 0x%02x", msg, *itr++);
+        while (itr != end_itr)
         {
-            formatted += detail::format(", 0x%02x", u8[i]);
+            formatted += detail::format(", 0x%02x", *itr++);
         }
         formatted += " ]";
         return formatted;
@@ -1625,163 +1629,168 @@ public:
         }
 
         // The first byte starts with 0b10XX'XXXX or 0b1111'1XXX -> invalid
-        std::array<int, 1> bytes {{first_byte}};
-        throw fkyaml::invalid_encoding("Invalid UTF-8 encoding.", bytes);
+        throw fkyaml::invalid_encoding("Invalid UTF-8 encoding.", {first_byte});
     }
 
     /// @brief Validates the encoding of a given byte array whose length is 1.
     /// @param[in] byte_array The byte array to be validated.
     /// @return true if a given byte array is valid, false otherwise.
-    static bool validate(std::array<int, 1> byte_array) noexcept
+    static bool validate(const std::initializer_list<uint8_t>& byte_array) noexcept
     {
-        // U+0000..U+007F
-        return (0x00 <= byte_array[0] && byte_array[0] <= 0x7F);
-    }
-
-    /// @brief Validates the encoding of a given byte array whose length is 2.
-    /// @param[in] byte_array The byte array to be validated.
-    /// @return true if a given byte array is valid, false otherwise.
-    static bool validate(std::array<int, 2> byte_array) noexcept
-    {
-        // U+0080..U+07FF
-        //   1st Byte: 0xC2..0xDF
-        //   2nd Byte: 0x80..0xBF
-        if (0xC2 <= byte_array[0] && byte_array[0] <= 0xDF)
+        switch (byte_array.size())
         {
-            if (0x80 <= byte_array[1] && byte_array[1] <= 0xBF)
-            {
-                return true;
-            }
-        }
+        case 1:
+            // U+0000..U+007F
+            return uint8_t(*(byte_array.begin())) <= uint8_t(0x7Fu);
+        case 2: {
+            auto itr = byte_array.begin();
+            uint8_t first = *itr++;
+            uint8_t second = *itr;
 
-        // The rest of byte combinations are invalid.
-        return false;
-    }
-
-    /// @brief Validates the encoding of a given byte array whose length is 3.
-    /// @param[in] byte_array The byte array to be validated.
-    /// @return true if a given byte array is valid, false otherwise.
-    static bool validate(std::array<int, 3> byte_array) noexcept
-    {
-        // U+1000..U+CFFF:
-        //   1st Byte: 0xE0..0xEC
-        //   2nd Byte: 0x80..0xBF
-        //   3rd Byte: 0x80..0xBF
-        if (0xE0 <= byte_array[0] && byte_array[0] <= 0xEC)
-        {
-            if (0x80 <= byte_array[1] && byte_array[1] <= 0xBF)
+            // U+0080..U+07FF
+            //   1st Byte: 0xC2..0xDF
+            //   2nd Byte: 0x80..0xBF
+            if (uint8_t(0xC2u) <= first && first <= uint8_t(0xDFu))
             {
-                if (0x80 <= byte_array[2] && byte_array[2] <= 0xBF)
+                if (0x80 <= second && second <= 0xBF)
                 {
                     return true;
                 }
             }
+
+            // The rest of byte combinations are invalid.
             return false;
         }
+        case 3: {
+            auto itr = byte_array.begin();
+            uint8_t first = *itr++;
+            uint8_t second = *itr++;
+            uint8_t third = *itr;
 
-        // U+D000..U+D7FF:
-        //   1st Byte: 0xED
-        //   2nd Byte: 0x80..0x9F
-        //   3rd Byte: 0x80..0xBF
-        if (byte_array[0] == 0xED)
-        {
-            if (0x80 <= byte_array[1] && byte_array[1] <= 0x9F)
+            // U+1000..U+CFFF:
+            //   1st Byte: 0xE0..0xEC
+            //   2nd Byte: 0x80..0xBF
+            //   3rd Byte: 0x80..0xBF
+            if (0xE0 <= first && first <= 0xEC)
             {
-                if (0x80 <= byte_array[2] && byte_array[2] <= 0xBF)
+                if (0x80 <= second && second <= 0xBF)
                 {
-                    return true;
-                }
-            }
-            return false;
-        }
-
-        // U+E000..U+FFFF:
-        //   1st Byte: 0xEE..0xEF
-        //   2nd Byte: 0x80..0xBF
-        //   3rd Byte: 0x80..0xBF
-        if (byte_array[0] == 0xEE || byte_array[0] == 0xEF)
-        {
-            if (0x80 <= byte_array[1] && byte_array[1] <= 0xBF)
-            {
-                if (0x80 <= byte_array[2] && byte_array[2] <= 0xBF)
-                {
-                    return true;
-                }
-            }
-            return false;
-        }
-
-        // The rest of byte combinations are invalid.
-        return false;
-    }
-
-    /// @brief Validates the encoding of a given byte array whose length is 4.
-    /// @param[in] byte_array The byte array to be validated.
-    /// @return true if a given byte array is valid, false otherwise.
-    static bool validate(std::array<int, 4> byte_array) noexcept
-    {
-        // U+10000..U+3FFFF:
-        //   1st Byte: 0xF0
-        //   2nd Byte: 0x90..0xBF
-        //   3rd Byte: 0x80..0xBF
-        //   4th Byte: 0x80..0xBF
-        if (byte_array[0] == 0xF0)
-        {
-            if (0x90 <= byte_array[1] && byte_array[1] <= 0xBF)
-            {
-                if (0x80 <= byte_array[2] && byte_array[2] <= 0xBF)
-                {
-                    if (0x80 <= byte_array[3] && byte_array[3] <= 0xBF)
+                    if (0x80 <= third && third <= 0xBF)
                     {
                         return true;
                     }
                 }
+                return false;
             }
-            return false;
-        }
 
-        // U+40000..U+FFFFF:
-        //   1st Byte: 0xF1..0xF3
-        //   2nd Byte: 0x80..0xBF
-        //   3rd Byte: 0x80..0xBF
-        //   4th Byte: 0x80..0xBF
-        if (0xF1 <= byte_array[0] && byte_array[0] <= 0xF3)
-        {
-            if (0x80 <= byte_array[1] && byte_array[1] <= 0xBF)
+            // U+D000..U+D7FF:
+            //   1st Byte: 0xED
+            //   2nd Byte: 0x80..0x9F
+            //   3rd Byte: 0x80..0xBF
+            if (first == 0xED)
             {
-                if (0x80 <= byte_array[2] && byte_array[2] <= 0xBF)
+                if (0x80 <= second && second <= 0x9F)
                 {
-                    if (0x80 <= byte_array[3] && byte_array[3] <= 0xBF)
+                    if (0x80 <= third && third <= 0xBF)
                     {
                         return true;
                     }
                 }
+                return false;
             }
-            return false;
-        }
 
-        // U+100000..U+10FFFF:
-        //   1st Byte: 0xF4
-        //   2nd Byte: 0x80..0x8F
-        //   3rd Byte: 0x80..0xBF
-        //   4th Byte: 0x80..0xBF
-        if (byte_array[0] == 0xF4)
-        {
-            if (0x80 <= byte_array[1] && byte_array[1] <= 0x8F)
+            // U+E000..U+FFFF:
+            //   1st Byte: 0xEE..0xEF
+            //   2nd Byte: 0x80..0xBF
+            //   3rd Byte: 0x80..0xBF
+            if (first == 0xEE || first == 0xEF)
             {
-                if (0x80 <= byte_array[2] && byte_array[2] <= 0xBF)
+                if (0x80 <= second && second <= 0xBF)
                 {
-                    if (0x80 <= byte_array[3] && byte_array[3] <= 0xBF)
+                    if (0x80 <= third && third <= 0xBF)
                     {
                         return true;
                     }
                 }
+                return false;
             }
+
+            // The rest of byte combinations are invalid.
             return false;
         }
+        case 4: {
+            auto itr = byte_array.begin();
+            uint8_t first = *itr++;
+            uint8_t second = *itr++;
+            uint8_t third = *itr++;
+            uint8_t fourth = *itr;
 
-        // The rest of byte combinations are invalid.
-        return false;
+            // U+10000..U+3FFFF:
+            //   1st Byte: 0xF0
+            //   2nd Byte: 0x90..0xBF
+            //   3rd Byte: 0x80..0xBF
+            //   4th Byte: 0x80..0xBF
+            if (first == 0xF0)
+            {
+                if (0x90 <= second && second <= 0xBF)
+                {
+                    if (0x80 <= third && third <= 0xBF)
+                    {
+                        if (0x80 <= fourth && fourth <= 0xBF)
+                        {
+                            return true;
+                        }
+                    }
+                }
+                return false;
+            }
+
+            // U+40000..U+FFFFF:
+            //   1st Byte: 0xF1..0xF3
+            //   2nd Byte: 0x80..0xBF
+            //   3rd Byte: 0x80..0xBF
+            //   4th Byte: 0x80..0xBF
+            if (0xF1 <= first && first <= 0xF3)
+            {
+                if (0x80 <= second && second <= 0xBF)
+                {
+                    if (0x80 <= third && third <= 0xBF)
+                    {
+                        if (0x80 <= fourth && fourth <= 0xBF)
+                        {
+                            return true;
+                        }
+                    }
+                }
+                return false;
+            }
+
+            // U+100000..U+10FFFF:
+            //   1st Byte: 0xF4
+            //   2nd Byte: 0x80..0x8F
+            //   3rd Byte: 0x80..0xBF
+            //   4th Byte: 0x80..0xBF
+            if (first == 0xF4)
+            {
+                if (0x80 <= second && second <= 0x8F)
+                {
+                    if (0x80 <= third && third <= 0xBF)
+                    {
+                        if (0x80 <= fourth && fourth <= 0xBF)
+                        {
+                            return true;
+                        }
+                    }
+                }
+                return false;
+            }
+
+            // The rest of byte combinations are invalid.
+            return false;
+        }
+        default:          // LCOV_EXCL_LINE
+            return false; // LCOV_EXCL_LINE
+        }
     }
 
     /// @brief Converts UTF-16 encoded characters to UTF-8 encoded bytes.
@@ -5793,7 +5802,7 @@ private:
             switch (num_bytes)
             {
             case 2: {
-                std::array<int, 2> bytes {{first, uint8_t(*current++)}};
+                std::initializer_list<uint8_t> bytes {first, uint8_t(*current++)};
                 bool is_valid = utf8_encoding::validate(bytes);
                 if (!is_valid)
                 {
@@ -5802,7 +5811,7 @@ private:
                 break;
             }
             case 3: {
-                std::array<int, 3> bytes {{first, uint8_t(*current++), uint8_t(*current++)}};
+                std::initializer_list<uint8_t> bytes {first, uint8_t(*current++), uint8_t(*current++)};
                 bool is_valid = utf8_encoding::validate(bytes);
                 if (!is_valid)
                 {
@@ -5811,7 +5820,8 @@ private:
                 break;
             }
             case 4: {
-                std::array<int, 4> bytes {{first, uint8_t(*current++), uint8_t(*current++), uint8_t(*current++)}};
+                std::initializer_list<uint8_t> bytes {
+                    first, uint8_t(*current++), uint8_t(*current++), uint8_t(*current++)};
                 bool is_valid = utf8_encoding::validate(bytes);
                 if (!is_valid)
                 {
@@ -5957,45 +5967,42 @@ public:
         IterType current = m_current;
         while (current != m_end)
         {
-            char first = *current++;
+            uint8_t first = static_cast<uint8_t>(*current++);
+            uint32_t num_bytes = utf8_encoding::get_num_bytes(first);
 
-            // The first byte starts with 0b0XXX'XXXX -> 1-byte character
-            if ((first & 0xC0) == 0x80)
+            switch (num_bytes)
             {
-                // The first byte must not start with 0b10XX'XXXX
-                std::array<int, 1> bytes {{first}};
-                throw fkyaml::invalid_encoding("Invalid UTF-8 encoding.", bytes);
-            }
-            // The first byte starts with 0b110X'XXXX -> 2-byte character
-            else if ((first & 0xE0) == 0xC0)
-            {
-                std::array<int, 2> bytes {{uint8_t(first), uint8_t(*current++)}};
+            case 2: {
+                std::initializer_list<uint8_t> bytes {first, uint8_t(*current++)};
                 bool is_valid = utf8_encoding::validate(bytes);
                 if (!is_valid)
                 {
                     throw fkyaml::invalid_encoding("Invalid UTF-8 encoding.", bytes);
                 }
+                break;
             }
-            // The first byte starts with 0b1110'XXXX -> 3-byte character
-            else if ((first & 0xF0) == 0xE0)
-            {
-                std::array<int, 3> bytes {{uint8_t(first), uint8_t(*current++), uint8_t(*current++)}};
+            case 3: {
+                std::initializer_list<uint8_t> bytes {first, uint8_t(*current++), uint8_t(*current++)};
                 bool is_valid = utf8_encoding::validate(bytes);
                 if (!is_valid)
                 {
                     throw fkyaml::invalid_encoding("Invalid UTF-8 encoding.", bytes);
                 }
+                break;
             }
-            // The first byte starts with 0x1111'0XXX -> 4-byte character
-            else if ((first & 0xF8) == 0xF0)
-            {
-                std::array<int, 4> bytes {
-                    {uint8_t(first), uint8_t(*current++), uint8_t(*current++), uint8_t(*current++)}};
+            case 4: {
+                std::initializer_list<uint8_t> bytes {
+                    first, uint8_t(*current++), uint8_t(*current++), uint8_t(*current++)};
                 bool is_valid = utf8_encoding::validate(bytes);
                 if (!is_valid)
                 {
                     throw fkyaml::invalid_encoding("Invalid UTF-8 encoding.", bytes);
                 }
+                break;
+            }
+            case 1:
+            default:
+                break;
             }
         }
 
@@ -6222,45 +6229,42 @@ private:
         auto end = buffer.end();
         while (current != end)
         {
-            char first = *current++;
+            uint8_t first = static_cast<uint8_t>(*current++);
+            uint32_t num_bytes = utf8_encoding::get_num_bytes(first);
 
-            // The first byte starts with 0b0XXX'XXXX -> 1-byte character
-            if ((first & 0xC0) == 0x80)
+            switch (num_bytes)
             {
-                // The first byte must not start with 0b10XX'XXXX
-                std::array<int, 1> bytes {{first}};
-                throw fkyaml::invalid_encoding("Invalid UTF-8 encoding.", bytes);
-            }
-            // The first byte starts with 0b110X'XXXX -> 2-byte character
-            else if ((first & 0xE0) == 0xC0)
-            {
-                std::array<int, 2> bytes {{uint8_t(first), uint8_t(*current++)}};
+            case 2: {
+                std::initializer_list<uint8_t> bytes {first, uint8_t(*current++)};
                 bool is_valid = utf8_encoding::validate(bytes);
                 if (!is_valid)
                 {
                     throw fkyaml::invalid_encoding("Invalid UTF-8 encoding.", bytes);
                 }
+                break;
             }
-            // The first byte starts with 0b1110'XXXX -> 3-byte character
-            else if ((first & 0xF0) == 0xE0)
-            {
-                std::array<int, 3> bytes {{uint8_t(first), uint8_t(*current++), uint8_t(*current++)}};
+            case 3: {
+                std::initializer_list<uint8_t> bytes {first, uint8_t(*current++), uint8_t(*current++)};
                 bool is_valid = utf8_encoding::validate(bytes);
                 if (!is_valid)
                 {
                     throw fkyaml::invalid_encoding("Invalid UTF-8 encoding.", bytes);
                 }
+                break;
             }
-            // The first byte starts with 0x1111'0XXX -> 4-byte character
-            else if ((first & 0xF8) == 0xF0)
-            {
-                std::array<int, 4> bytes {
-                    {uint8_t(first), uint8_t(*current++), uint8_t(*current++), uint8_t(*current++)}};
+            case 4: {
+                std::initializer_list<uint8_t> bytes {
+                    first, uint8_t(*current++), uint8_t(*current++), uint8_t(*current++)};
                 bool is_valid = utf8_encoding::validate(bytes);
                 if (!is_valid)
                 {
                     throw fkyaml::invalid_encoding("Invalid UTF-8 encoding.", bytes);
                 }
+                break;
+            }
+            case 1:
+            default:
+                break;
             }
         }
     }
@@ -6420,45 +6424,42 @@ private:
         auto end = buffer.end();
         while (current != end)
         {
-            char first = *current++;
+            uint8_t first = static_cast<uint8_t>(*current++);
+            uint32_t num_bytes = utf8_encoding::get_num_bytes(first);
 
-            // The first byte starts with 0b0XXX'XXXX -> 1-byte character
-            if ((first & 0xC0) == 0x80)
+            switch (num_bytes)
             {
-                // The first byte must not start with 0b10XX'XXXX
-                std::array<int, 1> bytes {{first}};
-                throw fkyaml::invalid_encoding("Invalid UTF-8 encoding.", bytes);
-            }
-            // The first byte starts with 0b110X'XXXX -> 2-byte character
-            else if ((first & 0xE0) == 0xC0)
-            {
-                std::array<int, 2> bytes {{uint8_t(first), uint8_t(*current++)}};
+            case 2: {
+                std::initializer_list<uint8_t> bytes {first, uint8_t(*current++)};
                 bool is_valid = utf8_encoding::validate(bytes);
                 if (!is_valid)
                 {
                     throw fkyaml::invalid_encoding("Invalid UTF-8 encoding.", bytes);
                 }
+                break;
             }
-            // The first byte starts with 0b1110'XXXX -> 3-byte character
-            else if ((first & 0xF0) == 0xE0)
-            {
-                std::array<int, 3> bytes {{uint8_t(first), uint8_t(*current++), uint8_t(*current++)}};
+            case 3: {
+                std::initializer_list<uint8_t> bytes {first, uint8_t(*current++), uint8_t(*current++)};
                 bool is_valid = utf8_encoding::validate(bytes);
                 if (!is_valid)
                 {
                     throw fkyaml::invalid_encoding("Invalid UTF-8 encoding.", bytes);
                 }
+                break;
             }
-            // The first byte starts with 0x1111'0XXX -> 4-byte character
-            else if ((first & 0xF8) == 0xF0)
-            {
-                std::array<int, 4> bytes {
-                    {uint8_t(first), uint8_t(*current++), uint8_t(*current++), uint8_t(*current++)}};
+            case 4: {
+                std::initializer_list<uint8_t> bytes {
+                    first, uint8_t(*current++), uint8_t(*current++), uint8_t(*current++)};
                 bool is_valid = utf8_encoding::validate(bytes);
                 if (!is_valid)
                 {
                     throw fkyaml::invalid_encoding("Invalid UTF-8 encoding.", bytes);
                 }
+                break;
+            }
+            case 1:
+            default:
+                break;
             }
         }
     }

--- a/test/unit_test/test_utf8_encoding_class.cpp
+++ b/test/unit_test/test_utf8_encoding_class.cpp
@@ -20,16 +20,16 @@ TEST_CASE("UTF8Encoding_GetNumBytes")
     {
         using test_value_pair_t = std::pair<uint8_t, uint32_t>;
         auto pair = GENERATE(
-            test_value_pair_t(0u, 1),
-            test_value_pair_t(0x7Fu, 1),
-            test_value_pair_t(0xC0u, 2),
-            test_value_pair_t(0xC1u, 2),
-            test_value_pair_t(0xDFu, 2),
-            test_value_pair_t(0xE0u, 3),
-            test_value_pair_t(0xE1u, 3),
-            test_value_pair_t(0xEFu, 3),
-            test_value_pair_t(0xF0u, 4),
-            test_value_pair_t(0xF1u, 4));
+            test_value_pair_t(uint8_t(0u), 1u),
+            test_value_pair_t(uint8_t(0x7Fu), 1u),
+            test_value_pair_t(uint8_t(0xC0u), 2u),
+            test_value_pair_t(uint8_t(0xC1u), 2u),
+            test_value_pair_t(uint8_t(0xDFu), 2u),
+            test_value_pair_t(uint8_t(0xE0u), 3u),
+            test_value_pair_t(uint8_t(0xE1u), 3u),
+            test_value_pair_t(uint8_t(0xEFu), 3u),
+            test_value_pair_t(uint8_t(0xF0u), 4u),
+            test_value_pair_t(uint8_t(0xF1u), 4u));
 
         REQUIRE(fkyaml::detail::utf8_encoding::get_num_bytes(pair.first) == pair.second);
     }
@@ -43,171 +43,249 @@ TEST_CASE("UTF8Encoding_GetNumBytes")
 
 TEST_CASE("UTF8Encoding_Validate")
 {
-    using int_type = std::char_traits<char>::int_type;
-
     SECTION("1 byte character encoded in UTF-8")
     {
-        using array_ret_pair_t = std::pair<std::array<int_type, 1>, bool>;
-        auto pair = GENERATE(
-            array_ret_pair_t({{-2}}, false),
-            array_ret_pair_t({{-1}}, false),
-            array_ret_pair_t({{0x00}}, true),
-            array_ret_pair_t({{0x01}}, true),
-            array_ret_pair_t({{0x02}}, true),
-            array_ret_pair_t({{0x7D}}, true),
-            array_ret_pair_t({{0x7E}}, true),
-            array_ret_pair_t({{0x7F}}, true),
-            array_ret_pair_t({{0x80}}, false),
-            array_ret_pair_t({{0x81}}, false));
-
-        REQUIRE(fkyaml::detail::utf8_encoding::validate(pair.first) == pair.second);
+        REQUIRE(fkyaml::detail::utf8_encoding::validate({uint8_t(0x00u)}) == true);
+        REQUIRE(fkyaml::detail::utf8_encoding::validate({uint8_t(0x01u)}) == true);
+        REQUIRE(fkyaml::detail::utf8_encoding::validate({uint8_t(0x02u)}) == true);
+        REQUIRE(fkyaml::detail::utf8_encoding::validate({uint8_t(0x7Du)}) == true);
+        REQUIRE(fkyaml::detail::utf8_encoding::validate({uint8_t(0x7Eu)}) == true);
+        REQUIRE(fkyaml::detail::utf8_encoding::validate({uint8_t(0x7Fu)}) == true);
+        REQUIRE(fkyaml::detail::utf8_encoding::validate({uint8_t(0x80u)}) == false);
+        REQUIRE(fkyaml::detail::utf8_encoding::validate({uint8_t(0x81u)}) == false);
     }
 
     SECTION("2 byte characters encoded in UTF-8")
     {
-        using array_ret_pair_t = std::pair<std::array<int_type, 2>, bool>;
-        auto pair = GENERATE(
-            array_ret_pair_t({{0xC0, 0x80}}, false),
-            array_ret_pair_t({{0xC1, 0x80}}, false),
-            array_ret_pair_t({{0xC2, 0x7E}}, false),
-            array_ret_pair_t({{0xC2, 0x7F}}, false),
-            array_ret_pair_t({{0xC2, 0x80}}, true),
-            array_ret_pair_t({{0xC3, 0x81}}, true),
-            array_ret_pair_t({{0xD0, 0xA0}}, true),
-            array_ret_pair_t({{0xDE, 0xBE}}, true),
-            array_ret_pair_t({{0xDF, 0xBF}}, true),
-            array_ret_pair_t({{0xDF, 0xC0}}, false),
-            array_ret_pair_t({{0xDF, 0xC1}}, false),
-            array_ret_pair_t({{0xE0, 0xBF}}, false),
-            array_ret_pair_t({{0xE1, 0xBF}}, false));
-
-        REQUIRE(fkyaml::detail::utf8_encoding::validate(pair.first) == pair.second);
+        REQUIRE(fkyaml::detail::utf8_encoding::validate({uint8_t(0xC0u), uint8_t(0x80u)}) == false);
+        REQUIRE(fkyaml::detail::utf8_encoding::validate({uint8_t(0xC1u), uint8_t(0x80u)}) == false);
+        REQUIRE(fkyaml::detail::utf8_encoding::validate({uint8_t(0xC2u), uint8_t(0x7Eu)}) == false);
+        REQUIRE(fkyaml::detail::utf8_encoding::validate({uint8_t(0xC2u), uint8_t(0x7Fu)}) == false);
+        REQUIRE(fkyaml::detail::utf8_encoding::validate({uint8_t(0xC2u), uint8_t(0x80u)}) == true);
+        REQUIRE(fkyaml::detail::utf8_encoding::validate({uint8_t(0xC3u), uint8_t(0x81u)}) == true);
+        REQUIRE(fkyaml::detail::utf8_encoding::validate({uint8_t(0xD0u), uint8_t(0xA0u)}) == true);
+        REQUIRE(fkyaml::detail::utf8_encoding::validate({uint8_t(0xDEu), uint8_t(0xBEu)}) == true);
+        REQUIRE(fkyaml::detail::utf8_encoding::validate({uint8_t(0xDFu), uint8_t(0xBFu)}) == true);
+        REQUIRE(fkyaml::detail::utf8_encoding::validate({uint8_t(0xDFu), uint8_t(0xC0u)}) == false);
+        REQUIRE(fkyaml::detail::utf8_encoding::validate({uint8_t(0xDFu), uint8_t(0xC1u)}) == false);
+        REQUIRE(fkyaml::detail::utf8_encoding::validate({uint8_t(0xE0u), uint8_t(0xBFu)}) == false);
+        REQUIRE(fkyaml::detail::utf8_encoding::validate({uint8_t(0xE1u), uint8_t(0xBFu)}) == false);
     }
 
     SECTION("3 byte characters encoded in UTF-8")
     {
-        using array_ret_pair_t = std::pair<std::array<int_type, 3>, bool>;
-        auto pair = GENERATE(
-            array_ret_pair_t({{0xDE, 0x80, 0x80}}, false),
-            array_ret_pair_t({{0xDF, 0x80, 0x80}}, false),
-            array_ret_pair_t({{0xE0, 0x7E, 0x80}}, false),
-            array_ret_pair_t({{0xE0, 0x7F, 0x80}}, false),
-            array_ret_pair_t({{0xE0, 0x80, 0x7E}}, false),
-            array_ret_pair_t({{0xE0, 0x80, 0x7F}}, false),
+        REQUIRE(fkyaml::detail::utf8_encoding::validate({uint8_t(0xDEu), uint8_t(0x80u), uint8_t(0x80u)}) == false);
+        REQUIRE(fkyaml::detail::utf8_encoding::validate({uint8_t(0xDFu), uint8_t(0x80u), uint8_t(0x80u)}) == false);
+        REQUIRE(fkyaml::detail::utf8_encoding::validate({uint8_t(0xE0u), uint8_t(0x7Eu), uint8_t(0x80u)}) == false);
+        REQUIRE(fkyaml::detail::utf8_encoding::validate({uint8_t(0xE0u), uint8_t(0x7Fu), uint8_t(0x80u)}) == false);
+        REQUIRE(fkyaml::detail::utf8_encoding::validate({uint8_t(0xE0u), uint8_t(0x80u), uint8_t(0x7Eu)}) == false);
+        REQUIRE(fkyaml::detail::utf8_encoding::validate({uint8_t(0xE0u), uint8_t(0x80u), uint8_t(0x7Fu)}) == false);
 
-            array_ret_pair_t({{0xE0, 0x80, 0x80}}, true),
-            array_ret_pair_t({{0xE6, 0xA0, 0xA0}}, true),
-            array_ret_pair_t({{0xEC, 0xBF, 0xBF}}, true),
+        REQUIRE(fkyaml::detail::utf8_encoding::validate({uint8_t(0xE0u), uint8_t(0x80u), uint8_t(0x80u)}) == true);
+        REQUIRE(fkyaml::detail::utf8_encoding::validate({uint8_t(0xE6u), uint8_t(0xA0u), uint8_t(0xA0u)}) == true);
+        REQUIRE(fkyaml::detail::utf8_encoding::validate({uint8_t(0xECu), uint8_t(0xBFu), uint8_t(0xBFu)}) == true);
 
-            array_ret_pair_t({{0xEC, 0xC0, 0xBF}}, false),
-            array_ret_pair_t({{0xEC, 0xC1, 0xBF}}, false),
-            array_ret_pair_t({{0xEC, 0xBF, 0xC0}}, false),
-            array_ret_pair_t({{0xEC, 0xBF, 0xC1}}, false),
+        REQUIRE(fkyaml::detail::utf8_encoding::validate({uint8_t(0xECu), uint8_t(0xC0u), uint8_t(0xBFu)}) == false);
+        REQUIRE(fkyaml::detail::utf8_encoding::validate({uint8_t(0xECu), uint8_t(0xC1u), uint8_t(0xBFu)}) == false);
+        REQUIRE(fkyaml::detail::utf8_encoding::validate({uint8_t(0xECu), uint8_t(0xBFu), uint8_t(0xC0u)}) == false);
+        REQUIRE(fkyaml::detail::utf8_encoding::validate({uint8_t(0xECu), uint8_t(0xBFu), uint8_t(0xC1u)}) == false);
 
-            //////////////////////////////////////////////
+        //////////////////////////////////////////////
 
-            array_ret_pair_t({{0xED, 0x7E, 0x80}}, false),
-            array_ret_pair_t({{0xED, 0x7F, 0x80}}, false),
-            array_ret_pair_t({{0xED, 0x80, 0x7E}}, false),
-            array_ret_pair_t({{0xED, 0x80, 0x7F}}, false),
+        REQUIRE(fkyaml::detail::utf8_encoding::validate({uint8_t(0xEDu), uint8_t(0x7Eu), uint8_t(0x80u)}) == false);
+        REQUIRE(fkyaml::detail::utf8_encoding::validate({uint8_t(0xEDu), uint8_t(0x7Fu), uint8_t(0x80u)}) == false);
+        REQUIRE(fkyaml::detail::utf8_encoding::validate({uint8_t(0xEDu), uint8_t(0x80u), uint8_t(0x7Eu)}) == false);
+        REQUIRE(fkyaml::detail::utf8_encoding::validate({uint8_t(0xEDu), uint8_t(0x80u), uint8_t(0x7Fu)}) == false);
 
-            array_ret_pair_t({{0xED, 0x80, 0x80}}, true),
-            array_ret_pair_t({{0xED, 0x90, 0xA0}}, true),
-            array_ret_pair_t({{0xED, 0x9F, 0xBF}}, true),
+        REQUIRE(fkyaml::detail::utf8_encoding::validate({uint8_t(0xEDu), uint8_t(0x80u), uint8_t(0x80u)}) == true);
+        REQUIRE(fkyaml::detail::utf8_encoding::validate({uint8_t(0xEDu), uint8_t(0x90u), uint8_t(0xA0u)}) == true);
+        REQUIRE(fkyaml::detail::utf8_encoding::validate({uint8_t(0xEDu), uint8_t(0x9Fu), uint8_t(0xBFu)}) == true);
 
-            array_ret_pair_t({{0xED, 0xA0, 0xBF}}, false),
-            array_ret_pair_t({{0xED, 0xA1, 0xBF}}, false),
-            array_ret_pair_t({{0xED, 0x9F, 0xC0}}, false),
-            array_ret_pair_t({{0xED, 0x9F, 0xC1}}, false),
+        REQUIRE(fkyaml::detail::utf8_encoding::validate({uint8_t(0xEDu), uint8_t(0xA0u), uint8_t(0xBFu)}) == false);
+        REQUIRE(fkyaml::detail::utf8_encoding::validate({uint8_t(0xEDu), uint8_t(0xA1u), uint8_t(0xBFu)}) == false);
+        REQUIRE(fkyaml::detail::utf8_encoding::validate({uint8_t(0xEDu), uint8_t(0x9Fu), uint8_t(0xC0u)}) == false);
+        REQUIRE(fkyaml::detail::utf8_encoding::validate({uint8_t(0xEDu), uint8_t(0x9Fu), uint8_t(0xC1u)}) == false);
 
-            //////////////////////////////////////////////
+        //////////////////////////////////////////////
 
-            array_ret_pair_t({{0xEE, 0x7E, 0x80}}, false),
-            array_ret_pair_t({{0xEE, 0x7F, 0x80}}, false),
-            array_ret_pair_t({{0xEE, 0x80, 0x7E}}, false),
-            array_ret_pair_t({{0xEE, 0x80, 0x7F}}, false),
+        REQUIRE(fkyaml::detail::utf8_encoding::validate({uint8_t(0xEEu), uint8_t(0x7Eu), uint8_t(0x80u)}) == false);
+        REQUIRE(fkyaml::detail::utf8_encoding::validate({uint8_t(0xEEu), uint8_t(0x7Fu), uint8_t(0x80u)}) == false);
+        REQUIRE(fkyaml::detail::utf8_encoding::validate({uint8_t(0xEEu), uint8_t(0x80u), uint8_t(0x7Eu)}) == false);
+        REQUIRE(fkyaml::detail::utf8_encoding::validate({uint8_t(0xEEu), uint8_t(0x80u), uint8_t(0x7Fu)}) == false);
 
-            array_ret_pair_t({{0xEE, 0x80, 0x80}}, true),
-            array_ret_pair_t({{0xEE, 0xA0, 0xA0}}, true),
-            array_ret_pair_t({{0xEF, 0xBF, 0xBF}}, true),
+        REQUIRE(fkyaml::detail::utf8_encoding::validate({uint8_t(0xEEu), uint8_t(0x80u), uint8_t(0x80u)}) == true);
+        REQUIRE(fkyaml::detail::utf8_encoding::validate({uint8_t(0xEEu), uint8_t(0xA0u), uint8_t(0xA0u)}) == true);
+        REQUIRE(fkyaml::detail::utf8_encoding::validate({uint8_t(0xEFu), uint8_t(0xBFu), uint8_t(0xBFu)}) == true);
 
-            array_ret_pair_t({{0xEF, 0xC0, 0xBF}}, false),
-            array_ret_pair_t({{0xEF, 0xC1, 0xBF}}, false),
-            array_ret_pair_t({{0xEF, 0xBF, 0xC0}}, false),
-            array_ret_pair_t({{0xEF, 0xBF, 0xC1}}, false),
-            array_ret_pair_t({{0xF0, 0xBF, 0xBF}}, false),
-            array_ret_pair_t({{0xF1, 0xBF, 0xBF}}, false));
-
-        REQUIRE(fkyaml::detail::utf8_encoding::validate(pair.first) == pair.second);
+        REQUIRE(fkyaml::detail::utf8_encoding::validate({uint8_t(0xEFu), uint8_t(0xC0u), uint8_t(0xBFu)}) == false);
+        REQUIRE(fkyaml::detail::utf8_encoding::validate({uint8_t(0xEFu), uint8_t(0xC1u), uint8_t(0xBFu)}) == false);
+        REQUIRE(fkyaml::detail::utf8_encoding::validate({uint8_t(0xEFu), uint8_t(0xBFu), uint8_t(0xC0u)}) == false);
+        REQUIRE(fkyaml::detail::utf8_encoding::validate({uint8_t(0xEFu), uint8_t(0xBFu), uint8_t(0xC1u)}) == false);
+        REQUIRE(fkyaml::detail::utf8_encoding::validate({uint8_t(0xF0u), uint8_t(0xBFu), uint8_t(0xBFu)}) == false);
+        REQUIRE(fkyaml::detail::utf8_encoding::validate({uint8_t(0xF1u), uint8_t(0xBFu), uint8_t(0xBFu)}) == false);
     }
 
     SECTION("4 byte characters encoded in UTF-8")
     {
-        using array_ret_pair_t = std::pair<std::array<int_type, 4>, bool>;
-        auto pair = GENERATE(
-            array_ret_pair_t({{0xDE, 0x90, 0x80, 0x80}}, false),
-            array_ret_pair_t({{0xDF, 0x90, 0x80, 0x80}}, false),
-            array_ret_pair_t({{0xE0, 0x8E, 0x80, 0x80}}, false),
-            array_ret_pair_t({{0xE0, 0x8F, 0x80, 0x80}}, false),
-            array_ret_pair_t({{0xE0, 0x90, 0x7E, 0x80}}, false),
-            array_ret_pair_t({{0xE0, 0x90, 0x7F, 0x80}}, false),
-            array_ret_pair_t({{0xE0, 0x90, 0x80, 0x7E}}, false),
-            array_ret_pair_t({{0xE0, 0x90, 0x80, 0x7F}}, false),
+        REQUIRE(
+            fkyaml::detail::utf8_encoding::validate({uint8_t(0xDEu), uint8_t(0x90u), uint8_t(0x80u), uint8_t(0x80u)}) ==
+            false);
+        REQUIRE(
+            fkyaml::detail::utf8_encoding::validate({uint8_t(0xDFu), uint8_t(0x90u), uint8_t(0x80u), uint8_t(0x80u)}) ==
+            false);
+        REQUIRE(
+            fkyaml::detail::utf8_encoding::validate({uint8_t(0xE0u), uint8_t(0x8Eu), uint8_t(0x80u), uint8_t(0x80u)}) ==
+            false);
+        REQUIRE(
+            fkyaml::detail::utf8_encoding::validate({uint8_t(0xE0u), uint8_t(0x8Fu), uint8_t(0x80u), uint8_t(0x80u)}) ==
+            false);
+        REQUIRE(
+            fkyaml::detail::utf8_encoding::validate({uint8_t(0xE0u), uint8_t(0x90u), uint8_t(0x7Eu), uint8_t(0x80u)}) ==
+            false);
+        REQUIRE(
+            fkyaml::detail::utf8_encoding::validate({uint8_t(0xE0u), uint8_t(0x90u), uint8_t(0x7Fu), uint8_t(0x80u)}) ==
+            false);
+        REQUIRE(
+            fkyaml::detail::utf8_encoding::validate({uint8_t(0xE0u), uint8_t(0x90u), uint8_t(0x80u), uint8_t(0x7Eu)}) ==
+            false);
+        REQUIRE(
+            fkyaml::detail::utf8_encoding::validate({uint8_t(0xE0u), uint8_t(0x90u), uint8_t(0x80u), uint8_t(0x7Fu)}) ==
+            false);
 
-            array_ret_pair_t({{0xF0, 0x90, 0x80, 0x80}}, true),
-            array_ret_pair_t({{0xF0, 0xA8, 0xA0, 0xA0}}, true),
-            array_ret_pair_t({{0xF0, 0xBF, 0xBF, 0xBF}}, true),
+        REQUIRE(
+            fkyaml::detail::utf8_encoding::validate({uint8_t(0xF0u), uint8_t(0x90u), uint8_t(0x80u), uint8_t(0x80u)}) ==
+            true);
+        REQUIRE(
+            fkyaml::detail::utf8_encoding::validate({uint8_t(0xF0u), uint8_t(0xA8u), uint8_t(0xA0u), uint8_t(0xA0u)}) ==
+            true);
+        REQUIRE(
+            fkyaml::detail::utf8_encoding::validate({uint8_t(0xF0u), uint8_t(0xBFu), uint8_t(0xBFu), uint8_t(0xBFu)}) ==
+            true);
 
-            array_ret_pair_t({{0xF0, 0xC0, 0xBF, 0xBF}}, false),
-            array_ret_pair_t({{0xF0, 0xC1, 0xBF, 0xBF}}, false),
-            array_ret_pair_t({{0xF0, 0xBF, 0xC0, 0xBF}}, false),
-            array_ret_pair_t({{0xF0, 0xBF, 0xC1, 0xBF}}, false),
-            array_ret_pair_t({{0xF0, 0xBF, 0xBF, 0xC0}}, false),
-            array_ret_pair_t({{0xF0, 0xBF, 0xBF, 0xC1}}, false),
+        REQUIRE(
+            fkyaml::detail::utf8_encoding::validate({uint8_t(0xF0u), uint8_t(0xC0u), uint8_t(0xBFu), uint8_t(0xBFu)}) ==
+            false);
+        REQUIRE(
+            fkyaml::detail::utf8_encoding::validate({uint8_t(0xF0u), uint8_t(0xC1u), uint8_t(0xBFu), uint8_t(0xBFu)}) ==
+            false);
+        REQUIRE(
+            fkyaml::detail::utf8_encoding::validate({uint8_t(0xF0u), uint8_t(0xBFu), uint8_t(0xC0u), uint8_t(0xBFu)}) ==
+            false);
+        REQUIRE(
+            fkyaml::detail::utf8_encoding::validate({uint8_t(0xF0u), uint8_t(0xBFu), uint8_t(0xC1u), uint8_t(0xBFu)}) ==
+            false);
+        REQUIRE(
+            fkyaml::detail::utf8_encoding::validate({uint8_t(0xF0u), uint8_t(0xBFu), uint8_t(0xBFu), uint8_t(0xC0u)}) ==
+            false);
+        REQUIRE(
+            fkyaml::detail::utf8_encoding::validate({uint8_t(0xF0u), uint8_t(0xBFu), uint8_t(0xBFu), uint8_t(0xC1u)}) ==
+            false);
 
-            ////////////////////////////////////////////////////
+        ////////////////////////////////////////////////////
 
-            array_ret_pair_t({{0xF1, 0x7E, 0x80, 0x80}}, false),
-            array_ret_pair_t({{0xF1, 0x7F, 0x80, 0x80}}, false),
-            array_ret_pair_t({{0xF1, 0x80, 0x7E, 0x80}}, false),
-            array_ret_pair_t({{0xF1, 0x80, 0x7F, 0x80}}, false),
-            array_ret_pair_t({{0xF1, 0x80, 0x80, 0x7E}}, false),
-            array_ret_pair_t({{0xF1, 0x80, 0x80, 0x7F}}, false),
+        REQUIRE(
+            fkyaml::detail::utf8_encoding::validate({uint8_t(0xF1u), uint8_t(0x7Eu), uint8_t(0x80u), uint8_t(0x80u)}) ==
+            false);
+        REQUIRE(
+            fkyaml::detail::utf8_encoding::validate({uint8_t(0xF1u), uint8_t(0x7Fu), uint8_t(0x80u), uint8_t(0x80u)}) ==
+            false);
+        REQUIRE(
+            fkyaml::detail::utf8_encoding::validate({uint8_t(0xF1u), uint8_t(0x80u), uint8_t(0x7Eu), uint8_t(0x80u)}) ==
+            false);
+        REQUIRE(
+            fkyaml::detail::utf8_encoding::validate({uint8_t(0xF1u), uint8_t(0x80u), uint8_t(0x7Fu), uint8_t(0x80u)}) ==
+            false);
+        REQUIRE(
+            fkyaml::detail::utf8_encoding::validate({uint8_t(0xF1u), uint8_t(0x80u), uint8_t(0x80u), uint8_t(0x7Eu)}) ==
+            false);
+        REQUIRE(
+            fkyaml::detail::utf8_encoding::validate({uint8_t(0xF1u), uint8_t(0x80u), uint8_t(0x80u), uint8_t(0x7Fu)}) ==
+            false);
 
-            array_ret_pair_t({{0xF1, 0x80, 0x80, 0x80}}, true),
-            array_ret_pair_t({{0xF2, 0xA0, 0xA0, 0xA0}}, true),
-            array_ret_pair_t({{0xF3, 0xBF, 0xBF, 0xBF}}, true),
+        REQUIRE(
+            fkyaml::detail::utf8_encoding::validate({uint8_t(0xF1u), uint8_t(0x80u), uint8_t(0x80u), uint8_t(0x80u)}) ==
+            true);
+        REQUIRE(
+            fkyaml::detail::utf8_encoding::validate({uint8_t(0xF2u), uint8_t(0xA0u), uint8_t(0xA0u), uint8_t(0xA0u)}) ==
+            true);
+        REQUIRE(
+            fkyaml::detail::utf8_encoding::validate({uint8_t(0xF3u), uint8_t(0xBFu), uint8_t(0xBFu), uint8_t(0xBFu)}) ==
+            true);
 
-            array_ret_pair_t({{0xF3, 0xC0, 0xBF, 0xBF}}, false),
-            array_ret_pair_t({{0xF3, 0xC1, 0xBF, 0xBF}}, false),
-            array_ret_pair_t({{0xF3, 0xBF, 0xC0, 0xBF}}, false),
-            array_ret_pair_t({{0xF3, 0xBF, 0xC1, 0xBF}}, false),
-            array_ret_pair_t({{0xF3, 0xBF, 0xBF, 0xC0}}, false),
-            array_ret_pair_t({{0xF3, 0xBF, 0xBF, 0xC1}}, false),
+        REQUIRE(
+            fkyaml::detail::utf8_encoding::validate({uint8_t(0xF3u), uint8_t(0xC0u), uint8_t(0xBFu), uint8_t(0xBFu)}) ==
+            false);
+        REQUIRE(
+            fkyaml::detail::utf8_encoding::validate({uint8_t(0xF3u), uint8_t(0xC1u), uint8_t(0xBFu), uint8_t(0xBFu)}) ==
+            false);
+        REQUIRE(
+            fkyaml::detail::utf8_encoding::validate({uint8_t(0xF3u), uint8_t(0xBFu), uint8_t(0xC0u), uint8_t(0xBFu)}) ==
+            false);
+        REQUIRE(
+            fkyaml::detail::utf8_encoding::validate({uint8_t(0xF3u), uint8_t(0xBFu), uint8_t(0xC1u), uint8_t(0xBFu)}) ==
+            false);
+        REQUIRE(
+            fkyaml::detail::utf8_encoding::validate({uint8_t(0xF3u), uint8_t(0xBFu), uint8_t(0xBFu), uint8_t(0xC0u)}) ==
+            false);
+        REQUIRE(
+            fkyaml::detail::utf8_encoding::validate({uint8_t(0xF3u), uint8_t(0xBFu), uint8_t(0xBFu), uint8_t(0xC1u)}) ==
+            false);
 
-            ////////////////////////////////////////////////////
+        ////////////////////////////////////////////////////
 
-            array_ret_pair_t({{0xF4, 0x7E, 0x80, 0x80}}, false),
-            array_ret_pair_t({{0xF4, 0x7F, 0x80, 0x80}}, false),
-            array_ret_pair_t({{0xF4, 0x80, 0x7E, 0x80}}, false),
-            array_ret_pair_t({{0xF4, 0x80, 0x7F, 0x80}}, false),
-            array_ret_pair_t({{0xF4, 0x80, 0x80, 0x7E}}, false),
-            array_ret_pair_t({{0xF4, 0x80, 0x80, 0x7F}}, false),
+        REQUIRE(
+            fkyaml::detail::utf8_encoding::validate({uint8_t(0xF4u), uint8_t(0x7Eu), uint8_t(0x80u), uint8_t(0x80u)}) ==
+            false);
+        REQUIRE(
+            fkyaml::detail::utf8_encoding::validate({uint8_t(0xF4u), uint8_t(0x7Fu), uint8_t(0x80u), uint8_t(0x80u)}) ==
+            false);
+        REQUIRE(
+            fkyaml::detail::utf8_encoding::validate({uint8_t(0xF4u), uint8_t(0x80u), uint8_t(0x7Eu), uint8_t(0x80u)}) ==
+            false);
+        REQUIRE(
+            fkyaml::detail::utf8_encoding::validate({uint8_t(0xF4u), uint8_t(0x80u), uint8_t(0x7Fu), uint8_t(0x80u)}) ==
+            false);
+        REQUIRE(
+            fkyaml::detail::utf8_encoding::validate({uint8_t(0xF4u), uint8_t(0x80u), uint8_t(0x80u), uint8_t(0x7Eu)}) ==
+            false);
+        REQUIRE(
+            fkyaml::detail::utf8_encoding::validate({uint8_t(0xF4u), uint8_t(0x80u), uint8_t(0x80u), uint8_t(0x7Fu)}) ==
+            false);
 
-            array_ret_pair_t({{0xF4, 0x80, 0x80, 0x80}}, true),
-            array_ret_pair_t({{0xF4, 0x88, 0xA0, 0x80}}, true),
-            array_ret_pair_t({{0xF4, 0x8F, 0xBF, 0xBF}}, true),
+        REQUIRE(
+            fkyaml::detail::utf8_encoding::validate({uint8_t(0xF4u), uint8_t(0x80u), uint8_t(0x80u), uint8_t(0x80u)}) ==
+            true);
+        REQUIRE(
+            fkyaml::detail::utf8_encoding::validate({uint8_t(0xF4u), uint8_t(0x88u), uint8_t(0xA0u), uint8_t(0x80u)}) ==
+            true);
+        REQUIRE(
+            fkyaml::detail::utf8_encoding::validate({uint8_t(0xF4u), uint8_t(0x8Fu), uint8_t(0xBFu), uint8_t(0xBFu)}) ==
+            true);
 
-            array_ret_pair_t({{0xF4, 0x90, 0xBF, 0xBF}}, false),
-            array_ret_pair_t({{0xF4, 0x91, 0xBF, 0xBF}}, false),
-            array_ret_pair_t({{0xF4, 0x8F, 0xC0, 0xBF}}, false),
-            array_ret_pair_t({{0xF4, 0x8F, 0xC1, 0xBF}}, false),
-            array_ret_pair_t({{0xF4, 0x8F, 0xBF, 0xC0}}, false),
-            array_ret_pair_t({{0xF4, 0x8F, 0xBF, 0xC1}}, false),
-            array_ret_pair_t({{0xF5, 0x8F, 0xBF, 0xBF}}, false),
-            array_ret_pair_t({{0xF6, 0x8F, 0xBF, 0xBF}}, false));
-
-        REQUIRE(fkyaml::detail::utf8_encoding::validate(pair.first) == pair.second);
+        REQUIRE(
+            fkyaml::detail::utf8_encoding::validate({uint8_t(0xF4u), uint8_t(0x90u), uint8_t(0xBFu), uint8_t(0xBFu)}) ==
+            false);
+        REQUIRE(
+            fkyaml::detail::utf8_encoding::validate({uint8_t(0xF4u), uint8_t(0x91u), uint8_t(0xBFu), uint8_t(0xBFu)}) ==
+            false);
+        REQUIRE(
+            fkyaml::detail::utf8_encoding::validate({uint8_t(0xF4u), uint8_t(0x8Fu), uint8_t(0xC0u), uint8_t(0xBFu)}) ==
+            false);
+        REQUIRE(
+            fkyaml::detail::utf8_encoding::validate({uint8_t(0xF4u), uint8_t(0x8Fu), uint8_t(0xC1u), uint8_t(0xBFu)}) ==
+            false);
+        REQUIRE(
+            fkyaml::detail::utf8_encoding::validate({uint8_t(0xF4u), uint8_t(0x8Fu), uint8_t(0xBFu), uint8_t(0xC0u)}) ==
+            false);
+        REQUIRE(
+            fkyaml::detail::utf8_encoding::validate({uint8_t(0xF4u), uint8_t(0x8Fu), uint8_t(0xBFu), uint8_t(0xC1u)}) ==
+            false);
+        REQUIRE(
+            fkyaml::detail::utf8_encoding::validate({uint8_t(0xF5u), uint8_t(0x8Fu), uint8_t(0xBFu), uint8_t(0xBFu)}) ==
+            false);
+        REQUIRE(
+            fkyaml::detail::utf8_encoding::validate({uint8_t(0xF6u), uint8_t(0x8Fu), uint8_t(0xBFu), uint8_t(0xBFu)}) ==
+            false);
     }
 }
 

--- a/test/unit_test/test_utf8_encoding_class.cpp
+++ b/test/unit_test/test_utf8_encoding_class.cpp
@@ -14,6 +14,33 @@
 
 #include <fkYAML/node.hpp>
 
+TEST_CASE("UTF8Encoding_GetNumBytes")
+{
+    SECTION("valid bytes")
+    {
+        using test_value_pair_t = std::pair<uint8_t, uint32_t>;
+        auto pair = GENERATE(
+            test_value_pair_t(0u, 1),
+            test_value_pair_t(0x7Fu, 1),
+            test_value_pair_t(0xC0u, 2),
+            test_value_pair_t(0xC1u, 2),
+            test_value_pair_t(0xDFu, 2),
+            test_value_pair_t(0xE0u, 3),
+            test_value_pair_t(0xE1u, 3),
+            test_value_pair_t(0xEFu, 3),
+            test_value_pair_t(0xF0u, 4),
+            test_value_pair_t(0xF1u, 4));
+
+        REQUIRE(fkyaml::detail::utf8_encoding::get_num_bytes(pair.first) == pair.second);
+    }
+
+    SECTION("invalid bytes")
+    {
+        uint8_t byte = GENERATE(uint8_t(0x80u), uint8_t(0xF8u));
+        REQUIRE_THROWS_AS(fkyaml::detail::utf8_encoding::get_num_bytes(byte), fkyaml::invalid_encoding);
+    }
+}
+
 TEST_CASE("UTF8Encoding_Validate")
 {
     using int_type = std::char_traits<char>::int_type;

--- a/tool/clang_format/run_clang_format.sh
+++ b/tool/clang_format/run_clang_format.sh
@@ -4,7 +4,7 @@ CALLER_DIR=$(pwd)
 ROOT_DIR=$(cd "$(dirname "$0")" && cd ../.. && pwd)
 
 # move to the directory where this script is placed.
-cd test/clang_format
+cd tool/clang_format
 
 # install the clang-format package if not installed yet.
 if [ ! -e ./venv/bin/clang-format ]; then


### PR DESCRIPTION
Before this PR, not only `utf8_encoding` class but also `lexical_analyzer` and `input_adapter` types knows too much of the concrete UTF-8 encoding format so those classes can get the actual number of bytes for a target UTF-8 character.  
So, this PR has added the feature with which the actual number of bytes can be aquired from the first byte of a target UTF-8 character.  

Also, `invalid_encoding` exception class constructor requires a `std::array<int, N>` parameter and the instanciation consts unnecessarily.  
To fix that, the constructor now receives a `std::initializer_list<uint8_t>` parameter.  

---

## Pull Request Checklist

Read the [CONTRIBUTING.md](https://github.com/fktn-k/fkYAML/blob/develop/CONTRIBUTING.md) file for detailed information.  

- [x] Changes are described in the pull request or in a referenced [issue](https://github.com/fktn-k/fkYAML/issues).
- [x] The test suite compiles and runs without any error.
- [x] [The code coverage](https://coveralls.io/github/fktn-k/fkYAML) on your branch is 100%.
- [x] The documentation is updated if you added/changed a feature.

## Please don't

- The C++11 support varies between different **compilers** and versions. Please note the [list of supported compilers](https://github.com/fktn-k/fkYAML/blob/develop/README.md#supported-compilers). Some compilers like GCC 4.7 (and earlier), Clang 3.3 (and earlier), or Microsoft Visual Studio 13.0 and earlier are known not to work due to missing or incomplete C++11 support. Please refrain from proposing changes that work around these compiler's limitations with `#ifdef`s or other means.
- Please refrain from proposing changes that would **break [YAML](https://yaml.org/) specifications**. If you propose a conformant extension of YAML to be supported by the library, please motivate this extension.
- Please do not open pull requests that address **multiple issues**.
