### PR TITLE
Allow backslashes in plain/single-quoted scalars

### DIFF
--- a/include/fkYAML/detail/input/lexical_analyzer.hpp
+++ b/include/fkYAML/detail/input/lexical_analyzer.hpp
@@ -738,9 +738,6 @@ private:
             m_token_begin_itr = m_cur_itr + 1;
             ret = true;
             break;
-
-        case '\\':
-            emit_error("Escaped characters are only available in a double-quoted string token.");
         }
 
         return ret;
@@ -940,9 +937,6 @@ private:
 
             m_value_buffer.append(m_token_begin_itr, m_cur_itr);
             break;
-
-        case '\\':
-            emit_error("Escaped characters are only available in a double-quoted string token.");
         }
 
         return ret;
@@ -956,7 +950,7 @@ private:
         // * double quoted
         // * plain
 
-        std::string check_filters {"\r\n\\"};
+        std::string check_filters {"\r\n"};
         bool (lexical_analyzer::*pfn_is_allowed)(char) = nullptr;
 
         if (needs_last_single_quote) {
@@ -964,7 +958,7 @@ private:
             pfn_is_allowed = &lexical_analyzer::is_allowed_single;
         }
         else if (needs_last_double_quote) {
-            check_filters.append("\"");
+            check_filters.append("\"\\");
             pfn_is_allowed = &lexical_analyzer::is_allowed_double;
         }
         else // plain scalars

--- a/single_include/fkYAML/node.hpp
+++ b/single_include/fkYAML/node.hpp
@@ -2992,9 +2992,6 @@ private:
             m_token_begin_itr = m_cur_itr + 1;
             ret = true;
             break;
-
-        case '\\':
-            emit_error("Escaped characters are only available in a double-quoted string token.");
         }
 
         return ret;
@@ -3194,9 +3191,6 @@ private:
 
             m_value_buffer.append(m_token_begin_itr, m_cur_itr);
             break;
-
-        case '\\':
-            emit_error("Escaped characters are only available in a double-quoted string token.");
         }
 
         return ret;
@@ -3210,7 +3204,7 @@ private:
         // * double quoted
         // * plain
 
-        std::string check_filters {"\r\n\\"};
+        std::string check_filters {"\r\n"};
         bool (lexical_analyzer::*pfn_is_allowed)(char) = nullptr;
 
         if (needs_last_single_quote) {
@@ -3218,7 +3212,7 @@ private:
             pfn_is_allowed = &lexical_analyzer::is_allowed_single;
         }
         else if (needs_last_double_quote) {
-            check_filters.append("\"");
+            check_filters.append("\"\\");
             pfn_is_allowed = &lexical_analyzer::is_allowed_double;
         }
         else // plain scalars

--- a/test/unit_test/test_lexical_analyzer_class.cpp
+++ b/test/unit_test/test_lexical_analyzer_class.cpp
@@ -515,6 +515,7 @@ TEST_CASE("LexicalAnalyzer_String") {
         value_pair_t(std::string("foo bar"), fkyaml::node::string_type("foo bar")),
         value_pair_t(std::string("foo\"bar"), fkyaml::node::string_type("foo\"bar")),
         value_pair_t(std::string("foo\'s bar"), fkyaml::node::string_type("foo\'s bar")),
+        value_pair_t(std::string("foo\\bar"), fkyaml::node::string_type("foo\\bar")),
         value_pair_t(std::string("nullValue"), fkyaml::node::string_type("nullValue")),
         value_pair_t(std::string("NullValue"), fkyaml::node::string_type("NullValue")),
         value_pair_t(std::string("NULL_VALUE"), fkyaml::node::string_type("NULL_VALUE")),
@@ -543,6 +544,7 @@ TEST_CASE("LexicalAnalyzer_String") {
         value_pair_t(std::string("\'foo}bar\'"), fkyaml::node::string_type("foo}bar")),
         value_pair_t(std::string("\'foo\"bar\'"), fkyaml::node::string_type("foo\"bar")),
         value_pair_t(std::string("\'foo:bar\'"), fkyaml::node::string_type("foo:bar")),
+        value_pair_t(std::string("\'foo\\bar\'"), fkyaml::node::string_type("foo\\bar")),
 
         value_pair_t(std::string("\"foo bar\""), fkyaml::node::string_type("foo bar")),
         value_pair_t(std::string("\"foo's bar\""), fkyaml::node::string_type("foo's bar")),
@@ -736,7 +738,6 @@ TEST_CASE("LexicalAnalyzer_EscapedUnicodeCharacter") {
 TEST_CASE("LexicalAnalyzer_InvalidString") {
     SECTION("parse error") {
         auto buffer = GENERATE(
-            std::string("foo\\tbar"),
             std::string("\"test"),
             std::string("\'test"),
             std::string("\'test\n\'"),
@@ -746,7 +747,6 @@ TEST_CASE("LexicalAnalyzer_InvalidString") {
             std::string("\"\\x=\""),
             std::string("\"\\x^\""),
             std::string("\"\\x{\""),
-            std::string("\'\\t\'"),
             std::string("\"\\Q\""));
 
         lexer_t lexer(fkyaml::detail::input_adapter(buffer));


### PR DESCRIPTION
The current fkYAML parser throws a `parse_error` exception when a plain/single-quoted scalar contains backslashes (\) which are allowed in the YAML spec.  
For example, the following valid YAML snippet cannot be parsed correctly because of that wrong implementation:  
```yaml
plain: foo\bar.yaml
single quoted: 'foo\bar.yaml'
```

This PR has fixed the above issue and updated some related test cases which have wrong expectations.  

---

## Pull Request Checklist

Read the [CONTRIBUTING.md](https://github.com/fktn-k/fkYAML/blob/develop/CONTRIBUTING.md) file for detailed information.  

- [x] Changes are described in the pull request or in a referenced [issue](https://github.com/fktn-k/fkYAML/issues).
- [x] The test suite compiles and runs without any error.
- [x] [The code coverage](https://coveralls.io/github/fktn-k/fkYAML) on your branch is 100%.
- [x] The documentation is updated if you added/changed a feature.

## Please don't

- The C++11 support varies between different **compilers** and versions. Please note the [list of supported compilers](https://github.com/fktn-k/fkYAML/blob/develop/README.md#supported-compilers). Some compilers like GCC 4.7 (and earlier), Clang 3.3 (and earlier), or Microsoft Visual Studio 13.0 and earlier are known not to work due to missing or incomplete C++11 support. Please refrain from proposing changes that work around these compiler's limitations with `#ifdef`s or other means.
- Please refrain from proposing changes that would **break [YAML](https://yaml.org/) specifications**. If you propose a conformant extension of YAML to be supported by the library, please motivate this extension.
- Please do not open pull requests that address **multiple issues**.
