### PR TITLE
Detect missing the end of directives markers (---)

### DIFF
--- a/include/fkYAML/detail/input/deserializer.hpp
+++ b/include/fkYAML/detail/input/deserializer.hpp
@@ -165,6 +165,8 @@ private:
     /// @param lexer The lexical analyzer to be used.
     /// @param last_type The variable to store the last lexical token type.
     void deserialize_directives(lexer_type& lexer, lexical_token_t& last_type) {
+        bool lacks_end_of_directives_marker = false;
+
         for (;;) {
             lexical_token_t type = lexer.get_next_token();
 
@@ -179,6 +181,7 @@ private:
 
                 mp_meta->version = convert_yaml_version(lexer.get_yaml_version());
                 mp_meta->is_version_specified = true;
+                lacks_end_of_directives_marker = true;
                 break;
             case lexical_token_t::TAG_DIRECTIVE: {
                 const std::string& tag_handle = lexer.get_tag_handle();
@@ -192,6 +195,7 @@ private:
                             lexer.get_last_token_begin_pos());
                     }
                     mp_meta->primary_handle_prefix = lexer.get_tag_prefix();
+                    lacks_end_of_directives_marker = true;
                     break;
                 }
                 case 2: {
@@ -203,6 +207,7 @@ private:
                             lexer.get_last_token_begin_pos());
                     }
                     mp_meta->secondary_handle_prefix = lexer.get_tag_prefix();
+                    lacks_end_of_directives_marker = true;
                     break;
                 }
                 default: {
@@ -214,6 +219,7 @@ private:
                             lexer.get_lines_processed(),
                             lexer.get_last_token_begin_pos());
                     }
+                    lacks_end_of_directives_marker = true;
                     break;
                 }
                 }
@@ -223,9 +229,15 @@ private:
                 // TODO: should output a warning log. Currently just ignore this case.
                 break;
             case lexical_token_t::END_OF_DIRECTIVES:
-                // Ignore this directives end marker so the caller will get the beginning token of the contents.
+                lacks_end_of_directives_marker = false;
                 break;
             default:
+                if (lacks_end_of_directives_marker) {
+                    throw parse_error(
+                        "The end of directives marker (---) is missing after directives.",
+                        lexer.get_lines_processed(),
+                        lexer.get_last_token_begin_pos());
+                }
                 // end the parsing of directives if the other tokens are found.
                 last_type = type;
                 return;

--- a/test/unit_test/test_deserializer_class.cpp
+++ b/test/unit_test/test_deserializer_class.cpp
@@ -1921,6 +1921,11 @@ TEST_CASE("Deserializer_YAMLVerDirective") {
         REQUIRE_THROWS_AS(
             deserializer.deserialize(fkyaml::detail::input_adapter("%YAML 1.1\n%YAML 1.2\n")), fkyaml::parse_error);
     }
+
+    SECTION("lacks the end of directives marker after YAML directive") {
+        REQUIRE_THROWS_AS(
+            deserializer.deserialize(fkyaml::detail::input_adapter("%YAML 1.2\nfoo: bar")), fkyaml::parse_error);
+    }
 }
 
 TEST_CASE("Deserializer_TagDirective") {
@@ -2007,6 +2012,12 @@ TEST_CASE("Deserializer_TagDirective") {
         std::string input = "%TAG !e! tag:test.com,2000:\n"
                             "%TAG !e! !foo-\n"
                             "---\n"
+                            "foo: bar";
+        REQUIRE_THROWS_AS(deserializer.deserialize(fkyaml::detail::input_adapter(input)), fkyaml::parse_error);
+    }
+
+    SECTION("lacks the end of directives marker after TAG directive") {
+        std::string input = "%TAG ! tag:test.com,2000:\n"
                             "foo: bar";
         REQUIRE_THROWS_AS(deserializer.deserialize(fkyaml::detail::input_adapter(input)), fkyaml::parse_error);
     }


### PR DESCRIPTION
The current parser can't detect missing end-of-directives markers (---) between directives and contents like the following invalid YAML snippet:

```yaml
%YAML 1.2
# The end-of-directives marker must be on this line.
foo: bar
```

So this PR has added detection of the lacking of those markers and several test cases to validate the added implementation.  

---

## Pull Request Checklist

Read the [CONTRIBUTING.md](https://github.com/fktn-k/fkYAML/blob/develop/CONTRIBUTING.md) file for detailed information.  

- [x] Changes are described in the pull request or in a referenced [issue](https://github.com/fktn-k/fkYAML/issues).
- [x] The test suite compiles and runs without any error.
- [x] [The code coverage](https://coveralls.io/github/fktn-k/fkYAML) on your branch is 100%.
- [x] The documentation is updated if you added/changed a feature.

## Please don't

- The C++11 support varies between different **compilers** and versions. Please note the [list of supported compilers](https://github.com/fktn-k/fkYAML/blob/develop/README.md#supported-compilers). Some compilers like GCC 4.7 (and earlier), Clang 3.3 (and earlier), or Microsoft Visual Studio 13.0 and earlier are known not to work due to missing or incomplete C++11 support. Please refrain from proposing changes that work around these compiler's limitations with `#ifdef`s or other means.
- Please refrain from proposing changes that would **break [YAML](https://yaml.org/) specifications**. If you propose a conformant extension of YAML to be supported by the library, please motivate this extension.
- Please do not open pull requests that address **multiple issues**.
