### PR TITLE
Add benchmarking tool

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -127,6 +127,10 @@ if(FK_YAML_RUN_IWYU)
   add_subdirectory(tool/iwyu)
 endif()
 
+if(FK_YAML_RUN_BENCHMARK)
+  add_subdirectory(tool/benchmark)
+endif()
+
 #################################
 #   Install a pkg-config file   #
 #################################

--- a/Makefile
+++ b/Makefile
@@ -167,6 +167,20 @@ html-coverage: lcov-coverage
 		--title "fkYAML: A C++ header-only YAML library" \
 		--legend --demangle-cpp --show-details --branch-coverage
 
+#################
+#   Benchmark   #
+#################
+
+bm-debug:
+	cmake -B build_bm_debug -S . -DCMAKE_BUILD_TYPE=Debug -DFK_YAML_RUN_BENCHMARK=ON
+	cmake --build build_bm_debug --config Debug
+	./build_bm_release/tool/benchmark/benchmarker ./tool/benchmark/macos.yml > ./tool/benchmark/result_debug.log
+
+bm-release:
+	cmake -B build_bm_release -S . -DCMAKE_BUILD_TYPE=Release -DFK_YAML_RUN_BENCHMARK=ON
+	cmake --build build_bm_release --config Release
+	./build_bm_release/tool/benchmark/benchmarker ./tool/benchmark/macos.yml > ./tool/benchmark/result_release.log
+
 ###################
 #   Maintenance   #
 ###################
@@ -174,6 +188,8 @@ html-coverage: lcov-coverage
 clean:
 	rm -rf \
 		build \
+		build_bm_debug \
+		build_bm_release \
 		build_clang_format \
 		build_clang_sanitizers \
 		build_clang_tidy \

--- a/README.md
+++ b/README.md
@@ -21,6 +21,7 @@ You can add YAML support into your projects by just including header files where
 - [Community Support](#community-support)
 - [How to use fkYAML](#how-to-use-fkyaml)
 - [How to test fkYAML](#how-to-test-fkYAML)
+- [Benchmarking](#benchmarking)
 - [Supported compilers](#supported-compilers)
 - [License](#license)
 - [Used third-party tools](#used-third-party-tools)
@@ -83,6 +84,22 @@ $ cmake -B build -S . -DCMAKE_BUILD_TYPE=Debug -DFK_YAML_BUILD_TEST=ON
 $ cmake --build build --config Debug
 $ ctest -C Debug --test-dir build --output-on-failure
 ```
+
+## Benchmarking
+
+Though experimental, benchmarking scores are now available with [the dedicated benchmarking tool](./tool/benchmark/README.md) for the parsing.  
+On an AMD Ryzen 7 5800H @3.20GHz with g++11.4.0 in Ubuntu22.04 (WSL2), fkYAML processes [the YAML source](https://github.com/fktn-k/fkYAML/blob/develop/tool/benchmark/macos.yml) at a competitive speed compared against other existing YAML libraries for C/C++:
+
+| Benchmark                          | Release (MB/s) | Debug (MB/s) |
+| ---------------------------------- | -------------- | ------------ |
+| fkYAML                             | 35.072         | 34.521       |
+| libfyaml                           | 30.601         | 29.784       |
+| rapidyaml<br>(with mutable buff)   | 142.444        | 144.956      |
+| rapidyaml<br>(with immutable buff) | 144.194        | 142.680      |
+| yaml-cpp                           | 7.228          | 7.278        |
+
+Although [rapidyaml](https://github.com/biojppm/rapidyaml) is in general 4x faster than fkYAML as it focuses on high performance, fkYAML is 14% faster than [libfyaml](https://github.com/pantoniou/libfyaml) and also 4.8x faster than [yaml-cpp](https://github.com/jbeder/yaml-cpp).  
+Note that, since fkYAML deserializes scalars into native booleans or integers during the parsing, the performance could be more faster in some real use cases.  
 
 ## Supported compilers
 Currently, the following compilers are known to work and used in GitHub Actions workflows:
@@ -179,6 +196,7 @@ Thanks a lot!
 - [**Codacy**](https://www.codacy.com/) for further [code analysis](https://app.codacy.com/gh/fktn-k/fkYAML/).
 - [**Coveralls**](https://coveralls.io/) to measure [code coverage](https://coveralls.io/github/fktn-k/fkYAML?branch=develop).
 - [**Catch2**](https://github.com/catchorg/Catch2) as a unit-test framework.
+- [**Google Benchmark**](https://github.com/google/benchmark) as a benchmarking framework.
 - [**github-changelog-generator**](https://github.com/github-changelog-generator/github-changelog-generator) to generate the [CHANGELOG.md](https://github.com/fktn-k/fkYAML/tree/develop/CHANGELOG.md) file.
 - [**include-what-you-use**](https://github.com/include-what-you-use/include-what-you-use) to check the fkYAML library source files are each self-contained.
 - [**lcov**](https://github.com/linux-test-project/lcov) to process coverage information and generate an HTML view.

--- a/scripts/run_clang_format.bat
+++ b/scripts/run_clang_format.bat
@@ -25,4 +25,8 @@ for /r %ROOT_PATH%\docs\examples %%f in (*.cpp) do (
     .\venv_clang_format\Scripts\clang-format.exe %%f -i
 )
 
+for /r %ROOT_PATH%\tool\benchmark %%f in (*.cpp) do (
+    .\venv_clang_format\Scripts\clang-format.exe %%f -i
+)
+
 cd %CALLER_DIR%

--- a/scripts/run_clang_format.sh
+++ b/scripts/run_clang_format.sh
@@ -23,6 +23,6 @@ if [ ! -e "$SCRIPT_DIR"/venv_clang_format/"$VENV_BINARY_DIR"/clang-format ]; the
     "$SCRIPT_DIR"/venv_clang_format/"$VENV_BINARY_DIR"/pip install clang-format==14.0.0
 fi
 
-for f in $(find "$ROOT_DIR/include" "$ROOT_DIR/test" "$ROOT_DIR/docs/examples" -type f -name "*.hpp" -o -name "*.cpp" | sort); do
+for f in $(find "$ROOT_DIR/include" "$ROOT_DIR/test" "$ROOT_DIR/docs/examples" "$ROOT_DIR/tool/benchmark" -type f -name "*.hpp" -o -name "*.cpp" | sort); do
     "$SCRIPT_DIR"/venv_clang_format/"$VENV_BINARY_DIR"/clang-format "$f" -i
 done

--- a/tool/benchmark/CMakeLists.txt
+++ b/tool/benchmark/CMakeLists.txt
@@ -1,0 +1,85 @@
+
+################################
+#   Set up benchmarking tool   #
+################################
+
+# disable building unit tests for Google Benchmark.
+set(BENCHMARK_ENABLE_TESTING OFF CACHE BOOL "" FORCE)
+set(BENCHMARK_ENABLE_GTEST_TESTS OFF CACHE BOOL "" FORCE)
+
+include(FetchContent)
+FetchContent_Declare(
+  gbench
+  URL https://github.com/google/benchmark/archive/refs/tags/v1.8.4.zip
+)
+FetchContent_MakeAvailable(gbench)
+
+###########################
+#   Set up YAML parsers   #
+###########################
+
+# libfyaml (not implemented for Windows)
+if(NOT WIN32)
+  FetchContent_Declare(
+    libfyaml
+    GIT_REPOSITORY https://github.com/pantoniou/libfyaml
+    GIT_TAG v0.9
+  )
+  FetchContent_MakeAvailable(libfyaml)
+endif()
+
+# rapidyaml
+FetchContent_Declare(
+  rapidyaml
+  GIT_REPOSITORY https://github.com/biojppm/rapidyaml
+  GIT_TAG v0.6.0
+  GIT_SUBMODULES "ext/c4core"
+)
+FetchContent_MakeAvailable(rapidyaml)
+
+# yaml-cpp
+set(YAML_CPP_BUILD_CONTRIB OFF CACHE BOOL "" FORCE)
+set(YAML_CPP_BUILD_TOOLS OFF CACHE BOOL "" FORCE)
+FetchContent_Declare(
+  yaml_cpp
+  GIT_REPOSITORY https://github.com/jbeder/yaml-cpp
+  GIT_TAG 0.8.0
+)
+FetchContent_MakeAvailable(yaml_cpp)
+
+###############################
+#   Set up benchmarking app   #
+###############################
+
+add_executable(
+  benchmarker
+  main.cpp
+)
+
+target_compile_options(
+  benchmarker
+  PRIVATE
+    $<$<CONFIG:Debug>:-O1>
+    $<$<CONFIG:Release>:-O2>
+)
+
+target_link_libraries(
+  benchmarker
+  PRIVATE
+    fkYAML::fkYAML
+    ryml::ryml
+    yaml-cpp::yaml-cpp
+    benchmark::benchmark
+)
+if(NOT WIN32)
+  target_link_libraries(
+    benchmarker
+    PRIVATE
+      fyaml
+  )
+  target_compile_definitions(
+    benchmarker
+    PRIVATE
+      FK_YAML_BM_HAS_LIBFYAML
+  )
+endif()

--- a/tool/benchmark/README.md
+++ b/tool/benchmark/README.md
@@ -1,0 +1,32 @@
+# Benchmark
+
+This tool runs benchmarking with [the Google Benchmark library](https://github.com/google/benchmark/) ([v1.8.4](https://github.com/google/benchmark/releases/tag/v1.8.4)) against fkYAML and the following C++ YAML libraries tagged with the specified versions respectively:  
+* [libfyaml](https://github.com/pantoniou/libfyaml) ([v0.9](https://github.com/pantoniou/libfyaml/releases/tag/v0.9))
+* [rapidyaml](https://github.com/biojppm/rapidyaml) ([v0.6.0](https://github.com/biojppm/rapidyaml/releases/tag/v0.6.0))
+* [yaml-cpp](https://github.com/jbeder/yaml-cpp) ([0.8.0](https://github.com/jbeder/yaml-cpp/releases/tag/0.8.0))
+
+Currently, the [macos.yml](https://github.com/fktn-k/fkYAML/blob/develop/tool/benchmark/macos.yml) file is used for the benchmarking which was copied from the [.github/workflows](https://github.com/fktn-k/fkYAML/tree/develop/.github/workflows) directory at the point of the commit hash [e1c740f0c93766cfdd0b704ffb46113acd6bd922](https://github.com/fktn-k/fkYAML/commit/e1c740f0c93766cfdd0b704ffb46113acd6bd922).  
+More YAML files are planned to be added for the benchmarking so the resulting score would be more accurate and reliable.  
+
+## How to Use
+
+Build and run this tool with the following commands:
+
+```bash
+$ cd path/to/fkYAML
+$ cmake -S . -B build -DCMAKE_BUILD_TYPE={Debug|Release} -DFK_YAML_RUN_BENCHMARK=ON
+$ cmake --build build --config {Debug|Release}
+$ ./build/tool/benchmark/benchmarker ./tool/benchmark/macos.yml
+```
+
+Then, you should see a console ouput from the Google Benchmark library in the following format.  
+
+```bash
+-------------------------------------------------------------------------------------
+Benchmark                           Time             CPU   Iterations UserCounters...
+-------------------------------------------------------------------------------------
+bm_fkyaml_parse                 xxxxx ns        xxxxx ns        xxxxx bytes_per_second=xx.xxxxMi/s items_per_second=xx.xxxxk/s
+...
+```
+
+Visit [the user guide](https://github.com/google/benchmark/blob/v1.8.4/docs/user_guide.md) in the Google Benchmark repository for more information on the output format.  

--- a/tool/benchmark/macos.yml
+++ b/tool/benchmark/macos.yml
@@ -1,0 +1,157 @@
+name: macOS
+
+on:
+  push:
+    branches:
+      - develop
+      - main
+    paths:
+      - .github/workflows/macos.yml
+      - cmake/**
+      - include/**
+      - single_include/**
+      - test/**
+      - CMakeLists.txt
+  pull_request:
+    paths:
+      - .github/workflows/macos.yml
+      - cmake/**
+      - include/**
+      - single_include/**
+      - test/**
+      - CMakeLists.txt
+  workflow_dispatch:
+
+concurrency:
+  group: ${{github.workflow}}-${{github.ref}}
+  cancel-in-progress: true
+
+jobs:
+  macos-latest:
+    timeout-minutes: 10
+    runs-on: macos-latest
+    strategy:
+      matrix:
+        build_type: [ Debug, Release ]
+        single_header: ["ON", "OFF"]
+    env:
+      JOBS: 2
+
+    steps:
+    - uses: actions/checkout@v4
+      with:
+        submodules: recursive
+
+    - name: Configure CMake
+      run: cmake -B ${{github.workspace}}/build -DCMAKE_BUILD_TYPE=${{matrix.build_type}} -DFK_YAML_BUILD_TEST=ON -DFK_YAML_USE_SINGLE_HEADER=${{matrix.single_header}}
+
+    - name: Build
+      run: cmake --build ${{github.workspace}}/build --config ${{matrix.build_type}} -j ${{env.JOBS}}
+
+    - name: Test
+      working-directory: ${{github.workspace}}/build
+      run: ctest -C ${{matrix.build_type}} --output-on-failure -j ${{env.JOBS}}
+
+  xcode_for_macos11:
+    timeout-minutes: 10
+    runs-on: macos-11
+    strategy:
+      matrix:
+        xcode: [ '11.7', '12.4', '12.5.1', '13.0', '13.1', '13.2.1' ]
+        build_type: [ Debug, Release ]
+    env:
+      DEVELOPER_DIR: /Applications/Xcode_${{matrix.xcode}}.app/Contents/Developer
+      JOBS: 2
+
+    steps:
+    - uses: actions/checkout@v4
+      with:
+        submodules: recursive
+
+    - name: Configure CMake
+      run: cmake -B ${{github.workspace}}/build -DCMAKE_BUILD_TYPE=${{matrix.build_type}} -DFK_YAML_BUILD_TEST=ON
+
+    - name: Build
+      run: cmake --build ${{github.workspace}}/build --config ${{matrix.build_type}} -j ${{env.JOBS}}
+
+    - name: Test
+      working-directory: ${{github.workspace}}/build
+      run: ctest -C ${{matrix.build_type}} --output-on-failure -j ${{env.JOBS}}
+
+  xcode_for_macos12:
+    timeout-minutes: 10
+    runs-on: macos-12
+    strategy:
+      matrix:
+        xcode: [ '13.1', '13.2.1', '13.3.1', '13.4.1', '14.0.1', '14.1', '14.2' ]
+        build_type: [ Debug, Release ]
+    env:
+      DEVELOPER_DIR: /Applications/Xcode_${{matrix.xcode}}.app/Contents/Developer
+      JOBS: 2
+
+    steps:
+    - uses: actions/checkout@v4
+      with:
+        submodules: recursive
+
+    - name: Configure CMake
+      run: cmake -B ${{github.workspace}}/build -DCMAKE_BUILD_TYPE=${{matrix.build_type}} -DFK_YAML_BUILD_TEST=ON
+
+    - name: Build
+      run: cmake --build ${{github.workspace}}/build --config ${{matrix.build_type}} -j ${{env.JOBS}}
+
+    - name: Test
+      working-directory: ${{github.workspace}}/build
+      run: ctest -C ${{matrix.build_type}} --output-on-failure -j ${{env.JOBS}}
+
+  xcode_for_macos13:
+    timeout-minutes: 10
+    runs-on: macos-13
+    strategy:
+      matrix:
+        xcode: [ '14.1', '14.2', '14.3.1', '15.0.1', '15.1', '15.2' ]
+        build_type: [ Debug, Release ]
+    env:
+      DEVELOPER_DIR: /Applications/Xcode_${{matrix.xcode}}.app/Contents/Developer
+      JOBS: 3
+
+    steps:
+    - uses: actions/checkout@v4
+      with:
+        submodules: recursive
+
+    - name: Configure CMake
+      run: cmake -B ${{github.workspace}}/build -DCMAKE_BUILD_TYPE=${{matrix.build_type}} -DFK_YAML_BUILD_TEST=ON
+
+    - name: Build
+      run: cmake --build ${{github.workspace}}/build --config ${{matrix.build_type}} -j ${{env.JOBS}}
+
+    - name: Test
+      working-directory: ${{github.workspace}}/build
+      run: ctest -C ${{matrix.build_type}} --output-on-failure -j ${{env.JOBS}}
+
+  xcode_for_macos14:
+    timeout-minutes: 10
+    runs-on: macos-14
+    strategy:
+      matrix:
+        xcode: [ '14.3.1', '15.0.1', '15.1', '15.2', '15.3' ]
+        build_type: [ Debug, Release ]
+    env:
+      DEVELOPER_DIR: /Applications/Xcode_${{matrix.xcode}}.app/Contents/Developer
+      JOBS: 2
+
+    steps:
+    - uses: actions/checkout@v4
+      with:
+        submodules: recursive
+
+    - name: Configure CMake
+      run: cmake -B ${{github.workspace}}/build -DCMAKE_BUILD_TYPE=${{matrix.build_type}} -DFK_YAML_BUILD_TEST=ON
+
+    - name: Build
+      run: cmake --build ${{github.workspace}}/build --config ${{matrix.build_type}} -j ${{env.JOBS}}
+
+    - name: Test
+      working-directory: ${{github.workspace}}/build
+      run: ctest -C ${{matrix.build_type}} --output-on-failure -j ${{env.JOBS}}

--- a/tool/benchmark/main.cpp
+++ b/tool/benchmark/main.cpp
@@ -68,12 +68,12 @@ void bm_yamlcpp_parse(benchmark::State& st) {
 #ifdef FK_YAML_BM_HAS_LIBFYAML
 // libfyaml
 void bm_libfyaml_parse(benchmark::State& st) {
-    fy_document* p_fyd = nullptr;
     const char* p_test_src = test_src.c_str();
     std::size_t test_src_size = std::distance(test_src.begin(), test_src.end());
 
     for (auto _ : st) {
-        p_fyd = fy_document_build_from_string(nullptr, p_test_src, test_src_size);
+        fy_document* p_fyd = fy_document_build_from_string(nullptr, p_test_src, test_src_size);
+        (void)p_fyd;
     }
 
     st.SetItemsProcessed(st.iterations());

--- a/tool/benchmark/main.cpp
+++ b/tool/benchmark/main.cpp
@@ -1,0 +1,114 @@
+//  _______   __ __   __  _____   __  __  __
+// |   __| |_/  |  \_/  |/  _  \ /  \/  \|  |     fkYAML: A C++ header-only YAML library (supporting code)
+// |   __|  _  < \_   _/|  ___  |    _   |  |___  version 0.3.8
+// |__|  |_| \__|  |_|  |_|   |_|___||___|______| https://github.com/fktn-k/fkYAML
+//
+// SPDX-FileCopyrightText: 2023-2024 Kensuke Fukutani <fktn.dev@gmail.com>
+// SPDX-License-Identifier: MIT
+
+#include <string>
+
+#include <benchmark/benchmark.h>
+
+#include <fkYAML/node.hpp>
+#include <yaml-cpp/yaml.h>
+#include <libfyaml.h>
+#include <ryml.hpp>
+#include <ryml_std.hpp>
+#include <c4/yml/parse.hpp>
+
+static std::string test_src {};
+
+void prepare_test_source(char* filename) {
+    FILE* fp = std::fopen(filename, "rb");
+    char tmp_buf[256] {};
+    std::size_t buf_size = sizeof(tmp_buf) / sizeof(char);
+    std::size_t read_size = 0;
+    while ((read_size = std::fread(&tmp_buf[0], sizeof(char), buf_size, fp)) > 0) {
+        test_src.append(tmp_buf, tmp_buf + read_size);
+    }
+    std::fclose(fp);
+    fp = nullptr;
+}
+
+int main(int argc, char** argv) {
+    prepare_test_source(argv[1]);
+
+    benchmark::Initialize(&argc, argv);
+    benchmark::RunSpecifiedBenchmarks();
+    benchmark::Shutdown();
+
+    return 0;
+}
+
+//
+// Benchmarking functions.
+//
+
+// fkYAML
+void bm_fkyaml_parse(benchmark::State& st) {
+    for (auto _ : st) {
+        fkyaml::node n = fkyaml::node::deserialize(test_src);
+    }
+
+    st.SetItemsProcessed(st.iterations());
+    st.SetBytesProcessed(st.iterations() * test_src.size());
+}
+
+// yaml-cpp
+void bm_yamlcpp_parse(benchmark::State& st) {
+    for (auto _ : st) {
+        YAML::Node n = YAML::Load(test_src);
+    }
+
+    st.SetItemsProcessed(st.iterations());
+    st.SetBytesProcessed(st.iterations() * test_src.size());
+}
+
+#ifdef FK_YAML_BM_HAS_LIBFYAML
+// libfyaml
+void bm_libfyaml_parse(benchmark::State& st) {
+    fy_document* p_fyd = nullptr;
+    const char* p_test_src = test_src.c_str();
+    std::size_t test_src_size = std::distance(test_src.begin(), test_src.end());
+
+    for (auto _ : st) {
+        p_fyd = fy_document_build_from_string(nullptr, p_test_src, test_src_size);
+    }
+
+    st.SetItemsProcessed(st.iterations());
+    st.SetBytesProcessed(st.iterations() * test_src.size());
+}
+#endif
+
+// rapidyaml (in place)
+void bm_rapidyaml_parse_inplace(benchmark::State& st) {
+    c4::substr c4_test_src = c4::to_substr(test_src).trimr('\0');
+    for (auto _ : st) {
+        ryml::Tree tree = ryml::parse_in_place(c4_test_src);
+    }
+
+    st.SetItemsProcessed(st.iterations());
+    st.SetBytesProcessed(st.iterations() * test_src.size());
+}
+
+// rapidyaml (arena)
+void bm_rapidyaml_parse_arena(benchmark::State& st) {
+    c4::csubstr src = c4::to_csubstr(test_src).trimr('\0');
+
+    for (auto _ : st) {
+        ryml::Tree tree = ryml::parse_in_arena(src);
+    }
+
+    st.SetItemsProcessed(st.iterations());
+    st.SetBytesProcessed(st.iterations() * test_src.size());
+}
+
+// Register benchmarking functions.
+BENCHMARK(bm_fkyaml_parse);
+BENCHMARK(bm_yamlcpp_parse);
+#ifdef FK_YAML_BM_HAS_LIBFYAML
+BENCHMARK(bm_libfyaml_parse);
+#endif
+BENCHMARK(bm_rapidyaml_parse_inplace);
+BENCHMARK(bm_rapidyaml_parse_arena);

--- a/tool/benchmark/result_debug.log
+++ b/tool/benchmark/result_debug.log
@@ -1,0 +1,8 @@
+-------------------------------------------------------------------------------------
+Benchmark                           Time             CPU   Iterations UserCounters...
+-------------------------------------------------------------------------------------
+bm_fkyaml_parse                124065 ns       124066 ns         5652 bytes_per_second=34.5214Mi/s items_per_second=8.0602k/s
+bm_yamlcpp_parse               588453 ns       588466 ns         1197 bytes_per_second=7.27816Mi/s items_per_second=1.69933k/s
+bm_libfyaml_parse              143796 ns       143796 ns         5611 bytes_per_second=29.7849Mi/s items_per_second=6.9543k/s
+bm_rapidyaml_parse_inplace      29546 ns        29547 ns        23558 bytes_per_second=144.956Mi/s items_per_second=33.8449k/s
+bm_rapidyaml_parse_arena        30017 ns        30018 ns        23275 bytes_per_second=142.68Mi/s items_per_second=33.3134k/s

--- a/tool/benchmark/result_release.log
+++ b/tool/benchmark/result_release.log
@@ -1,0 +1,8 @@
+-------------------------------------------------------------------------------------
+Benchmark                           Time             CPU   Iterations UserCounters...
+-------------------------------------------------------------------------------------
+bm_fkyaml_parse                122120 ns       122118 ns         5693 bytes_per_second=35.0722Mi/s items_per_second=8.18879k/s
+bm_yamlcpp_parse               592530 ns       592543 ns         1193 bytes_per_second=7.22809Mi/s items_per_second=1.68764k/s
+bm_libfyaml_parse              139955 ns       139959 ns         5477 bytes_per_second=30.6015Mi/s items_per_second=7.14497k/s
+bm_rapidyaml_parse_inplace      30067 ns        30068 ns        23568 bytes_per_second=142.444Mi/s items_per_second=33.2583k/s
+bm_rapidyaml_parse_arena        29702 ns        29703 ns        23177 bytes_per_second=144.194Mi/s items_per_second=33.6669k/s


### PR DESCRIPTION
This PR has added a dedicated benchmarking tool for fkYAML on the parsing speed.  
The tool compares the parsing speed against the following existing YAML libraries for C/C++:
* [libfyaml](https://github.com/pantoniou/libfyaml) ([v0.9](https://github.com/pantoniou/libfyaml/releases/tag/v0.9))
* [rapidyaml](https://github.com/biojppm/rapidyaml) ([v0.6.0](https://github.com/biojppm/rapidyaml/releases/tag/v0.6.0))
* [yaml-cpp](https://github.com/jbeder/yaml-cpp) ([0.8.0](https://github.com/jbeder/yaml-cpp/releases/tag/0.8.0))

See the [README.md](https://github.com/fktn-k/fkYAML/blob/develop/tool/benchmark/README.md) file for more details.  

---

## Pull Request Checklist

Read the [CONTRIBUTING.md](https://github.com/fktn-k/fkYAML/blob/develop/CONTRIBUTING.md) file for detailed information.  

- [x] Changes are described in the pull request or in a referenced [issue](https://github.com/fktn-k/fkYAML/issues).
- [x] The test suite compiles and runs without any error.
- [x] [The code coverage](https://coveralls.io/github/fktn-k/fkYAML) on your branch is 100%.
- [x] The documentation is updated if you added/changed a feature.

## Please don't

- The C++11 support varies between different **compilers** and versions. Please note the [list of supported compilers](https://github.com/fktn-k/fkYAML/blob/develop/README.md#supported-compilers). Some compilers like GCC 4.7 (and earlier), Clang 3.3 (and earlier), or Microsoft Visual Studio 13.0 and earlier are known not to work due to missing or incomplete C++11 support. Please refrain from proposing changes that work around these compiler's limitations with `#ifdef`s or other means.
- Please refrain from proposing changes that would **break [YAML](https://yaml.org/) specifications**. If you propose a conformant extension of YAML to be supported by the library, please motivate this extension.
- Please do not open pull requests that address **multiple issues**.
