### PR TITLE
Escape backslash(\) + 0x09 to a horizontal tab (\t)

### DIFF
--- a/include/fkYAML/detail/input/lexical_analyzer.hpp
+++ b/include/fkYAML/detail/input/lexical_analyzer.hpp
@@ -765,6 +765,7 @@ private:
                 m_value_buffer.push_back('\b');
                 break;
             case 't':
+            case char(0x09):
                 m_value_buffer.push_back('\t');
                 break;
             case 'n':

--- a/single_include/fkYAML/node.hpp
+++ b/single_include/fkYAML/node.hpp
@@ -3017,6 +3017,7 @@ private:
                 m_value_buffer.push_back('\b');
                 break;
             case 't':
+            case char(0x09):
                 m_value_buffer.push_back('\t');
                 break;
             case 'n':

--- a/test/unit_test/test_lexical_analyzer_class.cpp
+++ b/test/unit_test/test_lexical_analyzer_class.cpp
@@ -572,6 +572,7 @@ TEST_CASE("LexicalAnalyzer_String") {
         value_pair_t(std::string("\"foo\\abar\""), fkyaml::node::string_type("foo\abar")),
         value_pair_t(std::string("\"foo\\bbar\""), fkyaml::node::string_type("foo\bbar")),
         value_pair_t(std::string("\"foo\\tbar\""), fkyaml::node::string_type("foo\tbar")),
+        value_pair_t(std::string("\"foo\\\u0009bar\""), fkyaml::node::string_type("foo\tbar")),
         value_pair_t(std::string("\"foo\tbar\""), fkyaml::node::string_type("foo\tbar")),
         value_pair_t(std::string("\"foo\\nbar\""), fkyaml::node::string_type("foo\nbar")),
         value_pair_t(std::string("\"foo\\vbar\""), fkyaml::node::string_type("foo\vbar")),


### PR DESCRIPTION
The current lexer lacks implementation to unescape the escape sequence of a backslash(\) and 0x09 to a horizontal tab(\t) as the YAML standard specifies [here](https://yaml.org/spec/1.2.2/#57-escaped-characters).  
This PR has added the missing escaping and a related test case.  

---

## Pull Request Checklist

Read the [CONTRIBUTING.md](https://github.com/fktn-k/fkYAML/blob/develop/CONTRIBUTING.md) file for detailed information.  

- [x] Changes are described in the pull request or in a referenced [issue](https://github.com/fktn-k/fkYAML/issues).
- [x] The test suite compiles and runs without any error.
- [x] [The code coverage](https://coveralls.io/github/fktn-k/fkYAML) on your branch is 100%.
- [x] The documentation is updated if you added/changed a feature.

## Please don't

- The C++11 support varies between different **compilers** and versions. Please note the [list of supported compilers](https://github.com/fktn-k/fkYAML/blob/develop/README.md#supported-compilers). Some compilers like GCC 4.7 (and earlier), Clang 3.3 (and earlier), or Microsoft Visual Studio 13.0 and earlier are known not to work due to missing or incomplete C++11 support. Please refrain from proposing changes that work around these compiler's limitations with `#ifdef`s or other means.
- Please refrain from proposing changes that would **break [YAML](https://yaml.org/) specifications**. If you propose a conformant extension of YAML to be supported by the library, please motivate this extension.
- Please do not open pull requests that address **multiple issues**.
