### PR TITLE
Fixed error on node properties for child block sequences

### DIFF
--- a/include/fkYAML/detail/input/deserializer.hpp
+++ b/include/fkYAML/detail/input/deserializer.hpp
@@ -444,6 +444,8 @@ private:
                     mp_current_node->template get_value_ref<sequence_type&>().emplace_back(node_type::sequence());
                     mp_current_node = &(mp_current_node->template get_value_ref<sequence_type&>().back());
                     m_context_stack.emplace_back(line, indent, context_state_t::BLOCK_SEQUENCE, mp_current_node);
+                    apply_directive_set(*mp_current_node);
+                    apply_node_properties(*mp_current_node);
                     break;
                 }
 

--- a/single_include/fkYAML/node.hpp
+++ b/single_include/fkYAML/node.hpp
@@ -4560,6 +4560,8 @@ private:
                     mp_current_node->template get_value_ref<sequence_type&>().emplace_back(node_type::sequence());
                     mp_current_node = &(mp_current_node->template get_value_ref<sequence_type&>().back());
                     m_context_stack.emplace_back(line, indent, context_state_t::BLOCK_SEQUENCE, mp_current_node);
+                    apply_directive_set(*mp_current_node);
+                    apply_node_properties(*mp_current_node);
                     break;
                 }
 


### PR DESCRIPTION
This PR has fixed an assertion failure (in the debug mode) or an incorrect parse result (in the release mode) each of which occurs when the parser tries to deserialize a YAML snippet where node properties (a tag, a anchor, or both) is specified to a child block sequence, like the following one:  

```yaml
foo: !!seq # This property causes the assertion failure
- true
- 123
```

The root cause was that the parser didn't set node properties to an appropriate block sequence node and tried to parse a subsequent scalar node with the `!!seq` tag.  
Several test cases have also been added to check if the above issue has been resolved.  

---

## Pull Request Checklist

Read the [CONTRIBUTING.md](https://github.com/fktn-k/fkYAML/blob/develop/CONTRIBUTING.md) file for detailed information.  

- [x] Changes are described in the pull request or in a referenced [issue](https://github.com/fktn-k/fkYAML/issues).
- [x] The test suite compiles and runs without any error.
- [x] [The code coverage](https://coveralls.io/github/fktn-k/fkYAML) on your branch is 100%.
- [x] The documentation is updated if you added/changed a feature.

## Please don't

- The C++11 support varies between different **compilers** and versions. Please note the [list of supported compilers](https://github.com/fktn-k/fkYAML/blob/develop/README.md#supported-compilers). Some compilers like GCC 4.7 (and earlier), Clang 3.3 (and earlier), or Microsoft Visual Studio 13.0 and earlier are known not to work due to missing or incomplete C++11 support. Please refrain from proposing changes that work around these compiler's limitations with `#ifdef`s or other means.
- Please refrain from proposing changes that would **break [YAML](https://yaml.org/) specifications**. If you propose a conformant extension of YAML to be supported by the library, please motivate this extension.
- Please do not open pull requests that address **multiple issues**.
