### PR TITLE
Fixed no such file/directory error when running Bash scripts on Windows

### DIFF
--- a/scripts/run_amalgamation.sh
+++ b/scripts/run_amalgamation.sh
@@ -1,4 +1,17 @@
 #!/bin/bash
 
+set -eu
+
+# Platform switches are taken from https://gist.github.com/prabirshrestha/3080525
+UNAME=$(uname)
+if [ "$UNAME" = "Linux" ] || [ "$UNAME" = "Darwin" ]; then
+    PYTHON_EXE=python3
+else
+    # Use the Python launcher if the runtime environment is Windows.
+    # No version option (`-<version>`) since running with the latest version should be enough.
+    PYTHON_EXE=py
+fi
+
 ROOT_DIR="$(dirname "$0")"/..
-python3 "$ROOT_DIR"/tool/amalgamation/amalgamate.py -c "$ROOT_DIR"/tool/amalgamation/fkYAML.json -s . --verbose=yes
+AMALGAMATION_TOOL_DIR="$ROOT_DIR/tool/amalgamation"
+"$PYTHON_EXE" "$AMALGAMATION_TOOL_DIR"/amalgamate.py -c "$AMALGAMATION_TOOL_DIR"/fkYAML.json -s . --verbose=yes

--- a/scripts/run_clang_format.sh
+++ b/scripts/run_clang_format.sh
@@ -3,12 +3,26 @@
 SCRIPT_DIR="$(dirname "$0")"
 ROOT_DIR="$SCRIPT_DIR/.."
 
+# Platform switches are taken from https://gist.github.com/prabirshrestha/3080525
+UNAME=$(uname)
+if [ "$UNAME" = "Linux" ] || [ "$UNAME" = "Darwin" ]; then
+    PYTHON_EXE=python3
+    VENV_BINARY_DIR=bin
+else
+    # Use the Python launcher if the runtime environment is Windows.
+    # No version option (`-<version>`) since running with the latest version should be enough.
+    PYTHON_EXE=py
+    # Binaries are stored in the `venv\Scripts` directory using Python venv module for Windows.
+    VENV_BINARY_DIR=Scripts
+fi
+
+
 # install the clang-format package if not installed yet.
-if [ ! -e "$SCRIPT_DIR"/venv_clang_format/bin/clang-format ]; then
-    python3 -m venv "$SCRIPT_DIR/venv_clang_format"
-    "$SCRIPT_DIR"/venv_clang_format/bin/pip install clang-format==14.0.0
+if [ ! -e "$SCRIPT_DIR"/venv_clang_format/"$VENV_BINARY_DIR"/clang-format ]; then
+    "PYTHON_EXE" -m venv "$SCRIPT_DIR/venv_clang_format"
+    "$SCRIPT_DIR"/venv_clang_format/"$VENV_BINARY_DIR"/pip install clang-format==14.0.0
 fi
 
 for f in $(find "$ROOT_DIR/include" "$ROOT_DIR/test" "$ROOT_DIR/docs/examples" -type f -name "*.hpp" -o -name "*.cpp" | sort); do
-    "$SCRIPT_DIR"/venv_clang_format/bin/clang-format "$f" -i
+    "$SCRIPT_DIR"/venv_clang_format/"$VENV_BINARY_DIR"/clang-format "$f" -i
 done

--- a/scripts/run_clang_format.sh
+++ b/scripts/run_clang_format.sh
@@ -19,7 +19,7 @@ fi
 
 # install the clang-format package if not installed yet.
 if [ ! -e "$SCRIPT_DIR"/venv_clang_format/"$VENV_BINARY_DIR"/clang-format ]; then
-    "PYTHON_EXE" -m venv "$SCRIPT_DIR/venv_clang_format"
+    "$PYTHON_EXE" -m venv "$SCRIPT_DIR/venv_clang_format"
     "$SCRIPT_DIR"/venv_clang_format/"$VENV_BINARY_DIR"/pip install clang-format==14.0.0
 fi
 


### PR DESCRIPTION
When the Bash scripts for running clang-format and amalagamation on Windows, they ends up with errors which says no such file/directory.  
This is because (1) Python distributions for Windows have no `python3` executable and (2) binaries are stored in the `venv\Scripts` directory, not in the `venv/bin` directory, when Python venv module is used on Windows.  
To fix the above issues, this PR has added platform switches using the output from the `uname` command.  
Both on Ubuntu22.04 with WSL2 and Windows10 with Git for Windows (2.44.0-windows.1), the scripts now work as expected.  

---

## Pull Request Checklist

Read the [CONTRIBUTING.md](https://github.com/fktn-k/fkYAML/blob/develop/CONTRIBUTING.md) file for detailed information.  

- [x] Changes are described in the pull request or in a referenced [issue](https://github.com/fktn-k/fkYAML/issues).
- [x] The test suite compiles and runs without any error.
- [x] [The code coverage](https://coveralls.io/github/fktn-k/fkYAML) on your branch is 100%.
- [x] The documentation is updated if you added/changed a feature.

## Please don't

- The C++11 support varies between different **compilers** and versions. Please note the [list of supported compilers](https://github.com/fktn-k/fkYAML/blob/develop/README.md#supported-compilers). Some compilers like GCC 4.7 (and earlier), Clang 3.3 (and earlier), or Microsoft Visual Studio 13.0 and earlier are known not to work due to missing or incomplete C++11 support. Please refrain from proposing changes that work around these compiler's limitations with `#ifdef`s or other means.
- Please refrain from proposing changes that would **break [YAML](https://yaml.org/) specifications**. If you propose a conformant extension of YAML to be supported by the library, please motivate this extension.
- Please do not open pull requests that address **multiple issues**.
