### PR TITLE
Force LF newline codes in the amalgamated file

### DIFF
--- a/tool/amalgamation/CHANGES.md
+++ b/tool/amalgamation/CHANGES.md
@@ -5,3 +5,4 @@ The following changes have been made to the code with respect to <https://github
     * removed unused import `sys`
     * removed unused local variable `actual_path` in the generate() method of class Amalgamation
     * fixed issues which are against the style conventions in PEP 8
+* Forced newline codes in the amalgamated file to be LF to avoid huge diff (LF->CRLF) after running amalgamation on Windows.

--- a/tool/amalgamation/amalgamate.py
+++ b/tool/amalgamation/amalgamate.py
@@ -91,7 +91,9 @@ class Amalgamation(object):
 			t = TranslationUnit(file_path, self, True)
 			amalgamation += t.content
 
-		with open(self.target, 'w') as f:
+		# Force newline codes to be LF.
+		# Without the parameter, they would be CRLF on Windows.
+		with open(self.target, 'w', newline='\n') as f:
 			f.write(amalgamation)
 
 		print("...done!\n")


### PR DESCRIPTION
Running amalgamation on Windows produces huge diff due to changes from LF to CRLF, which is a valid behavior of Python's built-in `open()` function without specifying the `newline` parameter.  
That isn't desirable and would confuse contributors who want to run amalgamation on Windows.  
So, this PR has fixed the above issue by modifying the `amalgamate.py` script, updating the `tool/amalgamation/CHANGELOG.md` file.  

---

## Pull Request Checklist

Read the [CONTRIBUTING.md](https://github.com/fktn-k/fkYAML/blob/develop/CONTRIBUTING.md) file for detailed information.  

- [x] Changes are described in the pull request or in a referenced [issue](https://github.com/fktn-k/fkYAML/issues).
- [x] The test suite compiles and runs without any error.
- [x] [The code coverage](https://coveralls.io/github/fktn-k/fkYAML) on your branch is 100%.
- [x] The documentation is updated if you added/changed a feature.

## Please don't

- The C++11 support varies between different **compilers** and versions. Please note the [list of supported compilers](https://github.com/fktn-k/fkYAML/blob/develop/README.md#supported-compilers). Some compilers like GCC 4.7 (and earlier), Clang 3.3 (and earlier), or Microsoft Visual Studio 13.0 and earlier are known not to work due to missing or incomplete C++11 support. Please refrain from proposing changes that work around these compiler's limitations with `#ifdef`s or other means.
- Please refrain from proposing changes that would **break [YAML](https://yaml.org/) specifications**. If you propose a conformant extension of YAML to be supported by the library, please motivate this extension.
- Please do not open pull requests that address **multiple issues**.
