### PR TITLE
Fix parse error on empty flow containers

### DIFF
--- a/include/fkYAML/detail/input/deserializer.hpp
+++ b/include/fkYAML/detail/input/deserializer.hpp
@@ -505,7 +505,15 @@ private:
 
                 apply_directive_set(*mp_current_node);
                 apply_node_properties(*mp_current_node);
-                break;
+
+                type = lexer.get_next_token();
+                if (type == lexical_token_t::SEQUENCE_FLOW_END) {
+                    // enable the flag for the next loop for the empty flow sequence.
+                    m_needs_value_separator_or_suffix = true;
+                }
+                line = lexer.get_lines_processed();
+                indent = lexer.get_last_token_begin_pos();
+                continue;
             case lexical_token_t::SEQUENCE_FLOW_END: {
                 if (!m_needs_value_separator_or_suffix) {
                     throw parse_error("invalid flow sequence ending is found.", line, indent);
@@ -639,7 +647,15 @@ private:
 
                 apply_directive_set(*mp_current_node);
                 apply_node_properties(*mp_current_node);
-                break;
+
+                type = lexer.get_next_token();
+                if (type == lexical_token_t::MAPPING_FLOW_END) {
+                    // enable the flag for the next loop for the empty flow mapping.
+                    m_needs_value_separator_or_suffix = true;
+                }
+                line = lexer.get_lines_processed();
+                indent = lexer.get_last_token_begin_pos();
+                continue;
             case lexical_token_t::MAPPING_FLOW_END: {
                 if (!m_needs_value_separator_or_suffix) {
                     throw parse_error("invalid flow mapping ending is found.", line, indent);

--- a/single_include/fkYAML/node.hpp
+++ b/single_include/fkYAML/node.hpp
@@ -4714,7 +4714,15 @@ private:
 
                 apply_directive_set(*mp_current_node);
                 apply_node_properties(*mp_current_node);
-                break;
+
+                type = lexer.get_next_token();
+                if (type == lexical_token_t::SEQUENCE_FLOW_END) {
+                    // enable the flag for the next loop for the empty flow sequence.
+                    m_needs_value_separator_or_suffix = true;
+                }
+                line = lexer.get_lines_processed();
+                indent = lexer.get_last_token_begin_pos();
+                continue;
             case lexical_token_t::SEQUENCE_FLOW_END: {
                 if (!m_needs_value_separator_or_suffix) {
                     throw parse_error("invalid flow sequence ending is found.", line, indent);
@@ -4848,7 +4856,15 @@ private:
 
                 apply_directive_set(*mp_current_node);
                 apply_node_properties(*mp_current_node);
-                break;
+
+                type = lexer.get_next_token();
+                if (type == lexical_token_t::MAPPING_FLOW_END) {
+                    // enable the flag for the next loop for the empty flow mapping.
+                    m_needs_value_separator_or_suffix = true;
+                }
+                line = lexer.get_lines_processed();
+                indent = lexer.get_last_token_begin_pos();
+                continue;
             case lexical_token_t::MAPPING_FLOW_END: {
                 if (!m_needs_value_separator_or_suffix) {
                     throw parse_error("invalid flow mapping ending is found.", line, indent);

--- a/test/unit_test/test_deserializer_class.cpp
+++ b/test/unit_test/test_deserializer_class.cpp
@@ -1441,6 +1441,19 @@ TEST_CASE("Deserializer_FlowSequence") {
         std::string input = "[123,,true]";
         REQUIRE_THROWS_AS(deserializer.deserialize(fkyaml::detail::input_adapter(input)), fkyaml::parse_error);
     }
+
+    SECTION("empty flow sequence") {
+        std::string input = "foo: []";
+        REQUIRE_NOTHROW(root = deserializer.deserialize(fkyaml::detail::input_adapter(input)));
+
+        REQUIRE(root.is_mapping());
+        REQUIRE(root.size() == 1);
+        REQUIRE(root.contains("foo"));
+
+        fkyaml::node& foo_node = root["foo"];
+        REQUIRE(foo_node.is_sequence());
+        REQUIRE(foo_node.empty());
+    }
 }
 
 TEST_CASE("Deserializer_FlowMapping") {
@@ -1738,6 +1751,19 @@ TEST_CASE("Deserializer_FlowMapping") {
     SECTION("too many value separators") {
         std::string input = "{foo: 123,,bar: true}";
         REQUIRE_THROWS_AS(deserializer.deserialize(fkyaml::detail::input_adapter(input)), fkyaml::parse_error);
+    }
+
+    SECTION("empty flow mapping") {
+        std::string input = "foo: {}";
+        REQUIRE_NOTHROW(root = deserializer.deserialize(fkyaml::detail::input_adapter(input)));
+
+        REQUIRE(root.is_mapping());
+        REQUIRE(root.size() == 1);
+        REQUIRE(root.contains("foo"));
+
+        fkyaml::node& foo_node = root["foo"];
+        REQUIRE(foo_node.is_mapping());
+        REQUIRE(foo_node.empty());
     }
 }
 


### PR DESCRIPTION
As reported in the issue #347, the latest parser mistakenly emits the parse errors on empty flow containers like:

```yaml
foo: {}
bar: []
```

They are caused because the PR #350 lacked implementation for empty flow containers.  
So, this PR has fixed them by adding the missing implementation and added some test cases to validate the changes.  

---

## Pull Request Checklist

Read the [CONTRIBUTING.md](https://github.com/fktn-k/fkYAML/blob/develop/CONTRIBUTING.md) file for detailed information.  

- [x] Changes are described in the pull request or in a referenced [issue](https://github.com/fktn-k/fkYAML/issues).
- [x] The test suite compiles and runs without any error.
- [x] [The code coverage](https://coveralls.io/github/fktn-k/fkYAML) on your branch is 100%.
- [x] The documentation is updated if you added/changed a feature.

## Please don't

- The C++11 support varies between different **compilers** and versions. Please note the [list of supported compilers](https://github.com/fktn-k/fkYAML/blob/develop/README.md#supported-compilers). Some compilers like GCC 4.7 (and earlier), Clang 3.3 (and earlier), or Microsoft Visual Studio 13.0 and earlier are known not to work due to missing or incomplete C++11 support. Please refrain from proposing changes that work around these compiler's limitations with `#ifdef`s or other means.
- Please refrain from proposing changes that would **break [YAML](https://yaml.org/) specifications**. If you propose a conformant extension of YAML to be supported by the library, please motivate this extension.
- Please do not open pull requests that address **multiple issues**.
