### PR TITLE
Fix workflow errors on PRs from fork repos

### DIFF
--- a/.github/workflows/coverage.yml
+++ b/.github/workflows/coverage.yml
@@ -12,7 +12,7 @@ on:
       - test/**
       - CMakeLists.txt
       - Makefile
-  pull_request:
+  pull_request_target:
     paths:
       - .github/workflows/coverage.yml
       - cmake/**
@@ -21,8 +21,6 @@ on:
       - CMakeLists.txt
       - Makefile
   workflow_dispatch:
-
-
 
 jobs:
   coverage:

--- a/.github/workflows/format_check.yml
+++ b/.github/workflows/format_check.yml
@@ -14,7 +14,7 @@ on:
       - tool/amalgamation/**
       - CMakeLists.txt
       - .clang-format
-  pull_request:
+  pull_request_target:
     paths:
       - .github/workflows/format_check.yml
       - include/**


### PR DESCRIPTION
With this PR, I try to fix workflow errors on a PR from a fork repository since some workflows need to write permission to the PR or acceess to secrets to push an automatically created commit.  
One way to resolve them is change the trigger event from pull_request to pull_request_target, just as this PR does.  
Note, according to [the official document](https://docs.github.com/en/actions/writing-workflows/choosing-when-your-workflow-runs/events-that-trigger-workflows#pull_request_target), that can be insecure against stealing secrets or running a malicious code.  
So, further changes will be required to increase security in the future since this is first aid to the errors.  

---

## Pull Request Checklist

Read the [CONTRIBUTING.md](https://github.com/fktn-k/fkYAML/blob/develop/CONTRIBUTING.md) file for detailed information.  

- [x] Changes are described in the pull request or in a referenced [issue](https://github.com/fktn-k/fkYAML/issues).
- [x] The test suite compiles and runs without any error.
- [x] [The code coverage](https://coveralls.io/github/fktn-k/fkYAML) on your branch is 100%.
- [x] The documentation is updated if you added/changed a feature.

## Please don't

- The C++11 support varies between different **compilers** and versions. Please note the [list of supported compilers](https://github.com/fktn-k/fkYAML/blob/develop/README.md#supported-compilers). Some compilers like GCC 4.7 (and earlier), Clang 3.3 (and earlier), or Microsoft Visual Studio 13.0 and earlier are known not to work due to missing or incomplete C++11 support. Please refrain from proposing changes that work around these compiler's limitations with `#ifdef`s or other means.
- Please refrain from proposing changes that would **break [YAML](https://yaml.org/) specifications**. If you propose a conformant extension of YAML to be supported by the library, please motivate this extension.
- Please do not open pull requests that address **multiple issues**.
