### PR TITLE
Fix wrong parse result from a block sequence as a nested block mapping value

### DIFF
--- a/include/fkYAML/detail/input/deserializer.hpp
+++ b/include/fkYAML/detail/input/deserializer.hpp
@@ -962,7 +962,7 @@ private:
             if (indent == 0) {
                 pop_num = static_cast<uint32_t>(m_context_stack.size() - 1);
             }
-            else if (indent < m_context_stack.back().indent) {
+            else if (indent <= m_context_stack.back().indent) {
                 auto target_itr =
                     std::find_if(m_context_stack.rbegin(), m_context_stack.rend(), [indent](const parse_context& c) {
                         // the target node is a block mapping key node with the same indentation.

--- a/single_include/fkYAML/node.hpp
+++ b/single_include/fkYAML/node.hpp
@@ -5191,7 +5191,7 @@ private:
             if (indent == 0) {
                 pop_num = static_cast<uint32_t>(m_context_stack.size() - 1);
             }
-            else if (indent < m_context_stack.back().indent) {
+            else if (indent <= m_context_stack.back().indent) {
                 auto target_itr =
                     std::find_if(m_context_stack.rbegin(), m_context_stack.rend(), [indent](const parse_context& c) {
                         // the target node is a block mapping key node with the same indentation.

--- a/test/unit_test/test_deserializer_class.cpp
+++ b/test/unit_test/test_deserializer_class.cpp
@@ -510,6 +510,36 @@ TEST_CASE("Deserializer_BlockSequence") {
         REQUIRE(root_1_avg_node.is_float_number());
         REQUIRE(root_1_avg_node.get_value<double>() == 0.288);
     }
+
+    SECTION("block sequence as a nested block mapping value in the middle") {
+        std::string input = "foo:\n"
+                            "  bar:\n"
+                            "  - 123\n"
+                            "  baz: true\n";
+        REQUIRE_NOTHROW(root = deserializer.deserialize(fkyaml::detail::input_adapter(input)));
+
+        REQUIRE(root.is_mapping());
+        REQUIRE(root.size() == 1);
+        REQUIRE(root.contains("foo"));
+
+        fkyaml::node& foo_node = root["foo"];
+        REQUIRE(foo_node.is_mapping());
+        REQUIRE(foo_node.size() == 2);
+        REQUIRE(foo_node.contains("bar"));
+        REQUIRE(foo_node.contains("baz"));
+
+        fkyaml::node& foo_bar_node = foo_node["bar"];
+        REQUIRE(foo_bar_node.is_sequence());
+        REQUIRE(foo_bar_node.size() == 1);
+
+        fkyaml::node& foo_bar_0_node = foo_bar_node[0];
+        REQUIRE(foo_bar_0_node.is_integer());
+        REQUIRE(foo_bar_0_node.get_value<int>() == 123);
+
+        fkyaml::node& foo_baz_node = foo_node["baz"];
+        REQUIRE(foo_baz_node.is_boolean());
+        REQUIRE(foo_baz_node.get_value<bool>() == true);
+    }
 }
 
 TEST_CASE("Deserializer_BlockMapping") {


### PR DESCRIPTION
This PR has fixed a wrong parse result generated from a YAML document which contains a block sequence as a nested block mapping value in the middle like the following:  

```yaml
foo:
  bar:
  - 123
  baz: true
```

The `baz: true` part mistakenly became a part of the `bar` block sequence's entry.  
For the parser didn't get back to the proper node when a block sequence entry prefix (`- `) is as much indented as the parent mapping keys before parsing the `baz` key. (if the prefix is more indented than the keys, the parse result was correct.)  

So, this PR has fixed the node traversal logic and added a new test case to validate the change.  
With the fix, the above YAML document is now parsed as expected.  

---

## Pull Request Checklist

Read the [CONTRIBUTING.md](https://github.com/fktn-k/fkYAML/blob/develop/CONTRIBUTING.md) file for detailed information.  

- [x] Changes are described in the pull request or in a referenced [issue](https://github.com/fktn-k/fkYAML/issues).
- [x] The test suite compiles and runs without any error.
- [x] [The code coverage](https://coveralls.io/github/fktn-k/fkYAML) on your branch is 100%.
- [x] The documentation is updated if you added/changed a feature.

## Please don't

- The C++11 support varies between different **compilers** and versions. Please note the [list of supported compilers](https://github.com/fktn-k/fkYAML/blob/develop/README.md#supported-compilers). Some compilers like GCC 4.7 (and earlier), Clang 3.3 (and earlier), or Microsoft Visual Studio 13.0 and earlier are known not to work due to missing or incomplete C++11 support. Please refrain from proposing changes that work around these compiler's limitations with `#ifdef`s or other means.
- Please refrain from proposing changes that would **break [YAML](https://yaml.org/) specifications**. If you propose a conformant extension of YAML to be supported by the library, please motivate this extension.
- Please do not open pull requests that address **multiple issues**.
