### PR TITLE
Apply node properties for the root node

### DIFF
--- a/docs/mkdocs/docs/api/basic_node/serialize.md
+++ b/docs/mkdocs/docs/api/basic_node/serialize.md
@@ -8,8 +8,8 @@ static std::string serialize(const basic_node& node);
 
 Serializes YAML node values recursively.  
 Currently, the serialization of mappings and sequences only supports block styles.  
-That means that, even if a deserialized source input contains container nodes written in flow styles, the serialization processes force them to be emitted in block styles.  
-Moreover, fkYAML unconditionally uses LFs as the line break format in serialization outputs and there is currently no way to change it to use CR+LFs.  
+That means that, even if a deserialized source input contains container nodes written in flow styles, this function forces them to be emitted in block styles.  
+Moreover, fkYAML unconditionally uses LFs as the line break format in serialization outputs, and there is currently no way to change it to use CR+LFs instead.  
 This function serializes the given `node` parameter in the following format.  
 
 ```yaml

--- a/docs/mkdocs/docs/api/basic_node/serialize_docs.md
+++ b/docs/mkdocs/docs/api/basic_node/serialize_docs.md
@@ -9,13 +9,13 @@ static std::string serialize_docs(const std::vector<basic_node>& docs);
 Serializes YAML documents into a string.  
 This function serializes the given `docs` parameter with the separation line (...) between YAML documents.  
 Regarding the serialization of each document, see the documentation for the [`serialize()`](serialize.md) function which this function calls internally.  
-Just as the [`serialize()`](serialize.md) function does, fkYAML unconditionally uses LFs as the line break format in serialization outputs and there is currently no way to change it to use CR+LFs.  
+Just as the [`serialize()`](serialize.md) function does, fkYAML unconditionally uses LFs as the line break format in serialization outputs, and there is currently no way to change it to use CR+LFs instead.  
 
 ```yaml
 <YAML Document 1>
 ...
 <YAML Document 2>
-# the last separation line will be omitted since it's redundant.
+# the last document end marker (...) is omitted since it's redundant.
 ```
 
 ### **Parameters**

--- a/include/fkYAML/detail/input/deserializer.hpp
+++ b/include/fkYAML/detail/input/deserializer.hpp
@@ -161,10 +161,20 @@ private:
         // parse directives first.
         deserialize_directives(lexer, type);
 
+        // parse node properties for root node if any
+        uint32_t line = lexer.get_lines_processed();
+        uint32_t indent = lexer.get_last_token_begin_pos();
+        bool found_props = deserialize_node_properties(lexer, type, line, indent);
+
         switch (type) {
         case lexical_token_t::SEQUENCE_BLOCK_PREFIX: {
             root = node_type::sequence();
             apply_directive_set(root);
+            if (found_props) {
+                // If node properties are found before the block sequence entry prefix, the properties belong to the
+                // root sequence node.
+                apply_node_properties(root);
+            }
             parse_context context(
                 lexer.get_lines_processed(), lexer.get_last_token_begin_pos(), context_state_t::BLOCK_SEQUENCE, &root);
             m_context_stack.emplace_back(std::move(context));
@@ -175,6 +185,7 @@ private:
             ++m_flow_context_depth;
             root = node_type::sequence();
             apply_directive_set(root);
+            apply_node_properties(root);
             m_context_stack.emplace_back(
                 lexer.get_lines_processed(), lexer.get_last_token_begin_pos(), context_state_t::FLOW_SEQUENCE, &root);
             type = lexer.get_next_token();
@@ -183,6 +194,7 @@ private:
             ++m_flow_context_depth;
             root = node_type::mapping();
             apply_directive_set(root);
+            apply_node_properties(root);
             m_context_stack.emplace_back(
                 lexer.get_lines_processed(), lexer.get_last_token_begin_pos(), context_state_t::FLOW_MAPPING, &root);
             type = lexer.get_next_token();
@@ -190,6 +202,11 @@ private:
         default: {
             root = node_type::mapping();
             apply_directive_set(root);
+            if (found_props && line < lexer.get_lines_processed()) {
+                // If node properties and a followed node are on the different line, the properties belong to the root
+                // node.
+                apply_node_properties(root);
+            }
             parse_context context(
                 lexer.get_lines_processed(), lexer.get_last_token_begin_pos(), context_state_t::BLOCK_MAPPING, &root);
             m_context_stack.emplace_back(std::move(context));

--- a/include/fkYAML/detail/output/serializer.hpp
+++ b/include/fkYAML/detail/output/serializer.hpp
@@ -63,14 +63,27 @@ public:
 
 private:
     void serialize_document(const BasicNodeType& node, std::string& str) {
-        serialize_directives(node, str);
+        bool dirs_serialized = serialize_directives(node, str);
+
+        // the root node cannot be an alias node.
+        bool root_has_props = node.is_anchor() || node.has_tag_name();
+
+        if (root_has_props) {
+            if (dirs_serialized) {
+                str.back() = ' '; // replace the last LF with a white space
+            }
+            bool is_anchor_appended = try_append_anchor(node, false, str);
+            try_append_tag(node, is_anchor_appended, str);
+            str += "\n";
+        }
         serialize_node(node, 0, str);
     }
 
     /// @brief Serialize the directives if any is applied to the node.
     /// @param node The targe node.
     /// @param str A string to hold serialization result.
-    void serialize_directives(const BasicNodeType& node, std::string& str) {
+    /// @return bool true if any directive is serialized, false otherwise.
+    bool serialize_directives(const BasicNodeType& node, std::string& str) {
         const auto& p_meta = node.mp_meta;
         bool needs_directive_end = false;
 
@@ -115,6 +128,8 @@ private:
         if (needs_directive_end) {
             str += "---\n";
         }
+
+        return needs_directive_end;
     }
 
     /// @brief Recursively serialize each Node object.

--- a/test/unit_test/test_deserializer_class.cpp
+++ b/test/unit_test/test_deserializer_class.cpp
@@ -2286,6 +2286,80 @@ TEST_CASE("Deserializer_Anchor") {
         REQUIRE(test_1_node.get_value<int>() == 123);
     }
 
+    SECTION("anchor for the root block mapping node") {
+        std::string input = "&anchor\n"
+                            "foo: bar";
+        REQUIRE_NOTHROW(root = deserializer.deserialize(fkyaml::detail::input_adapter(input)));
+
+        REQUIRE(root.is_mapping());
+        REQUIRE(root.size() == 1);
+        REQUIRE(root.contains("foo"));
+        REQUIRE(root.is_anchor());
+        REQUIRE(root.has_anchor_name());
+        REQUIRE(root.get_anchor_name() == "anchor");
+
+        fkyaml::node& foo_node = root["foo"];
+        REQUIRE(foo_node.is_string());
+        REQUIRE(foo_node.get_value_ref<std::string&>() == "bar");
+    }
+
+    SECTION("anchor for the root block sequence node") {
+        std::string input = "&anchor\n"
+                            "- foo: bar";
+        REQUIRE_NOTHROW(root = deserializer.deserialize(fkyaml::detail::input_adapter(input)));
+
+        REQUIRE(root.is_sequence());
+        REQUIRE(root.size() == 1);
+        REQUIRE(root.is_anchor());
+        REQUIRE(root.has_anchor_name());
+        REQUIRE(root.get_anchor_name() == "anchor");
+
+        fkyaml::node& root_0_node = root[0];
+        REQUIRE(root_0_node.is_mapping());
+        REQUIRE(root_0_node.size() == 1);
+        REQUIRE(root_0_node.contains("foo"));
+
+        fkyaml::node& root_0_foo_node = root_0_node["foo"];
+        REQUIRE(root_0_foo_node.is_string());
+        REQUIRE(root_0_foo_node.get_value_ref<std::string&>() == "bar");
+    }
+
+    SECTION("anchor for the root flow mapping node") {
+        std::string input = "&anchor {foo: bar}";
+        REQUIRE_NOTHROW(root = deserializer.deserialize(fkyaml::detail::input_adapter(input)));
+
+        REQUIRE(root.is_mapping());
+        REQUIRE(root.size() == 1);
+        REQUIRE(root.contains("foo"));
+        REQUIRE(root.is_anchor());
+        REQUIRE(root.has_anchor_name());
+        REQUIRE(root.get_anchor_name() == "anchor");
+
+        fkyaml::node& foo_node = root["foo"];
+        REQUIRE(foo_node.is_string());
+        REQUIRE(foo_node.get_value_ref<std::string&>() == "bar");
+    }
+
+    SECTION("anchor for the root flow sequence node") {
+        std::string input = "&anchor [{foo: bar}]";
+        REQUIRE_NOTHROW(root = deserializer.deserialize(fkyaml::detail::input_adapter(input)));
+
+        REQUIRE(root.is_sequence());
+        REQUIRE(root.size() == 1);
+        REQUIRE(root.is_anchor());
+        REQUIRE(root.has_anchor_name());
+        REQUIRE(root.get_anchor_name() == "anchor");
+
+        fkyaml::node& root_0_node = root[0];
+        REQUIRE(root_0_node.is_mapping());
+        REQUIRE(root_0_node.size() == 1);
+        REQUIRE(root_0_node.contains("foo"));
+
+        fkyaml::node& root_0_foo_node = root_0_node["foo"];
+        REQUIRE(root_0_foo_node.is_string());
+        REQUIRE(root_0_foo_node.get_value_ref<std::string&>() == "bar");
+    }
+
     SECTION("multiple anchors specified") {
         auto input =
             GENERATE(std::string("foo: &anchor &anchor2\n  bar: baz"), std::string("&anchor &anchor2 foo: bar"));
@@ -2492,6 +2566,76 @@ TEST_CASE("Deserializer_Tag") {
         REQUIRE(root_0_node.get_value_ref<std::string&>() == "bar");
     }
 
+    SECTION("tag for the root block mapping node") {
+        std::string input = "!!map\n"
+                            "foo: bar";
+        REQUIRE_NOTHROW(root = deserializer.deserialize(fkyaml::detail::input_adapter(input)));
+
+        REQUIRE(root.is_mapping());
+        REQUIRE(root.size() == 1);
+        REQUIRE(root.contains("foo"));
+        REQUIRE(root.has_tag_name());
+        REQUIRE(root.get_tag_name() == "!!map");
+
+        fkyaml::node& foo_node = root["foo"];
+        REQUIRE(foo_node.is_string());
+        REQUIRE(foo_node.get_value_ref<std::string&>() == "bar");
+    }
+
+    SECTION("tag for the root block sequence node") {
+        std::string input = "!!seq\n"
+                            "- foo: bar";
+        REQUIRE_NOTHROW(root = deserializer.deserialize(fkyaml::detail::input_adapter(input)));
+
+        REQUIRE(root.is_sequence());
+        REQUIRE(root.size() == 1);
+        REQUIRE(root.has_tag_name());
+        REQUIRE(root.get_tag_name() == "!!seq");
+
+        fkyaml::node& root_0_node = root[0];
+        REQUIRE(root_0_node.is_mapping());
+        REQUIRE(root_0_node.size() == 1);
+        REQUIRE(root_0_node.contains("foo"));
+
+        fkyaml::node& root_0_foo_node = root_0_node["foo"];
+        REQUIRE(root_0_foo_node.is_string());
+        REQUIRE(root_0_foo_node.get_value_ref<std::string&>() == "bar");
+    }
+
+    SECTION("tag for the root flow mapping node") {
+        std::string input = "!!map {foo: bar}";
+        REQUIRE_NOTHROW(root = deserializer.deserialize(fkyaml::detail::input_adapter(input)));
+
+        REQUIRE(root.is_mapping());
+        REQUIRE(root.size() == 1);
+        REQUIRE(root.contains("foo"));
+        REQUIRE(root.has_tag_name());
+        REQUIRE(root.get_tag_name() == "!!map");
+
+        fkyaml::node& foo_node = root["foo"];
+        REQUIRE(foo_node.is_string());
+        REQUIRE(foo_node.get_value_ref<std::string&>() == "bar");
+    }
+
+    SECTION("tag for the root flow sequence node") {
+        std::string input = "!!seq [{foo: bar}]";
+        REQUIRE_NOTHROW(root = deserializer.deserialize(fkyaml::detail::input_adapter(input)));
+
+        REQUIRE(root.is_sequence());
+        REQUIRE(root.size() == 1);
+        REQUIRE(root.has_tag_name());
+        REQUIRE(root.get_tag_name() == "!!seq");
+
+        fkyaml::node& root_0_node = root[0];
+        REQUIRE(root_0_node.is_mapping());
+        REQUIRE(root_0_node.size() == 1);
+        REQUIRE(root_0_node.contains("foo"));
+
+        fkyaml::node& root_0_foo_node = root_0_node["foo"];
+        REQUIRE(root_0_foo_node.is_string());
+        REQUIRE(root_0_foo_node.get_value_ref<std::string&>() == "bar");
+    }
+
     SECTION("multiple tags specified") {
         auto input = GENERATE(std::string("foo: !!map !!map\n  bar: baz"), std::string("!!str !!bool true: 123"));
         REQUIRE_THROWS_AS(deserializer.deserialize(fkyaml::detail::input_adapter(input)), fkyaml::parse_error);
@@ -2572,6 +2716,107 @@ TEST_CASE("Deserializer_NodeProperties") {
         fkyaml::node& values_0_include_node = values_0_node["include"];
         REQUIRE(values_0_include_node.is_boolean());
         REQUIRE(values_0_include_node.get_value<bool>() == false);
+    }
+
+    SECTION("anchor and tag for the root block mapping node") {
+        std::string input = "&anchor !!map\n"
+                            "foo: bar";
+        REQUIRE_NOTHROW(root = deserializer.deserialize(fkyaml::detail::input_adapter(input)));
+
+        REQUIRE(root.is_mapping());
+        REQUIRE(root.size() == 1);
+        REQUIRE(root.contains("foo"));
+        REQUIRE(root.is_anchor());
+        REQUIRE(root.has_anchor_name());
+        REQUIRE(root.get_anchor_name() == "anchor");
+        REQUIRE(root.has_tag_name());
+        REQUIRE(root.get_tag_name() == "!!map");
+
+        fkyaml::node& foo_node = root["foo"];
+        REQUIRE(foo_node.is_string());
+        REQUIRE(foo_node.get_value_ref<std::string&>() == "bar");
+    }
+
+    SECTION("anchor and tag for the root block sequence node") {
+        std::string input = "&anchor !!seq\n"
+                            "- foo: bar";
+        REQUIRE_NOTHROW(root = deserializer.deserialize(fkyaml::detail::input_adapter(input)));
+
+        REQUIRE(root.is_sequence());
+        REQUIRE(root.size() == 1);
+        REQUIRE(root.is_anchor());
+        REQUIRE(root.has_anchor_name());
+        REQUIRE(root.get_anchor_name() == "anchor");
+        REQUIRE(root.has_tag_name());
+        REQUIRE(root.get_tag_name() == "!!seq");
+
+        fkyaml::node& root_0_node = root[0];
+        REQUIRE(root_0_node.is_mapping());
+        REQUIRE(root_0_node.size() == 1);
+        REQUIRE(root_0_node.contains("foo"));
+
+        fkyaml::node& root_0_foo_node = root_0_node["foo"];
+        REQUIRE(root_0_foo_node.is_string());
+        REQUIRE(root_0_foo_node.get_value_ref<std::string&>() == "bar");
+    }
+
+    SECTION("anchor and tag for the root flow mapping node") {
+        std::string input = "&anchor !!map {foo: bar}";
+        REQUIRE_NOTHROW(root = deserializer.deserialize(fkyaml::detail::input_adapter(input)));
+
+        REQUIRE(root.is_mapping());
+        REQUIRE(root.size() == 1);
+        REQUIRE(root.contains("foo"));
+        REQUIRE(root.is_anchor());
+        REQUIRE(root.has_anchor_name());
+        REQUIRE(root.get_anchor_name() == "anchor");
+        REQUIRE(root.has_tag_name());
+        REQUIRE(root.get_tag_name() == "!!map");
+
+        fkyaml::node& foo_node = root["foo"];
+        REQUIRE(foo_node.is_string());
+        REQUIRE(foo_node.get_value_ref<std::string&>() == "bar");
+    }
+
+    SECTION("anchor and tag for the root flow sequence node") {
+        std::string input = "&anchor !!seq [{foo: bar}]";
+        REQUIRE_NOTHROW(root = deserializer.deserialize(fkyaml::detail::input_adapter(input)));
+
+        REQUIRE(root.is_sequence());
+        REQUIRE(root.size() == 1);
+        REQUIRE(root.is_anchor());
+        REQUIRE(root.has_anchor_name());
+        REQUIRE(root.get_anchor_name() == "anchor");
+        REQUIRE(root.has_tag_name());
+        REQUIRE(root.get_tag_name() == "!!seq");
+
+        fkyaml::node& root_0_node = root[0];
+        REQUIRE(root_0_node.is_mapping());
+        REQUIRE(root_0_node.size() == 1);
+        REQUIRE(root_0_node.contains("foo"));
+
+        fkyaml::node& root_0_foo_node = root_0_node["foo"];
+        REQUIRE(root_0_foo_node.is_string());
+        REQUIRE(root_0_foo_node.get_value_ref<std::string&>() == "bar");
+    }
+
+    SECTION("anchor and tag for the root block mapping node with the end-of-directives marker") {
+        std::string input = "--- &anchor !!map\n"
+                            "foo: bar";
+        REQUIRE_NOTHROW(root = deserializer.deserialize(fkyaml::detail::input_adapter(input)));
+
+        REQUIRE(root.is_mapping());
+        REQUIRE(root.size() == 1);
+        REQUIRE(root.contains("foo"));
+        REQUIRE(root.is_anchor());
+        REQUIRE(root.has_anchor_name());
+        REQUIRE(root.get_anchor_name() == "anchor");
+        REQUIRE(root.has_tag_name());
+        REQUIRE(root.get_tag_name() == "!!map");
+
+        fkyaml::node& foo_node = root["foo"];
+        REQUIRE(foo_node.is_string());
+        REQUIRE(foo_node.get_value_ref<std::string&>() == "bar");
     }
 }
 


### PR DESCRIPTION
fkYAML currently ignores node properties for the root node unintentionally, like parsing the following   valid YAML snippet:  

```yaml
--- !!map
foo: bar
```

They are obviously allowed in the spec.  
So this PR has fixed the serializer/deserializer to properly handle them and added some test cases to validate the changes.  

---

## Pull Request Checklist

Read the [CONTRIBUTING.md](https://github.com/fktn-k/fkYAML/blob/develop/CONTRIBUTING.md) file for detailed information.  

- [x] Changes are described in the pull request or in a referenced [issue](https://github.com/fktn-k/fkYAML/issues).
- [x] The test suite compiles and runs without any error.
- [x] [The code coverage](https://coveralls.io/github/fktn-k/fkYAML) on your branch is 100%.
- [x] The documentation is updated if you added/changed a feature.

## Please don't

- The C++11 support varies between different **compilers** and versions. Please note the [list of supported compilers](https://github.com/fktn-k/fkYAML/blob/develop/README.md#supported-compilers). Some compilers like GCC 4.7 (and earlier), Clang 3.3 (and earlier), or Microsoft Visual Studio 13.0 and earlier are known not to work due to missing or incomplete C++11 support. Please refrain from proposing changes that work around these compiler's limitations with `#ifdef`s or other means.
- Please refrain from proposing changes that would **break [YAML](https://yaml.org/) specifications**. If you propose a conformant extension of YAML to be supported by the library, please motivate this extension.
- Please do not open pull requests that address **multiple issues**.
