### PR TITLE
#375 Fix newline code normalization in UTF-8 encoded file input

### DIFF
--- a/include/fkYAML/detail/input/input_adapter.hpp
+++ b/include/fkYAML/detail/input/input_adapter.hpp
@@ -508,9 +508,10 @@ private:
                 // find CR in `tmp_buf`.
                 char* p_cr_or_end = p_current;
                 while (p_cr_or_end != p_end) {
-                    if (*p_cr_or_end++ == '\r') {
+                    if (*p_cr_or_end == '\r') {
                         break;
                     }
+                    ++p_cr_or_end;
                 }
 
                 buffer.append(p_current, p_cr_or_end);
@@ -700,9 +701,10 @@ private:
                 // find CR in `tmp_buf`.
                 char* p_cr_or_end = p_current;
                 while (p_cr_or_end != p_end) {
-                    if (*p_cr_or_end++ == '\r') {
+                    if (*p_cr_or_end == '\r') {
                         break;
                     }
+                    ++p_cr_or_end;
                 }
 
                 buffer.append(p_current, p_cr_or_end);

--- a/single_include/fkYAML/node.hpp
+++ b/single_include/fkYAML/node.hpp
@@ -6260,9 +6260,10 @@ private:
                 // find CR in `tmp_buf`.
                 char* p_cr_or_end = p_current;
                 while (p_cr_or_end != p_end) {
-                    if (*p_cr_or_end++ == '\r') {
+                    if (*p_cr_or_end == '\r') {
                         break;
                     }
+                    ++p_cr_or_end;
                 }
 
                 buffer.append(p_current, p_cr_or_end);
@@ -6452,9 +6453,10 @@ private:
                 // find CR in `tmp_buf`.
                 char* p_cr_or_end = p_current;
                 while (p_cr_or_end != p_end) {
-                    if (*p_cr_or_end++ == '\r') {
+                    if (*p_cr_or_end == '\r') {
                         break;
                     }
+                    ++p_cr_or_end;
                 }
 
                 buffer.append(p_current, p_cr_or_end);

--- a/test/unit_test/test_input_adapter.cpp
+++ b/test/unit_test/test_input_adapter.cpp
@@ -1683,6 +1683,18 @@ TEST_CASE("InputAdapter_FillBuffer_UTF8NewlineCodeNormalization") {
         std::string buffer {};
         input_adapter.fill_buffer(buffer);
 
+        REQUIRE(buffer.size() == 10);
+        REQUIRE(buffer[0] == 't');
+        REQUIRE(buffer[1] == 'e');
+        REQUIRE(buffer[2] == 's');
+        REQUIRE(buffer[3] == 't');
+        REQUIRE(buffer[4] == '\n');
+        REQUIRE(buffer[5] == 'd');
+        REQUIRE(buffer[6] == 'a');
+        REQUIRE(buffer[7] == 't');
+        REQUIRE(buffer[8] == 'a');
+        REQUIRE(buffer[9] == '\n');
+
         std::fclose(p_file);
     }
 
@@ -1693,6 +1705,18 @@ TEST_CASE("InputAdapter_FillBuffer_UTF8NewlineCodeNormalization") {
 
         std::string buffer {};
         input_adapter.fill_buffer(buffer);
+
+        REQUIRE(buffer.size() == 10);
+        REQUIRE(buffer[0] == 't');
+        REQUIRE(buffer[1] == 'e');
+        REQUIRE(buffer[2] == 's');
+        REQUIRE(buffer[3] == 't');
+        REQUIRE(buffer[4] == '\n');
+        REQUIRE(buffer[5] == 'd');
+        REQUIRE(buffer[6] == 'a');
+        REQUIRE(buffer[7] == 't');
+        REQUIRE(buffer[8] == 'a');
+        REQUIRE(buffer[9] == '\n');
     }
 }
 


### PR DESCRIPTION
This PR has fixed the newline code normalization of CR+LF into LF contained in a given file for deserialization, which is the root cause of the bug reported in the issue #375.  
Before the fix, CR+LF newline codes were normalized mistakenly into CR, which broke the subsequent deserialization process which intentionally ignores the existence of CR for optimization.  
By correcting the normalization logic, CR+LF are now successfully normalized into LF.  

Furthermore, since the normalized input value checks were somehow dropped in the input_adapter module test cases, the appropriate checks have also been added.

---

## Pull Request Checklist

Read the [CONTRIBUTING.md](https://github.com/fktn-k/fkYAML/blob/develop/CONTRIBUTING.md) file for detailed information.  

- [x] Changes are described in the pull request or in a referenced [issue](https://github.com/fktn-k/fkYAML/issues).
- [x] The test suite compiles and runs without any error.
- [x] [The code coverage](https://coveralls.io/github/fktn-k/fkYAML) on your branch is 100%.
- [x] The documentation is updated if you added/changed a feature.

## Please don't

- The C++11 support varies between different **compilers** and versions. Please note the [list of supported compilers](https://github.com/fktn-k/fkYAML/blob/develop/README.md#supported-compilers). Some compilers like GCC 4.7 (and earlier), Clang 3.3 (and earlier), or Microsoft Visual Studio 13.0 and earlier are known not to work due to missing or incomplete C++11 support. Please refrain from proposing changes that work around these compiler's limitations with `#ifdef`s or other means.
- Please refrain from proposing changes that would **break [YAML](https://yaml.org/) specifications**. If you propose a conformant extension of YAML to be supported by the library, please motivate this extension.
- Please do not open pull requests that address **multiple issues**.
