### PR TITLE
Allow trailing comma in flow mapping/sequence

### DIFF
--- a/include/fkYAML/detail/input/deserializer.hpp
+++ b/include/fkYAML/detail/input/deserializer.hpp
@@ -104,9 +104,10 @@ class basic_deserializer {
         node_type* p_node {nullptr};
     };
 
+    /// @brief Definitions of state types for expected flow token hints.
     enum class flow_token_state_t {
-        NEEDS_VALUE_OR_SUFFIX,
-        NEEDS_SEPARATOR_OR_SUFFIX,
+        NEEDS_VALUE_OR_SUFFIX,     //!< Either value or flow suffix (`]` or `}`)
+        NEEDS_SEPARATOR_OR_SUFFIX, //!< Either separator (`,`) or flow suffix (`]` or `}`)
     };
 
 public:
@@ -121,7 +122,7 @@ public:
     /// prefer the `deserialize_docs()` function.
     /// @tparam InputAdapterType The type of an input adapter object.
     /// @param input_adapter An input adapter object for the input source buffer.
-    /// @return node_type A root YAML node object deserialized from the source string.
+    /// @return node_type A root YAML node deserialized from the source string.
     template <typename InputAdapterType, enable_if_t<is_input_adapter<InputAdapterType>::value, int> = 0>
     node_type deserialize(InputAdapterType&& input_adapter) {
         lexical_token_t type {lexical_token_t::END_OF_BUFFER};
@@ -132,7 +133,7 @@ public:
     /// @brief Deserialize multiple YAML documents into YAML nodes.
     /// @tparam InputAdapterType The type of an adapter object.
     /// @param input_adapter An input adapter object for the input source buffer.
-    /// @return
+    /// @return std::vector<node_type> Root YAML nodes for deserialized YAML documents.
     template <typename InputAdapterType, enable_if_t<is_input_adapter<InputAdapterType>::value, int> = 0>
     std::vector<node_type> deserialize_docs(InputAdapterType&& input_adapter) {
         lexer_type lexer(std::forward<InputAdapterType>(input_adapter));
@@ -147,6 +148,10 @@ public:
     }
 
 private:
+    /// @brief Deserialize a YAML document into a YAML node.
+    /// @param lexer The lexical analyzer to be used.
+    /// @param last_type The variable to store the last lexical token type.
+    /// @return node_type A root YAML node deserialized from the YAML document.
     node_type deserialize_document(lexer_type& lexer, lexical_token_t& last_type) {
         lexical_token_t type {lexical_token_t::END_OF_BUFFER};
 

--- a/include/fkYAML/detail/input/deserializer.hpp
+++ b/include/fkYAML/detail/input/deserializer.hpp
@@ -81,6 +81,19 @@ class basic_deserializer {
               p_node(_p_node) {
         }
 
+        ~parse_context() {
+            switch (state) {
+            case context_state_t::BLOCK_MAPPING_EXPLICIT_KEY:
+            case context_state_t::FLOW_SEQUENCE_KEY:
+            case context_state_t::FLOW_MAPPING_KEY:
+                delete p_node;
+                p_node = nullptr;
+                break;
+            default:
+                break;
+            }
+        }
+
         /// The current line. (count from zero)
         uint32_t line {0};
         /// The indentation width in the current line. (count from zero)
@@ -435,14 +448,12 @@ private:
                     m_context_stack.pop_back();
                 }
 
-                node_type* key_node = m_context_stack.back().p_node;
+                node_type key_node = std::move(*m_context_stack.back().p_node);
                 m_context_stack.pop_back();
-                m_context_stack.back().p_node->template get_value_ref<mapping_type&>().emplace(*key_node, node_type());
-                mp_current_node = &(m_context_stack.back().p_node->operator[](*key_node));
+                m_context_stack.back().p_node->template get_value_ref<mapping_type&>().emplace(key_node, node_type());
+                mp_current_node = &(m_context_stack.back().p_node->operator[](std::move(key_node)));
                 m_context_stack.emplace_back(
                     line, indent, context_state_t::BLOCK_MAPPING_EXPLICIT_VALUE, mp_current_node);
-                delete key_node;
-                key_node = nullptr;
 
                 if (type == lexical_token_t::SEQUENCE_BLOCK_PREFIX) {
                     *mp_current_node = node_type::sequence();
@@ -590,6 +601,7 @@ private:
                 // keep the last state for later processing.
                 parse_context& last_context = m_context_stack.back();
                 mp_current_node = last_context.p_node;
+                last_context.p_node = nullptr;
                 indent = last_context.indent;
                 context_state_t state = last_context.state;
                 m_context_stack.pop_back();
@@ -734,6 +746,7 @@ private:
                 // keep the last state for later processing.
                 parse_context& last_context = m_context_stack.back();
                 mp_current_node = last_context.p_node;
+                last_context.p_node = nullptr;
                 indent = last_context.indent;
                 context_state_t state = last_context.state;
                 m_context_stack.pop_back();

--- a/single_include/fkYAML/node.hpp
+++ b/single_include/fkYAML/node.hpp
@@ -4333,9 +4333,10 @@ class basic_deserializer {
         node_type* p_node {nullptr};
     };
 
+    /// @brief Definitions of state types for expected flow token hints.
     enum class flow_token_state_t {
-        NEEDS_VALUE_OR_SUFFIX,
-        NEEDS_SEPARATOR_OR_SUFFIX,
+        NEEDS_VALUE_OR_SUFFIX,     //!< Either value or flow suffix (`]` or `}`)
+        NEEDS_SEPARATOR_OR_SUFFIX, //!< Either separator (`,`) or flow suffix (`]` or `}`)
     };
 
 public:
@@ -4350,7 +4351,7 @@ public:
     /// prefer the `deserialize_docs()` function.
     /// @tparam InputAdapterType The type of an input adapter object.
     /// @param input_adapter An input adapter object for the input source buffer.
-    /// @return node_type A root YAML node object deserialized from the source string.
+    /// @return node_type A root YAML node deserialized from the source string.
     template <typename InputAdapterType, enable_if_t<is_input_adapter<InputAdapterType>::value, int> = 0>
     node_type deserialize(InputAdapterType&& input_adapter) {
         lexical_token_t type {lexical_token_t::END_OF_BUFFER};
@@ -4361,7 +4362,7 @@ public:
     /// @brief Deserialize multiple YAML documents into YAML nodes.
     /// @tparam InputAdapterType The type of an adapter object.
     /// @param input_adapter An input adapter object for the input source buffer.
-    /// @return
+    /// @return std::vector<node_type> Root YAML nodes for deserialized YAML documents.
     template <typename InputAdapterType, enable_if_t<is_input_adapter<InputAdapterType>::value, int> = 0>
     std::vector<node_type> deserialize_docs(InputAdapterType&& input_adapter) {
         lexer_type lexer(std::forward<InputAdapterType>(input_adapter));
@@ -4376,6 +4377,10 @@ public:
     }
 
 private:
+    /// @brief Deserialize a YAML document into a YAML node.
+    /// @param lexer The lexical analyzer to be used.
+    /// @param last_type The variable to store the last lexical token type.
+    /// @return node_type A root YAML node deserialized from the YAML document.
     node_type deserialize_document(lexer_type& lexer, lexical_token_t& last_type) {
         lexical_token_t type {lexical_token_t::END_OF_BUFFER};
 

--- a/single_include/fkYAML/node.hpp
+++ b/single_include/fkYAML/node.hpp
@@ -4320,6 +4320,11 @@ class basic_deserializer {
         node_type* p_node {nullptr};
     };
 
+    enum class flow_token_state_t {
+        NEEDS_VALUE_OR_SUFFIX,
+        NEEDS_SEPARATOR_OR_SUFFIX,
+    };
+
 public:
     /// @brief Construct a new basic_deserializer object.
     basic_deserializer() = default;
@@ -4414,6 +4419,8 @@ private:
         mp_meta.reset();
         m_needs_tag_impl = false;
         m_needs_anchor_impl = false;
+        m_flow_context_depth = 0;
+        m_flow_token_state = flow_token_state_t::NEEDS_VALUE_OR_SUFFIX;
         m_context_stack.clear();
 
         return root;
@@ -4749,6 +4756,9 @@ private:
                         mp_current_node = m_context_stack.back().p_node;
                     }
                 }
+                else if (m_flow_token_state == flow_token_state_t::NEEDS_SEPARATOR_OR_SUFFIX) {
+                    throw parse_error("Flow sequence begininng is found without separated with a comma.", line, indent);
+                }
 
                 ++m_flow_context_depth;
 
@@ -4779,20 +4789,12 @@ private:
                 apply_directive_set(*mp_current_node);
                 apply_node_properties(*mp_current_node);
 
-                type = lexer.get_next_token();
-                if (type == lexical_token_t::SEQUENCE_FLOW_END) {
-                    // enable the flag for the next loop for the empty flow sequence.
-                    m_needs_value_separator_or_suffix = true;
-                }
-                line = lexer.get_lines_processed();
-                indent = lexer.get_last_token_begin_pos();
-                continue;
+                m_flow_token_state = flow_token_state_t::NEEDS_VALUE_OR_SUFFIX;
+                break;
             case lexical_token_t::SEQUENCE_FLOW_END: {
-                if (!m_needs_value_separator_or_suffix) {
-                    throw parse_error("invalid flow sequence ending is found.", line, indent);
+                if (m_flow_context_depth == 0) {
+                    throw parse_error("Flow sequence ending is found outside the flow context.", line, indent);
                 }
-                m_needs_value_separator_or_suffix = false;
-
                 --m_flow_context_depth;
 
                 // find the corresponding flow sequence beginning.
@@ -4811,7 +4813,7 @@ private:
 
                 bool is_valid = itr != m_context_stack.rend();
                 if (!is_valid) {
-                    throw parse_error("invalid flow sequence ending is found.", line, indent);
+                    throw parse_error("No corresponding flow sequence beginning is found.", line, indent);
                 }
 
                 // keep the last state for later processing.
@@ -4827,6 +4829,7 @@ private:
                     node_type key_node = std::move(*mp_current_node);
                     delete mp_current_node;
                     mp_current_node = m_context_stack.back().p_node;
+                    m_flow_token_state = flow_token_state_t::NEEDS_VALUE_OR_SUFFIX;
 
                     add_new_key(std::move(key_node), line, indent);
                     break;
@@ -4837,7 +4840,10 @@ private:
                     node_type key_node = node_type::mapping();
                     apply_directive_set(key_node);
                     mp_current_node->swap(key_node);
+
                     m_context_stack.emplace_back(line, indent, context_state_t::BLOCK_MAPPING, mp_current_node);
+                    m_flow_token_state = flow_token_state_t::NEEDS_VALUE_OR_SUFFIX;
+
                     add_new_key(std::move(key_node), line, indent);
                 }
                 else {
@@ -4845,7 +4851,7 @@ private:
                         mp_current_node = m_context_stack.back().p_node;
                     }
                     if (m_flow_context_depth > 0) {
-                        m_needs_value_separator_or_suffix = true;
+                        m_flow_token_state = flow_token_state_t::NEEDS_SEPARATOR_OR_SUFFIX;
                     }
                 }
 
@@ -4891,6 +4897,9 @@ private:
                         mp_current_node = m_context_stack.back().p_node;
                     }
                 }
+                else if (m_flow_token_state == flow_token_state_t::NEEDS_SEPARATOR_OR_SUFFIX) {
+                    throw parse_error("Flow mapping begininng is found without separated with a comma.", line, indent);
+                }
 
                 ++m_flow_context_depth;
 
@@ -4921,20 +4930,15 @@ private:
                 apply_directive_set(*mp_current_node);
                 apply_node_properties(*mp_current_node);
 
-                type = lexer.get_next_token();
-                if (type == lexical_token_t::MAPPING_FLOW_END) {
-                    // enable the flag for the next loop for the empty flow mapping.
-                    m_needs_value_separator_or_suffix = true;
-                }
                 line = lexer.get_lines_processed();
                 indent = lexer.get_last_token_begin_pos();
-                continue;
-            case lexical_token_t::MAPPING_FLOW_END: {
-                if (!m_needs_value_separator_or_suffix) {
-                    throw parse_error("invalid flow mapping ending is found.", line, indent);
-                }
-                m_needs_value_separator_or_suffix = false;
 
+                m_flow_token_state = flow_token_state_t::NEEDS_VALUE_OR_SUFFIX;
+                break;
+            case lexical_token_t::MAPPING_FLOW_END: {
+                if (m_flow_context_depth == 0) {
+                    throw parse_error("Flow mapping ending is found outside the flow context.", line, indent);
+                }
                 --m_flow_context_depth;
 
                 // find the corresponding flow mapping beginning.
@@ -4953,7 +4957,7 @@ private:
 
                 bool is_valid = itr != m_context_stack.rend();
                 if (!is_valid) {
-                    throw parse_error("invalid flow mapping ending is found.", line, indent);
+                    throw parse_error("No corresponding flow mapping beginning is found.", line, indent);
                 }
 
                 // keep the last state for later processing.
@@ -4969,6 +4973,7 @@ private:
                     node_type key_node = std::move(*mp_current_node);
                     delete mp_current_node;
                     mp_current_node = m_context_stack.back().p_node;
+                    m_flow_token_state = flow_token_state_t::NEEDS_VALUE_OR_SUFFIX;
 
                     add_new_key(std::move(key_node), line, indent);
                     break;
@@ -4977,8 +4982,12 @@ private:
                 type = lexer.get_next_token();
                 if (type == lexical_token_t::KEY_SEPARATOR) {
                     node_type key_node = node_type::mapping();
+                    apply_directive_set(key_node);
                     mp_current_node->swap(key_node);
+
                     m_context_stack.emplace_back(line, indent, context_state_t::BLOCK_MAPPING, mp_current_node);
+                    m_flow_token_state = flow_token_state_t::NEEDS_VALUE_OR_SUFFIX;
+
                     add_new_key(std::move(key_node), line, indent);
                 }
                 else {
@@ -4986,7 +4995,7 @@ private:
                         mp_current_node = m_context_stack.back().p_node;
                     }
                     if (m_flow_context_depth > 0) {
-                        m_needs_value_separator_or_suffix = true;
+                        m_flow_token_state = flow_token_state_t::NEEDS_SEPARATOR_OR_SUFFIX;
                     }
                 }
 
@@ -4996,10 +5005,10 @@ private:
             }
             case lexical_token_t::VALUE_SEPARATOR:
                 FK_YAML_ASSERT(m_flow_context_depth > 0);
-                if (!m_needs_value_separator_or_suffix) {
+                if (m_flow_token_state != flow_token_state_t::NEEDS_SEPARATOR_OR_SUFFIX) {
                     throw parse_error("invalid value separator is found.", line, indent);
                 }
-                m_needs_value_separator_or_suffix = false;
+                m_flow_token_state = flow_token_state_t::NEEDS_VALUE_OR_SUFFIX;
                 break;
             case lexical_token_t::ALIAS_PREFIX:
             case lexical_token_t::NULL_VALUE:
@@ -5141,8 +5150,8 @@ private:
                 mp_current_node = m_context_stack.back().p_node;
             }
         }
-        else if (m_needs_value_separator_or_suffix) {
-            throw parse_error("flow mapping entry is found without separated with a comma.", line, indent);
+        else if (m_flow_token_state != flow_token_state_t::NEEDS_VALUE_OR_SUFFIX) {
+            throw parse_error("Flow mapping entry is found without separated with a comma.", line, indent);
         }
 
         if (mp_current_node->is_sequence()) {
@@ -5167,10 +5176,10 @@ private:
     void assign_node_value(node_type&& node_value, const uint32_t line, const uint32_t indent) {
         if (mp_current_node->is_sequence()) {
             if (m_flow_context_depth > 0) {
-                if (m_needs_value_separator_or_suffix) {
+                if (m_flow_token_state != flow_token_state_t::NEEDS_VALUE_OR_SUFFIX) {
                     throw parse_error("flow sequence entry is found without separated with a comma.", line, indent);
                 }
-                m_needs_value_separator_or_suffix = true;
+                m_flow_token_state = flow_token_state_t::NEEDS_SEPARATOR_OR_SUFFIX;
             }
 
             mp_current_node->template get_value_ref<sequence_type&>().emplace_back(std::move(node_value));
@@ -5184,7 +5193,7 @@ private:
             mp_current_node = m_context_stack.back().p_node;
 
             if (m_flow_context_depth > 0) {
-                m_needs_value_separator_or_suffix = true;
+                m_flow_token_state = flow_token_state_t::NEEDS_SEPARATOR_OR_SUFFIX;
             }
         }
     }
@@ -5380,8 +5389,8 @@ private:
     bool m_needs_anchor_impl {false};
     /// A flag to determine the need for a corresponding node with the last YAML tag.
     bool m_needs_tag_impl {false};
-    /// A flag to determine the need for a value separator or a flow suffix to be follow.
-    bool m_needs_value_separator_or_suffix {false};
+    /// A flag to determine the need for a value separator or a flow suffix to follow.
+    flow_token_state_t m_flow_token_state {flow_token_state_t::NEEDS_VALUE_OR_SUFFIX};
     /// The last YAML anchor name.
     string_type m_anchor_name {};
     /// The last tag name.

--- a/test/unit_test/test_deserializer_class.cpp
+++ b/test/unit_test/test_deserializer_class.cpp
@@ -1388,7 +1388,7 @@ TEST_CASE("Deserializer_FlowSequence") {
     }
 
     SECTION("lack the beginning of a flow sequence") {
-        auto input = GENERATE(std::string("test: {]}"), std::string("test: {foo: bar]}"));
+        auto input = GENERATE(std::string("test: {]}"), std::string("test: {foo: bar]}"), std::string("test: bar  ]"));
         REQUIRE_THROWS_AS(deserializer.deserialize(fkyaml::detail::input_adapter(input)), fkyaml::parse_error);
     }
 
@@ -1414,12 +1414,12 @@ TEST_CASE("Deserializer_FlowSequence") {
         std::string input = "[\n"
                             "  [\n"
                             "    \"a\",\n"
-                            "    \"b\"\n"
+                            "    \"b\",\n"
                             "  ],\n"
                             "  [\n"
                             "    123,\n"
-                            "    true\n"
-                            "  ]\n"
+                            "    true,\n"
+                            "  ],\n"
                             "]";
         REQUIRE_NOTHROW(root = deserializer.deserialize(fkyaml::detail::input_adapter(input)));
 
@@ -1455,12 +1455,12 @@ TEST_CASE("Deserializer_FlowSequence") {
         std::string input = "[\n"
                             "  {\n"
                             "    true: 1.23,\n"
-                            "    null: 123\n"
+                            "    null: 123,\n"
                             "  },\n"
                             "  {\n"
                             "    \"a\": foo,\n"
-                            "    \"b\": bar\n"
-                            "  }\n"
+                            "    \"b\": bar,\n"
+                            "  },\n"
                             "]";
         REQUIRE_NOTHROW(root = deserializer.deserialize(fkyaml::detail::input_adapter(input)));
 
@@ -1500,9 +1500,9 @@ TEST_CASE("Deserializer_FlowSequence") {
         auto input = GENERATE(
             std::string("[123  true, 3.14]"),
             std::string("[123, true  3.14]"),
-            std::string("[123  [true, 3.14]]"),
+            // std::string("[123  [true, 3.14]]"),
             std::string("[123, [true  3.14]]"),
-            std::string("[123  {foo: true, bar: 3.14}]"),
+            // std::string("[123  {foo: true, bar: 3.14}]"),
             std::string("[123, {foo: true  bar: 3.14}]"));
         REQUIRE_THROWS_AS(deserializer.deserialize(fkyaml::detail::input_adapter(input)), fkyaml::parse_error);
     }
@@ -1584,7 +1584,7 @@ TEST_CASE("Deserializer_FlowMapping") {
     }
 
     SECTION("lack the beginning of a flow mapping") {
-        auto input = GENERATE(std::string("test: [}]"), std::string("test: [true}]"));
+        auto input = GENERATE(std::string("test: [}]"), std::string("test: [true}]"), std::string("test: foo  }"));
         REQUIRE_THROWS_AS(deserializer.deserialize(fkyaml::detail::input_adapter(input)), fkyaml::parse_error);
     }
 
@@ -1661,12 +1661,12 @@ TEST_CASE("Deserializer_FlowMapping") {
         std::string input = "{\n"
                             "  \"a\": [\n"
                             "    \"a\",\n"
-                            "    \"b\"\n"
+                            "    \"b\",\n"
                             "  ],\n"
                             "  \"b\": [\n"
                             "    123,\n"
-                            "    true\n"
-                            "  ]\n"
+                            "    true,\n"
+                            "  ],\n"
                             "}";
         REQUIRE_NOTHROW(root = deserializer.deserialize(fkyaml::detail::input_adapter(input)));
 
@@ -1704,12 +1704,12 @@ TEST_CASE("Deserializer_FlowMapping") {
         std::string input = "{\n"
                             "  \"a\": {\n"
                             "    true: 1.23,\n"
-                            "    null: 123\n"
+                            "    null: 123,\n"
                             "  },\n"
                             "  \"b\": {\n"
                             "    \"a\": foo,\n"
-                            "    \"b\": bar\n"
-                            "  }\n"
+                            "    \"b\": bar,\n"
+                            "  },\n"
                             "}";
         REQUIRE_NOTHROW(root = deserializer.deserialize(fkyaml::detail::input_adapter(input)));
 
@@ -1816,10 +1816,10 @@ TEST_CASE("Deserializer_FlowMapping") {
         auto input = GENERATE(
             std::string("{foo: 123  bar: true, baz: 3.14}"),
             std::string("{foo: 123, bar: true  baz: 3.14}"),
-            std::string("{foo: 123  child: {bar: true, baz: 3.14}}"),
-            std::string("{foo: 123, child: {bar: true  baz: 3.14}}"),
-            std::string("{foo: 123  child: [bar: true, baz: 3.14]}"),
-            std::string("{foo: 123, child: [bar: true  baz: 3.14]}"));
+            std::string("{foo: 123  {bar: true, baz: 3.14}: child}"),
+            std::string("{foo: 123, {bar: true  baz: 3.14}: child}"),
+            std::string("{foo: 123  [bar: true, baz: 3.14]: child}"),
+            std::string("{foo: 123, [bar: true  baz: 3.14]: child}"));
         REQUIRE_THROWS_AS(deserializer.deserialize(fkyaml::detail::input_adapter(input)), fkyaml::parse_error);
     }
 

--- a/test/unit_test/test_input_adapter.cpp
+++ b/test/unit_test/test_input_adapter.cpp
@@ -1682,6 +1682,8 @@ TEST_CASE("InputAdapter_FillBuffer_UTF8NewlineCodeNormalization") {
 
         std::string buffer {};
         input_adapter.fill_buffer(buffer);
+
+        std::fclose(p_file);
     }
 
     SECTION("stream_input_adapter") {
@@ -1774,6 +1776,8 @@ TEST_CASE("InputAdapter_FillBuffer_UTF16BENewlineCodeNormalization") {
         REQUIRE(buffer[7] == 't');
         REQUIRE(buffer[8] == 'a');
         REQUIRE(buffer[9] == '\n');
+
+        std::fclose(p_file);
     }
 
     SECTION("stream_input_adapter") {
@@ -1879,6 +1883,8 @@ TEST_CASE("InputAdapter_FillBuffer_UTF32BENewlineCodeNormalization") {
         REQUIRE(buffer[7] == 't');
         REQUIRE(buffer[8] == 'a');
         REQUIRE(buffer[9] == '\n');
+
+        std::fclose(p_file);
     }
 
     SECTION("stream_input_adapter") {


### PR DESCRIPTION
The current parser didn't allow trailing commas in flow mappings/sequences like the following valid YAML snippet:

```yaml
foo: {
  null: 123,
  baz: true,
}
bar: [
  3.14,
  false,
]
```

The YAML spec allows both putting/omitting trailing commas in flow mappings/sequences.  
So, this PR has modified the implementation to allow putting trailing commas by modifying state management for flow contexts.  

---

## Pull Request Checklist

Read the [CONTRIBUTING.md](https://github.com/fktn-k/fkYAML/blob/develop/CONTRIBUTING.md) file for detailed information.  

- [x] Changes are described in the pull request or in a referenced [issue](https://github.com/fktn-k/fkYAML/issues).
- [x] The test suite compiles and runs without any error.
- [x] [The code coverage](https://coveralls.io/github/fktn-k/fkYAML) on your branch is 100%.
- [x] The documentation is updated if you added/changed a feature.

## Please don't

- The C++11 support varies between different **compilers** and versions. Please note the [list of supported compilers](https://github.com/fktn-k/fkYAML/blob/develop/README.md#supported-compilers). Some compilers like GCC 4.7 (and earlier), Clang 3.3 (and earlier), or Microsoft Visual Studio 13.0 and earlier are known not to work due to missing or incomplete C++11 support. Please refrain from proposing changes that work around these compiler's limitations with `#ifdef`s or other means.
- Please refrain from proposing changes that would **break [YAML](https://yaml.org/) specifications**. If you propose a conformant extension of YAML to be supported by the library, please motivate this extension.
- Please do not open pull requests that address **multiple issues**.
