### PR TITLE
Fix compile errors on Windows

### DIFF
--- a/.github/workflows/windows.yml
+++ b/.github/workflows/windows.yml
@@ -30,7 +30,7 @@ env:
   JOBS: 3
 
 jobs:
-  msvc2019:
+  vs2019:
     timeout-minutes: 10
     runs-on: windows-2019
     strategy:
@@ -54,9 +54,9 @@ jobs:
       working-directory: ${{github.workspace}}/build
       run: ctest -C ${{matrix.build_type}} --output-on-failure -j ${{env.JOBS}}
 
-  msvc2022:
+  vs2022:
     timeout-minutes: 10
-    runs-on: windows-latest
+    runs-on: windows-2022
     strategy:
       matrix:
         arch: [ Win32, x64 ]
@@ -70,6 +70,29 @@ jobs:
 
     - name: Configure CMake
       run: cmake -B ${{github.workspace}}/build -G "Visual Studio 17 2022" -A ${{matrix.arch}} -DFK_YAML_BUILD_TEST=ON -DFK_YAML_USE_SINGLE_HEADER=${{matrix.single_header}}
+
+    - name: Build
+      run: cmake --build ${{github.workspace}}/build --config ${{matrix.build_type}} -j ${{env.JOBS}}
+
+    - name: Test
+      working-directory: ${{github.workspace}}/build
+      run: ctest -C ${{matrix.build_type}} --output-on-failure -j ${{env.JOBS}}
+
+  vs2022_cxx_standard:
+    timeout-minutes: 10
+    runs-on: windows-2022
+    strategy:
+      matrix:
+        cxx_standards: [ "11", "14", "17", "20", "23" ]
+        build_type: [ Debug, Release ]
+
+    steps:
+    - uses: actions/checkout@v4
+      with:
+        submodules: recursive
+
+    - name: Configure CMake
+      run: cmake -B ${{github.workspace}}/build -G "Visual Studio 17 2022" -A x64 -DFK_YAML_BUILD_TEST=ON -DFK_YAML_TEST_CXX_STANDARD=${{matrix.cxx_standards}}
 
     - name: Build
       run: cmake --build ${{github.workspace}}/build --config ${{matrix.build_type}} -j ${{env.JOBS}}

--- a/include/fkYAML/node.hpp
+++ b/include/fkYAML/node.hpp
@@ -331,8 +331,8 @@ public:
                 detail::disjunction<detail::is_node_compatible_type<basic_node, U>>>::value,
             int> = 0>
     basic_node(CompatibleType&& val) noexcept(
-        noexcept(ConverterType<U>::to_node(std::declval<basic_node&>(), std::declval<CompatibleType>()))) {
-        ConverterType<U>::to_node(*this, std::forward<CompatibleType>(val));
+        noexcept(ConverterType<U, void>::to_node(std::declval<basic_node&>(), std::declval<CompatibleType>()))) {
+        ConverterType<U, void>::to_node(*this, std::forward<CompatibleType>(val));
     }
 
     /// @brief Construct a new basic node object with a node_ref_storage object.
@@ -1234,16 +1234,16 @@ public:
             detail::conjunction<
                 std::is_default_constructible<ValueType>, detail::has_from_node<basic_node, ValueType>>::value,
             int> = 0>
-    T get_value() const noexcept(
-        noexcept(ConverterType<ValueType>::from_node(std::declval<const basic_node&>(), std::declval<ValueType&>()))) {
+    T get_value() const noexcept(noexcept(
+        ConverterType<ValueType, void>::from_node(std::declval<const basic_node&>(), std::declval<ValueType&>()))) {
         auto ret = ValueType();
         if (has_anchor_name()) {
             auto itr = mp_meta->anchor_table.equal_range(m_prop.anchor).first;
             std::advance(itr, m_prop.anchor_offset);
-            ConverterType<ValueType>::from_node(itr->second, ret);
+            ConverterType<ValueType, void>::from_node(itr->second, ret);
         }
         else {
-            ConverterType<ValueType>::from_node(*this, ret);
+            ConverterType<ValueType, void>::from_node(*this, ret);
         }
         return ret;
     }
@@ -1593,7 +1593,7 @@ inline namespace yaml_literals {
 /// @return The resulting `node` object deserialized from `s`.
 /// @sa https://fktn-k.github.io/fkYAML/api/operator_literal_yaml/
 inline fkyaml::node operator"" _yaml(const char* s, std::size_t n) {
-    return fkyaml::node::deserialize((const char*)s, (const char*)s + n);
+    return fkyaml::node::deserialize(std::move(s), std::move(s + n));
 }
 
 /// @brief The user-defined string literal which deserializes a `char16_t` array into a `node` object.
@@ -1602,7 +1602,7 @@ inline fkyaml::node operator"" _yaml(const char* s, std::size_t n) {
 /// @return The resulting `node` object deserialized from `s`.
 /// @sa https://fktn-k.github.io/fkYAML/api/operator_literal_yaml/
 inline fkyaml::node operator"" _yaml(const char16_t* s, std::size_t n) {
-    return fkyaml::node::deserialize((const char16_t*)s, (const char16_t*)s + n);
+    return fkyaml::node::deserialize(std::move(s), std::move(s + n));
 }
 
 /// @brief The user-defined string literal which deserializes a `char32_t` array into a `node` object.
@@ -1611,7 +1611,7 @@ inline fkyaml::node operator"" _yaml(const char16_t* s, std::size_t n) {
 /// @return The resulting `node` object deserialized from `s`.
 /// @sa https://fktn-k.github.io/fkYAML/api/operator_literal_yaml/
 inline fkyaml::node operator"" _yaml(const char32_t* s, std::size_t n) {
-    return fkyaml::node::deserialize((const char32_t*)s, (const char32_t*)s + n);
+    return fkyaml::node::deserialize(std::move(s), std::move(s + n));
 }
 
 #ifdef FK_YAML_HAS_CHAR8_T

--- a/single_include/fkYAML/node.hpp
+++ b/single_include/fkYAML/node.hpp
@@ -8664,8 +8664,8 @@ public:
                 detail::disjunction<detail::is_node_compatible_type<basic_node, U>>>::value,
             int> = 0>
     basic_node(CompatibleType&& val) noexcept(
-        noexcept(ConverterType<U>::to_node(std::declval<basic_node&>(), std::declval<CompatibleType>()))) {
-        ConverterType<U>::to_node(*this, std::forward<CompatibleType>(val));
+        noexcept(ConverterType<U, void>::to_node(std::declval<basic_node&>(), std::declval<CompatibleType>()))) {
+        ConverterType<U, void>::to_node(*this, std::forward<CompatibleType>(val));
     }
 
     /// @brief Construct a new basic node object with a node_ref_storage object.
@@ -9567,16 +9567,16 @@ public:
             detail::conjunction<
                 std::is_default_constructible<ValueType>, detail::has_from_node<basic_node, ValueType>>::value,
             int> = 0>
-    T get_value() const noexcept(
-        noexcept(ConverterType<ValueType>::from_node(std::declval<const basic_node&>(), std::declval<ValueType&>()))) {
+    T get_value() const noexcept(noexcept(
+        ConverterType<ValueType, void>::from_node(std::declval<const basic_node&>(), std::declval<ValueType&>()))) {
         auto ret = ValueType();
         if (has_anchor_name()) {
             auto itr = mp_meta->anchor_table.equal_range(m_prop.anchor).first;
             std::advance(itr, m_prop.anchor_offset);
-            ConverterType<ValueType>::from_node(itr->second, ret);
+            ConverterType<ValueType, void>::from_node(itr->second, ret);
         }
         else {
-            ConverterType<ValueType>::from_node(*this, ret);
+            ConverterType<ValueType, void>::from_node(*this, ret);
         }
         return ret;
     }
@@ -9926,7 +9926,7 @@ inline namespace yaml_literals {
 /// @return The resulting `node` object deserialized from `s`.
 /// @sa https://fktn-k.github.io/fkYAML/api/operator_literal_yaml/
 inline fkyaml::node operator"" _yaml(const char* s, std::size_t n) {
-    return fkyaml::node::deserialize((const char*)s, (const char*)s + n);
+    return fkyaml::node::deserialize(std::move(s), std::move(s + n));
 }
 
 /// @brief The user-defined string literal which deserializes a `char16_t` array into a `node` object.
@@ -9935,7 +9935,7 @@ inline fkyaml::node operator"" _yaml(const char* s, std::size_t n) {
 /// @return The resulting `node` object deserialized from `s`.
 /// @sa https://fktn-k.github.io/fkYAML/api/operator_literal_yaml/
 inline fkyaml::node operator"" _yaml(const char16_t* s, std::size_t n) {
-    return fkyaml::node::deserialize((const char16_t*)s, (const char16_t*)s + n);
+    return fkyaml::node::deserialize(std::move(s), std::move(s + n));
 }
 
 /// @brief The user-defined string literal which deserializes a `char32_t` array into a `node` object.
@@ -9944,7 +9944,7 @@ inline fkyaml::node operator"" _yaml(const char16_t* s, std::size_t n) {
 /// @return The resulting `node` object deserialized from `s`.
 /// @sa https://fktn-k.github.io/fkYAML/api/operator_literal_yaml/
 inline fkyaml::node operator"" _yaml(const char32_t* s, std::size_t n) {
-    return fkyaml::node::deserialize((const char32_t*)s, (const char32_t*)s + n);
+    return fkyaml::node::deserialize(std::move(s), std::move(s + n));
 }
 
 #ifdef FK_YAML_HAS_CHAR8_T


### PR DESCRIPTION
This PR fixes the following compile errors on Windows:
* errors from too few template parameters for `node_value_converter` when compiled with C++20 or newer and Visual Studio 2022, as reported in #357
* errors from ambiguous parameter type for `basic_node::deserialize(ItrType, ItrType)` called from the user defined literal `operator"" _yaml(...)` when compiled with C++11, C++14, C++17 without the `/permissive-` flag.

Also, workflow jobs have been added to test builds with existing C++ standards and Visual Studio 2022.  

---

## Pull Request Checklist

Read the [CONTRIBUTING.md](https://github.com/fktn-k/fkYAML/blob/develop/CONTRIBUTING.md) file for detailed information.  

- [x] Changes are described in the pull request or in a referenced [issue](https://github.com/fktn-k/fkYAML/issues).
- [x] The test suite compiles and runs without any error.
- [x] [The code coverage](https://coveralls.io/github/fktn-k/fkYAML) on your branch is 100%.
- [x] The documentation is updated if you added/changed a feature.

## Please don't

- The C++11 support varies between different **compilers** and versions. Please note the [list of supported compilers](https://github.com/fktn-k/fkYAML/blob/develop/README.md#supported-compilers). Some compilers like GCC 4.7 (and earlier), Clang 3.3 (and earlier), or Microsoft Visual Studio 13.0 and earlier are known not to work due to missing or incomplete C++11 support. Please refrain from proposing changes that work around these compiler's limitations with `#ifdef`s or other means.
- Please refrain from proposing changes that would **break [YAML](https://yaml.org/) specifications**. If you propose a conformant extension of YAML to be supported by the library, please motivate this extension.
- Please do not open pull requests that address **multiple issues**.
