### PR TITLE
Throw exception when loading a nonexistent stream

### DIFF
--- a/include/fkYAML/detail/input/input_adapter.hpp
+++ b/include/fkYAML/detail/input/input_adapter.hpp
@@ -926,7 +926,10 @@ inline file_input_adapter input_adapter(std::FILE* file) {
 /// @brief A factory method for stream_input_adapter objects with std::istream objects.
 /// @param stream An input stream.
 /// @return stream_input_adapter A stream_input_adapter object.
-inline stream_input_adapter input_adapter(std::istream& stream) noexcept {
+inline stream_input_adapter input_adapter(std::istream& stream) {
+    if (!stream.good()) {
+        throw fkyaml::exception("Invalid stream.");
+    }
     utf_encode_t encode_type = detect_encoding_and_skip_bom(stream);
     return stream_input_adapter(stream, encode_type);
 }

--- a/single_include/fkYAML/node.hpp
+++ b/single_include/fkYAML/node.hpp
@@ -6678,7 +6678,10 @@ inline file_input_adapter input_adapter(std::FILE* file) {
 /// @brief A factory method for stream_input_adapter objects with std::istream objects.
 /// @param stream An input stream.
 /// @return stream_input_adapter A stream_input_adapter object.
-inline stream_input_adapter input_adapter(std::istream& stream) noexcept {
+inline stream_input_adapter input_adapter(std::istream& stream) {
+    if (!stream.good()) {
+        throw fkyaml::exception("Invalid stream.");
+    }
     utf_encode_t encode_type = detect_encoding_and_skip_bom(stream);
     return stream_input_adapter(stream, encode_type);
 }

--- a/test/unit_test/test_input_adapter.cpp
+++ b/test/unit_test/test_input_adapter.cpp
@@ -153,10 +153,17 @@ TEST_CASE("InputAdapter_FileInputAdapterProvider") {
 }
 
 TEST_CASE("InputAdapter_StreamInputAdapterProvider") {
-    std::ifstream ifs(input_file_path);
-    REQUIRE(ifs);
-    auto input_adapter = fkyaml::detail::input_adapter(ifs);
-    REQUIRE(std::is_same<decltype(input_adapter), fkyaml::detail::stream_input_adapter>::value);
+    SECTION("invalid stream") {
+        std::ifstream ifs("");
+        REQUIRE_THROWS_AS(fkyaml::detail::input_adapter(ifs), fkyaml::exception);
+    }
+
+    SECTION("valid stream") {
+        std::ifstream ifs(input_file_path);
+        REQUIRE(ifs);
+        auto input_adapter = fkyaml::detail::input_adapter(ifs);
+        REQUIRE(std::is_same<decltype(input_adapter), fkyaml::detail::stream_input_adapter>::value);
+    }
 }
 
 TEST_CASE("InputAdapter_FillBuffer_UTF8N") {


### PR DESCRIPTION
This PR fixes the issue with attempting to call a deserialization function on a nonexistent stream (std::ifstream), reported in issue #378.

Previously, when attempting to read data from a nonexistent stream, an infinite loop would occur, trying to read data that was not there.

Now, if the stream is empty, an exception will be thrown, which can be handled using a try-catch block.

---

## Pull Request Checklist

Read the [CONTRIBUTING.md](https://github.com/fktn-k/fkYAML/blob/develop/CONTRIBUTING.md) file for detailed information.  

- [x] Changes are described in the pull request or in a referenced [issue](https://github.com/fktn-k/fkYAML/issues).
- [x] The test suite compiles and runs without any error.
- [x] [The code coverage](https://coveralls.io/github/fktn-k/fkYAML) on your branch is 100%.
- [x] The documentation is updated if you added/changed a feature.

## Please don't

- The C++11 support varies between different **compilers** and versions. Please note the [list of supported compilers](https://github.com/fktn-k/fkYAML/blob/develop/README.md#supported-compilers). Some compilers like GCC 4.7 (and earlier), Clang 3.3 (and earlier), or Microsoft Visual Studio 13.0 and earlier are known not to work due to missing or incomplete C++11 support. Please refrain from proposing changes that work around these compiler's limitations with `#ifdef`s or other means.
- Please refrain from proposing changes that would **break [YAML](https://yaml.org/) specifications**. If you propose a conformant extension of YAML to be supported by the library, please motivate this extension.
- Please do not open pull requests that address **multiple issues**.
