### PR TITLE
Support serializing multiple YAML docs

### DIFF
--- a/docs/examples/ex_basic_node_serialize_docs.cpp
+++ b/docs/examples/ex_basic_node_serialize_docs.cpp
@@ -1,0 +1,33 @@
+//  _______   __ __   __  _____   __  __  __
+// |   __| |_/  |  \_/  |/  _  \ /  \/  \|  |     fkYAML: A C++ header-only YAML library (supporting code)
+// |   __|  _  < \_   _/|  ___  |    _   |  |___  version 0.3.9
+// |__|  |_| \__|  |_|  |_|   |_|___||___|______| https://github.com/fktn-k/fkYAML
+//
+// SPDX-FileCopyrightText: 2023-2024 Kensuke Fukutani <fktn.dev@gmail.com>
+// SPDX-License-Identifier: MIT
+
+#include <iostream>
+#include <fkYAML/node.hpp>
+
+int main() {
+    // create a basic_node object.
+    fkyaml::node n1 = {
+        {"foo", true},
+        {"bar", {1, 2, 3}},
+        {"baz", {{"qux", 3.14}, {"corge", nullptr}}},
+        {{{true, 123}}, false},
+        {{1.23, 4.56, 7.89}, 123456789}};
+    // set tags to some nodes.
+    n1["foo"].add_tag_name("!!bool");
+    n1["bar"][1].add_tag_name("!<tag:yaml.org,2002:int>");
+    // set an anchor name to a node.
+    n1["baz"].add_anchor_name("anchor");
+
+    // create another one.
+    fkyaml::node n2 = {"foo", 123, true};
+
+    // serialize the basic_node objects into a string.
+    std::cout << fkyaml::node::serialize_docs({n1, n2}) << std::endl;
+
+    return 0;
+}

--- a/docs/examples/ex_basic_node_serialize_docs.output
+++ b/docs/examples/ex_basic_node_serialize_docs.output
@@ -1,0 +1,19 @@
+? - 1.23
+  - 4.56
+  - 7.89
+: 123456789
+? true: 123
+: false
+bar:
+  - 1
+  - !<tag:yaml.org,2002:int> 2
+  - 3
+baz: &anchor
+  corge: null
+  qux: 3.14
+foo: !!bool true
+...
+- foo
+- 123
+- true
+

--- a/docs/mkdocs/docs/api/basic_node/index.md
+++ b/docs/mkdocs/docs/api/basic_node/index.md
@@ -80,6 +80,7 @@ This class provides features to handle YAML nodes.
 | [deserialize_docs](deserialize_docs.md) | (static) | deserializes all YAML documents into basic_node objects.           |
 | [operator>>](extraction_operator.md)    |          | deserializes an input stream into a basic_node.                    |
 | [serialize](serialize.md)               | (static) | serializes a basic_node into a YAML formatted string.              |
+| [serialize_docs](serialize_docs.md)     | (static) | serializes basic_node objects into a YAML formatted string.        |
 | [operator<<](insertion_operator.md)     |          | serializes a basic_node into an output stream.                     |
 | [get_value](get_value.md)               |          | converts a basic_node into a target native data type.              |
 | [get_value_ref](get_value_ref.md)       |          | converts a basic_node into reference to a target native data type. |

--- a/docs/mkdocs/docs/api/basic_node/serialize_docs.md
+++ b/docs/mkdocs/docs/api/basic_node/serialize_docs.md
@@ -1,0 +1,48 @@
+<small>Defined in header [`<fkYAML/node.hpp>`](https://github.com/fktn-k/fkYAML/blob/develop/include/fkYAML/node.hpp)</small>
+
+# <small>fkyaml::basic_node::</small>serialize_docs
+
+```cpp
+static std::string serialize_docs(const std::vector<basic_node>& docs);
+```
+
+Serializes YAML documents into a string.  
+This function serializes the given `docs` parameter with the separation line (...) between YAML documents.  
+Regarding the serialization of each document, see the documentation for the [`serialize()`](serialize.md) function which this function calls internally.  
+Just as the [`serialize()`](serialize.md) function does, fkYAML unconditionally uses LFs as the line break format in serialization outputs and there is currently no way to change it to use CR+LFs.  
+
+```yaml
+<YAML Document 1>
+...
+<YAML Document 2>
+# the last separation line will be omitted since it's redundant.
+```
+
+### **Parameters**
+
+***`docs`*** [in]
+:   `basic_node` objects to be serialized.
+
+### **Return Value**
+
+The resulting string object from the serialization of the `docs` object.
+
+???+ Example
+
+    ```cpp
+    --8<-- "examples/ex_basic_node_serialize_docs.cpp:9"
+    ```
+
+    output:
+    ```bash
+    --8<-- "examples/ex_basic_node_serialize_docs.output"
+    ```
+
+### **See Also**
+
+* [basic_node](index.md)
+* [add_anchor_name](add_anchor_name.md)
+* [add_tag_name](add_tag_name.md)
+* [deserialize](deserialize.md)
+* [operator<<](insertion_operator.md)
+* [operator"" _yaml](../operator_literal_yaml.md)

--- a/docs/mkdocs/mkdocs.yml
+++ b/docs/mkdocs/mkdocs.yml
@@ -140,6 +140,7 @@ nav:
           - sequence_type: api/basic_node/sequence_type.md
           - sequence: api/basic_node/sequence.md
           - serialize: api/basic_node/serialize.md
+          - serialize_docs: api/basic_node/serialize_docs.md
           - set_yaml_version: api/basic_node/set_yaml_version.md
           - size: api/basic_node/size.md
           - string_type: api/basic_node/string_type.md

--- a/include/fkYAML/detail/output/serializer.hpp
+++ b/include/fkYAML/detail/output/serializer.hpp
@@ -42,12 +42,31 @@ public:
     /// @return std::string A serialization result of the given Node value.
     std::string serialize(const BasicNodeType& node) {
         std::string str {};
-        serialize_directives(node, str);
-        serialize_node(node, 0, str);
+        serialize_document(node, str);
         return str;
     } // LCOV_EXCL_LINE
 
+    std::string serialize_docs(const std::vector<BasicNodeType>& docs) {
+        std::string str {};
+
+        uint32_t size = static_cast<uint32_t>(docs.size());
+        for (uint32_t i = 0; i < size; i++) {
+            serialize_document(docs[i], str);
+            if (i + 1 < size) {
+                // Append the end-of-document marker for the next document.
+                str += "...\n";
+            }
+        }
+
+        return str;
+    }
+
 private:
+    void serialize_document(const BasicNodeType& node, std::string& str) {
+        serialize_directives(node, str);
+        serialize_node(node, 0, str);
+    }
+
     /// @brief Serialize the directives if any is applied to the node.
     /// @param node The targe node.
     /// @param str A string to hold serialization result.

--- a/include/fkYAML/detail/output/serializer.hpp
+++ b/include/fkYAML/detail/output/serializer.hpp
@@ -59,7 +59,7 @@ public:
         }
 
         return str;
-    }
+    } // LCOV_EXCL_LINE
 
 private:
     void serialize_document(const BasicNodeType& node, std::string& str) {

--- a/include/fkYAML/node.hpp
+++ b/include/fkYAML/node.hpp
@@ -447,10 +447,18 @@ public:
 
     /// @brief Serialize a basic_node object into a string.
     /// @param[in] node A basic_node object to be serialized.
-    /// @return The resulting string object from the serialization of the node object.
+    /// @return The resulting string object from the serialization of the given node.
     /// @sa https://fktn-k.github.io/fkYAML/api/basic_node/serialize/
     static std::string serialize(const basic_node& node) {
         return serializer_type().serialize(node);
+    }
+
+    /// @brief Serialize basic_node objects into a string.
+    /// @param docs basic_node objects to be serialized.
+    /// @return The resulting string object from the serialization of the given nodes.
+    /// @sa https://fktn-k.github.io/fkYAML/api/basic_node/serialize_docs/
+    static std::string serialize_docs(const std::vector<basic_node>& docs) {
+        return serializer_type().serialize_docs(docs);
     }
 
     /// @brief A factory method for sequence basic_node objects without sequence_type objects.

--- a/single_include/fkYAML/node.hpp
+++ b/single_include/fkYAML/node.hpp
@@ -7275,7 +7275,7 @@ public:
         }
 
         return str;
-    }
+    } // LCOV_EXCL_LINE
 
 private:
     void serialize_document(const BasicNodeType& node, std::string& str) {

--- a/single_include/fkYAML/node.hpp
+++ b/single_include/fkYAML/node.hpp
@@ -7258,12 +7258,31 @@ public:
     /// @return std::string A serialization result of the given Node value.
     std::string serialize(const BasicNodeType& node) {
         std::string str {};
-        serialize_directives(node, str);
-        serialize_node(node, 0, str);
+        serialize_document(node, str);
         return str;
     } // LCOV_EXCL_LINE
 
+    std::string serialize_docs(const std::vector<BasicNodeType>& docs) {
+        std::string str {};
+
+        uint32_t size = static_cast<uint32_t>(docs.size());
+        for (uint32_t i = 0; i < size; i++) {
+            serialize_document(docs[i], str);
+            if (i + 1 < size) {
+                // Append the end-of-document marker for the next document.
+                str += "...\n";
+            }
+        }
+
+        return str;
+    }
+
 private:
+    void serialize_document(const BasicNodeType& node, std::string& str) {
+        serialize_directives(node, str);
+        serialize_node(node, 0, str);
+    }
+
     /// @brief Serialize the directives if any is applied to the node.
     /// @param node The targe node.
     /// @param str A string to hold serialization result.
@@ -8824,10 +8843,18 @@ public:
 
     /// @brief Serialize a basic_node object into a string.
     /// @param[in] node A basic_node object to be serialized.
-    /// @return The resulting string object from the serialization of the node object.
+    /// @return The resulting string object from the serialization of the given node.
     /// @sa https://fktn-k.github.io/fkYAML/api/basic_node/serialize/
     static std::string serialize(const basic_node& node) {
         return serializer_type().serialize(node);
+    }
+
+    /// @brief Serialize basic_node objects into a string.
+    /// @param docs basic_node objects to be serialized.
+    /// @return The resulting string object from the serialization of the given nodes.
+    /// @sa https://fktn-k.github.io/fkYAML/api/basic_node/serialize_docs/
+    static std::string serialize_docs(const std::vector<basic_node>& docs) {
+        return serializer_type().serialize_docs(docs);
     }
 
     /// @brief A factory method for sequence basic_node objects without sequence_type objects.

--- a/test/unit_test/test_node_class.cpp
+++ b/test/unit_test/test_node_class.cpp
@@ -371,7 +371,7 @@ TEST_CASE("Node_CopyAssignmentOperator") {
 }
 
 //
-// test cases for serialization/deserialization features
+// test cases for deserialization
 //
 
 TEST_CASE("Node_Deserialize") {
@@ -433,26 +433,6 @@ TEST_CASE("Node_DeserializeDocs") {
     REQUIRE(seq1.get_value<double>() == 3.14);
     fkyaml::node& seq2 = root1[2];
     REQUIRE(seq2.is_null());
-}
-
-TEST_CASE("Node_Serialize") {
-    fkyaml::node node = fkyaml::node::deserialize("foo: bar");
-    REQUIRE(fkyaml::node::serialize(node) == "foo: bar\n");
-}
-
-TEST_CASE("Node_SerializeDocs") {
-    std::vector<fkyaml::node> docs = fkyaml::node::deserialize_docs("foo: bar\n"
-                                                                    "...\n"
-                                                                    "123: true");
-    REQUIRE(fkyaml::node::serialize_docs(docs) == "foo: bar\n...\n123: true\n");
-}
-
-TEST_CASE("Node_InsertionOperator") {
-    fkyaml::node node = {{"foo", 123}, {"bar", nullptr}, {"baz", true}};
-    std::stringstream ss;
-    ss << node;
-
-    REQUIRE(ss.str() == "bar: null\nbaz: true\nfoo: 123\n");
 }
 
 TEST_CASE("Node_ExtractionOperator") {
@@ -587,6 +567,30 @@ TEST_CASE("Node_UserDefinedLiteralYaml") {
         REQUIRE(node["en"].get_value_ref<std::string&>() == "hello");
         REQUIRE(node["jp"].get_value_ref<std::string&>() == reinterpret_cast<const char*>(u8"こんにちは"));
     }
+}
+
+//
+// test cases for serialization
+//
+
+TEST_CASE("Node_Serialize") {
+    fkyaml::node node = fkyaml::node::deserialize("foo: bar");
+    REQUIRE(fkyaml::node::serialize(node) == "foo: bar\n");
+}
+
+TEST_CASE("Node_SerializeDocs") {
+    std::vector<fkyaml::node> docs = fkyaml::node::deserialize_docs("foo: bar\n"
+                                                                    "...\n"
+                                                                    "123: true");
+    REQUIRE(fkyaml::node::serialize_docs(docs) == "foo: bar\n...\n123: true\n");
+}
+
+TEST_CASE("Node_InsertionOperator") {
+    fkyaml::node node = {{"foo", 123}, {"bar", nullptr}, {"baz", true}};
+    std::stringstream ss;
+    ss << node;
+
+    REQUIRE(ss.str() == "bar: null\nbaz: true\nfoo: 123\n");
 }
 
 //

--- a/test/unit_test/test_node_class.cpp
+++ b/test/unit_test/test_node_class.cpp
@@ -440,6 +440,13 @@ TEST_CASE("Node_Serialize") {
     REQUIRE(fkyaml::node::serialize(node) == "foo: bar\n");
 }
 
+TEST_CASE("Node_SerializeDocs") {
+    std::vector<fkyaml::node> docs = fkyaml::node::deserialize_docs("foo: bar\n"
+                                                                    "...\n"
+                                                                    "123: true");
+    REQUIRE(fkyaml::node::serialize_docs(docs) == "foo: bar\n...\n123: true\n");
+}
+
 TEST_CASE("Node_InsertionOperator") {
     fkyaml::node node = {{"foo", 123}, {"bar", nullptr}, {"baz", true}};
     std::stringstream ss;

--- a/test/unit_test/test_serializer_class.cpp
+++ b/test/unit_test/test_serializer_class.cpp
@@ -251,3 +251,31 @@ TEST_CASE("Serializer_NodesWithDirectives") {
         REQUIRE(serializer.serialize(root) == expected);
     }
 }
+
+TEST_CASE("Serializer_MultipleDocuments") {
+    std::vector<fkyaml::node> docs;
+    fkyaml::detail::basic_deserializer<fkyaml::node> deserializer;
+    fkyaml::detail::basic_serializer<fkyaml::node> serializer;
+
+    SECTION("bare documents") {
+        std::string expected = "foo: bar\n"
+                               "...\n"
+                               "123: true\n";
+
+        REQUIRE_NOTHROW(docs = deserializer.deserialize_docs(fkyaml::detail::input_adapter(expected)));
+        REQUIRE(serializer.serialize_docs(docs) == expected);
+    }
+
+    SECTION("with directives") {
+        std::string expected = "%YAML 1.2\n"
+                               "---\n"
+                               "foo: !!str bar\n"
+                               "...\n"
+                               "%TAG !t! !test-\n"
+                               "---\n"
+                               "test: !t!result success\n";
+
+        REQUIRE_NOTHROW(docs = deserializer.deserialize_docs(fkyaml::detail::input_adapter(expected)));
+        REQUIRE(serializer.serialize_docs(docs) == expected);
+    }
+}


### PR DESCRIPTION
This PR has added the new support of serializing multiple YAML documents by implementing the `fkyaml::basic_node::serialize_docs()` function.  
It accepts a vector of basic_node objects like the `fkyaml::basic_node::deserialize_docs()` function returns, and returns a string as the serialization result with separation lines (`...`) between documents.  
See the updated API documentation for details about the function.  

---

## Pull Request Checklist

Read the [CONTRIBUTING.md](https://github.com/fktn-k/fkYAML/blob/develop/CONTRIBUTING.md) file for detailed information.  

- [x] Changes are described in the pull request or in a referenced [issue](https://github.com/fktn-k/fkYAML/issues).
- [x] The test suite compiles and runs without any error.
- [x] [The code coverage](https://coveralls.io/github/fktn-k/fkYAML) on your branch is 100%.
- [x] The documentation is updated if you added/changed a feature.

## Please don't

- The C++11 support varies between different **compilers** and versions. Please note the [list of supported compilers](https://github.com/fktn-k/fkYAML/blob/develop/README.md#supported-compilers). Some compilers like GCC 4.7 (and earlier), Clang 3.3 (and earlier), or Microsoft Visual Studio 13.0 and earlier are known not to work due to missing or incomplete C++11 support. Please refrain from proposing changes that work around these compiler's limitations with `#ifdef`s or other means.
- Please refrain from proposing changes that would **break [YAML](https://yaml.org/) specifications**. If you propose a conformant extension of YAML to be supported by the library, please motivate this extension.
- Please do not open pull requests that address **multiple issues**.
