### PR TITLE
Fix conditional branching for pull_request_target events

### DIFF
--- a/.github/workflows/coverage.yml
+++ b/.github/workflows/coverage.yml
@@ -12,6 +12,7 @@ on:
       - test/**
       - CMakeLists.txt
       - Makefile
+  # to grant pull-requests write permission to fork repos as well
   pull_request_target:
     paths:
       - .github/workflows/coverage.yml
@@ -32,6 +33,7 @@ jobs:
     steps:
     - uses: actions/checkout@v4
       with:
+        ref: ${{github.head_ref}}
         submodules: recursive
 
     - name: Install lcov
@@ -52,7 +54,7 @@ jobs:
 
     - name: Decide the artifact name
       id: create_zip
-      if: github.event_name == 'pull_request'
+      if: github.event_name == 'pull_request_target'
       env:
         PR_NUMBER: ${{github.event.number}}
       run: |

--- a/.github/workflows/format_check.yml
+++ b/.github/workflows/format_check.yml
@@ -14,6 +14,7 @@ on:
       - tool/amalgamation/**
       - CMakeLists.txt
       - .clang-format
+  # to grant contents write permission to fork repos as well
   pull_request_target:
     paths:
       - .github/workflows/format_check.yml


### PR DESCRIPTION
This PR fixes conditional branching based on the trigerring event name (pull_request_target or push) to not try to comment to a PR if the triggering event name is push.  

---

## Pull Request Checklist

Read the [CONTRIBUTING.md](https://github.com/fktn-k/fkYAML/blob/develop/CONTRIBUTING.md) file for detailed information.  

- [x] Changes are described in the pull request or in a referenced [issue](https://github.com/fktn-k/fkYAML/issues).
- [x] The test suite compiles and runs without any error.
- [x] [The code coverage](https://coveralls.io/github/fktn-k/fkYAML) on your branch is 100%.
- [x] The documentation is updated if you added/changed a feature.

## Please don't

- The C++11 support varies between different **compilers** and versions. Please note the [list of supported compilers](https://github.com/fktn-k/fkYAML/blob/develop/README.md#supported-compilers). Some compilers like GCC 4.7 (and earlier), Clang 3.3 (and earlier), or Microsoft Visual Studio 13.0 and earlier are known not to work due to missing or incomplete C++11 support. Please refrain from proposing changes that work around these compiler's limitations with `#ifdef`s or other means.
- Please refrain from proposing changes that would **break [YAML](https://yaml.org/) specifications**. If you propose a conformant extension of YAML to be supported by the library, please motivate this extension.
- Please do not open pull requests that address **multiple issues**.
