### PR TITLE
Allow the document end marker omitted

### DIFF
--- a/include/fkYAML/detail/input/deserializer.hpp
+++ b/include/fkYAML/detail/input/deserializer.hpp
@@ -218,7 +218,9 @@ private:
 
         // parse YAML nodes recursively
         deserialize_node(lexer, type, last_type);
-        FK_YAML_ASSERT(last_type == lexical_token_t::END_OF_BUFFER || last_type == lexical_token_t::END_OF_DOCUMENT);
+        FK_YAML_ASSERT(
+            last_type == lexical_token_t::END_OF_BUFFER || last_type == lexical_token_t::END_OF_DIRECTIVES ||
+            last_type == lexical_token_t::END_OF_DOCUMENT);
 
         // reset parameters for the next call.
         mp_current_node = nullptr;
@@ -864,12 +866,10 @@ private:
                 }
                 break;
             }
+            // these tokens end parsing the current YAML document.
+            case lexical_token_t::END_OF_BUFFER: // This handles an empty input.
             case lexical_token_t::END_OF_DIRECTIVES:
-                throw parse_error("invalid end-of-directives marker (---) found in the contents.", line, indent);
-            case lexical_token_t::END_OF_BUFFER:
-                // This handles an empty input.
             case lexical_token_t::END_OF_DOCUMENT:
-                // TODO: This token should be handled to support multiple documents.
                 last_type = type;
                 return;
             }

--- a/single_include/fkYAML/node.hpp
+++ b/single_include/fkYAML/node.hpp
@@ -4447,7 +4447,9 @@ private:
 
         // parse YAML nodes recursively
         deserialize_node(lexer, type, last_type);
-        FK_YAML_ASSERT(last_type == lexical_token_t::END_OF_BUFFER || last_type == lexical_token_t::END_OF_DOCUMENT);
+        FK_YAML_ASSERT(
+            last_type == lexical_token_t::END_OF_BUFFER || last_type == lexical_token_t::END_OF_DIRECTIVES ||
+            last_type == lexical_token_t::END_OF_DOCUMENT);
 
         // reset parameters for the next call.
         mp_current_node = nullptr;
@@ -5093,12 +5095,10 @@ private:
                 }
                 break;
             }
+            // these tokens end parsing the current YAML document.
+            case lexical_token_t::END_OF_BUFFER: // This handles an empty input.
             case lexical_token_t::END_OF_DIRECTIVES:
-                throw parse_error("invalid end-of-directives marker (---) found in the contents.", line, indent);
-            case lexical_token_t::END_OF_BUFFER:
-                // This handles an empty input.
             case lexical_token_t::END_OF_DOCUMENT:
-                // TODO: This token should be handled to support multiple documents.
                 last_type = type;
                 return;
             }

--- a/test/unit_test/test_deserializer_class.cpp
+++ b/test/unit_test/test_deserializer_class.cpp
@@ -2844,14 +2844,6 @@ TEST_CASE("Deserializer_DocumentWithMarkers") {
         REQUIRE(foo_node.is_string());
         REQUIRE(foo_node.get_value_ref<std::string&>() == "one");
     }
-
-    SECTION("invalid end-of-directives marker") {
-        std::string input = "foo: bar\n"
-                            "---\n"
-                            "123: false\n"
-                            "...";
-        REQUIRE_THROWS_AS(deserializer.deserialize(fkyaml::detail::input_adapter(input)), fkyaml::parse_error);
-    }
 }
 
 TEST_CASE("Deserializer_MultipleDocuments") {
@@ -2859,55 +2851,119 @@ TEST_CASE("Deserializer_MultipleDocuments") {
     fkyaml::node root;
     std::vector<fkyaml::node> docs;
 
-    std::string input = "%YAML 1.1\n"
-                        "---\n"
-                        "foo: 123\n"
-                        "...\n"
-                        "%TAG ! tag:com.example,2024:\n"
-                        "---\n"
-                        "- !foo bar\n"
-                        "- 3.14\n"
-                        "- Null";
+    SECTION("both directives/document end markers") {
+        std::string input = "%YAML 1.1\n"
+                            "---\n"
+                            "foo: 123\n"
+                            "...\n"
+                            "%TAG ! tag:com.example,2024:\n"
+                            "---\n"
+                            "- !foo bar\n"
+                            "- 3.14\n"
+                            "- Null";
 
-    SECTION("parse only the first document") {
-        REQUIRE_NOTHROW(root = deserializer.deserialize(fkyaml::detail::input_adapter(input)));
-        REQUIRE(root.is_mapping());
-        REQUIRE(root.size() == 1);
-        REQUIRE(root.contains("foo"));
+        SECTION("parse only the first document") {
+            REQUIRE_NOTHROW(root = deserializer.deserialize(fkyaml::detail::input_adapter(input)));
+            REQUIRE(root.is_mapping());
+            REQUIRE(root.size() == 1);
+            REQUIRE(root.contains("foo"));
 
-        fkyaml::node& foo_node = root["foo"];
-        REQUIRE(foo_node.is_integer());
-        REQUIRE(foo_node.get_value<int>() == 123);
+            fkyaml::node& foo_node = root["foo"];
+            REQUIRE(foo_node.is_integer());
+            REQUIRE(foo_node.get_value<int>() == 123);
+        }
+
+        SECTION("parse all documents") {
+            REQUIRE_NOTHROW(docs = deserializer.deserialize_docs(fkyaml::detail::input_adapter(input)));
+            REQUIRE(docs.size() == 2);
+
+            fkyaml::node& root0 = docs[0];
+            REQUIRE(root0.is_mapping());
+            REQUIRE(root0.size() == 1);
+            REQUIRE(root0.contains("foo"));
+
+            fkyaml::node& foo_node = root0["foo"];
+            REQUIRE(foo_node.is_integer());
+            REQUIRE(foo_node.get_value<int>() == 123);
+
+            fkyaml::node& root1 = docs[1];
+            REQUIRE(root1.is_sequence());
+            REQUIRE(root1.size() == 3);
+
+            fkyaml::node& seq0 = root1[0];
+            REQUIRE(seq0.has_tag_name());
+            REQUIRE(seq0.get_tag_name() == "!foo");
+            REQUIRE(seq0.is_string());
+            REQUIRE(seq0.get_value_ref<std::string&>() == "bar");
+
+            fkyaml::node& seq1 = root1[1];
+            REQUIRE(seq1.is_float_number());
+            REQUIRE(seq1.get_value<double>() == 3.14);
+
+            fkyaml::node& seq2 = root1[2];
+            REQUIRE(seq2.is_null());
+        }
     }
 
-    SECTION("parse all documents") {
-        REQUIRE_NOTHROW(docs = deserializer.deserialize_docs(fkyaml::detail::input_adapter(input)));
-        REQUIRE(docs.size() == 2);
+    SECTION("document end marker omitted") {
+        std::string input = "--- !!map\n"
+                            "? a\n"
+                            ": b\n"
+                            "--- !!seq\n"
+                            "- !!str c\n"
+                            "--- !!map\n"
+                            "d: e";
 
-        fkyaml::node& root0 = docs[0];
-        REQUIRE(root0.is_mapping());
-        REQUIRE(root0.size() == 1);
-        REQUIRE(root0.contains("foo"));
+        SECTION("parse only the first document") {
+            REQUIRE_NOTHROW(root = deserializer.deserialize(fkyaml::detail::input_adapter(input)));
+            REQUIRE(root.is_mapping());
+            REQUIRE(root.size() == 1);
+            REQUIRE(root.contains("a"));
+            REQUIRE(root.has_tag_name());
+            REQUIRE(root.get_tag_name() == "!!map");
 
-        fkyaml::node& foo_node = root0["foo"];
-        REQUIRE(foo_node.is_integer());
-        REQUIRE(foo_node.get_value<int>() == 123);
+            fkyaml::node& a_node = root["a"];
+            REQUIRE(a_node.is_string());
+            REQUIRE(a_node.get_value_ref<std::string&>() == "b");
+        }
 
-        fkyaml::node& root1 = docs[1];
-        REQUIRE(root1.is_sequence());
-        REQUIRE(root1.size() == 3);
+        SECTION("parse all documents") {
+            REQUIRE_NOTHROW(docs = deserializer.deserialize_docs(fkyaml::detail::input_adapter(input)));
+            REQUIRE(docs.size() == 3);
 
-        fkyaml::node& seq0 = root1[0];
-        REQUIRE(seq0.has_tag_name());
-        REQUIRE(seq0.get_tag_name() == "!foo");
-        REQUIRE(seq0.is_string());
-        REQUIRE(seq0.get_value_ref<std::string&>() == "bar");
+            fkyaml::node& root0 = docs[0];
+            REQUIRE(root0.is_mapping());
+            REQUIRE(root0.size() == 1);
+            REQUIRE(root0.contains("a"));
+            REQUIRE(root0.has_tag_name());
+            REQUIRE(root0.get_tag_name() == "!!map");
 
-        fkyaml::node& seq1 = root1[1];
-        REQUIRE(seq1.is_float_number());
-        REQUIRE(seq1.get_value<double>() == 3.14);
+            fkyaml::node& a_node = root0["a"];
+            REQUIRE(a_node.is_string());
+            REQUIRE(a_node.get_value_ref<std::string&>() == "b");
 
-        fkyaml::node& seq2 = root1[2];
-        REQUIRE(seq2.is_null());
+            fkyaml::node& root1 = docs[1];
+            REQUIRE(root1.is_sequence());
+            REQUIRE(root1.size() == 1);
+            REQUIRE(root1.has_tag_name());
+            REQUIRE(root1.get_tag_name() == "!!seq");
+
+            fkyaml::node& seq0_node = root1[0];
+            REQUIRE(seq0_node.is_string());
+            REQUIRE(seq0_node.get_value_ref<std::string&>() == "c");
+            REQUIRE(seq0_node.has_tag_name());
+            REQUIRE(seq0_node.get_tag_name() == "!!str");
+
+            fkyaml::node& root2 = docs[2];
+            REQUIRE(root2.is_mapping());
+            REQUIRE(root2.size() == 1);
+            REQUIRE(root2.contains("d"));
+            REQUIRE(root2.has_tag_name());
+            REQUIRE(root2.get_tag_name() == "!!map");
+
+            fkyaml::node& d_node = root2["d"];
+            REQUIRE(d_node.is_string());
+            REQUIRE(d_node.get_value_ref<std::string&>() == "e");
+        }
     }
 }


### PR DESCRIPTION
The current fkYAML doesn't allow the document end marker (...) omitted before a new YAML document like the following YAML snippet (extracted from the yaml-test-suite's 35KP/in.yaml):  
```yaml
--- !!map
? a
: b
--- !!seq
- !!str c
--- !!str
d
e
# Note that the last multiline plain scalar isn't supported by fkYAML yet.
```

Parsing the above YAML with fkYAML causes a false parse error which says "invalid end-of-directives marker (---) found in the contents.".  
To resolve the false error, this PR has changed the implementation to allow the document end marker omitted, and the library thus assumes no directives preceeded in the next YAML document instead.  

---

## Pull Request Checklist

Read the [CONTRIBUTING.md](https://github.com/fktn-k/fkYAML/blob/develop/CONTRIBUTING.md) file for detailed information.  

- [x] Changes are described in the pull request or in a referenced [issue](https://github.com/fktn-k/fkYAML/issues).
- [x] The test suite compiles and runs without any error.
- [x] [The code coverage](https://coveralls.io/github/fktn-k/fkYAML) on your branch is 100%.
- [x] The documentation is updated if you added/changed a feature.

## Please don't

- The C++11 support varies between different **compilers** and versions. Please note the [list of supported compilers](https://github.com/fktn-k/fkYAML/blob/develop/README.md#supported-compilers). Some compilers like GCC 4.7 (and earlier), Clang 3.3 (and earlier), or Microsoft Visual Studio 13.0 and earlier are known not to work due to missing or incomplete C++11 support. Please refrain from proposing changes that work around these compiler's limitations with `#ifdef`s or other means.
- Please refrain from proposing changes that would **break [YAML](https://yaml.org/) specifications**. If you propose a conformant extension of YAML to be supported by the library, please motivate this extension.
- Please do not open pull requests that address **multiple issues**.
