### PR TITLE
Add workflows items to test Win32 builds

### DIFF
--- a/.github/workflows/windows.yml
+++ b/.github/workflows/windows.yml
@@ -35,8 +35,9 @@ jobs:
     runs-on: windows-2019
     strategy:
       matrix:
+        arch: [ Win32, x64 ]
         build_type: [ Debug, Release ]
-        single_header: ["ON", "OFF"]
+        single_header: [ "ON", "OFF" ]
 
     steps:
     - uses: actions/checkout@v4
@@ -44,7 +45,7 @@ jobs:
         submodules: recursive
 
     - name: Configure CMake
-      run: cmake -B ${{github.workspace}}/build -G "Visual Studio 16 2019" -A x64 -DFK_YAML_BUILD_TEST=ON -DFK_YAML_USE_SINGLE_HEADER=${{matrix.single_header}}
+      run: cmake -B ${{github.workspace}}/build -G "Visual Studio 16 2019" -A ${{matrix.arch}} -DFK_YAML_BUILD_TEST=ON -DFK_YAML_USE_SINGLE_HEADER=${{matrix.single_header}}
 
     - name: Build
       run: cmake --build ${{github.workspace}}/build --config ${{matrix.build_type}} -j ${{env.JOBS}}
@@ -58,8 +59,9 @@ jobs:
     runs-on: windows-latest
     strategy:
       matrix:
+        arch: [ Win32, x64 ]
         build_type: [ Debug, Release ]
-        single_header: ["ON", "OFF"]
+        single_header: [ "ON", "OFF" ]
 
     steps:
     - uses: actions/checkout@v4
@@ -67,7 +69,7 @@ jobs:
         submodules: recursive
 
     - name: Configure CMake
-      run: cmake -B ${{github.workspace}}/build -G "Visual Studio 17 2022" -A x64 -DFK_YAML_BUILD_TEST=ON -DFK_YAML_USE_SINGLE_HEADER=${{matrix.single_header}}
+      run: cmake -B ${{github.workspace}}/build -G "Visual Studio 17 2022" -A ${{matrix.arch}} -DFK_YAML_BUILD_TEST=ON -DFK_YAML_USE_SINGLE_HEADER=${{matrix.single_header}}
 
     - name: Build
       run: cmake --build ${{github.workspace}}/build --config ${{matrix.build_type}} -j ${{env.JOBS}}

--- a/include/fkYAML/detail/input/input_adapter.hpp
+++ b/include/fkYAML/detail/input/input_adapter.hpp
@@ -656,7 +656,7 @@ private:
         char tmp_buf[256] {};
         do {
             m_istream->read(&tmp_buf[0], 256);
-            std::size_t read_size = m_istream->gcount();
+            std::size_t read_size = static_cast<std::size_t>(m_istream->gcount());
             buffer.append(tmp_buf, read_size);
         } while (!m_istream->eof());
 

--- a/single_include/fkYAML/node.hpp
+++ b/single_include/fkYAML/node.hpp
@@ -5638,7 +5638,7 @@ private:
         char tmp_buf[256] {};
         do {
             m_istream->read(&tmp_buf[0], 256);
-            std::size_t read_size = m_istream->gcount();
+            std::size_t read_size = static_cast<std::size_t>(m_istream->gcount());
             buffer.append(tmp_buf, read_size);
         } while (!m_istream->eof());
 


### PR DESCRIPTION
This PR has added workflow items to test Win32 builds.  
Also, a warning due to implicit casting from signed to unsigned was found while making the change, and it has also been resolved.  

---

## Pull Request Checklist

Read the [CONTRIBUTING.md](https://github.com/fktn-k/fkYAML/blob/develop/CONTRIBUTING.md) file for detailed information.  

- [x] Changes are described in the pull request or in a referenced [issue](https://github.com/fktn-k/fkYAML/issues).
- [x] The test suite compiles and runs without any error.
- [x] [The code coverage](https://coveralls.io/github/fktn-k/fkYAML) on your branch is 100%.
- [x] The documentation is updated if you added/changed a feature.

## Please don't

- The C++11 support varies between different **compilers** and versions. Please note the [list of supported compilers](https://github.com/fktn-k/fkYAML/blob/develop/README.md#supported-compilers). Some compilers like GCC 4.7 (and earlier), Clang 3.3 (and earlier), or Microsoft Visual Studio 13.0 and earlier are known not to work due to missing or incomplete C++11 support. Please refrain from proposing changes that work around these compiler's limitations with `#ifdef`s or other means.
- Please refrain from proposing changes that would **break [YAML](https://yaml.org/) specifications**. If you propose a conformant extension of YAML to be supported by the library, please motivate this extension.
- Please do not open pull requests that address **multiple issues**.
