### PR TITLE
Fix wrong parse result from mappings containing the non-first block sequence

### DIFF
--- a/include/fkYAML/detail/input/deserializer.hpp
+++ b/include/fkYAML/detail/input/deserializer.hpp
@@ -641,7 +641,17 @@ private:
         else if (indent < m_context_stack.back().indent) {
             auto target_itr =
                 std::find_if(m_context_stack.rbegin(), m_context_stack.rend(), [indent](const parse_context& c) {
-                    return indent == c.indent;
+                    if (indent != c.indent) {
+                        return false;
+                    }
+
+                    switch (c.state) {
+                    case context_state_t::BLOCK_MAPPING:
+                    case context_state_t::MAPPING_VALUE:
+                        return true;
+                    default:
+                        return false;
+                    }
                 });
             bool is_indent_valid = (target_itr != m_context_stack.rend());
             if (!is_indent_valid) {

--- a/single_include/fkYAML/node.hpp
+++ b/single_include/fkYAML/node.hpp
@@ -4850,7 +4850,17 @@ private:
         else if (indent < m_context_stack.back().indent) {
             auto target_itr =
                 std::find_if(m_context_stack.rbegin(), m_context_stack.rend(), [indent](const parse_context& c) {
-                    return indent == c.indent;
+                    if (indent != c.indent) {
+                        return false;
+                    }
+
+                    switch (c.state) {
+                    case context_state_t::BLOCK_MAPPING:
+                    case context_state_t::MAPPING_VALUE:
+                        return true;
+                    default:
+                        return false;
+                    }
                 });
             bool is_indent_valid = (target_itr != m_context_stack.rend());
             if (!is_indent_valid) {

--- a/test/unit_test/test_deserializer_class.cpp
+++ b/test/unit_test/test_deserializer_class.cpp
@@ -1016,6 +1016,83 @@ TEST_CASE("Deserializer_BlockMappingAsBlockSequenceEntry") {
         REQUIRE(stuff_1_name_node.is_string());
         REQUIRE(stuff_1_name_node.get_value_ref<std::string&>() == "Bar");
     }
+
+    SECTION("block mapping entry with child block sequence of block mapping entries") {
+        std::string input = "contexts:\n"
+                            "- context:\n"
+                            "    cluster: abcdef\n"
+                            "    extension:\n"
+                            "    - extension:\n"
+                            "        last-update: blah\n"
+                            "        version: 0.1.0\n"
+                            "      name: blah\n"
+                            "    bug: default\n"
+                            "  ctx: ctx";
+        REQUIRE_NOTHROW(root = deserializer.deserialize(fkyaml::detail::input_adapter(input)));
+
+        REQUIRE(root.is_mapping());
+        REQUIRE(root.size() == 1);
+        REQUIRE(root.contains("contexts"));
+
+        fkyaml::node& contexts_node = root["contexts"];
+        REQUIRE(contexts_node.is_sequence());
+        REQUIRE(contexts_node.size() == 1);
+
+        fkyaml::node& contexts_0_node = contexts_node[0];
+        REQUIRE(contexts_0_node.is_mapping());
+        REQUIRE(contexts_0_node.size() == 2);
+        REQUIRE(contexts_0_node.contains("context"));
+        REQUIRE(contexts_0_node.contains("ctx"));
+
+        fkyaml::node& contexts_0_context_node = contexts_0_node["context"];
+        REQUIRE(contexts_0_context_node.is_mapping());
+        REQUIRE(contexts_0_context_node.size() == 3);
+        REQUIRE(contexts_0_context_node.contains("cluster"));
+        REQUIRE(contexts_0_context_node.contains("extension"));
+        REQUIRE(contexts_0_context_node.contains("bug"));
+
+        fkyaml::node& contexts_0_context_cluster_node = contexts_0_context_node["cluster"];
+        REQUIRE(contexts_0_context_cluster_node.is_string());
+        REQUIRE(contexts_0_context_cluster_node.get_value_ref<std::string&>() == "abcdef");
+
+        fkyaml::node& contexts_0_context_extension_node = contexts_0_context_node["extension"];
+        REQUIRE(contexts_0_context_extension_node.is_sequence());
+        REQUIRE(contexts_0_context_extension_node.size() == 1);
+
+        fkyaml::node& contexts_0_context_extension_0_node = contexts_0_context_extension_node[0];
+        REQUIRE(contexts_0_context_extension_0_node.is_mapping());
+        REQUIRE(contexts_0_context_extension_0_node.size() == 2);
+        REQUIRE(contexts_0_context_extension_0_node.contains("extension"));
+        REQUIRE(contexts_0_context_extension_0_node.contains("name"));
+
+        fkyaml::node& contexts_0_context_extension_0_extension_node = contexts_0_context_extension_0_node["extension"];
+        REQUIRE(contexts_0_context_extension_0_extension_node.is_mapping());
+        REQUIRE(contexts_0_context_extension_0_extension_node.size() == 2);
+        REQUIRE(contexts_0_context_extension_0_extension_node.contains("last-update"));
+        REQUIRE(contexts_0_context_extension_0_extension_node.contains("version"));
+
+        fkyaml::node& contexts_0_context_extension_0_extension_lastupdate_node =
+            contexts_0_context_extension_0_extension_node["last-update"];
+        REQUIRE(contexts_0_context_extension_0_extension_lastupdate_node.is_string());
+        REQUIRE(contexts_0_context_extension_0_extension_lastupdate_node.get_value_ref<std::string&>() == "blah");
+
+        fkyaml::node& contexts_0_context_extension_0_extension_version_node =
+            contexts_0_context_extension_0_extension_node["version"];
+        REQUIRE(contexts_0_context_extension_0_extension_version_node.is_string());
+        REQUIRE(contexts_0_context_extension_0_extension_version_node.get_value_ref<std::string&>() == "0.1.0");
+
+        fkyaml::node& contexts_0_context_extension_0_name_node = contexts_0_context_extension_0_node["name"];
+        REQUIRE(contexts_0_context_extension_0_name_node.is_string());
+        REQUIRE(contexts_0_context_extension_0_name_node.get_value_ref<std::string&>() == "blah");
+
+        fkyaml::node& contexts_0_context_bug_node = contexts_0_context_node["bug"];
+        REQUIRE(contexts_0_context_bug_node.is_string());
+        REQUIRE(contexts_0_context_bug_node.get_value_ref<std::string&>() == "default");
+
+        fkyaml::node& contexts_0_ctx_node = contexts_0_node["ctx"];
+        REQUIRE(contexts_0_ctx_node.is_string());
+        REQUIRE(contexts_0_ctx_node.get_value_ref<std::string&>() == "ctx");
+    }
 }
 
 TEST_CASE("Deserializer_ExplicitBlockMapping") {


### PR DESCRIPTION
This PR has fixed wrong parse results from YAML which contains the non-first node pair whose value is a block sequence, like the YAML snippet in the issue #347 due to the wrong tracing back to a parent mapping node.  

---

## Pull Request Checklist

Read the [CONTRIBUTING.md](https://github.com/fktn-k/fkYAML/blob/develop/CONTRIBUTING.md) file for detailed information.  

- [x] Changes are described in the pull request or in a referenced [issue](https://github.com/fktn-k/fkYAML/issues).
- [x] The test suite compiles and runs without any error.
- [x] [The code coverage](https://coveralls.io/github/fktn-k/fkYAML) on your branch is 100%.
- [x] The documentation is updated if you added/changed a feature.

## Please don't

- The C++11 support varies between different **compilers** and versions. Please note the [list of supported compilers](https://github.com/fktn-k/fkYAML/blob/develop/README.md#supported-compilers). Some compilers like GCC 4.7 (and earlier), Clang 3.3 (and earlier), or Microsoft Visual Studio 13.0 and earlier are known not to work due to missing or incomplete C++11 support. Please refrain from proposing changes that work around these compiler's limitations with `#ifdef`s or other means.
- Please refrain from proposing changes that would **break [YAML](https://yaml.org/) specifications**. If you propose a conformant extension of YAML to be supported by the library, please motivate this extension.
- Please do not open pull requests that address **multiple issues**.
