### PR TITLE
Fix bug in serializing alias keys

### DIFF
--- a/include/fkYAML/detail/output/serializer.hpp
+++ b/include/fkYAML/detail/output/serializer.hpp
@@ -154,7 +154,11 @@ private:
                 insert_indentation(cur_indent, str);
 
                 bool is_appended = try_append_alias(itr.key(), false, str);
-                if (!is_appended) {
+                if (is_appended) {
+                    // The trailing white space is necessary since anchor names can contain a colon (:) at its end.
+                    str += " ";
+                }
+                else {
                     bool is_anchor_appended = try_append_anchor(itr.key(), false, str);
                     bool is_tag_appended = try_append_tag(itr.key(), is_anchor_appended, str);
                     if (is_anchor_appended || is_tag_appended) {

--- a/single_include/fkYAML/node.hpp
+++ b/single_include/fkYAML/node.hpp
@@ -7370,7 +7370,11 @@ private:
                 insert_indentation(cur_indent, str);
 
                 bool is_appended = try_append_alias(itr.key(), false, str);
-                if (!is_appended) {
+                if (is_appended) {
+                    // The trailing white space is necessary since anchor names can contain a colon (:) at its end.
+                    str += " ";
+                }
+                else {
                     bool is_anchor_appended = try_append_anchor(itr.key(), false, str);
                     bool is_tag_appended = try_append_tag(itr.key(), is_anchor_appended, str);
                     if (is_anchor_appended || is_tag_appended) {

--- a/test/unit_test/test_serializer_class.cpp
+++ b/test/unit_test/test_serializer_class.cpp
@@ -156,7 +156,7 @@ TEST_CASE("Serializer_AliasNode") {
                            "  - bar\n"
                            "  - *A\n"
                            "true: *A\n"
-                           "*A: 3.14\n"
+                           "*A : 3.14\n"
                            "foo: &A 123\n";
 
     fkyaml::detail::basic_serializer<fkyaml::node> serializer;


### PR DESCRIPTION
The current serializer changes alias names when they are used as a mapping key.  
For example, serializing the following YAML snippet:

```yaml
foo: &A bar
*A : baz
```

the serializer emits the following wrong result since alias names can contain colons:

```yaml
foo: &A bar
*A: baz # alias name mistakenly becomes "*A:".
```

So, this PR has fixed the above issue and now the serializer emits correct alias keys.  

---

## Pull Request Checklist

Read the [CONTRIBUTING.md](https://github.com/fktn-k/fkYAML/blob/develop/CONTRIBUTING.md) file for detailed information.  

- [x] Changes are described in the pull request or in a referenced [issue](https://github.com/fktn-k/fkYAML/issues).
- [x] The test suite compiles and runs without any error.
- [x] [The code coverage](https://coveralls.io/github/fktn-k/fkYAML) on your branch is 100%.
- [x] The documentation is updated if you added/changed a feature.

## Please don't

- The C++11 support varies between different **compilers** and versions. Please note the [list of supported compilers](https://github.com/fktn-k/fkYAML/blob/develop/README.md#supported-compilers). Some compilers like GCC 4.7 (and earlier), Clang 3.3 (and earlier), or Microsoft Visual Studio 13.0 and earlier are known not to work due to missing or incomplete C++11 support. Please refrain from proposing changes that work around these compiler's limitations with `#ifdef`s or other means.
- Please refrain from proposing changes that would **break [YAML](https://yaml.org/) specifications**. If you propose a conformant extension of YAML to be supported by the library, please motivate this extension.
- Please do not open pull requests that address **multiple issues**.
