### PR TITLE
Fix error on parsing a floating point value which ends with a dot

### DIFF
--- a/include/fkYAML/detail/input/scalar_scanner.hpp
+++ b/include/fkYAML/detail/input/scalar_scanner.hpp
@@ -142,7 +142,8 @@ private:
         switch (*itr) {
         case '.': {
             if (size == 1) {
-                return lexical_token_t::STRING_VALUE;
+                // 0 is omitted after `0.`.
+                return lexical_token_t::FLOAT_NUMBER_VALUE;
             }
             lexical_token_t ret = scan_after_decimal_point(++itr, --size, true);
             return (ret == lexical_token_t::STRING_VALUE) ? lexical_token_t::STRING_VALUE
@@ -170,6 +171,10 @@ private:
             if (has_decimal_point) {
                 // the token has more than one period, e.g., a semantic version `1.2.3`.
                 return lexical_token_t::STRING_VALUE;
+            }
+            if (size == 1) {
+                // 0 is omitted after the decimal point
+                return lexical_token_t::FLOAT_NUMBER_VALUE;
             }
             lexical_token_t ret = scan_after_decimal_point(++itr, --size, true);
             return (ret == lexical_token_t::STRING_VALUE) ? lexical_token_t::STRING_VALUE

--- a/single_include/fkYAML/node.hpp
+++ b/single_include/fkYAML/node.hpp
@@ -2382,7 +2382,8 @@ private:
         switch (*itr) {
         case '.': {
             if (size == 1) {
-                return lexical_token_t::STRING_VALUE;
+                // 0 is omitted after `0.`.
+                return lexical_token_t::FLOAT_NUMBER_VALUE;
             }
             lexical_token_t ret = scan_after_decimal_point(++itr, --size, true);
             return (ret == lexical_token_t::STRING_VALUE) ? lexical_token_t::STRING_VALUE
@@ -2410,6 +2411,10 @@ private:
             if (has_decimal_point) {
                 // the token has more than one period, e.g., a semantic version `1.2.3`.
                 return lexical_token_t::STRING_VALUE;
+            }
+            if (size == 1) {
+                // 0 is omitted after the decimal point
+                return lexical_token_t::FLOAT_NUMBER_VALUE;
             }
             lexical_token_t ret = scan_after_decimal_point(++itr, --size, true);
             return (ret == lexical_token_t::STRING_VALUE) ? lexical_token_t::STRING_VALUE

--- a/test/unit_test/test_lexical_analyzer_class.cpp
+++ b/test/unit_test/test_lexical_analyzer_class.cpp
@@ -418,6 +418,9 @@ TEST_CASE("LexicalAnalyzer_FloatingPointNumber") {
         using value_pair_t = std::pair<std::string, fkyaml::node::float_number_type>;
         auto value_pair = GENERATE(
             value_pair_t(std::string("-1.234"), -1.234),
+            value_pair_t(std::string("-21."), -21.),
+            value_pair_t(std::string("0."), 0.),
+            value_pair_t(std::string("12."), 12.),
             value_pair_t(std::string("567.8"), 567.8),
             value_pair_t(std::string("0.24"), 0.24),
             value_pair_t(std::string("9.8e-3"), 9.8e-3),
@@ -433,7 +436,7 @@ TEST_CASE("LexicalAnalyzer_FloatingPointNumber") {
     }
 
     SECTION("valid floating point number scalar token edge cases") {
-        auto input = GENERATE(std::string("0."), std::string("1.23e"), std::string("1.2e-z"));
+        auto input = GENERATE(std::string("1.23e"), std::string("1.2e-z"));
         lexer_t lexer(fkyaml::detail::input_adapter(input));
         REQUIRE_FALSE(lexer.get_next_token() == fkyaml::detail::lexical_token_t::FLOAT_NUMBER_VALUE);
     }

--- a/test/unit_test/test_scalar_scanner_class.cpp
+++ b/test/unit_test/test_scalar_scanner_class.cpp
@@ -61,7 +61,9 @@ TEST_CASE("ScalarScanner_FloatNumberValue") {
         std::string("-.INF"),
         std::string("-1.234"),
         std::string("567.8"),
+        std::string("123."),
         std::string("0.24"),
+        std::string("0."),
         std::string("9.8e-3"),
         std::string("3.95E3"),
         std::string("1.863e+3"));
@@ -73,6 +75,7 @@ TEST_CASE("ScalarScanner_StringValue") {
         std::string("abc"),
         std::string("0th"),
         std::string("0123"),
+        std::string("1.2.3"),
         std::string("1.non-digit"),
         std::string("-.foo"),
         std::string("1exe"),


### PR DESCRIPTION
As reported in the issue #380, the current parser emits an error on parsing a floating point value which ends with a dot.  
That is because, while scanning a parsed scalar, the parser mistakenly assumes decimals after a dot.  
However, the spec explicitly allows omitting decimals after a dot [here](https://yaml.org/spec/1.2.2/#1032-tag-resolution) as the regular expression for the float tag.  

So, this PR has fixed implementation to follow the spec, and the updated parser now correctly parse such floating point values.  
To validate the changes, some relevant test cases have also been added to the test suite.  

---

## Pull Request Checklist

Read the [CONTRIBUTING.md](https://github.com/fktn-k/fkYAML/blob/develop/CONTRIBUTING.md) file for detailed information.  

- [x] Changes are described in the pull request or in a referenced [issue](https://github.com/fktn-k/fkYAML/issues).
- [x] The test suite compiles and runs without any error.
- [x] [The code coverage](https://coveralls.io/github/fktn-k/fkYAML) on your branch is 100%.
- [x] The documentation is updated if you added/changed a feature.

## Please don't

- The C++11 support varies between different **compilers** and versions. Please note the [list of supported compilers](https://github.com/fktn-k/fkYAML/blob/develop/README.md#supported-compilers). Some compilers like GCC 4.7 (and earlier), Clang 3.3 (and earlier), or Microsoft Visual Studio 13.0 and earlier are known not to work due to missing or incomplete C++11 support. Please refrain from proposing changes that work around these compiler's limitations with `#ifdef`s or other means.
- Please refrain from proposing changes that would **break [YAML](https://yaml.org/) specifications**. If you propose a conformant extension of YAML to be supported by the library, please motivate this extension.
- Please do not open pull requests that address **multiple issues**.
