### PR TITLE
Fixed parse error on root block sequence with child block sequences

### DIFF
--- a/include/fkYAML/detail/input/deserializer.hpp
+++ b/include/fkYAML/detail/input/deserializer.hpp
@@ -90,6 +90,7 @@ public:
         case lexical_token_t::SEQUENCE_FLOW_BEGIN:
             root = node_type::sequence();
             apply_directive_set(root);
+            m_indent_stack.emplace_back(lexer.get_lines_processed(), lexer.get_last_token_begin_pos(), false);
             break;
         default:
             break;
@@ -250,9 +251,9 @@ private:
                 continue;
             }
             case lexical_token_t::KEY_SEPARATOR: {
-                bool is_stack_empty = m_node_stack.empty();
-                if (is_stack_empty) {
-                    throw parse_error("A key separator found without key.", line, indent);
+                bool is_empty_seq = mp_current_node->is_sequence() && mp_current_node->empty();
+                if (is_empty_seq) {
+                    throw parse_error("sequence key should not be empty.", line, indent);
                 }
 
                 // hold the line count of the key separator for later use.
@@ -299,12 +300,15 @@ private:
                         }
                     }
 
+                    bool do_continue = true;
                     switch (type) {
                     case lexical_token_t::SEQUENCE_BLOCK_PREFIX:
                         // a key separator preceeding block sequence entries
                         *mp_current_node = node_type::sequence();
                         apply_directive_set(*mp_current_node);
                         apply_node_properties(*mp_current_node);
+                        m_indent_stack.emplace_back(line, indent, false);
+                        do_continue = false;
                         break;
                     case lexical_token_t::EXPLICIT_KEY_PREFIX:
                         // a key separator for a explicit block mapping key.
@@ -326,7 +330,10 @@ private:
                         break; // LCOV_EXCL_LINE
                     }
 
-                    continue;
+                    if (do_continue) {
+                        continue;
+                    }
+                    break;
                 }
 
                 // handle explicit mapping key separators.
@@ -363,9 +370,10 @@ private:
                     *mp_current_node = node_type::sequence();
                     apply_directive_set(*mp_current_node);
                     apply_node_properties(*mp_current_node);
+                    m_indent_stack.emplace_back(line, indent, false);
+                    break;
                 }
-                indent = lexer.get_last_token_begin_pos();
-                line = lexer.get_lines_processed();
+
                 continue;
             }
             case lexical_token_t::VALUE_SEPARATOR:
@@ -391,6 +399,13 @@ private:
                 if (mp_current_node->is_sequence()) {
                     bool is_empty = mp_current_node->empty();
                     if (is_empty) {
+                        bool is_further_nested = !m_indent_stack.empty() && m_indent_stack.back().indent < indent;
+                        if (is_further_nested) {
+                            mp_current_node->template get_value_ref<sequence_type&>().emplace_back(
+                                node_type::sequence());
+                            m_node_stack.push_back(mp_current_node);
+                            mp_current_node = &(mp_current_node->template get_value_ref<sequence_type&>().back());
+                        }
                         m_indent_stack.emplace_back(line, indent, false);
                         break;
                     }

--- a/test/unit_test/test_deserializer_class.cpp
+++ b/test/unit_test/test_deserializer_class.cpp
@@ -32,7 +32,7 @@ TEST_CASE("Deserializer_KeySeparator") {
     }
 
     SECTION("error cases") {
-        auto input_str = GENERATE(std::string(": foo"), std::string("- : foo"), std::string("- - : foo"));
+        auto input_str = GENERATE(std::string("- : foo"), std::string("- - : foo"));
         REQUIRE_THROWS_AS(
             root = deserializer.deserialize(fkyaml::detail::input_adapter(input_str)), fkyaml::parse_error);
     }
@@ -302,6 +302,26 @@ TEST_CASE("Deserializer_BlockSequence") {
 
         REQUIRE(root[2].is_float_number());
         REQUIRE(root[2].get_value<double>() == 3.14);
+    }
+
+    SECTION("root sequence with nested child block sequence") {
+        std::string input = "- - foo\n"
+                            "  - 123\n"
+                            "- 3.14";
+        REQUIRE_NOTHROW(root = deserializer.deserialize(fkyaml::detail::input_adapter(input)));
+
+        REQUIRE(root.is_sequence());
+        REQUIRE(root.size() == 2);
+
+        REQUIRE(root[0].is_sequence());
+        REQUIRE(root[0].size() == 2);
+        REQUIRE(root[0][0].is_string());
+        REQUIRE(root[0][0].get_value_ref<std::string&>() == "foo");
+        REQUIRE(root[0][1].is_integer());
+        REQUIRE(root[0][1].get_value<int>() == 123);
+
+        REQUIRE(root[1].is_float_number());
+        REQUIRE(root[1].get_value<double>() == 3.14);
     }
 }
 


### PR DESCRIPTION
This PR has fixed parse errors which the current parser emits on root block sequence containing child block sequences, like the following valid YAML snippet (slightly modified version of [the official YAML test suite `3ALJ`](https://github.com/yaml/yaml-test-suite/blob/data-2022-01-17/3ALJ/in.yaml)):  
```yaml
- - foo
  - 123
- 3.14
```

The test case with the above snippet has also been added to the test suite to validate the change.  

---

## Pull Request Checklist

Read the [CONTRIBUTING.md](https://github.com/fktn-k/fkYAML/blob/develop/CONTRIBUTING.md) file for detailed information.  

- [x] Changes are described in the pull request or in a referenced [issue](https://github.com/fktn-k/fkYAML/issues).
- [x] The test suite compiles and runs without any error.
- [x] [The code coverage](https://coveralls.io/github/fktn-k/fkYAML) on your branch is 100%.
- [x] The documentation is updated if you added/changed a feature.

## Please don't

- The C++11 support varies between different **compilers** and versions. Please note the [list of supported compilers](https://github.com/fktn-k/fkYAML/blob/develop/README.md#supported-compilers). Some compilers like GCC 4.7 (and earlier), Clang 3.3 (and earlier), or Microsoft Visual Studio 13.0 and earlier are known not to work due to missing or incomplete C++11 support. Please refrain from proposing changes that work around these compiler's limitations with `#ifdef`s or other means.
- Please refrain from proposing changes that would **break [YAML](https://yaml.org/) specifications**. If you propose a conformant extension of YAML to be supported by the library, please motivate this extension.
- Please do not open pull requests that address **multiple issues**.
