### PR TITLE
Allow false error on anchor names containing colons (:)

### DIFF
--- a/include/fkYAML/detail/input/lexical_analyzer.hpp
+++ b/include/fkYAML/detail/input/lexical_analyzer.hpp
@@ -556,24 +556,6 @@ private:
             case ',':
                 ends_loop = true;
                 break;
-            case ':': {
-                auto next_itr = m_cur_itr + 1;
-                if (next_itr == m_end_itr) {
-                    ++m_cur_itr;
-                    ends_loop = true;
-                    break;
-                }
-                switch (*next_itr) {
-                case ' ':
-                case '\t':
-                case '\r':
-                case '\n':
-                    // Stop the extraction at the key separator.
-                    ends_loop = true;
-                    break;
-                }
-                break;
-            }
             default:
                 break;
             }

--- a/single_include/fkYAML/node.hpp
+++ b/single_include/fkYAML/node.hpp
@@ -2808,24 +2808,6 @@ private:
             case ',':
                 ends_loop = true;
                 break;
-            case ':': {
-                auto next_itr = m_cur_itr + 1;
-                if (next_itr == m_end_itr) {
-                    ++m_cur_itr;
-                    ends_loop = true;
-                    break;
-                }
-                switch (*next_itr) {
-                case ' ':
-                case '\t':
-                case '\r':
-                case '\n':
-                    // Stop the extraction at the key separator.
-                    ends_loop = true;
-                    break;
-                }
-                break;
-            }
             default:
                 break;
             }

--- a/test/unit_test/test_deserializer_class.cpp
+++ b/test/unit_test/test_deserializer_class.cpp
@@ -1616,7 +1616,8 @@ TEST_CASE("Deserializer_Anchor") {
     }
 
     SECTION("parse alias mapping key") {
-        REQUIRE_NOTHROW(root = deserializer.deserialize(fkyaml::detail::input_adapter("&anchor foo:\n  *anchor: 123")));
+        REQUIRE_NOTHROW(
+            root = deserializer.deserialize(fkyaml::detail::input_adapter("&anchor foo:\n  *anchor : 123")));
 
         REQUIRE(root.is_mapping());
         REQUIRE(root.size() == 1);

--- a/test/unit_test/test_lexical_analyzer_class.cpp
+++ b/test/unit_test/test_lexical_analyzer_class.cpp
@@ -1246,28 +1246,26 @@ TEST_CASE("LexicalAnalyzer_Anchor") {
     fkyaml::detail::lexical_token_t token;
 
     SECTION("valid anchor name") {
-        auto input = GENERATE(
-            std::string("&:anchor"),
-            std::string("&:anchor "),
-            std::string("&:anchor\t"),
-            std::string("&:anchor\r"),
-            std::string("&:anchor\n"),
-            std::string("&:anchor{"),
-            std::string("&:anchor}"),
-            std::string("&:anchor["),
-            std::string("&:anchor]"),
-            std::string("&:anchor,"),
-            std::string("&:anchor: "),
-            std::string("&:anchor:\t"),
-            std::string("&:anchor:\r"),
-            std::string("&:anchor:\n"),
-            std::string("&:anchor:"));
+        using test_data_t = std::pair<std::string, std::string>;
+        auto test_data = GENERATE(
+            test_data_t {"&anchor", "anchor"},
+            test_data_t {"&anchor name", "anchor"},
+            test_data_t {"&anchor\tname", "anchor"},
+            test_data_t {"&anchor\rname", "anchor"},
+            test_data_t {"&anchor\nname", "anchor"},
+            test_data_t {"&anchor{name", "anchor"},
+            test_data_t {"&anchor}name", "anchor"},
+            test_data_t {"&anchor[name", "anchor"},
+            test_data_t {"&anchor]name", "anchor"},
+            test_data_t {"&anchor,name", "anchor"},
+            test_data_t {"&anchor: ", "anchor:"},
+            test_data_t {"&anchor:", "anchor:"});
 
-        lexer_t lexer(fkyaml::detail::input_adapter(input));
+        lexer_t lexer(fkyaml::detail::input_adapter(test_data.first));
 
         REQUIRE_NOTHROW(token = lexer.get_next_token());
         REQUIRE(token == fkyaml::detail::lexical_token_t::ANCHOR_PREFIX);
-        REQUIRE_NOTHROW(lexer.get_string() == ":anchor");
+        REQUIRE_NOTHROW(lexer.get_string() == test_data.second);
     }
 
     SECTION("invalid anchor name") {
@@ -1281,8 +1279,7 @@ TEST_CASE("LexicalAnalyzer_Anchor") {
             std::string("&}"),
             std::string("&["),
             std::string("&]"),
-            std::string("&,"),
-            std::string("&: "));
+            std::string("&,"));
 
         lexer_t lexer(fkyaml::detail::input_adapter(input));
         REQUIRE_THROWS_AS(lexer.get_next_token(), fkyaml::parse_error);
@@ -1293,24 +1290,26 @@ TEST_CASE("LexicalAnalyzer_Alias") {
     fkyaml::detail::lexical_token_t token;
 
     SECTION("valid anchor name") {
-        auto input = GENERATE(
-            std::string("*:anchor"),
-            std::string("*:anchor "),
-            std::string("*:anchor\t"),
-            std::string("*:anchor\r"),
-            std::string("*:anchor\n"),
-            std::string("*:anchor{"),
-            std::string("*:anchor}"),
-            std::string("*:anchor["),
-            std::string("*:anchor]"),
-            std::string("*:anchor,"),
-            std::string("*:anchor: "));
+        using test_data_t = std::pair<std::string, std::string>;
+        auto test_data = GENERATE(
+            test_data_t {"*anchor", "anchor"},
+            test_data_t {"*anchor name", "anchor"},
+            test_data_t {"*anchor\tname", "anchor"},
+            test_data_t {"*anchor\rname", "anchor"},
+            test_data_t {"*anchor\nname", "anchor"},
+            test_data_t {"*anchor{name", "anchor"},
+            test_data_t {"*anchor}name", "anchor"},
+            test_data_t {"*anchor[name", "anchor"},
+            test_data_t {"*anchor]name", "anchor"},
+            test_data_t {"*anchor,name", "anchor"},
+            test_data_t {"*anchor: ", "anchor:"},
+            test_data_t {"*anchor:", "anchor:"});
 
-        lexer_t lexer(fkyaml::detail::input_adapter(input));
+        lexer_t lexer(fkyaml::detail::input_adapter(test_data.first));
 
         REQUIRE_NOTHROW(token = lexer.get_next_token());
         REQUIRE(token == fkyaml::detail::lexical_token_t::ALIAS_PREFIX);
-        REQUIRE_NOTHROW(lexer.get_string() == ":anchor");
+        REQUIRE_NOTHROW(lexer.get_string() == test_data.second);
     }
 
     SECTION("invalid anchor name") {
@@ -1324,8 +1323,7 @@ TEST_CASE("LexicalAnalyzer_Alias") {
             std::string("*}"),
             std::string("*["),
             std::string("*]"),
-            std::string("*,"),
-            std::string("*: "));
+            std::string("*,"));
 
         lexer_t lexer(fkyaml::detail::input_adapter(input));
         REQUIRE_THROWS_AS(lexer.get_next_token(), fkyaml::parse_error);


### PR DESCRIPTION
The latest lexer emits a wrong error on anchor names which contains colons(:).  
According to the YAML spec, anchor names consist of printable characters (including colons) EXCEPT newline codes, white spaces and flow indicators.  
So, this PR has corrected the way of extracting an anchor name from the input source to follow the spec by modifying the lexer and the related test cases.  

---

## Pull Request Checklist

Read the [CONTRIBUTING.md](https://github.com/fktn-k/fkYAML/blob/develop/CONTRIBUTING.md) file for detailed information.  

- [x] Changes are described in the pull request or in a referenced [issue](https://github.com/fktn-k/fkYAML/issues).
- [x] The test suite compiles and runs without any error.
- [x] [The code coverage](https://coveralls.io/github/fktn-k/fkYAML) on your branch is 100%.
- [x] The documentation is updated if you added/changed a feature.

## Please don't

- The C++11 support varies between different **compilers** and versions. Please note the [list of supported compilers](https://github.com/fktn-k/fkYAML/blob/develop/README.md#supported-compilers). Some compilers like GCC 4.7 (and earlier), Clang 3.3 (and earlier), or Microsoft Visual Studio 13.0 and earlier are known not to work due to missing or incomplete C++11 support. Please refrain from proposing changes that work around these compiler's limitations with `#ifdef`s or other means.
- Please refrain from proposing changes that would **break [YAML](https://yaml.org/) specifications**. If you propose a conformant extension of YAML to be supported by the library, please motivate this extension.
- Please do not open pull requests that address **multiple issues**.
