### PR TITLE
fixed parse error on explicit mappings as a block sequence entry

### DIFF
--- a/include/fkYAML/detail/input/deserializer.hpp
+++ b/include/fkYAML/detail/input/deserializer.hpp
@@ -281,6 +281,12 @@ private:
                     apply_directive_set(*mp_current_node);
                 }
 
+                if (m_context_stack.back().state == context_state_t::BLOCK_SEQUENCE) {
+                    sequence_type& seq = mp_current_node->template get_value_ref<sequence_type&>();
+                    seq.emplace_back(node_type::mapping());
+                    m_context_stack.emplace_back(line, indent, context_state_t::BLOCK_MAPPING, &(seq.back()));
+                }
+
                 type = lexer.get_next_token();
                 if (type == lexical_token_t::SEQUENCE_BLOCK_PREFIX) {
                     // heap-allocated node will be freed in handling the corresponding KEY_SEPARATOR event
@@ -1012,19 +1018,25 @@ private:
 
         type = lexer.get_next_token();
         if (type == lexical_token_t::KEY_SEPARATOR) {
-            if (mp_current_node->is_scalar()) {
-                if (line != lexer.get_lines_processed()) {
-                    // This path is for explicit mapping key separator(:)
-                    assign_node_value(std::move(node), line, indent);
-                    if (m_context_stack.back().state != context_state_t::BLOCK_MAPPING_EXPLICIT_KEY) {
-                        mp_current_node = m_context_stack.back().p_node;
-                        m_context_stack.pop_back();
-                    }
-                    indent = lexer.get_last_token_begin_pos();
-                    line = lexer.get_lines_processed();
-                    return true;
+            if (line != lexer.get_lines_processed()) {
+                // This path is for explicit mapping key separator like:
+                //
+                // ```yaml
+                //   ? foo
+                //   : bar
+                // # ^ this separator
+                // ```
+                assign_node_value(std::move(node), line, indent);
+                if (m_context_stack.back().state != context_state_t::BLOCK_MAPPING_EXPLICIT_KEY) {
+                    mp_current_node = m_context_stack.back().p_node;
+                    m_context_stack.pop_back();
                 }
+                indent = lexer.get_last_token_begin_pos();
+                line = lexer.get_lines_processed();
+                return true;
+            }
 
+            if (mp_current_node->is_scalar()) {
                 parse_context& cur_context = m_context_stack.back();
                 switch (cur_context.state) {
                 case context_state_t::BLOCK_MAPPING_EXPLICIT_KEY:


### PR DESCRIPTION
This PR has fixed parse errors on explicit mappings as a block sequence entry like the following valid YAML snippet:

```yaml
- ? foo: 123
  : bar: true
- ? - baz
  : - null
```

The root cause was that the fkYAML parser just didn't assume explicit mappings as a block sequence entry.  
So, implementation has been added for such nodes with some update of the test suite which validates the functionality.  

---

## Pull Request Checklist

Read the [CONTRIBUTING.md](https://github.com/fktn-k/fkYAML/blob/develop/CONTRIBUTING.md) file for detailed information.  

- [x] Changes are described in the pull request or in a referenced [issue](https://github.com/fktn-k/fkYAML/issues).
- [x] The test suite compiles and runs without any error.
- [x] [The code coverage](https://coveralls.io/github/fktn-k/fkYAML) on your branch is 100%.
- [x] The documentation is updated if you added/changed a feature.

## Please don't

- The C++11 support varies between different **compilers** and versions. Please note the [list of supported compilers](https://github.com/fktn-k/fkYAML/blob/develop/README.md#supported-compilers). Some compilers like GCC 4.7 (and earlier), Clang 3.3 (and earlier), or Microsoft Visual Studio 13.0 and earlier are known not to work due to missing or incomplete C++11 support. Please refrain from proposing changes that work around these compiler's limitations with `#ifdef`s or other means.
- Please refrain from proposing changes that would **break [YAML](https://yaml.org/) specifications**. If you propose a conformant extension of YAML to be supported by the library, please motivate this extension.
- Please do not open pull requests that address **multiple issues**.
