### PR TITLE
Remove CI jobs running with macOS 11

### DIFF
--- a/.github/workflows/macos.yml
+++ b/.github/workflows/macos.yml
@@ -52,32 +52,6 @@ jobs:
       working-directory: ${{github.workspace}}/build
       run: ctest -C ${{matrix.build_type}} --output-on-failure -j ${{env.JOBS}}
 
-  xcode_for_macos11:
-    timeout-minutes: 10
-    runs-on: macos-11
-    strategy:
-      matrix:
-        xcode: [ '11.7', '12.4', '12.5.1', '13.0', '13.1', '13.2.1' ]
-        build_type: [ Debug, Release ]
-    env:
-      DEVELOPER_DIR: /Applications/Xcode_${{matrix.xcode}}.app/Contents/Developer
-      JOBS: 2
-
-    steps:
-    - uses: actions/checkout@v4
-      with:
-        submodules: recursive
-
-    - name: Configure CMake
-      run: cmake -B ${{github.workspace}}/build -DCMAKE_BUILD_TYPE=${{matrix.build_type}} -DFK_YAML_BUILD_TEST=ON
-
-    - name: Build
-      run: cmake --build ${{github.workspace}}/build --config ${{matrix.build_type}} -j ${{env.JOBS}}
-
-    - name: Test
-      working-directory: ${{github.workspace}}/build
-      run: ctest -C ${{matrix.build_type}} --output-on-failure -j ${{env.JOBS}}
-
   xcode_for_macos12:
     timeout-minutes: 10
     runs-on: macos-12

--- a/README.md
+++ b/README.md
@@ -106,10 +106,6 @@ Currently, the following compilers are known to work and used in GitHub Actions 
 
 | Compiler                   | Operating System                                                                                               |
 | -------------------------- | -------------------------------------------------------------------------------------------------------------- |
-| AppleClang 11.0.3.11030032 | [macOS 11](https://github.com/actions/runner-images/blob/main/images/macos/macos-11-Readme.md)                 |
-| AppleClang 12.0.0.12000032 | [macOS 11](https://github.com/actions/runner-images/blob/main/images/macos/macos-11-Readme.md)                 |
-| AppleClang 12.0.5.12050022 | [macOS 11](https://github.com/actions/runner-images/blob/main/images/macos/macos-11-Readme.md)                 |
-| AppleClang 13.0.0.13000029 | [macOS 11](https://github.com/actions/runner-images/blob/main/images/macos/macos-11-Readme.md)                 |
 | AppleClang 13.0.0.13000029 | [macOS 12](https://github.com/actions/runner-images/blob/main/images/macos/macos-12-Readme.md)                 |
 | AppleClang 13.1.6.13160021 | [macOS 12](https://github.com/actions/runner-images/blob/main/images/macos/macos-12-Readme.md)                 |
 | AppleClang 14.0.0.14000029 | [macOS 12](https://github.com/actions/runner-images/blob/main/images/macos/macos-12-Readme.md)                 |

--- a/docs/mkdocs/docs/home/supported_compilers.md
+++ b/docs/mkdocs/docs/home/supported_compilers.md
@@ -4,10 +4,6 @@ Currently, the following compilers are known to work and used in GitHub Actions 
 
 | Compiler                   | Operating System                                                                                               |
 | -------------------------- | -------------------------------------------------------------------------------------------------------------- |
-| AppleClang 11.0.3.11030032 | [macOS 11](https://github.com/actions/runner-images/blob/main/images/macos/macos-11-Readme.md)                 |
-| AppleClang 12.0.0.12000032 | [macOS 11](https://github.com/actions/runner-images/blob/main/images/macos/macos-11-Readme.md)                 |
-| AppleClang 12.0.5.12050022 | [macOS 11](https://github.com/actions/runner-images/blob/main/images/macos/macos-11-Readme.md)                 |
-| AppleClang 13.0.0.13000029 | [macOS 11](https://github.com/actions/runner-images/blob/main/images/macos/macos-11-Readme.md)                 |
 | AppleClang 13.0.0.13000029 | [macOS 12](https://github.com/actions/runner-images/blob/main/images/macos/macos-12-Readme.md)                 |
 | AppleClang 13.1.6.13160021 | [macOS 12](https://github.com/actions/runner-images/blob/main/images/macos/macos-12-Readme.md)                 |
 | AppleClang 14.0.0.14000029 | [macOS 12](https://github.com/actions/runner-images/blob/main/images/macos/macos-12-Readme.md)                 |


### PR DESCRIPTION
The GitHub Actions runner image for macOS 11 has been deprecated, and the CI jobs running with the image now don't work anymore.  
So, this PR has removed them and AppleClang compiler support has therefore been shrunk.  
The supported compilers list has also been updated in the documentation.  

---

## Pull Request Checklist

Read the [CONTRIBUTING.md](https://github.com/fktn-k/fkYAML/blob/develop/CONTRIBUTING.md) file for detailed information.  

- [x] Changes are described in the pull request or in a referenced [issue](https://github.com/fktn-k/fkYAML/issues).
- [x] The test suite compiles and runs without any error.
- [x] [The code coverage](https://coveralls.io/github/fktn-k/fkYAML) on your branch is 100%.
- [x] The documentation is updated if you added/changed a feature.

## Please don't

- The C++11 support varies between different **compilers** and versions. Please note the [list of supported compilers](https://github.com/fktn-k/fkYAML/blob/develop/README.md#supported-compilers). Some compilers like GCC 4.7 (and earlier), Clang 3.3 (and earlier), or Microsoft Visual Studio 13.0 and earlier are known not to work due to missing or incomplete C++11 support. Please refrain from proposing changes that work around these compiler's limitations with `#ifdef`s or other means.
- Please refrain from proposing changes that would **break [YAML](https://yaml.org/) specifications**. If you propose a conformant extension of YAML to be supported by the library, please motivate this extension.
- Please do not open pull requests that address **multiple issues**.
