### PR TITLE
Fix parse error on smal negative integer keys

### DIFF
--- a/include/fkYAML/detail/input/lexical_analyzer.hpp
+++ b/include/fkYAML/detail/input/lexical_analyzer.hpp
@@ -164,16 +164,11 @@ public:
             default:
                 break;
             }
-            // if (next == ' ') {
-            //     // Move a cursor to the beginning of the next token.
-            //     m_cur_itr += 2;
-            //     return lexical_token_t::SEQUENCE_BLOCK_PREFIX;
-            // }
 
             bool is_available = (std::distance(m_cur_itr, m_end_itr) > 2);
             if (is_available) {
-                m_cur_itr += 3;
-                if (std::equal(m_token_begin_itr, m_cur_itr, "---")) {
+                if (std::equal(m_token_begin_itr, m_cur_itr + 3, "---")) {
+                    m_cur_itr += 3;
                     return lexical_token_t::END_OF_DIRECTIVES;
                 }
             }

--- a/single_include/fkYAML/node.hpp
+++ b/single_include/fkYAML/node.hpp
@@ -2771,16 +2771,11 @@ public:
             default:
                 break;
             }
-            // if (next == ' ') {
-            //     // Move a cursor to the beginning of the next token.
-            //     m_cur_itr += 2;
-            //     return lexical_token_t::SEQUENCE_BLOCK_PREFIX;
-            // }
 
             bool is_available = (std::distance(m_cur_itr, m_end_itr) > 2);
             if (is_available) {
-                m_cur_itr += 3;
-                if (std::equal(m_token_begin_itr, m_cur_itr, "---")) {
+                if (std::equal(m_token_begin_itr, m_cur_itr + 3, "---")) {
+                    m_cur_itr += 3;
                     return lexical_token_t::END_OF_DIRECTIVES;
                 }
             }

--- a/test/unit_test/test_deserializer_class.cpp
+++ b/test/unit_test/test_deserializer_class.cpp
@@ -1634,16 +1634,21 @@ TEST_CASE("Deserializer_FlowMapping") {
     }
 
     SECTION("root flow mapping") {
-        REQUIRE_NOTHROW(root = deserializer.deserialize(fkyaml::detail::input_adapter("{foo: 123, true: 3.14}")));
+        REQUIRE_NOTHROW(
+            root = deserializer.deserialize(fkyaml::detail::input_adapter("{foo: 123,-4: null,true: 3.14}")));
 
         REQUIRE(root.is_mapping());
-        REQUIRE(root.size() == 2);
+        REQUIRE(root.size() == 3);
         REQUIRE(root.contains("foo"));
+        REQUIRE(root.contains(-4));
         REQUIRE(root.contains(true));
 
         fkyaml::node& foo_node = root["foo"];
         REQUIRE(foo_node.is_integer());
         REQUIRE(foo_node.get_value<int>() == 123);
+
+        fkyaml::node& minus4_node = root[-4];
+        REQUIRE(minus4_node.is_null());
 
         fkyaml::node& true_node = root[true];
         REQUIRE(true_node.is_float_number());


### PR DESCRIPTION
The current parser mistakenly emits parse errors on small negative integer keys like the following valid YAML snippet:

```yaml
# This causes a false error which tells there is an invalid ending of a flow mapping.
{-4: bar}
```

This was caused by the wrong lookahead implemented for tokens which start with a hyphen(-).  
So, this PR has fixed it and the above snipet is now parsed successfully.  

---

## Pull Request Checklist

Read the [CONTRIBUTING.md](https://github.com/fktn-k/fkYAML/blob/develop/CONTRIBUTING.md) file for detailed information.  

- [x] Changes are described in the pull request or in a referenced [issue](https://github.com/fktn-k/fkYAML/issues).
- [x] The test suite compiles and runs without any error.
- [x] [The code coverage](https://coveralls.io/github/fktn-k/fkYAML) on your branch is 100%.
- [x] The documentation is updated if you added/changed a feature.

## Please don't

- The C++11 support varies between different **compilers** and versions. Please note the [list of supported compilers](https://github.com/fktn-k/fkYAML/blob/develop/README.md#supported-compilers). Some compilers like GCC 4.7 (and earlier), Clang 3.3 (and earlier), or Microsoft Visual Studio 13.0 and earlier are known not to work due to missing or incomplete C++11 support. Please refrain from proposing changes that work around these compiler's limitations with `#ifdef`s or other means.
- Please refrain from proposing changes that would **break [YAML](https://yaml.org/) specifications**. If you propose a conformant extension of YAML to be supported by the library, please motivate this extension.
- Please do not open pull requests that address **multiple issues**.
