### PR TITLE
Fix parse error on the first node which isn't a block mapping

### DIFF
--- a/include/fkYAML/detail/input/deserializer.hpp
+++ b/include/fkYAML/detail/input/deserializer.hpp
@@ -85,6 +85,16 @@ public:
         // parse directives first.
         deserialize_directives(lexer, root, type);
 
+        switch (type) {
+        case lexical_token_t::SEQUENCE_BLOCK_PREFIX:
+        case lexical_token_t::SEQUENCE_FLOW_BEGIN:
+            root = node_type::sequence();
+            apply_directive_set(root);
+            break;
+        default:
+            break;
+        }
+
         // parse YAML nodes recursively
         deserialize_node(lexer, type);
 
@@ -359,6 +369,7 @@ private:
                 continue;
             }
             case lexical_token_t::VALUE_SEPARATOR:
+                FK_YAML_ASSERT(m_flow_context_depth > 0);
                 break;
             // just ignore directives
             case lexical_token_t::YAML_VER_DIRECTIVE:
@@ -417,23 +428,32 @@ private:
                 apply_directive_set(*mp_current_node);
                 apply_node_properties(*mp_current_node);
                 break;
-            case lexical_token_t::SEQUENCE_FLOW_END:
+            case lexical_token_t::SEQUENCE_FLOW_END: {
                 FK_YAML_ASSERT(m_flow_context_depth > 0);
                 --m_flow_context_depth;
-                mp_current_node = m_node_stack.back();
-                m_node_stack.pop_back();
+                bool is_stack_empty = m_node_stack.empty();
+                if (!is_stack_empty) {
+                    mp_current_node = m_node_stack.back();
+                    m_node_stack.pop_back();
+                }
                 break;
+            }
             case lexical_token_t::MAPPING_FLOW_BEGIN:
                 ++m_flow_context_depth;
                 *mp_current_node = node_type::mapping();
                 apply_directive_set(*mp_current_node);
                 apply_node_properties(*mp_current_node);
                 break;
-            case lexical_token_t::MAPPING_FLOW_END:
+            case lexical_token_t::MAPPING_FLOW_END: {
                 FK_YAML_ASSERT(m_flow_context_depth > 0);
                 --m_flow_context_depth;
-                mp_current_node = m_node_stack.back();
+                bool is_stack_empty = m_node_stack.empty();
+                if (!is_stack_empty) {
+                    mp_current_node = m_node_stack.back();
+                    m_node_stack.pop_back();
+                }
                 break;
+            }
             case lexical_token_t::ALIAS_PREFIX:
             case lexical_token_t::NULL_VALUE:
             case lexical_token_t::BOOLEAN_VALUE:
@@ -453,9 +473,8 @@ private:
                 break;
             }
 
-            lexical_token_t prev_type = type;
             type = lexer.get_next_token();
-            indent = (prev_type == lexical_token_t::ANCHOR_PREFIX) ? indent : lexer.get_last_token_begin_pos();
+            indent = lexer.get_last_token_begin_pos();
             line = lexer.get_lines_processed();
         } while (type != lexical_token_t::END_OF_BUFFER);
     }
@@ -568,7 +587,9 @@ private:
         mapping_type& map = mp_current_node->template get_value_ref<mapping_type&>();
         bool is_empty = map.empty();
         if (is_empty) {
-            m_indent_stack.emplace_back(line, indent, false);
+            if (m_flow_context_depth == 0) {
+                m_indent_stack.emplace_back(line, indent, false);
+            }
         }
         else {
             // check key duplication in the current mapping if not empty.
@@ -593,7 +614,7 @@ private:
 
         // a scalar node
         *mp_current_node = std::move(node_value);
-        if (!m_indent_stack.back().is_explicit_key) {
+        if (m_flow_context_depth > 0 || !m_indent_stack.back().is_explicit_key) {
             mp_current_node = m_node_stack.back();
             m_node_stack.pop_back();
         }

--- a/include/fkYAML/detail/input/deserializer.hpp
+++ b/include/fkYAML/detail/input/deserializer.hpp
@@ -404,11 +404,6 @@ private:
                     break;
                 }
 
-                // if the current node is a mapping.
-                if (m_node_stack.empty()) {
-                    throw parse_error("Invalid sequence block prefix(- ) found.", line, indent);
-                }
-
                 // move back to the previous sequence if necessary.
                 while (!mp_current_node->is_sequence() || indent != m_indent_stack.back().indent) {
                     mp_current_node = m_node_stack.back();

--- a/single_include/fkYAML/node.hpp
+++ b/single_include/fkYAML/node.hpp
@@ -4295,11 +4295,6 @@ private:
                     break;
                 }
 
-                // if the current node is a mapping.
-                if (m_node_stack.empty()) {
-                    throw parse_error("Invalid sequence block prefix(- ) found.", line, indent);
-                }
-
                 // move back to the previous sequence if necessary.
                 while (!mp_current_node->is_sequence() || indent != m_indent_stack.back().indent) {
                     mp_current_node = m_node_stack.back();

--- a/single_include/fkYAML/node.hpp
+++ b/single_include/fkYAML/node.hpp
@@ -3976,6 +3976,16 @@ public:
         // parse directives first.
         deserialize_directives(lexer, root, type);
 
+        switch (type) {
+        case lexical_token_t::SEQUENCE_BLOCK_PREFIX:
+        case lexical_token_t::SEQUENCE_FLOW_BEGIN:
+            root = node_type::sequence();
+            apply_directive_set(root);
+            break;
+        default:
+            break;
+        }
+
         // parse YAML nodes recursively
         deserialize_node(lexer, type);
 
@@ -4250,6 +4260,7 @@ private:
                 continue;
             }
             case lexical_token_t::VALUE_SEPARATOR:
+                FK_YAML_ASSERT(m_flow_context_depth > 0);
                 break;
             // just ignore directives
             case lexical_token_t::YAML_VER_DIRECTIVE:
@@ -4308,23 +4319,32 @@ private:
                 apply_directive_set(*mp_current_node);
                 apply_node_properties(*mp_current_node);
                 break;
-            case lexical_token_t::SEQUENCE_FLOW_END:
+            case lexical_token_t::SEQUENCE_FLOW_END: {
                 FK_YAML_ASSERT(m_flow_context_depth > 0);
                 --m_flow_context_depth;
-                mp_current_node = m_node_stack.back();
-                m_node_stack.pop_back();
+                bool is_stack_empty = m_node_stack.empty();
+                if (!is_stack_empty) {
+                    mp_current_node = m_node_stack.back();
+                    m_node_stack.pop_back();
+                }
                 break;
+            }
             case lexical_token_t::MAPPING_FLOW_BEGIN:
                 ++m_flow_context_depth;
                 *mp_current_node = node_type::mapping();
                 apply_directive_set(*mp_current_node);
                 apply_node_properties(*mp_current_node);
                 break;
-            case lexical_token_t::MAPPING_FLOW_END:
+            case lexical_token_t::MAPPING_FLOW_END: {
                 FK_YAML_ASSERT(m_flow_context_depth > 0);
                 --m_flow_context_depth;
-                mp_current_node = m_node_stack.back();
+                bool is_stack_empty = m_node_stack.empty();
+                if (!is_stack_empty) {
+                    mp_current_node = m_node_stack.back();
+                    m_node_stack.pop_back();
+                }
                 break;
+            }
             case lexical_token_t::ALIAS_PREFIX:
             case lexical_token_t::NULL_VALUE:
             case lexical_token_t::BOOLEAN_VALUE:
@@ -4344,9 +4364,8 @@ private:
                 break;
             }
 
-            lexical_token_t prev_type = type;
             type = lexer.get_next_token();
-            indent = (prev_type == lexical_token_t::ANCHOR_PREFIX) ? indent : lexer.get_last_token_begin_pos();
+            indent = lexer.get_last_token_begin_pos();
             line = lexer.get_lines_processed();
         } while (type != lexical_token_t::END_OF_BUFFER);
     }
@@ -4459,7 +4478,9 @@ private:
         mapping_type& map = mp_current_node->template get_value_ref<mapping_type&>();
         bool is_empty = map.empty();
         if (is_empty) {
-            m_indent_stack.emplace_back(line, indent, false);
+            if (m_flow_context_depth == 0) {
+                m_indent_stack.emplace_back(line, indent, false);
+            }
         }
         else {
             // check key duplication in the current mapping if not empty.
@@ -4484,7 +4505,7 @@ private:
 
         // a scalar node
         *mp_current_node = std::move(node_value);
-        if (!m_indent_stack.back().is_explicit_key) {
+        if (m_flow_context_depth > 0 || !m_indent_stack.back().is_explicit_key) {
             mp_current_node = m_node_stack.back();
             m_node_stack.pop_back();
         }

--- a/test/unit_test/test_deserializer_class.cpp
+++ b/test/unit_test/test_deserializer_class.cpp
@@ -287,6 +287,22 @@ TEST_CASE("Deserializer_BlockSequence") {
         REQUIRE(root["foo"][0].is_string());
         REQUIRE(root["foo"][0].get_value_ref<std::string&>() == "bar");
     }
+
+    SECTION("root sequence") {
+        REQUIRE_NOTHROW(root = deserializer.deserialize(fkyaml::detail::input_adapter("- foo\n- 123\n- 3.14")));
+
+        REQUIRE(root.is_sequence());
+        REQUIRE(root.size() == 3);
+
+        REQUIRE(root[0].is_string());
+        REQUIRE(root[0].get_value_ref<std::string&>() == "foo");
+
+        REQUIRE(root[1].is_integer());
+        REQUIRE(root[1].get_value<int>() == 123);
+
+        REQUIRE(root[2].is_float_number());
+        REQUIRE(root[2].get_value<double>() == 3.14);
+    }
 }
 
 TEST_CASE("Deserializer_BlockMapping") {
@@ -788,6 +804,21 @@ TEST_CASE("Deserializer_FlowSequence") {
     SECTION("lack the beginning of a flow sequence") {
         REQUIRE_THROWS_AS(deserializer.deserialize(fkyaml::detail::input_adapter("test: ]")), fkyaml::parse_error);
     }
+
+    SECTION("root flow sequence") {
+        REQUIRE_NOTHROW(root = deserializer.deserialize(fkyaml::detail::input_adapter("[foo,123,3.14]")));
+        REQUIRE(root.is_sequence());
+        REQUIRE(root.size() == 3);
+
+        REQUIRE(root[0].is_string());
+        REQUIRE(root[0].get_value_ref<std::string&>() == "foo");
+
+        REQUIRE(root[1].is_integer());
+        REQUIRE(root[1].get_value<int>() == 123);
+
+        REQUIRE(root[2].is_float_number());
+        REQUIRE(root[2].get_value<double>() == 3.14);
+    }
 }
 
 TEST_CASE("Deserializer_FlowMapping") {
@@ -879,6 +910,21 @@ TEST_CASE("Deserializer_FlowMapping") {
 
         REQUIRE(test_foo_node[1].is_integer());
         REQUIRE(test_foo_node[1].get_value<int>() == 123);
+    }
+
+    SECTION("root flow mapping") {
+        REQUIRE_NOTHROW(root = deserializer.deserialize(fkyaml::detail::input_adapter("{foo: 123, true: 3.14}")));
+
+        REQUIRE(root.is_mapping());
+        REQUIRE(root.size() == 2);
+        REQUIRE(root.contains("foo"));
+        REQUIRE(root.contains(true));
+
+        REQUIRE(root["foo"].is_integer());
+        REQUIRE(root["foo"].get_value<int>() == 123);
+
+        REQUIRE(root[true].is_float_number());
+        REQUIRE(root[true].get_value<double>() == 3.14);
     }
 }
 


### PR DESCRIPTION
fkYAML in the latest develop branch emits a parse error when an input buffer starts with a node which is not a block mapping, like the following valid YAML snippets:  
(block sequence)
```yaml
- 123
- foo
- 3.14
```

(flow sequence)  
```yaml
[123, foo, 3.14]
```

(flow mapping)  
```yaml
{foo: 123, true: 3.14}
```

So, this PR has fixed the error and added some test cases to validate the changes.  

---

## Pull Request Checklist

Read the [CONTRIBUTING.md](https://github.com/fktn-k/fkYAML/blob/develop/CONTRIBUTING.md) file for detailed information.  

- [ ] Changes are described in the pull request or in a referenced [issue](https://github.com/fktn-k/fkYAML/issues).
- [ ] The test suite compiles and runs without any error.
- [ ] [The code coverage](https://coveralls.io/github/fktn-k/fkYAML) on your branch is 100%.
- [ ] The documentation is updated if you added/changed a feature.

## Please don't

- The C++11 support varies between different **compilers** and versions. Please note the [list of supported compilers](https://github.com/fktn-k/fkYAML/blob/develop/README.md#supported-compilers). Some compilers like GCC 4.7 (and earlier), Clang 3.3 (and earlier), or Microsoft Visual Studio 13.0 and earlier are known not to work due to missing or incomplete C++11 support. Please refrain from proposing changes that work around these compiler's limitations with `#ifdef`s or other means.
- Please refrain from proposing changes that would **break [YAML](https://yaml.org/) specifications**. If you propose a conformant extension of YAML to be supported by the library, please motivate this extension.
- Please do not open pull requests that address **multiple issues**.
