### PR TITLE
Fixed parse error on block sequences with child block mappings split by a newline code

### DIFF
--- a/include/fkYAML/detail/input/lexical_analyzer.hpp
+++ b/include/fkYAML/detail/input/lexical_analyzer.hpp
@@ -154,11 +154,27 @@ public:
             return scan_directive();
         case '-': {
             char next = *(m_cur_itr + 1);
-            if (next == ' ') {
+            switch (next) {
+            case ' ':
+            case '\t':
+            case '\n':
                 // Move a cursor to the beginning of the next token.
                 m_cur_itr += 2;
                 return lexical_token_t::SEQUENCE_BLOCK_PREFIX;
+            case '\r':
+                next = *(m_cur_itr + 2);
+                // Move a cursor to the beginning of the next token.
+                m_cur_itr += 2 + (next == '\n' ? 1 : 0);
+                return lexical_token_t::SEQUENCE_BLOCK_PREFIX;
+                break;
+            default:
+                break;
             }
+            // if (next == ' ') {
+            //     // Move a cursor to the beginning of the next token.
+            //     m_cur_itr += 2;
+            //     return lexical_token_t::SEQUENCE_BLOCK_PREFIX;
+            // }
 
             bool is_available = (std::distance(m_cur_itr, m_end_itr) > 2);
             if (is_available) {

--- a/single_include/fkYAML/node.hpp
+++ b/single_include/fkYAML/node.hpp
@@ -2406,11 +2406,27 @@ public:
             return scan_directive();
         case '-': {
             char next = *(m_cur_itr + 1);
-            if (next == ' ') {
+            switch (next) {
+            case ' ':
+            case '\t':
+            case '\n':
                 // Move a cursor to the beginning of the next token.
                 m_cur_itr += 2;
                 return lexical_token_t::SEQUENCE_BLOCK_PREFIX;
+            case '\r':
+                next = *(m_cur_itr + 2);
+                // Move a cursor to the beginning of the next token.
+                m_cur_itr += 2 + (next == '\n' ? 1 : 0);
+                return lexical_token_t::SEQUENCE_BLOCK_PREFIX;
+                break;
+            default:
+                break;
             }
+            // if (next == ' ') {
+            //     // Move a cursor to the beginning of the next token.
+            //     m_cur_itr += 2;
+            //     return lexical_token_t::SEQUENCE_BLOCK_PREFIX;
+            // }
 
             bool is_available = (std::distance(m_cur_itr, m_end_itr) > 2);
             if (is_available) {

--- a/test/unit_test/test_deserializer_class.cpp
+++ b/test/unit_test/test_deserializer_class.cpp
@@ -437,6 +437,59 @@ TEST_CASE("Deserializer_BlockSequence") {
         REQUIRE(root_1_bar_1_node.is_integer());
         REQUIRE(root_1_bar_1_node.get_value<int>() == 030);
     }
+
+    SECTION("block mapping with child block mapping (split by a newline code)") {
+        std::string input = "-\n"
+                            "  name: Mark McGwire\n"
+                            "  hr:   65\n"
+                            "  avg:  0.278\n"
+                            "-\n"
+                            "  name: Sammy Sosa\n"
+                            "  hr:   63\n"
+                            "  avg:  0.288";
+        REQUIRE_NOTHROW(root = deserializer.deserialize(fkyaml::detail::input_adapter(input)));
+
+        REQUIRE(root.is_sequence());
+        REQUIRE(root.size() == 2);
+
+        fkyaml::node& root_0_node = root[0];
+        REQUIRE(root_0_node.is_mapping());
+        REQUIRE(root_0_node.size() == 3);
+        REQUIRE(root_0_node.contains("name"));
+        REQUIRE(root_0_node.contains("hr"));
+        REQUIRE(root_0_node.contains("avg"));
+
+        fkyaml::node& root_0_name_node = root_0_node["name"];
+        REQUIRE(root_0_name_node.is_string());
+        REQUIRE(root_0_name_node.get_value_ref<std::string&>() == "Mark McGwire");
+
+        fkyaml::node& root_0_hr_node = root_0_node["hr"];
+        REQUIRE(root_0_hr_node.is_integer());
+        REQUIRE(root_0_hr_node.get_value<int>() == 65);
+
+        fkyaml::node& root_0_avg_node = root_0_node["avg"];
+        REQUIRE(root_0_avg_node.is_float_number());
+        REQUIRE(root_0_avg_node.get_value<double>() == 0.278);
+
+        fkyaml::node& root_1_node = root[1];
+        REQUIRE(root_1_node.is_mapping());
+        REQUIRE(root_1_node.size() == 3);
+        REQUIRE(root_1_node.contains("name"));
+        REQUIRE(root_1_node.contains("hr"));
+        REQUIRE(root_1_node.contains("avg"));
+
+        fkyaml::node& root_1_name_node = root_1_node["name"];
+        REQUIRE(root_1_name_node.is_string());
+        REQUIRE(root_1_name_node.get_value_ref<std::string&>() == "Sammy Sosa");
+
+        fkyaml::node& root_1_hr_node = root_1_node["hr"];
+        REQUIRE(root_1_hr_node.is_integer());
+        REQUIRE(root_1_hr_node.get_value<int>() == 63);
+
+        fkyaml::node& root_1_avg_node = root_1_node["avg"];
+        REQUIRE(root_1_avg_node.is_float_number());
+        REQUIRE(root_1_avg_node.get_value<double>() == 0.288);
+    }
 }
 
 TEST_CASE("Deserializer_BlockMapping") {

--- a/test/unit_test/test_lexical_analyzer_class.cpp
+++ b/test/unit_test/test_lexical_analyzer_class.cpp
@@ -309,6 +309,23 @@ TEST_CASE("LexicalAnalyzer_Colon") {
     }
 }
 
+TEST_CASE("LexicalAnalzer_BlockSequenceEntryPrefix") {
+    auto input = GENERATE(
+        std::string("- foo"),
+        std::string("-\tfoo"),
+        std::string("-\r  foo"),
+        std::string("-\r\n  foo"),
+        std::string("-\n  foo"));
+
+    fkyaml::detail::lexical_token_t token;
+    lexer_t lexer(fkyaml::detail::input_adapter(input));
+    REQUIRE_NOTHROW(token = lexer.get_next_token());
+    REQUIRE(token == fkyaml::detail::lexical_token_t::SEQUENCE_BLOCK_PREFIX);
+    REQUIRE_NOTHROW(token = lexer.get_next_token());
+    REQUIRE(token == fkyaml::detail::lexical_token_t::STRING_VALUE);
+    REQUIRE(lexer.get_string() == "foo");
+}
+
 TEST_CASE("LexicalAnalyzer_Null") {
     fkyaml::detail::lexical_token_t token;
 


### PR DESCRIPTION
This PR has fixed parse errors which the current parser emits on a block sequence containing child block mappings, like the following valid YAML snippet (taken from [the official YAML test suite `229Q`](https://github.com/yaml/yaml-test-suite/blob/data-2022-01-17/229Q/in.yaml)):
```yaml
-
  name: Mark McGwire
  hr:   65
  avg:  0.278
-
  name: Sammy Sosa
  hr:   63
  avg:  0.288
```

The parser now interprets `-` followed by a newline code (either CR, LF, or CR+LF) as a block sequence entry prefix and the change is validated by adding the above YAML snippet to the test suite.  

---

## Pull Request Checklist

Read the [CONTRIBUTING.md](https://github.com/fktn-k/fkYAML/blob/develop/CONTRIBUTING.md) file for detailed information.  

- [x] Changes are described in the pull request or in a referenced [issue](https://github.com/fktn-k/fkYAML/issues).
- [x] The test suite compiles and runs without any error.
- [x] [The code coverage](https://coveralls.io/github/fktn-k/fkYAML) on your branch is 100%.
- [x] The documentation is updated if you added/changed a feature.

## Please don't

- The C++11 support varies between different **compilers** and versions. Please note the [list of supported compilers](https://github.com/fktn-k/fkYAML/blob/develop/README.md#supported-compilers). Some compilers like GCC 4.7 (and earlier), Clang 3.3 (and earlier), or Microsoft Visual Studio 13.0 and earlier are known not to work due to missing or incomplete C++11 support. Please refrain from proposing changes that work around these compiler's limitations with `#ifdef`s or other means.
- Please refrain from proposing changes that would **break [YAML](https://yaml.org/) specifications**. If you propose a conformant extension of YAML to be supported by the library, please motivate this extension.
- Please do not open pull requests that address **multiple issues**.
