### PR TITLE
#368 Fix line advancement after node props

### DIFF
--- a/include/fkYAML/detail/input/deserializer.hpp
+++ b/include/fkYAML/detail/input/deserializer.hpp
@@ -510,11 +510,11 @@ private:
             case lexical_token_t::INVALID_DIRECTIVE:
                 break;
             case lexical_token_t::ANCHOR_PREFIX:
-            case lexical_token_t::TAG_PREFIX: {
+            case lexical_token_t::TAG_PREFIX:
                 deserialize_node_properties(lexer, type, line, indent);
                 // Skip updating the current indent to avoid stacking a wrong indentation.
-                // (Node properties for block sequences as a mapping value are processed when a
-                // `lexical_token_t::KEY_SEPARATOR` token is processed.)
+                // Note that node properties for block sequences as a mapping value are processed when a
+                // `lexical_token_t::KEY_SEPARATOR` token is processed.
                 //
                 // ```yaml
                 // &foo bar: baz
@@ -522,7 +522,6 @@ private:
                 // the correct indent width for the "bar" node key.
                 // ```
                 continue;
-            }
             case lexical_token_t::SEQUENCE_BLOCK_PREFIX: {
                 bool is_further_nested = m_context_stack.back().indent < indent;
                 if (is_further_nested) {

--- a/include/fkYAML/detail/input/deserializer.hpp
+++ b/include/fkYAML/detail/input/deserializer.hpp
@@ -949,17 +949,8 @@ private:
             else if (indent < m_context_stack.back().indent) {
                 auto target_itr =
                     std::find_if(m_context_stack.rbegin(), m_context_stack.rend(), [indent](const parse_context& c) {
-                        if (indent != c.indent) {
-                            return false;
-                        }
-
-                        switch (c.state) {
-                        case context_state_t::BLOCK_MAPPING:
-                            // case context_state_t::MAPPING_VALUE:
-                            return true;
-                        default:
-                            return false;
-                        }
+                        // the target node is a block mapping key node with the same indentation.
+                        return (indent == c.indent) && (c.state == context_state_t::BLOCK_MAPPING);
                     });
                 bool is_indent_valid = (target_itr != m_context_stack.rend());
                 if (!is_indent_valid) {

--- a/include/fkYAML/detail/input/deserializer.hpp
+++ b/include/fkYAML/detail/input/deserializer.hpp
@@ -413,7 +413,7 @@ private:
                 if (line > old_line) {
                     if (m_needs_tag_impl) {
                         tag_t tag_type = tag_resolver_type::resolve_tag(m_tag_name, mp_meta);
-                        if (tag_type == tag_t::MAPPING) {
+                        if (tag_type == tag_t::MAPPING || tag_type == tag_t::CUSTOM_TAG) {
                             // set YAML node properties here to distinguish them from those for the first key node
                             // as shown in the following snippet:
                             //
@@ -426,6 +426,7 @@ private:
                             *mp_current_node = node_type::mapping();
                             apply_directive_set(*mp_current_node);
                             apply_node_properties(*mp_current_node);
+                            m_context_stack.emplace_back(line, indent, context_state_t::BLOCK_MAPPING, mp_current_node);
                             continue;
                         }
                     }
@@ -439,7 +440,40 @@ private:
                         cur_context.line = line;
                         cur_context.indent = indent;
                         cur_context.state = context_state_t::BLOCK_SEQUENCE;
-                        break;
+
+                        type = lexer.get_next_token();
+                        line = lexer.get_lines_processed();
+                        indent = lexer.get_last_token_begin_pos();
+
+                        bool has_props = deserialize_node_properties(lexer, type, line, indent);
+                        if (has_props) {
+                            uint32_t line_after_props = lexer.get_lines_processed();
+                            if (line == line_after_props) {
+                                // Skip updating the current indent to avoid stacking a wrong indentation.
+                                //
+                                // ```yaml
+                                // &foo bar: baz
+                                // ^
+                                // the correct indent width for the "bar" node key.
+                                // ```
+                                continue;
+                            }
+
+                            // if node properties and the followed node are on different lines (i.e., the properties are
+                            // for a container node), the application and the line advancement must happen here.
+                            // Otherwise, a false indent error will be emitted. See
+                            // https://github.com/fktn-k/fkYAML/issues/368 for more details.
+                            line = line_after_props;
+                            indent = lexer.get_last_token_begin_pos();
+                            mp_current_node->template get_value_ref<sequence_type&>().emplace_back(
+                                node_type::mapping());
+                            mp_current_node = &mp_current_node->template get_value_ref<sequence_type&>().back();
+                            m_context_stack.emplace_back(
+                                line_after_props, indent, context_state_t::BLOCK_MAPPING, mp_current_node);
+                            apply_node_properties(*mp_current_node);
+                        }
+
+                        continue;
                     }
 
                     // defer checking the existence of a key separator after the following scalar until the next
@@ -476,16 +510,19 @@ private:
             case lexical_token_t::INVALID_DIRECTIVE:
                 break;
             case lexical_token_t::ANCHOR_PREFIX:
-            case lexical_token_t::TAG_PREFIX:
+            case lexical_token_t::TAG_PREFIX: {
                 deserialize_node_properties(lexer, type, line, indent);
-
                 // Skip updating the current indent to avoid stacking a wrong indentation.
+                // (Node properties for block sequences as a mapping value are processed when a
+                // `lexical_token_t::KEY_SEPARATOR` token is processed.)
                 //
-                //   &foo bar: baz
-                //   ^
-                //   the correct indent width for the "bar" node key.
-
+                // ```yaml
+                // &foo bar: baz
+                // ^
+                // the correct indent width for the "bar" node key.
+                // ```
                 continue;
+            }
             case lexical_token_t::SEQUENCE_BLOCK_PREFIX: {
                 bool is_further_nested = m_context_stack.back().indent < indent;
                 if (is_further_nested) {
@@ -918,7 +955,7 @@ private:
 
                         switch (c.state) {
                         case context_state_t::BLOCK_MAPPING:
-                        case context_state_t::MAPPING_VALUE:
+                            // case context_state_t::MAPPING_VALUE:
                             return true;
                         default:
                             return false;

--- a/single_include/fkYAML/node.hpp
+++ b/single_include/fkYAML/node.hpp
@@ -5178,17 +5178,8 @@ private:
             else if (indent < m_context_stack.back().indent) {
                 auto target_itr =
                     std::find_if(m_context_stack.rbegin(), m_context_stack.rend(), [indent](const parse_context& c) {
-                        if (indent != c.indent) {
-                            return false;
-                        }
-
-                        switch (c.state) {
-                        case context_state_t::BLOCK_MAPPING:
-                            // case context_state_t::MAPPING_VALUE:
-                            return true;
-                        default:
-                            return false;
-                        }
+                        // the target node is a block mapping key node with the same indentation.
+                        return (indent == c.indent) && (c.state == context_state_t::BLOCK_MAPPING);
                     });
                 bool is_indent_valid = (target_itr != m_context_stack.rend());
                 if (!is_indent_valid) {

--- a/single_include/fkYAML/node.hpp
+++ b/single_include/fkYAML/node.hpp
@@ -4739,11 +4739,11 @@ private:
             case lexical_token_t::INVALID_DIRECTIVE:
                 break;
             case lexical_token_t::ANCHOR_PREFIX:
-            case lexical_token_t::TAG_PREFIX: {
+            case lexical_token_t::TAG_PREFIX:
                 deserialize_node_properties(lexer, type, line, indent);
                 // Skip updating the current indent to avoid stacking a wrong indentation.
-                // (Node properties for block sequences as a mapping value are processed when a
-                // `lexical_token_t::KEY_SEPARATOR` token is processed.)
+                // Note that node properties for block sequences as a mapping value are processed when a
+                // `lexical_token_t::KEY_SEPARATOR` token is processed.
                 //
                 // ```yaml
                 // &foo bar: baz
@@ -4751,7 +4751,6 @@ private:
                 // the correct indent width for the "bar" node key.
                 // ```
                 continue;
-            }
             case lexical_token_t::SEQUENCE_BLOCK_PREFIX: {
                 bool is_further_nested = m_context_stack.back().indent < indent;
                 if (is_further_nested) {


### PR DESCRIPTION
This PR has fixed a bug reported in #368 as well as related, underlying ones by modifying implementation for parsing node properties.  
The major bugs are as follows:  
* no line advancement happens after parsing node properties for mappings as a block sequence entry (the reported bug),
* no parsing happens for mapping values whose node properties are user defined (i.e., neither `!!map` nor the likes), and
* incorrect node traversal to select a mapping key node with a desired indentation.

---

## Pull Request Checklist

Read the [CONTRIBUTING.md](https://github.com/fktn-k/fkYAML/blob/develop/CONTRIBUTING.md) file for detailed information.  

- [x] Changes are described in the pull request or in a referenced [issue](https://github.com/fktn-k/fkYAML/issues).
- [x] The test suite compiles and runs without any error.
- [x] [The code coverage](https://coveralls.io/github/fktn-k/fkYAML) on your branch is 100%.
- [x] The documentation is updated if you added/changed a feature.

## Please don't

- The C++11 support varies between different **compilers** and versions. Please note the [list of supported compilers](https://github.com/fktn-k/fkYAML/blob/develop/README.md#supported-compilers). Some compilers like GCC 4.7 (and earlier), Clang 3.3 (and earlier), or Microsoft Visual Studio 13.0 and earlier are known not to work due to missing or incomplete C++11 support. Please refrain from proposing changes that work around these compiler's limitations with `#ifdef`s or other means.
- Please refrain from proposing changes that would **break [YAML](https://yaml.org/) specifications**. If you propose a conformant extension of YAML to be supported by the library, please motivate this extension.
- Please do not open pull requests that address **multiple issues**.
