### PR TITLE
Fixed parser crashes on a sequence right after the directives end marker

### DIFF
--- a/include/fkYAML/detail/input/deserializer.hpp
+++ b/include/fkYAML/detail/input/deserializer.hpp
@@ -187,8 +187,8 @@ private:
                 // TODO: should output a warning log. Currently just ignore this case.
                 break;
             case lexical_token_t::END_OF_DIRECTIVES:
-                last_type = type;
-                return;
+                // Ignore this directives end marker so the caller will get the beginning token of the contents.
+                break;
             default:
                 // end the parsing of directives if the other tokens are found.
                 last_type = type;

--- a/include/fkYAML/detail/input/deserializer.hpp
+++ b/include/fkYAML/detail/input/deserializer.hpp
@@ -462,7 +462,6 @@ private:
                 break;
             }
             case lexical_token_t::END_OF_DIRECTIVES:
-                break;
             case lexical_token_t::END_OF_DOCUMENT:
                 // TODO: This token should be handled to support multiple documents.
                 break;

--- a/single_include/fkYAML/node.hpp
+++ b/single_include/fkYAML/node.hpp
@@ -4078,8 +4078,8 @@ private:
                 // TODO: should output a warning log. Currently just ignore this case.
                 break;
             case lexical_token_t::END_OF_DIRECTIVES:
-                last_type = type;
-                return;
+                // Ignore this directives end marker so the caller will get the beginning token of the contents.
+                break;
             default:
                 // end the parsing of directives if the other tokens are found.
                 last_type = type;

--- a/single_include/fkYAML/node.hpp
+++ b/single_include/fkYAML/node.hpp
@@ -4353,7 +4353,6 @@ private:
                 break;
             }
             case lexical_token_t::END_OF_DIRECTIVES:
-                break;
             case lexical_token_t::END_OF_DOCUMENT:
                 // TODO: This token should be handled to support multiple documents.
                 break;

--- a/test/unit_test/test_deserializer_class.cpp
+++ b/test/unit_test/test_deserializer_class.cpp
@@ -1449,6 +1449,21 @@ TEST_CASE("Deserializer_Tag") {
         REQUIRE(root["seq_flow"][1].get_value<float>() == 3.14f);
     }
 
+    SECTION("specify tags using TAG directives") {
+        std::string input = "%TAG !e! tag:example.com,2000:app/\n"
+                            "---\n"
+                            "- !e!foo \"bar\"";
+        REQUIRE_NOTHROW(root = deserializer.deserialize(fkyaml::detail::input_adapter(input)));
+
+        REQUIRE(root.is_sequence());
+        REQUIRE(root.size() == 1);
+
+        REQUIRE(root[0].has_tag_name());
+        REQUIRE(root[0].get_tag_name() == "!e!foo");
+        REQUIRE(root[0].is_string());
+        REQUIRE(root[0].get_value_ref<std::string&>() == "bar");
+    }
+
     SECTION("multiple tags specified") {
         auto input = GENERATE(std::string("foo: !!map !!map\n  bar: baz"), std::string("!!str !!bool true: 123"));
         REQUIRE_THROWS_AS(deserializer.deserialize(fkyaml::detail::input_adapter(input)), fkyaml::parse_error);


### PR DESCRIPTION
The fkYAML parser in the latest develop branch crashes with the following valid YAML snippets (taken from [the official YAML test suite `Z9M4/in.yaml`](https://github.com/yaml/yaml-test-suite/blob/data-2022-01-17/Z9M4/in.yaml)):  
```yml
%TAG !e! tag:example.com,2000:app/
---
- !e!foo "bar"
```

After some investigation, it's turned out that the parser doesn't process directive end markers (denoted with `---`) properly.  
So, this PR has fixed the parser's issue and added a test case to validate the change.  

## Pull Request Checklist

Read the [CONTRIBUTING.md](https://github.com/fktn-k/fkYAML/blob/develop/CONTRIBUTING.md) file for detailed information.  

- [x] Changes are described in the pull request or in a referenced [issue](https://github.com/fktn-k/fkYAML/issues).
- [x] The test suite compiles and runs without any error.
- [x] [The code coverage](https://coveralls.io/github/fktn-k/fkYAML) on your branch is 100%.
- [x] The documentation is updated if you added/changed a feature.

## Please don't

- The C++11 support varies between different **compilers** and versions. Please note the [list of supported compilers](https://github.com/fktn-k/fkYAML/blob/develop/README.md#supported-compilers). Some compilers like GCC 4.7 (and earlier), Clang 3.3 (and earlier), or Microsoft Visual Studio 13.0 and earlier are known not to work due to missing or incomplete C++11 support. Please refrain from proposing changes that work around these compiler's limitations with `#ifdef`s or other means.
- Please refrain from proposing changes that would **break [YAML](https://yaml.org/) specifications**. If you propose a conformant extension of YAML to be supported by the library, please motivate this extension.
- Please do not open pull requests that address **multiple issues**.
