### PR TITLE
Fix parse error on flow container keys

### DIFF
--- a/include/fkYAML/detail/input/deserializer.hpp
+++ b/include/fkYAML/detail/input/deserializer.hpp
@@ -59,6 +59,7 @@ class basic_deserializer {
         BLOCK_SEQUENCE,               //!< The underlying node is a block sequence.
         FLOW_SEQUENCE,                //!< The underlying node is a flow sequence.
         FLOW_MAPPING,                 //!< The underlying node is a flow mapping.
+        FLOW_MAPPING_KEY,             //!< The underlying node is a flow mapping as a key.
     };
 
     /// @brief Context information set for parsing.
@@ -281,6 +282,7 @@ private:
 
                 type = lexer.get_next_token();
                 if (type == lexical_token_t::SEQUENCE_BLOCK_PREFIX) {
+                    // heap-allocated node will be freed in handling the corresponding KEY_SEPARATOR event
                     m_context_stack.emplace_back(
                         line, indent, context_state_t::BLOCK_MAPPING_EXPLICIT_KEY, new node_type(node_t::SEQUENCE));
                     mp_current_node = m_context_stack.back().p_node;
@@ -294,6 +296,7 @@ private:
                     break;
                 }
 
+                // heap-allocated node will be freed in handling the corresponding KEY_SEPARATOR event
                 m_context_stack.emplace_back(
                     line, indent, context_state_t::BLOCK_MAPPING_EXPLICIT_KEY, new node_type());
                 mp_current_node = m_context_stack.back().p_node;
@@ -457,16 +460,20 @@ private:
             }
             case lexical_token_t::SEQUENCE_FLOW_BEGIN:
                 ++m_flow_context_depth;
-                if (mp_current_node->is_sequence()) {
+
+                switch (m_context_stack.back().state) {
+                case context_state_t::BLOCK_SEQUENCE:
+                case context_state_t::FLOW_SEQUENCE:
                     mp_current_node->template get_value_ref<sequence_type&>().emplace_back(node_type::sequence());
                     mp_current_node = &(mp_current_node->template get_value_ref<sequence_type&>().back());
                     m_context_stack.emplace_back(line, indent, context_state_t::FLOW_SEQUENCE, mp_current_node);
-                }
-                else {
+                    break;
+                default:
                     *mp_current_node = node_type::sequence();
-                    parse_context& last_context = m_context_stack.back();
-                    last_context.state = context_state_t::FLOW_SEQUENCE;
+                    m_context_stack.back().state = context_state_t::FLOW_SEQUENCE;
+                    break;
                 }
+
                 apply_directive_set(*mp_current_node);
                 apply_node_properties(*mp_current_node);
                 break;
@@ -496,17 +503,54 @@ private:
                 break;
             }
             case lexical_token_t::MAPPING_FLOW_BEGIN:
+                if (m_flow_context_depth == 0) {
+                    uint32_t pop_num = 0;
+                    if (indent == 0) {
+                        pop_num = static_cast<uint32_t>(m_context_stack.size() - 1);
+                    }
+                    else if (indent < m_context_stack.back().indent) {
+                        auto target_itr = std::find_if(
+                            m_context_stack.rbegin(), m_context_stack.rend(), [indent](const parse_context& c) {
+                                return indent == c.indent;
+                            });
+                        bool is_indent_valid = (target_itr != m_context_stack.rend());
+                        if (!is_indent_valid) {
+                            throw parse_error("Detected invalid indentaion.", line, indent);
+                        }
+
+                        pop_num = static_cast<uint32_t>(std::distance(m_context_stack.rbegin(), target_itr));
+                    }
+                    if (pop_num > 0) {
+                        for (uint32_t i = 0; i < pop_num; i++) {
+                            // move back to the previous container node.
+                            m_context_stack.pop_back();
+                        }
+                        mp_current_node = m_context_stack.back().p_node;
+                    }
+                }
+
                 ++m_flow_context_depth;
-                if (mp_current_node->is_sequence()) {
+
+                switch (m_context_stack.back().state) {
+                case context_state_t::BLOCK_SEQUENCE:
+                case context_state_t::FLOW_SEQUENCE:
                     mp_current_node->template get_value_ref<sequence_type&>().emplace_back(node_type::mapping());
                     mp_current_node = &(mp_current_node->template get_value_ref<sequence_type&>().back());
                     m_context_stack.emplace_back(line, indent, context_state_t::FLOW_MAPPING, mp_current_node);
-                }
-                else {
+                    break;
+                case context_state_t::BLOCK_MAPPING:
+                case context_state_t::FLOW_MAPPING:
+                    // heap-allocated node will be freed in handling the corresponding MAPPING_FLOW_END event.
+                    m_context_stack.emplace_back(
+                        line, indent, context_state_t::FLOW_MAPPING_KEY, new node_type(node_t::MAPPING));
+                    mp_current_node = m_context_stack.back().p_node;
+                    break;
+                default:
                     *mp_current_node = node_type::mapping();
-                    parse_context& last_context = m_context_stack.back();
-                    last_context.state = context_state_t::FLOW_MAPPING;
+                    m_context_stack.back().state = context_state_t::FLOW_MAPPING;
+                    break;
                 }
+
                 apply_directive_set(*mp_current_node);
                 apply_node_properties(*mp_current_node);
                 break;
@@ -517,7 +561,15 @@ private:
                 auto itr = std::find_if( // LCOV_EXCL_LINE
                     m_context_stack.rbegin(),
                     m_context_stack.rend(),
-                    [](const parse_context& c) { return c.state == context_state_t::FLOW_MAPPING; });
+                    [](const parse_context& c) {
+                        switch (c.state) {
+                        case context_state_t::FLOW_MAPPING_KEY:
+                        case context_state_t::FLOW_MAPPING:
+                            return true;
+                        default:
+                            return false;
+                        }
+                    });
 
                 bool is_valid = itr != m_context_stack.rend();
                 if (!is_valid) {
@@ -525,15 +577,45 @@ private:
                 }
 
                 // move back to the context before the flow sequence.
-                auto pop_num = std::distance(m_context_stack.rbegin(), itr) + 1;
-                for (auto i = 0; i < pop_num; i++) {
+                uint32_t pop_num = static_cast<uint32_t>(std::distance(m_context_stack.rbegin(), itr) + 1);
+                uint32_t stack_size = static_cast<uint32_t>(m_context_stack.size());
+
+                if (pop_num == stack_size) {
+                    indent = m_context_stack.front().indent;
+                    line = m_context_stack.front().line;
+                }
+
+                context_state_t state = context_state_t::FLOW_MAPPING;
+                for (uint32_t i = 0; i < pop_num; i++) {
                     mp_current_node = m_context_stack.back().p_node;
+                    state = m_context_stack.back().state;
                     m_context_stack.pop_back();
                 }
+
                 if (!m_context_stack.empty()) {
+                    if (state == context_state_t::FLOW_MAPPING_KEY) {
+                        node_type key_node = std::move(*mp_current_node);
+                        delete mp_current_node;
+                        mp_current_node = m_context_stack.back().p_node;
+
+                        add_new_key(std::move(key_node), indent, line);
+                        break;
+                    }
+
                     mp_current_node = m_context_stack.back().p_node;
+                    break;
                 }
-                break;
+
+                type = lexer.get_next_token();
+                if (type == lexical_token_t::KEY_SEPARATOR) {
+                    node_type key_node = node_type::mapping();
+                    mp_current_node->swap(key_node);
+                    m_context_stack.emplace_back(line, indent, context_state_t::BLOCK_MAPPING, mp_current_node);
+                    add_new_key(std::move(key_node), indent, line);
+                }
+                indent = lexer.get_last_token_begin_pos();
+                line = lexer.get_lines_processed();
+                continue;
             }
             case lexical_token_t::ALIAS_PREFIX:
             case lexical_token_t::NULL_VALUE:
@@ -634,38 +716,40 @@ private:
     /// @param indent The indentation width in the current line where the key is found.
     /// @param line The line where the key is found.
     void add_new_key(node_type&& key, const uint32_t indent, const uint32_t line) {
-        uint32_t pop_num = 0;
-        if (indent == 0) {
-            pop_num = static_cast<uint32_t>(m_context_stack.size() - 1);
-        }
-        else if (indent < m_context_stack.back().indent) {
-            auto target_itr =
-                std::find_if(m_context_stack.rbegin(), m_context_stack.rend(), [indent](const parse_context& c) {
-                    if (indent != c.indent) {
-                        return false;
-                    }
-
-                    switch (c.state) {
-                    case context_state_t::BLOCK_MAPPING:
-                    case context_state_t::MAPPING_VALUE:
-                        return true;
-                    default:
-                        return false;
-                    }
-                });
-            bool is_indent_valid = (target_itr != m_context_stack.rend());
-            if (!is_indent_valid) {
-                throw parse_error("Detected invalid indentaion.", line, indent);
+        if (m_flow_context_depth == 0) {
+            uint32_t pop_num = 0;
+            if (indent == 0) {
+                pop_num = static_cast<uint32_t>(m_context_stack.size() - 1);
             }
+            else if (indent < m_context_stack.back().indent) {
+                auto target_itr =
+                    std::find_if(m_context_stack.rbegin(), m_context_stack.rend(), [indent](const parse_context& c) {
+                        if (indent != c.indent) {
+                            return false;
+                        }
 
-            pop_num = static_cast<uint32_t>(std::distance(m_context_stack.rbegin(), target_itr));
-        }
-        if (pop_num > 0) {
-            for (uint32_t i = 0; i < pop_num; i++) {
-                // move back to the previous container node.
-                m_context_stack.pop_back();
+                        switch (c.state) {
+                        case context_state_t::BLOCK_MAPPING:
+                        case context_state_t::MAPPING_VALUE:
+                            return true;
+                        default:
+                            return false;
+                        }
+                    });
+                bool is_indent_valid = (target_itr != m_context_stack.rend());
+                if (!is_indent_valid) {
+                    throw parse_error("Detected invalid indentaion.", line, indent);
+                }
+
+                pop_num = static_cast<uint32_t>(std::distance(m_context_stack.rbegin(), target_itr));
             }
-            mp_current_node = m_context_stack.back().p_node;
+            if (pop_num > 0) {
+                for (uint32_t i = 0; i < pop_num; i++) {
+                    // move back to the previous container node.
+                    m_context_stack.pop_back();
+                }
+                mp_current_node = m_context_stack.back().p_node;
+            }
         }
 
         if (mp_current_node->is_sequence()) {

--- a/include/fkYAML/detail/input/deserializer.hpp
+++ b/include/fkYAML/detail/input/deserializer.hpp
@@ -494,6 +494,8 @@ private:
                     mp_current_node->template get_value_ref<sequence_type&>().emplace_back(node_type::sequence());
                     mp_current_node = &(mp_current_node->template get_value_ref<sequence_type&>().back());
                     m_context_stack.emplace_back(line, indent, context_state_t::FLOW_SEQUENCE, mp_current_node);
+                    apply_directive_set(*mp_current_node);
+                    apply_node_properties(*mp_current_node);
                     break;
                 case context_state_t::BLOCK_MAPPING:
                 case context_state_t::FLOW_MAPPING:
@@ -501,9 +503,13 @@ private:
                     m_context_stack.emplace_back(
                         line, indent, context_state_t::FLOW_SEQUENCE_KEY, new node_type(node_t::SEQUENCE));
                     mp_current_node = m_context_stack.back().p_node;
+                    apply_directive_set(*mp_current_node);
+                    apply_node_properties(*mp_current_node);
                     break;
                 default:
                     *mp_current_node = node_type::sequence();
+                    apply_directive_set(*mp_current_node);
+                    apply_node_properties(*mp_current_node);
                     m_context_stack.back().state = context_state_t::FLOW_SEQUENCE;
                     break;
                 }
@@ -609,6 +615,8 @@ private:
                     mp_current_node->template get_value_ref<sequence_type&>().emplace_back(node_type::mapping());
                     mp_current_node = &(mp_current_node->template get_value_ref<sequence_type&>().back());
                     m_context_stack.emplace_back(line, indent, context_state_t::FLOW_MAPPING, mp_current_node);
+                    apply_directive_set(*mp_current_node);
+                    apply_node_properties(*mp_current_node);
                     break;
                 case context_state_t::BLOCK_MAPPING:
                 case context_state_t::FLOW_MAPPING:
@@ -616,9 +624,13 @@ private:
                     m_context_stack.emplace_back(
                         line, indent, context_state_t::FLOW_MAPPING_KEY, new node_type(node_t::MAPPING));
                     mp_current_node = m_context_stack.back().p_node;
+                    apply_directive_set(*mp_current_node);
+                    apply_node_properties(*mp_current_node);
                     break;
                 default:
                     *mp_current_node = node_type::mapping();
+                    apply_directive_set(*mp_current_node);
+                    apply_node_properties(*mp_current_node);
                     m_context_stack.back().state = context_state_t::FLOW_MAPPING;
                     break;
                 }

--- a/include/fkYAML/detail/input/deserializer.hpp
+++ b/include/fkYAML/detail/input/deserializer.hpp
@@ -330,6 +330,10 @@ private:
                 line = lexer.get_lines_processed();
                 indent = lexer.get_last_token_begin_pos();
 
+                if (m_flow_context_depth > 0) {
+                    continue;
+                }
+
                 bool is_implicit_same_line =
                     (line == old_line) && (m_context_stack.empty() || old_indent > m_context_stack.back().indent);
                 if (is_implicit_same_line) {
@@ -465,10 +469,22 @@ private:
                     if (indent == 0) {
                         pop_num = static_cast<uint32_t>(m_context_stack.size() - 1);
                     }
-                    else if (indent < m_context_stack.back().indent) {
-                        auto target_itr = std::find_if(
-                            m_context_stack.rbegin(), m_context_stack.rend(), [indent](const parse_context& c) {
-                                return indent == c.indent;
+                    else if (indent <= m_context_stack.back().indent) {
+                        auto target_itr = std::find_if( // LCOV_EXCL_LINE
+                            m_context_stack.rbegin(),
+                            m_context_stack.rend(),
+                            [indent](const parse_context& c) {
+                                if (indent != c.indent) {
+                                    return false;
+                                }
+
+                                switch (c.state) {
+                                case context_state_t::BLOCK_MAPPING:
+                                case context_state_t::MAPPING_VALUE:
+                                    return true;
+                                default:
+                                    return false;
+                                }
                             });
                         bool is_indent_valid = (target_itr != m_context_stack.rend());
                         if (!is_indent_valid) {
@@ -537,12 +553,6 @@ private:
                     throw parse_error("invalid flow sequence ending is found.", line, indent);
                 }
 
-                // move back to the context before the flow sequence.
-                uint32_t pop_num = static_cast<uint32_t>(std::distance(m_context_stack.rbegin(), itr));
-                for (uint32_t i = 0; i < pop_num; i++) {
-                    m_context_stack.pop_back();
-                }
-
                 // keep the last state for later processing.
                 parse_context& last_context = m_context_stack.back();
                 mp_current_node = last_context.p_node;
@@ -583,10 +593,22 @@ private:
                     if (indent == 0) {
                         pop_num = static_cast<uint32_t>(m_context_stack.size() - 1);
                     }
-                    else if (indent < m_context_stack.back().indent) {
-                        auto target_itr = std::find_if(
-                            m_context_stack.rbegin(), m_context_stack.rend(), [indent](const parse_context& c) {
-                                return indent == c.indent;
+                    else if (indent <= m_context_stack.back().indent) {
+                        auto target_itr = std::find_if( // LCOV_EXCL_LINE
+                            m_context_stack.rbegin(),
+                            m_context_stack.rend(),
+                            [indent](const parse_context& c) {
+                                if (indent != c.indent) {
+                                    return false;
+                                }
+
+                                switch (c.state) {
+                                case context_state_t::BLOCK_MAPPING:
+                                case context_state_t::MAPPING_VALUE:
+                                    return true;
+                                default:
+                                    return false;
+                                }
                             });
                         bool is_indent_valid = (target_itr != m_context_stack.rend());
                         if (!is_indent_valid) {
@@ -653,12 +675,6 @@ private:
                 bool is_valid = itr != m_context_stack.rend();
                 if (!is_valid) {
                     throw parse_error("invalid flow mapping ending is found.", line, indent);
-                }
-
-                // move back to the context before the flow sequence.
-                uint32_t pop_num = static_cast<uint32_t>(std::distance(m_context_stack.rbegin(), itr));
-                for (uint32_t i = 0; i < pop_num; i++) {
-                    m_context_stack.pop_back();
                 }
 
                 // keep the last state for later processing.
@@ -841,7 +857,9 @@ private:
         }
 
         mp_current_node = &(itr.first->second);
-        m_context_stack.emplace_back(line, indent, context_state_t::MAPPING_VALUE, mp_current_node);
+        parse_context& key_context = m_context_stack.back();
+        m_context_stack.emplace_back(
+            key_context.line, key_context.indent, context_state_t::MAPPING_VALUE, mp_current_node);
     }
 
     /// @brief Assign node value to the current node.

--- a/include/fkYAML/detail/input/deserializer.hpp
+++ b/include/fkYAML/detail/input/deserializer.hpp
@@ -58,6 +58,7 @@ class basic_deserializer {
         MAPPING_VALUE,                //!< The underlying node is a block mapping value.
         BLOCK_SEQUENCE,               //!< The underlying node is a block sequence.
         FLOW_SEQUENCE,                //!< The underlying node is a flow sequence.
+        FLOW_SEQUENCE_KEY,            //!< The underlying node is a flow sequence as a key.
         FLOW_MAPPING,                 //!< The underlying node is a flow mapping.
         FLOW_MAPPING_KEY,             //!< The underlying node is a flow mapping as a key.
     };
@@ -459,6 +460,32 @@ private:
                 break;
             }
             case lexical_token_t::SEQUENCE_FLOW_BEGIN:
+                if (m_flow_context_depth == 0) {
+                    uint32_t pop_num = 0;
+                    if (indent == 0) {
+                        pop_num = static_cast<uint32_t>(m_context_stack.size() - 1);
+                    }
+                    else if (indent < m_context_stack.back().indent) {
+                        auto target_itr = std::find_if(
+                            m_context_stack.rbegin(), m_context_stack.rend(), [indent](const parse_context& c) {
+                                return indent == c.indent;
+                            });
+                        bool is_indent_valid = (target_itr != m_context_stack.rend());
+                        if (!is_indent_valid) {
+                            throw parse_error("Detected invalid indentaion.", line, indent);
+                        }
+
+                        pop_num = static_cast<uint32_t>(std::distance(m_context_stack.rbegin(), target_itr));
+                    }
+                    if (pop_num > 0) {
+                        for (uint32_t i = 0; i < pop_num; i++) {
+                            // move back to the previous container node.
+                            m_context_stack.pop_back();
+                        }
+                        mp_current_node = m_context_stack.back().p_node;
+                    }
+                }
+
                 ++m_flow_context_depth;
 
                 switch (m_context_stack.back().state) {
@@ -467,6 +494,13 @@ private:
                     mp_current_node->template get_value_ref<sequence_type&>().emplace_back(node_type::sequence());
                     mp_current_node = &(mp_current_node->template get_value_ref<sequence_type&>().back());
                     m_context_stack.emplace_back(line, indent, context_state_t::FLOW_SEQUENCE, mp_current_node);
+                    break;
+                case context_state_t::BLOCK_MAPPING:
+                case context_state_t::FLOW_MAPPING:
+                    // heap-allocated node will be freed in handling the corresponding SEQUENCE_FLOW_END event.
+                    m_context_stack.emplace_back(
+                        line, indent, context_state_t::FLOW_SEQUENCE_KEY, new node_type(node_t::SEQUENCE));
+                    mp_current_node = m_context_stack.back().p_node;
                     break;
                 default:
                     *mp_current_node = node_type::sequence();
@@ -484,7 +518,15 @@ private:
                 auto itr = std::find_if( // LCOV_EXCL_LINE
                     m_context_stack.rbegin(),
                     m_context_stack.rend(),
-                    [](const parse_context& c) { return c.state == context_state_t::FLOW_SEQUENCE; });
+                    [](const parse_context& c) {
+                        switch (c.state) {
+                        case context_state_t::FLOW_SEQUENCE_KEY:
+                        case context_state_t::FLOW_SEQUENCE:
+                            return true;
+                        default:
+                            return false;
+                        }
+                    });
 
                 bool is_valid = itr != m_context_stack.rend();
                 if (!is_valid) {
@@ -492,15 +534,45 @@ private:
                 }
 
                 // move back to the context before the flow sequence.
-                auto pop_num = std::distance(m_context_stack.rbegin(), itr) + 1;
-                for (auto i = 0; i < pop_num; i++) {
+                uint32_t pop_num = static_cast<uint32_t>(std::distance(m_context_stack.rbegin(), itr) + 1);
+                uint32_t stack_size = static_cast<uint32_t>(m_context_stack.size());
+
+                if (pop_num == stack_size) {
+                    indent = m_context_stack.front().indent;
+                    line = m_context_stack.front().line;
+                }
+
+                context_state_t state = context_state_t::FLOW_SEQUENCE;
+                for (uint32_t i = 0; i < pop_num; i++) {
                     mp_current_node = m_context_stack.back().p_node;
+                    state = m_context_stack.back().state;
                     m_context_stack.pop_back();
                 }
+
                 if (!m_context_stack.empty()) {
+                    if (state == context_state_t::FLOW_SEQUENCE_KEY) {
+                        node_type key_node = std::move(*mp_current_node);
+                        delete mp_current_node;
+                        mp_current_node = m_context_stack.back().p_node;
+
+                        add_new_key(std::move(key_node), indent, line);
+                        break;
+                    }
+
                     mp_current_node = m_context_stack.back().p_node;
+                    break;
                 }
-                break;
+
+                type = lexer.get_next_token();
+                if (type == lexical_token_t::KEY_SEPARATOR) {
+                    node_type key_node = node_type::mapping();
+                    mp_current_node->swap(key_node);
+                    m_context_stack.emplace_back(line, indent, context_state_t::BLOCK_MAPPING, mp_current_node);
+                    add_new_key(std::move(key_node), indent, line);
+                }
+                indent = lexer.get_last_token_begin_pos();
+                line = lexer.get_lines_processed();
+                continue;
             }
             case lexical_token_t::MAPPING_FLOW_BEGIN:
                 if (m_flow_context_depth == 0) {

--- a/single_include/fkYAML/node.hpp
+++ b/single_include/fkYAML/node.hpp
@@ -4703,6 +4703,8 @@ private:
                     mp_current_node->template get_value_ref<sequence_type&>().emplace_back(node_type::sequence());
                     mp_current_node = &(mp_current_node->template get_value_ref<sequence_type&>().back());
                     m_context_stack.emplace_back(line, indent, context_state_t::FLOW_SEQUENCE, mp_current_node);
+                    apply_directive_set(*mp_current_node);
+                    apply_node_properties(*mp_current_node);
                     break;
                 case context_state_t::BLOCK_MAPPING:
                 case context_state_t::FLOW_MAPPING:
@@ -4710,9 +4712,13 @@ private:
                     m_context_stack.emplace_back(
                         line, indent, context_state_t::FLOW_SEQUENCE_KEY, new node_type(node_t::SEQUENCE));
                     mp_current_node = m_context_stack.back().p_node;
+                    apply_directive_set(*mp_current_node);
+                    apply_node_properties(*mp_current_node);
                     break;
                 default:
                     *mp_current_node = node_type::sequence();
+                    apply_directive_set(*mp_current_node);
+                    apply_node_properties(*mp_current_node);
                     m_context_stack.back().state = context_state_t::FLOW_SEQUENCE;
                     break;
                 }
@@ -4818,6 +4824,8 @@ private:
                     mp_current_node->template get_value_ref<sequence_type&>().emplace_back(node_type::mapping());
                     mp_current_node = &(mp_current_node->template get_value_ref<sequence_type&>().back());
                     m_context_stack.emplace_back(line, indent, context_state_t::FLOW_MAPPING, mp_current_node);
+                    apply_directive_set(*mp_current_node);
+                    apply_node_properties(*mp_current_node);
                     break;
                 case context_state_t::BLOCK_MAPPING:
                 case context_state_t::FLOW_MAPPING:
@@ -4825,9 +4833,13 @@ private:
                     m_context_stack.emplace_back(
                         line, indent, context_state_t::FLOW_MAPPING_KEY, new node_type(node_t::MAPPING));
                     mp_current_node = m_context_stack.back().p_node;
+                    apply_directive_set(*mp_current_node);
+                    apply_node_properties(*mp_current_node);
                     break;
                 default:
                     *mp_current_node = node_type::mapping();
+                    apply_directive_set(*mp_current_node);
+                    apply_node_properties(*mp_current_node);
                     m_context_stack.back().state = context_state_t::FLOW_MAPPING;
                     break;
                 }

--- a/single_include/fkYAML/node.hpp
+++ b/single_include/fkYAML/node.hpp
@@ -4703,8 +4703,6 @@ private:
                     mp_current_node->template get_value_ref<sequence_type&>().emplace_back(node_type::sequence());
                     mp_current_node = &(mp_current_node->template get_value_ref<sequence_type&>().back());
                     m_context_stack.emplace_back(line, indent, context_state_t::FLOW_SEQUENCE, mp_current_node);
-                    apply_directive_set(*mp_current_node);
-                    apply_node_properties(*mp_current_node);
                     break;
                 case context_state_t::BLOCK_MAPPING:
                 case context_state_t::FLOW_MAPPING:
@@ -4712,15 +4710,15 @@ private:
                     m_context_stack.emplace_back(
                         line, indent, context_state_t::FLOW_SEQUENCE_KEY, new node_type(node_t::SEQUENCE));
                     mp_current_node = m_context_stack.back().p_node;
-                    apply_directive_set(*mp_current_node);
-                    apply_node_properties(*mp_current_node);
                     break;
-                default:
+                default: {
                     *mp_current_node = node_type::sequence();
-                    apply_directive_set(*mp_current_node);
-                    apply_node_properties(*mp_current_node);
-                    m_context_stack.back().state = context_state_t::FLOW_SEQUENCE;
+                    parse_context& last_context = m_context_stack.back();
+                    last_context.line = line;
+                    last_context.indent = indent;
+                    last_context.state = context_state_t::FLOW_SEQUENCE;
                     break;
+                }
                 }
 
                 apply_directive_set(*mp_current_node);
@@ -4749,42 +4747,41 @@ private:
                 }
 
                 // move back to the context before the flow sequence.
-                uint32_t pop_num = static_cast<uint32_t>(std::distance(m_context_stack.rbegin(), itr) + 1);
-                uint32_t stack_size = static_cast<uint32_t>(m_context_stack.size());
-
-                if (pop_num == stack_size) {
-                    indent = m_context_stack.front().indent;
-                    line = m_context_stack.front().line;
-                }
-
-                context_state_t state = context_state_t::FLOW_SEQUENCE;
+                uint32_t pop_num = static_cast<uint32_t>(std::distance(m_context_stack.rbegin(), itr));
                 for (uint32_t i = 0; i < pop_num; i++) {
-                    mp_current_node = m_context_stack.back().p_node;
-                    state = m_context_stack.back().state;
                     m_context_stack.pop_back();
                 }
 
-                if (!m_context_stack.empty()) {
-                    if (state == context_state_t::FLOW_SEQUENCE_KEY) {
-                        node_type key_node = std::move(*mp_current_node);
-                        delete mp_current_node;
-                        mp_current_node = m_context_stack.back().p_node;
+                // keep the last state for later processing.
+                parse_context& last_context = m_context_stack.back();
+                mp_current_node = last_context.p_node;
+                indent = last_context.indent;
+                context_state_t state = last_context.state;
+                m_context_stack.pop_back();
 
-                        add_new_key(std::move(key_node), indent, line);
-                        break;
-                    }
+                // handle cases where the flow sequence is a mapping key node.
 
+                if (!m_context_stack.empty() && state == context_state_t::FLOW_SEQUENCE_KEY) {
+                    node_type key_node = std::move(*mp_current_node);
+                    delete mp_current_node;
                     mp_current_node = m_context_stack.back().p_node;
+
+                    add_new_key(std::move(key_node), indent, line);
                     break;
                 }
 
                 type = lexer.get_next_token();
                 if (type == lexical_token_t::KEY_SEPARATOR) {
                     node_type key_node = node_type::mapping();
+                    apply_directive_set(key_node);
                     mp_current_node->swap(key_node);
                     m_context_stack.emplace_back(line, indent, context_state_t::BLOCK_MAPPING, mp_current_node);
                     add_new_key(std::move(key_node), indent, line);
                 }
+                else if (!m_context_stack.empty()) {
+                    mp_current_node = m_context_stack.back().p_node;
+                }
+
                 indent = lexer.get_last_token_begin_pos();
                 line = lexer.get_lines_processed();
                 continue;
@@ -4824,8 +4821,6 @@ private:
                     mp_current_node->template get_value_ref<sequence_type&>().emplace_back(node_type::mapping());
                     mp_current_node = &(mp_current_node->template get_value_ref<sequence_type&>().back());
                     m_context_stack.emplace_back(line, indent, context_state_t::FLOW_MAPPING, mp_current_node);
-                    apply_directive_set(*mp_current_node);
-                    apply_node_properties(*mp_current_node);
                     break;
                 case context_state_t::BLOCK_MAPPING:
                 case context_state_t::FLOW_MAPPING:
@@ -4833,15 +4828,15 @@ private:
                     m_context_stack.emplace_back(
                         line, indent, context_state_t::FLOW_MAPPING_KEY, new node_type(node_t::MAPPING));
                     mp_current_node = m_context_stack.back().p_node;
-                    apply_directive_set(*mp_current_node);
-                    apply_node_properties(*mp_current_node);
                     break;
-                default:
+                default: {
                     *mp_current_node = node_type::mapping();
-                    apply_directive_set(*mp_current_node);
-                    apply_node_properties(*mp_current_node);
-                    m_context_stack.back().state = context_state_t::FLOW_MAPPING;
+                    parse_context& last_context = m_context_stack.back();
+                    last_context.line = line;
+                    last_context.indent = indent;
+                    last_context.state = context_state_t::FLOW_MAPPING;
                     break;
+                }
                 }
 
                 apply_directive_set(*mp_current_node);
@@ -4870,32 +4865,26 @@ private:
                 }
 
                 // move back to the context before the flow sequence.
-                uint32_t pop_num = static_cast<uint32_t>(std::distance(m_context_stack.rbegin(), itr) + 1);
-                uint32_t stack_size = static_cast<uint32_t>(m_context_stack.size());
-
-                if (pop_num == stack_size) {
-                    indent = m_context_stack.front().indent;
-                    line = m_context_stack.front().line;
-                }
-
-                context_state_t state = context_state_t::FLOW_MAPPING;
+                uint32_t pop_num = static_cast<uint32_t>(std::distance(m_context_stack.rbegin(), itr));
                 for (uint32_t i = 0; i < pop_num; i++) {
-                    mp_current_node = m_context_stack.back().p_node;
-                    state = m_context_stack.back().state;
                     m_context_stack.pop_back();
                 }
 
-                if (!m_context_stack.empty()) {
-                    if (state == context_state_t::FLOW_MAPPING_KEY) {
-                        node_type key_node = std::move(*mp_current_node);
-                        delete mp_current_node;
-                        mp_current_node = m_context_stack.back().p_node;
+                // keep the last state for later processing.
+                parse_context& last_context = m_context_stack.back();
+                mp_current_node = last_context.p_node;
+                indent = last_context.indent;
+                context_state_t state = last_context.state;
+                m_context_stack.pop_back();
 
-                        add_new_key(std::move(key_node), indent, line);
-                        break;
-                    }
+                // handle cases where the flow mapping is a mapping key node.
 
+                if (!m_context_stack.empty() && state == context_state_t::FLOW_MAPPING_KEY) {
+                    node_type key_node = std::move(*mp_current_node);
+                    delete mp_current_node;
                     mp_current_node = m_context_stack.back().p_node;
+
+                    add_new_key(std::move(key_node), indent, line);
                     break;
                 }
 
@@ -4906,6 +4895,10 @@ private:
                     m_context_stack.emplace_back(line, indent, context_state_t::BLOCK_MAPPING, mp_current_node);
                     add_new_key(std::move(key_node), indent, line);
                 }
+                else if (!m_context_stack.empty()) {
+                    mp_current_node = m_context_stack.back().p_node;
+                }
+
                 indent = lexer.get_last_token_begin_pos();
                 line = lexer.get_lines_processed();
                 continue;

--- a/test/unit_test/test_deserializer_class.cpp
+++ b/test/unit_test/test_deserializer_class.cpp
@@ -842,8 +842,7 @@ TEST_CASE("Deserializer_BlockMapping") {
 
     SECTION("mapping with flow mapping keys") {
         std::string input = "{foo: bar}:\n"
-                            "  baz: # some comment\n"
-                            "    123\n"
+                            "  {baz: null}: 123\n"
                             "{true: 123}: \n"
                             "  3.14";
         REQUIRE_NOTHROW(root = deserializer.deserialize(fkyaml::detail::input_adapter(input)));
@@ -858,11 +857,12 @@ TEST_CASE("Deserializer_BlockMapping") {
         fkyaml::node& root_foobar_mapkey_node = root[std::move(foobar_mapkey)];
         REQUIRE(root_foobar_mapkey_node.is_mapping());
         REQUIRE(root_foobar_mapkey_node.size() == 1);
-        REQUIRE(root_foobar_mapkey_node.contains("baz"));
+        fkyaml::node baznull_mapkey = {{"baz", nullptr}};
+        REQUIRE(root_foobar_mapkey_node.contains(baznull_mapkey));
 
-        fkyaml::node& root_foobar_mapkey_baz_node = root_foobar_mapkey_node["baz"];
-        REQUIRE(root_foobar_mapkey_baz_node.is_integer());
-        REQUIRE(root_foobar_mapkey_baz_node.get_value<int>() == 123);
+        fkyaml::node& root_foobar_mapkey_baznull_mapkey_node = root_foobar_mapkey_node[std::move(baznull_mapkey)];
+        REQUIRE(root_foobar_mapkey_baznull_mapkey_node.is_integer());
+        REQUIRE(root_foobar_mapkey_baznull_mapkey_node.get_value<int>() == 123);
 
         fkyaml::node& root_true123_mapkey_node = root[std::move(true123_mapkey)];
         REQUIRE(root_true123_mapkey_node.is_float_number());
@@ -871,8 +871,7 @@ TEST_CASE("Deserializer_BlockMapping") {
 
     SECTION("mapping with flow sequence keys") {
         std::string input = "[foo,bar]:\n"
-                            "  baz: # some comment\n"
-                            "    123\n"
+                            "  [baz,null]: 123\n"
                             "[true,123]: \n"
                             "  3.14";
         REQUIRE_NOTHROW(root = deserializer.deserialize(fkyaml::detail::input_adapter(input)));
@@ -887,11 +886,12 @@ TEST_CASE("Deserializer_BlockMapping") {
         fkyaml::node& root_foobar_seqkey_node = root[std::move(foobar_seqkey)];
         REQUIRE(root_foobar_seqkey_node.is_mapping());
         REQUIRE(root_foobar_seqkey_node.size() == 1);
-        REQUIRE(root_foobar_seqkey_node.contains("baz"));
+        fkyaml::node baznull_seqkey = {"baz", nullptr};
+        REQUIRE(root_foobar_seqkey_node.contains(baznull_seqkey));
 
-        fkyaml::node& root_foobar_seqkey_baz_node = root_foobar_seqkey_node["baz"];
-        REQUIRE(root_foobar_seqkey_baz_node.is_integer());
-        REQUIRE(root_foobar_seqkey_baz_node.get_value<int>() == 123);
+        fkyaml::node& root_foobar_seqkey_baznull_seqkey_node = root_foobar_seqkey_node[baznull_seqkey];
+        REQUIRE(root_foobar_seqkey_baznull_seqkey_node.is_integer());
+        REQUIRE(root_foobar_seqkey_baznull_seqkey_node.get_value<int>() == 123);
 
         fkyaml::node& root_true123_seqkey_node = root[std::move(true123_seqkey)];
         REQUIRE(root_true123_seqkey_node.is_float_number());


### PR DESCRIPTION
This PR has fixed parse errors on flow container keys like the following valid YAML snippet:  
```yaml
{foo: bar}: 123
[true,false]: 3.14
```

The root cause is that the fkYAML deserializer wrongly assumed that flow containers weren't used as a mapping key.  
To validate the fix, the test suite has also been updated by adding several relevant test cases for the deserializer.  

---

## Pull Request Checklist

Read the [CONTRIBUTING.md](https://github.com/fktn-k/fkYAML/blob/develop/CONTRIBUTING.md) file for detailed information.  

- [x] Changes are described in the pull request or in a referenced [issue](https://github.com/fktn-k/fkYAML/issues).
- [x] The test suite compiles and runs without any error.
- [x] [The code coverage](https://coveralls.io/github/fktn-k/fkYAML) on your branch is 100%.
- [x] The documentation is updated if you added/changed a feature.

## Please don't

- The C++11 support varies between different **compilers** and versions. Please note the [list of supported compilers](https://github.com/fktn-k/fkYAML/blob/develop/README.md#supported-compilers). Some compilers like GCC 4.7 (and earlier), Clang 3.3 (and earlier), or Microsoft Visual Studio 13.0 and earlier are known not to work due to missing or incomplete C++11 support. Please refrain from proposing changes that work around these compiler's limitations with `#ifdef`s or other means.
- Please refrain from proposing changes that would **break [YAML](https://yaml.org/) specifications**. If you propose a conformant extension of YAML to be supported by the library, please motivate this extension.
- Please do not open pull requests that address **multiple issues**.
