### PR TITLE
Improve UTF encoding detection

### DIFF
--- a/include/fkYAML/detail/encodings/utf_encode_detector.hpp
+++ b/include/fkYAML/detail/encodings/utf_encode_detector.hpp
@@ -8,8 +8,8 @@
 ///
 /// @file
 
-#ifndef FK_YAML_DETAIL_ENCODINGS_ENCODE_DETECTOR_HPP_
-#define FK_YAML_DETAIL_ENCODINGS_ENCODE_DETECTOR_HPP_
+#ifndef FK_YAML_DETAIL_ENCODINGS_UTF_ENCODE_DETECTOR_HPP_
+#define FK_YAML_DETAIL_ENCODINGS_UTF_ENCODE_DETECTOR_HPP_
 
 #include <cstdint>
 #include <istream>
@@ -242,4 +242,4 @@ inline utf_encode_t detect_encoding_and_skip_bom(std::istream& is) noexcept {
 
 FK_YAML_DETAIL_NAMESPACE_END
 
-#endif /* FK_YAML_DETAIL_ENCODINGS_ENCODE_DETECTOR_HPP_ */
+#endif /* FK_YAML_DETAIL_ENCODINGS_UTF_ENCODE_DETECTOR_HPP_ */

--- a/include/fkYAML/detail/encodings/utf_encode_detector.hpp
+++ b/include/fkYAML/detail/encodings/utf_encode_detector.hpp
@@ -30,48 +30,53 @@ FK_YAML_DETAIL_NAMESPACE_BEGIN
 inline utf_encode_t detect_encoding_type(const std::array<uint8_t, 4>& bytes, bool& has_bom) noexcept {
     has_bom = false;
 
+    uint8_t byte0 = bytes[0];
+    uint8_t byte1 = bytes[1];
+    uint8_t byte2 = bytes[2];
+    uint8_t byte3 = bytes[3];
+
     // Check if a BOM exists.
 
-    if (bytes[0] == uint8_t(0xEFu) && bytes[1] == uint8_t(0xBBu) && bytes[2] == uint8_t(0xBFu)) {
+    if (byte0 == uint8_t(0xEFu) && byte1 == uint8_t(0xBBu) && byte2 == uint8_t(0xBFu)) {
         has_bom = true;
         return utf_encode_t::UTF_8;
     }
 
-    if (bytes[0] == 0 && bytes[1] == 0 && bytes[2] == uint8_t(0xFEu) && bytes[3] == uint8_t(0xFFu)) {
+    if (byte0 == 0 && byte1 == 0 && byte2 == uint8_t(0xFEu) && byte3 == uint8_t(0xFFu)) {
         has_bom = true;
         return utf_encode_t::UTF_32BE;
     }
 
-    if (bytes[0] == uint8_t(0xFFu) && bytes[1] == uint8_t(0xFEu) && bytes[2] == 0 && bytes[3] == 0) {
+    if (byte0 == uint8_t(0xFFu) && byte1 == uint8_t(0xFEu) && byte2 == 0 && byte3 == 0) {
         has_bom = true;
         return utf_encode_t::UTF_32LE;
     }
 
-    if (bytes[0] == uint8_t(0xFEu) && bytes[1] == uint8_t(0xFFu)) {
+    if (byte0 == uint8_t(0xFEu) && byte1 == uint8_t(0xFFu)) {
         has_bom = true;
         return utf_encode_t::UTF_16BE;
     }
 
-    if (bytes[0] == uint8_t(0xFFu) && bytes[1] == uint8_t(0xFEu)) {
+    if (byte0 == uint8_t(0xFFu) && byte1 == uint8_t(0xFEu)) {
         has_bom = true;
         return utf_encode_t::UTF_16LE;
     }
 
     // Test the first character assuming it's an ASCII character.
 
-    if (bytes[0] == 0 && bytes[1] == 0 && bytes[2] == 0 && 0 < bytes[3] && bytes[3] < uint8_t(0x80u)) {
+    if (byte0 == 0 && byte1 == 0 && byte2 == 0 && 0 < byte3 && byte3 < uint8_t(0x80u)) {
         return utf_encode_t::UTF_32BE;
     }
 
-    if (0 < bytes[0] && bytes[0] < uint8_t(0x80u) && bytes[1] == 0 && bytes[2] == 0 && bytes[3] == 0) {
+    if (0 < byte0 && byte0 < uint8_t(0x80u) && byte1 == 0 && byte2 == 0 && byte3 == 0) {
         return utf_encode_t::UTF_32LE;
     }
 
-    if (bytes[0] == 0 && 0 < bytes[1] && bytes[1] < uint8_t(0x80u)) {
+    if (byte0 == 0 && 0 < byte1 && byte1 < uint8_t(0x80u)) {
         return utf_encode_t::UTF_16BE;
     }
 
-    if (0 < bytes[0] && bytes[0] < uint8_t(0x80u) && bytes[1] == 0) {
+    if (0 < byte0 && byte0 < uint8_t(0x80u) && byte1 == 0) {
         return utf_encode_t::UTF_16LE;
     }
 

--- a/include/fkYAML/detail/input/input_adapter.hpp
+++ b/include/fkYAML/detail/input/input_adapter.hpp
@@ -20,7 +20,7 @@
 
 #include <fkYAML/detail/macros/version_macros.hpp>
 #include <fkYAML/detail/assert.hpp>
-#include <fkYAML/detail/encodings/encode_detector.hpp>
+#include <fkYAML/detail/encodings/utf_encode_detector.hpp>
 #include <fkYAML/detail/encodings/utf_encode_t.hpp>
 #include <fkYAML/detail/encodings/utf_encodings.hpp>
 #include <fkYAML/detail/meta/stl_supplement.hpp>

--- a/include/fkYAML/detail/input/input_adapter.hpp
+++ b/include/fkYAML/detail/input/input_adapter.hpp
@@ -856,9 +856,9 @@ private:
 /// @param begin The beginning of iterators.
 /// @param end The end of iterators.
 /// @return iterator_input_adapter<ItrType> An iterator_input_adapter object for the target iterator type.
-template <typename ItrType, size_t ElemSize = sizeof(decltype(*(std::declval<ItrType>())))>
+template <typename ItrType>
 inline iterator_input_adapter<ItrType> input_adapter(ItrType begin, ItrType end) {
-    utf_encode_t encode_type = detect_encoding_and_skip_bom(begin, end);
+    utf_encode_t encode_type = utf_encode_detector<ItrType>::detect(begin, end);
     return iterator_input_adapter<ItrType>(begin, end, encode_type);
 }
 
@@ -919,7 +919,7 @@ inline file_input_adapter input_adapter(std::FILE* file) {
     if (!file) {
         throw fkyaml::exception("Invalid FILE object pointer.");
     }
-    utf_encode_t encode_type = detect_encoding_and_skip_bom(file);
+    utf_encode_t encode_type = file_utf_encode_detector::detect(file);
     return file_input_adapter(file, encode_type);
 }
 
@@ -930,7 +930,7 @@ inline stream_input_adapter input_adapter(std::istream& stream) {
     if (!stream.good()) {
         throw fkyaml::exception("Invalid stream.");
     }
-    utf_encode_t encode_type = detect_encoding_and_skip_bom(stream);
+    utf_encode_t encode_type = stream_utf_encode_detector::detect(stream);
     return stream_input_adapter(stream, encode_type);
 }
 

--- a/include/fkYAML/detail/meta/type_traits.hpp
+++ b/include/fkYAML/detail/meta/type_traits.hpp
@@ -11,6 +11,7 @@
 #ifndef FK_YAML_DETAIL_META_TYPE_TRAITS_HPP_
 #define FK_YAML_DETAIL_META_TYPE_TRAITS_HPP_
 
+#include <iterator>
 #include <limits>
 #include <type_traits>
 
@@ -104,6 +105,12 @@ struct is_complete_type : std::false_type {};
 /// @tparam T
 template <typename T>
 struct is_complete_type<T, decltype(void(sizeof(T)))> : std::true_type {};
+
+/// @brief A utility alias to test if the value type of `ItrType` is `T`.
+/// @tparam ItrType An iterator type.
+/// @tparam T The target iterator value type.
+template <typename ItrType, typename T>
+using is_iterator_of = std::is_same<remove_cv_t<typename std::iterator_traits<ItrType>::value_type>, T>;
 
 /// @brief A utility struct to generate static constant instance.
 /// @tparam T A target type for the resulting static constant instance.

--- a/single_include/fkYAML/node.hpp
+++ b/single_include/fkYAML/node.hpp
@@ -476,6 +476,7 @@ FK_YAML_DETAIL_NAMESPACE_END
 #ifndef FK_YAML_DETAIL_META_TYPE_TRAITS_HPP_
 #define FK_YAML_DETAIL_META_TYPE_TRAITS_HPP_
 
+#include <iterator>
 #include <limits>
 #include <type_traits>
 
@@ -572,6 +573,12 @@ struct is_complete_type : std::false_type {};
 /// @tparam T
 template <typename T>
 struct is_complete_type<T, decltype(void(sizeof(T)))> : std::true_type {};
+
+/// @brief A utility alias to test if the value type of `ItrType` is `T`.
+/// @tparam ItrType An iterator type.
+/// @tparam T The target iterator value type.
+template <typename ItrType, typename T>
+using is_iterator_of = std::is_same<remove_cv_t<typename std::iterator_traits<ItrType>::value_type>, T>;
 
 /// @brief A utility struct to generate static constant instance.
 /// @tparam T A target type for the resulting static constant instance.
@@ -5493,7 +5500,7 @@ FK_YAML_DETAIL_NAMESPACE_END
 
 // #include <fkYAML/detail/assert.hpp>
 
-// #include <fkYAML/detail/encodings/encode_detector.hpp>
+// #include <fkYAML/detail/encodings/utf_encode_detector.hpp>
 ///  _______   __ __   __  _____   __  __  __
 /// |   __| |_/  |  \_/  |/  _  \ /  \/  \|  |     fkYAML: A C++ header-only YAML library
 /// |   __|  _  < \_   _/|  ___  |    _   |  |___  version 0.3.11
@@ -5504,8 +5511,8 @@ FK_YAML_DETAIL_NAMESPACE_END
 ///
 /// @file
 
-#ifndef FK_YAML_DETAIL_ENCODINGS_ENCODE_DETECTOR_HPP_
-#define FK_YAML_DETAIL_ENCODINGS_ENCODE_DETECTOR_HPP_
+#ifndef FK_YAML_DETAIL_ENCODINGS_UTF_ENCODE_DETECTOR_HPP_
+#define FK_YAML_DETAIL_ENCODINGS_UTF_ENCODE_DETECTOR_HPP_
 
 #include <cstdint>
 #include <istream>
@@ -5544,6 +5551,10 @@ enum class utf_encode_t {
 FK_YAML_DETAIL_NAMESPACE_END
 
 #endif /* FK_YAML_DETAIL_ENCODINGS_UTF_ENCODE_T_HPP_ */
+
+// #include <fkYAML/detail/meta/stl_supplement.hpp>
+
+// #include <fkYAML/detail/meta/type_traits.hpp>
 
 // #include <fkYAML/exception.hpp>
 
@@ -5606,17 +5617,26 @@ inline utf_encode_t detect_encoding_type(const std::array<uint8_t, 4>& bytes, bo
     return utf_encode_t::UTF_8;
 }
 
-/// @brief Detects the encoding type of the input, and consumes a BOM if it exists.
+/// @brief A class which detects UTF encoding type and the existence of a BOM at the beginning.
 /// @tparam ItrType Type of iterators for the input.
-/// @tparam ElemSize The size of one input element.
-/// @param begin The beginning of input iterators.
-/// @param end The end of input iterators.
-/// @return A detected encoding type.
-template <typename ItrType, size_t ElemSize = sizeof(decltype(*(std::declval<ItrType>())))>
-inline utf_encode_t detect_encoding_and_skip_bom(ItrType& begin, const ItrType& end) {
-    std::array<uint8_t, 4> bytes = {{0xFFu, 0xFFu, 0xFFu, 0xFFu}};
-    switch (ElemSize) {
-    case sizeof(char): { // this case covers char8_t as well when compiled with C++20 or better.
+template <typename ItrType, typename = void>
+struct utf_encode_detector {};
+
+/// @brief The partial specialization of utf_encode_detector for char iterators.
+/// @tparam ItrType An iterator type.
+template <typename ItrType>
+struct utf_encode_detector<ItrType, enable_if_t<is_iterator_of<ItrType, char>::value>> {
+    /// @brief Detects the encoding type of the input, and consumes a BOM if it exists.
+    /// @param begin The iterator to the first element of an input.
+    /// @param end The iterator to the past-the end element of an input.
+    /// @return A detected encoding type.
+    static utf_encode_t detect(ItrType& begin, const ItrType& end) noexcept {
+        if (begin == end) {
+            return utf_encode_t::UTF_8;
+        }
+
+        std::array<uint8_t, 4> bytes {};
+        bytes.fill(0xFFu);
         for (int i = 0; i < 4 && begin + i != end; i++) {
             bytes[i] = uint8_t(begin[i]);
         }
@@ -5643,13 +5663,66 @@ inline utf_encode_t detect_encoding_and_skip_bom(ItrType& begin, const ItrType& 
 
         return encode_type;
     }
-    case sizeof(char16_t): {
+};
+
+#ifdef FK_YAML_HAS_CHAR8_T
+
+/// @brief The partial specialization of utf_encode_detector for char8_t iterators.
+/// @tparam ItrType An iterator type.
+template <typename ItrType>
+struct utf_encode_detector<ItrType, enable_if_t<is_iterator_of<ItrType, char8_t>::value>> {
+    /// @brief Detects the encoding type of the input, and consumes a BOM if it exists.
+    /// @param begin The iterator to the first element of an input.
+    /// @param end The iterator to the past-the end element of an input.
+    /// @return A detected encoding type.
+    static utf_encode_t detect(ItrType& begin, const ItrType& end) {
+        if (begin == end) {
+            return utf_encode_t::UTF_8;
+        }
+
+        std::array<uint8_t, 4> bytes {};
+        bytes.fill(0xFFu);
+        for (int i = 0; i < 4 && begin + i != end; i++) {
+            bytes[i] = uint8_t(begin[i]);
+        }
+
+        bool has_bom = false;
+        utf_encode_t encode_type = detect_encoding_type(bytes, has_bom);
+
+        if (encode_type != utf_encode_t::UTF_8) {
+            throw exception("char8_t characters must be encoded in the UTF-8 format.");
+        }
+
+        if (has_bom) {
+            // skip reading the BOM.
+            std::advance(begin, 3);
+        }
+
+        return encode_type;
+    }
+};
+
+#endif // defined(FK_YAML_HAS_CHAR8_T)
+
+/// @brief The partial specialization of utf_encode_detector for char16_t iterators.
+/// @tparam ItrType An iterator type.
+template <typename ItrType>
+struct utf_encode_detector<ItrType, enable_if_t<is_iterator_of<ItrType, char16_t>::value>> {
+    /// @brief Detects the encoding type of the input, and consumes a BOM if it exists.
+    /// @param begin The iterator to the first element of an input.
+    /// @param end The iterator to the past-the end element of an input.
+    /// @return A detected encoding type.
+    static utf_encode_t detect(ItrType& begin, const ItrType& end) {
         if (begin == end) {
             return utf_encode_t::UTF_16BE;
         }
+
+        std::array<uint8_t, 4> bytes {};
+        bytes.fill(0xFFu);
         for (int i = 0; i < 2 && begin + i != end; i++) {
-            bytes[i * 2] = uint8_t((begin[i] & 0xFF00u) >> 8);
-            bytes[i * 2 + 1] = uint8_t(begin[i] & 0xFFu);
+            char16_t elem = begin[i];
+            bytes[i * 2] = uint8_t((elem & 0xFF00u) >> 8);
+            bytes[i * 2 + 1] = uint8_t(elem & 0xFFu);
         }
 
         bool has_bom = false;
@@ -5666,15 +5739,27 @@ inline utf_encode_t detect_encoding_and_skip_bom(ItrType& begin, const ItrType& 
 
         return encode_type;
     }
-    case sizeof(char32_t): {
+};
+
+/// @brief The partial specialization of utf_encode_detector for char32_t iterators.
+/// @tparam ItrType An iterator type.
+template <typename ItrType>
+struct utf_encode_detector<ItrType, enable_if_t<is_iterator_of<ItrType, char32_t>::value>> {
+    /// @brief Detects the encoding type of the input, and consumes a BOM if it exists.
+    /// @param begin The iterator to the first element of an input.
+    /// @param end The iterator to the past-the end element of an input.
+    /// @return A detected encoding type.
+    static utf_encode_t detect(ItrType& begin, const ItrType& end) {
         if (begin == end) {
             return utf_encode_t::UTF_32BE;
         }
 
-        bytes[0] = uint8_t((*begin & 0xFF000000u) >> 24);
-        bytes[1] = uint8_t((*begin & 0x00FF0000u) >> 16);
-        bytes[2] = uint8_t((*begin & 0x0000FF00u) >> 8);
-        bytes[3] = uint8_t(*begin & 0x000000FFu);
+        std::array<uint8_t, 4> bytes {};
+        char32_t elem = *begin;
+        bytes[0] = uint8_t((elem & 0xFF000000u) >> 24);
+        bytes[1] = uint8_t((elem & 0x00FF0000u) >> 16);
+        bytes[2] = uint8_t((elem & 0x0000FF00u) >> 8);
+        bytes[3] = uint8_t(elem & 0x000000FFu);
 
         bool has_bom = false;
         utf_encode_t encode_type = detect_encoding_type(bytes, has_bom);
@@ -5690,89 +5775,100 @@ inline utf_encode_t detect_encoding_and_skip_bom(ItrType& begin, const ItrType& 
 
         return encode_type;
     }
-    default:
-        throw exception("Unknown char size.");
-    }
-}
+};
 
-inline utf_encode_t detect_encoding_and_skip_bom(std::FILE* file) noexcept {
-    std::array<uint8_t, 4> bytes = {{0xFFu, 0xFFu, 0xFFu, 0xFFu}};
-    for (int i = 0; i < 4; i++) {
-        char byte = 0;
-        std::size_t size = std::fread(&byte, sizeof(char), 1, file);
-        if (size != sizeof(char)) {
-            break;
+/// @brief A class which detects UTF encoding type and the existence of a BOM from the input file.
+struct file_utf_encode_detector {
+    /// @brief Detects the encoding type of the input, and consumes a BOM if it exists.
+    /// @param p_file The input file handle.
+    /// @return A detected encoding type.
+    static utf_encode_t detect(std::FILE* p_file) noexcept {
+        std::array<uint8_t, 4> bytes {};
+        bytes.fill(0xFFu);
+        for (int i = 0; i < 4; i++) {
+            char byte = 0;
+            std::size_t size = std::fread(&byte, sizeof(char), 1, p_file);
+            if (size != sizeof(char)) {
+                break;
+            }
+            bytes[i] = uint8_t(byte & 0xFF);
         }
-        bytes[i] = uint8_t(byte & 0xFF);
-    }
 
-    bool has_bom = false;
-    utf_encode_t encode_type = detect_encoding_type(bytes, has_bom);
+        bool has_bom = false;
+        utf_encode_t encode_type = detect_encoding_type(bytes, has_bom);
 
-    // move back to the beginning if a BOM doesn't exist.
-    long offset = 0;
-    if (has_bom) {
-        switch (encode_type) {
-        case utf_encode_t::UTF_8:
-            offset = 3;
-            break;
-        case utf_encode_t::UTF_16BE:
-        case utf_encode_t::UTF_16LE:
-            offset = 2;
-            break;
-        case utf_encode_t::UTF_32BE:
-        case utf_encode_t::UTF_32LE:
-            offset = 4;
-            break;
+        // move back to the beginning if a BOM doesn't exist.
+        long offset = 0;
+        if (has_bom) {
+            switch (encode_type) {
+            case utf_encode_t::UTF_8:
+                offset = 3;
+                break;
+            case utf_encode_t::UTF_16BE:
+            case utf_encode_t::UTF_16LE:
+                offset = 2;
+                break;
+            case utf_encode_t::UTF_32BE:
+            case utf_encode_t::UTF_32LE:
+                offset = 4;
+                break;
+            }
         }
+        std::fseek(p_file, offset, SEEK_SET);
+
+        return encode_type;
     }
-    fseek(file, offset, SEEK_SET);
+};
 
-    return encode_type;
-}
-
-inline utf_encode_t detect_encoding_and_skip_bom(std::istream& is) noexcept {
-    std::array<uint8_t, 4> bytes = {{0xFFu, 0xFFu, 0xFFu, 0xFFu}};
-    for (int i = 0; i < 4; i++) {
-        char ch = 0;
-        is.read(&ch, 1);
-        std::streamsize size = is.gcount();
-        if (size != 1) {
-            // without this, seekg() fails in the switch-case statement below.
-            is.clear();
-            break;
+/// @brief A class which detects UTF encoding type and the existence of a BOM from the input file.
+struct stream_utf_encode_detector {
+    /// @brief Detects the encoding type of the input, and consumes a BOM if it exists.
+    /// @param p_file The input file handle.
+    /// @return A detected encoding type.
+    static utf_encode_t detect(std::istream& is) noexcept {
+        std::array<uint8_t, 4> bytes {};
+        bytes.fill(0xFFu);
+        for (int i = 0; i < 4; i++) {
+            char ch = 0;
+            is.read(&ch, 1);
+            std::streamsize size = is.gcount();
+            if (size != 1) {
+                // without this, seekg() will fail in the switch-case statement below.
+                is.clear();
+                break;
+            }
+            bytes[i] = uint8_t(ch & 0xFF);
         }
-        bytes[i] = uint8_t(ch & 0xFF);
-    }
 
-    bool has_bom = false;
-    utf_encode_t encode_type = detect_encoding_type(bytes, has_bom);
+        bool has_bom = false;
+        utf_encode_t encode_type = detect_encoding_type(bytes, has_bom);
 
-    // move back to the beginning if a BOM doesn't exist.
-    std::streamoff offset = 0;
-    if (has_bom) {
-        switch (encode_type) {
-        case utf_encode_t::UTF_8:
-            offset = 3;
-            break;
-        case utf_encode_t::UTF_16BE:
-        case utf_encode_t::UTF_16LE:
-            offset = 2;
-            break;
-        case utf_encode_t::UTF_32BE:
-        case utf_encode_t::UTF_32LE:
-            offset = 4;
-            break;
+        // move back to the beginning if a BOM doesn't exist.
+        std::streamoff offset = 0;
+        if (has_bom) {
+            switch (encode_type) {
+            case utf_encode_t::UTF_8:
+                offset = 3;
+                break;
+            case utf_encode_t::UTF_16BE:
+            case utf_encode_t::UTF_16LE:
+                offset = 2;
+                break;
+            case utf_encode_t::UTF_32BE:
+            case utf_encode_t::UTF_32LE:
+                offset = 4;
+                break;
+            }
         }
-    }
-    is.seekg(offset, std::ios_base::beg);
+        is.seekg(offset, std::ios_base::beg);
 
-    return encode_type;
-}
+        return encode_type;
+    }
+};
 
 FK_YAML_DETAIL_NAMESPACE_END
 
-#endif /* FK_YAML_DETAIL_ENCODINGS_ENCODE_DETECTOR_HPP_ */
+#endif /* FK_YAML_DETAIL_ENCODINGS_UTF_ENCODE_DETECTOR_HPP_ */
 
 // #include <fkYAML/detail/encodings/utf_encode_t.hpp>
 
@@ -6613,9 +6709,9 @@ private:
 /// @param begin The beginning of iterators.
 /// @param end The end of iterators.
 /// @return iterator_input_adapter<ItrType> An iterator_input_adapter object for the target iterator type.
-template <typename ItrType, size_t ElemSize = sizeof(decltype(*(std::declval<ItrType>())))>
+template <typename ItrType>
 inline iterator_input_adapter<ItrType> input_adapter(ItrType begin, ItrType end) {
-    utf_encode_t encode_type = detect_encoding_and_skip_bom(begin, end);
+    utf_encode_t encode_type = utf_encode_detector<ItrType>::detect(begin, end);
     return iterator_input_adapter<ItrType>(begin, end, encode_type);
 }
 
@@ -6676,7 +6772,7 @@ inline file_input_adapter input_adapter(std::FILE* file) {
     if (!file) {
         throw fkyaml::exception("Invalid FILE object pointer.");
     }
-    utf_encode_t encode_type = detect_encoding_and_skip_bom(file);
+    utf_encode_t encode_type = file_utf_encode_detector::detect(file);
     return file_input_adapter(file, encode_type);
 }
 
@@ -6687,7 +6783,7 @@ inline stream_input_adapter input_adapter(std::istream& stream) {
     if (!stream.good()) {
         throw fkyaml::exception("Invalid stream.");
     }
-    utf_encode_t encode_type = detect_encoding_and_skip_bom(stream);
+    utf_encode_t encode_type = stream_utf_encode_detector::detect(stream);
     return stream_input_adapter(stream, encode_type);
 }
 

--- a/single_include/fkYAML/node.hpp
+++ b/single_include/fkYAML/node.hpp
@@ -5569,48 +5569,53 @@ FK_YAML_DETAIL_NAMESPACE_BEGIN
 inline utf_encode_t detect_encoding_type(const std::array<uint8_t, 4>& bytes, bool& has_bom) noexcept {
     has_bom = false;
 
+    uint8_t byte0 = bytes[0];
+    uint8_t byte1 = bytes[1];
+    uint8_t byte2 = bytes[2];
+    uint8_t byte3 = bytes[3];
+
     // Check if a BOM exists.
 
-    if (bytes[0] == uint8_t(0xEFu) && bytes[1] == uint8_t(0xBBu) && bytes[2] == uint8_t(0xBFu)) {
+    if (byte0 == uint8_t(0xEFu) && byte1 == uint8_t(0xBBu) && byte2 == uint8_t(0xBFu)) {
         has_bom = true;
         return utf_encode_t::UTF_8;
     }
 
-    if (bytes[0] == 0 && bytes[1] == 0 && bytes[2] == uint8_t(0xFEu) && bytes[3] == uint8_t(0xFFu)) {
+    if (byte0 == 0 && byte1 == 0 && byte2 == uint8_t(0xFEu) && byte3 == uint8_t(0xFFu)) {
         has_bom = true;
         return utf_encode_t::UTF_32BE;
     }
 
-    if (bytes[0] == uint8_t(0xFFu) && bytes[1] == uint8_t(0xFEu) && bytes[2] == 0 && bytes[3] == 0) {
+    if (byte0 == uint8_t(0xFFu) && byte1 == uint8_t(0xFEu) && byte2 == 0 && byte3 == 0) {
         has_bom = true;
         return utf_encode_t::UTF_32LE;
     }
 
-    if (bytes[0] == uint8_t(0xFEu) && bytes[1] == uint8_t(0xFFu)) {
+    if (byte0 == uint8_t(0xFEu) && byte1 == uint8_t(0xFFu)) {
         has_bom = true;
         return utf_encode_t::UTF_16BE;
     }
 
-    if (bytes[0] == uint8_t(0xFFu) && bytes[1] == uint8_t(0xFEu)) {
+    if (byte0 == uint8_t(0xFFu) && byte1 == uint8_t(0xFEu)) {
         has_bom = true;
         return utf_encode_t::UTF_16LE;
     }
 
     // Test the first character assuming it's an ASCII character.
 
-    if (bytes[0] == 0 && bytes[1] == 0 && bytes[2] == 0 && 0 < bytes[3] && bytes[3] < uint8_t(0x80u)) {
+    if (byte0 == 0 && byte1 == 0 && byte2 == 0 && 0 < byte3 && byte3 < uint8_t(0x80u)) {
         return utf_encode_t::UTF_32BE;
     }
 
-    if (0 < bytes[0] && bytes[0] < uint8_t(0x80u) && bytes[1] == 0 && bytes[2] == 0 && bytes[3] == 0) {
+    if (0 < byte0 && byte0 < uint8_t(0x80u) && byte1 == 0 && byte2 == 0 && byte3 == 0) {
         return utf_encode_t::UTF_32LE;
     }
 
-    if (bytes[0] == 0 && 0 < bytes[1] && bytes[1] < uint8_t(0x80u)) {
+    if (byte0 == 0 && 0 < byte1 && byte1 < uint8_t(0x80u)) {
         return utf_encode_t::UTF_16BE;
     }
 
-    if (0 < bytes[0] && bytes[0] < uint8_t(0x80u) && bytes[1] == 0) {
+    if (0 < byte0 && byte0 < uint8_t(0x80u) && byte1 == 0) {
         return utf_encode_t::UTF_16LE;
     }
 

--- a/test/unit_test/CMakeLists.txt
+++ b/test/unit_test/CMakeLists.txt
@@ -212,7 +212,6 @@ add_executable(
   ${TEST_TARGET}
   test_custom_from_node.cpp
   test_deserializer_class.cpp
-  test_encode_detector.cpp
   test_exception_class.cpp
   test_from_string.cpp
   test_input_adapter.cpp
@@ -227,6 +226,7 @@ add_executable(
   test_string_formatter.cpp
   test_tag_resolver_class.cpp
   test_uri_encoding_class.cpp
+  test_utf_encode_detector.cpp
   test_utf_encodings.cpp
   test_yaml_escaper_class.cpp
   main.cpp

--- a/test/unit_test/test_utf_encode_detector.cpp
+++ b/test/unit_test/test_utf_encode_detector.cpp
@@ -23,7 +23,7 @@
 #define ENABLE_C4996
 #endif
 
-TEST_CASE("EncodeDetector_DetectEncodingType") {
+TEST_CASE("UTFEncodeDetector_DetectEncodingType") {
     struct test_data_t {
         test_data_t(std::array<uint8_t, 4> input_, fkyaml::detail::utf_encode_t encode_type_, bool has_bom_)
             : input(input_),
@@ -85,7 +85,7 @@ TEST_CASE("EncodeDetector_DetectEncodingType") {
     REQUIRE(has_bom == d.has_bom);
 }
 
-TEST_CASE("EncodeDetector_DetectEncodingAndSkipBom") {
+TEST_CASE("UTFEncodeDetector_DetectEncodingAndSkipBom") {
     ////////////////////////
     //   char iterators   //
     ////////////////////////

--- a/test/unit_test/test_utf_encode_detector.cpp
+++ b/test/unit_test/test_utf_encode_detector.cpp
@@ -190,6 +190,16 @@ TEST_CASE("UTFEncodeDetector_DetectEncodingAndSkipBom") {
         REQUIRE(begin == std::begin(input) + 4);
     }
 
+    SECTION("empty char iterators") {
+        std::string input = "";
+        auto begin = std::begin(input);
+        auto end = std::end(input);
+        using iterator_type = decltype(begin);
+        fkyaml::detail::utf_encode_t ret = fkyaml::detail::utf_encode_detector<iterator_type>::detect(begin, end);
+        REQUIRE(ret == fkyaml::detail::utf_encode_t::UTF_8);
+        REQUIRE(begin == std::begin(input));
+    }
+
     ///////////////////////////
     //   char8_t iterators   //
     ///////////////////////////

--- a/test/unit_test/test_utf_encode_detector.cpp
+++ b/test/unit_test/test_utf_encode_detector.cpp
@@ -94,7 +94,8 @@ TEST_CASE("UTFEncodeDetector_DetectEncodingAndSkipBom") {
         std::string input {char(0x60u), char(0x61u), char(0x62u), char(0x63u)};
         auto begin = std::begin(input);
         auto end = std::end(input);
-        fkyaml::detail::utf_encode_t ret = fkyaml::detail::detect_encoding_and_skip_bom(begin, end);
+        using iterator_type = decltype(begin);
+        fkyaml::detail::utf_encode_t ret = fkyaml::detail::utf_encode_detector<iterator_type>::detect(begin, end);
         REQUIRE(ret == fkyaml::detail::utf_encode_t::UTF_8);
         REQUIRE(begin == std::begin(input));
     }
@@ -103,7 +104,8 @@ TEST_CASE("UTFEncodeDetector_DetectEncodingAndSkipBom") {
         std::string input {char(0xEFu), char(0xBBu), char(0xBFu), char(0x60u)};
         auto begin = std::begin(input);
         auto end = std::end(input);
-        fkyaml::detail::utf_encode_t ret = fkyaml::detail::detect_encoding_and_skip_bom(begin, end);
+        using iterator_type = decltype(begin);
+        fkyaml::detail::utf_encode_t ret = fkyaml::detail::utf_encode_detector<iterator_type>::detect(begin, end);
         REQUIRE(ret == fkyaml::detail::utf_encode_t::UTF_8);
         REQUIRE(begin == std::begin(input) + 3);
     }
@@ -112,7 +114,8 @@ TEST_CASE("UTFEncodeDetector_DetectEncodingAndSkipBom") {
         std::string input {0, char(0x60u), 0, char(0x61u)};
         auto begin = std::begin(input);
         auto end = std::end(input);
-        fkyaml::detail::utf_encode_t ret = fkyaml::detail::detect_encoding_and_skip_bom(begin, end);
+        using iterator_type = decltype(begin);
+        fkyaml::detail::utf_encode_t ret = fkyaml::detail::utf_encode_detector<iterator_type>::detect(begin, end);
         REQUIRE(ret == fkyaml::detail::utf_encode_t::UTF_16BE);
         REQUIRE(begin == std::begin(input));
     }
@@ -121,7 +124,8 @@ TEST_CASE("UTFEncodeDetector_DetectEncodingAndSkipBom") {
         std::string input {char(0xFEu), char(0xFFu), 0, char(0x60u)};
         auto begin = std::begin(input);
         auto end = std::end(input);
-        fkyaml::detail::utf_encode_t ret = fkyaml::detail::detect_encoding_and_skip_bom(begin, end);
+        using iterator_type = decltype(begin);
+        fkyaml::detail::utf_encode_t ret = fkyaml::detail::utf_encode_detector<iterator_type>::detect(begin, end);
         REQUIRE(ret == fkyaml::detail::utf_encode_t::UTF_16BE);
         REQUIRE(begin == std::begin(input) + 2);
     }
@@ -130,7 +134,8 @@ TEST_CASE("UTFEncodeDetector_DetectEncodingAndSkipBom") {
         std::string input {char(0x60u), 0, char(0x61u), 0};
         auto begin = std::begin(input);
         auto end = std::end(input);
-        fkyaml::detail::utf_encode_t ret = fkyaml::detail::detect_encoding_and_skip_bom(begin, end);
+        using iterator_type = decltype(begin);
+        fkyaml::detail::utf_encode_t ret = fkyaml::detail::utf_encode_detector<iterator_type>::detect(begin, end);
         REQUIRE(ret == fkyaml::detail::utf_encode_t::UTF_16LE);
         REQUIRE(begin == std::begin(input));
     }
@@ -139,7 +144,8 @@ TEST_CASE("UTFEncodeDetector_DetectEncodingAndSkipBom") {
         std::string input {char(0xFFu), char(0xFEu), char(0x60u), 0};
         auto begin = std::begin(input);
         auto end = std::end(input);
-        fkyaml::detail::utf_encode_t ret = fkyaml::detail::detect_encoding_and_skip_bom(begin, end);
+        using iterator_type = decltype(begin);
+        fkyaml::detail::utf_encode_t ret = fkyaml::detail::utf_encode_detector<iterator_type>::detect(begin, end);
         REQUIRE(ret == fkyaml::detail::utf_encode_t::UTF_16LE);
         REQUIRE(begin == std::begin(input) + 2);
     }
@@ -148,7 +154,8 @@ TEST_CASE("UTFEncodeDetector_DetectEncodingAndSkipBom") {
         std::string input {0, 0, 0, char(0x60u), 0, 0, 0, char(0x61u)};
         auto begin = std::begin(input);
         auto end = std::end(input);
-        fkyaml::detail::utf_encode_t ret = fkyaml::detail::detect_encoding_and_skip_bom(begin, end);
+        using iterator_type = decltype(begin);
+        fkyaml::detail::utf_encode_t ret = fkyaml::detail::utf_encode_detector<iterator_type>::detect(begin, end);
         REQUIRE(ret == fkyaml::detail::utf_encode_t::UTF_32BE);
         REQUIRE(begin == std::begin(input));
     }
@@ -157,7 +164,8 @@ TEST_CASE("UTFEncodeDetector_DetectEncodingAndSkipBom") {
         std::string input {0, 0, char(0xFEu), char(0xFFu), 0, 0, 0, char(0x60u)};
         auto begin = std::begin(input);
         auto end = std::end(input);
-        fkyaml::detail::utf_encode_t ret = fkyaml::detail::detect_encoding_and_skip_bom(begin, end);
+        using iterator_type = decltype(begin);
+        fkyaml::detail::utf_encode_t ret = fkyaml::detail::utf_encode_detector<iterator_type>::detect(begin, end);
         REQUIRE(ret == fkyaml::detail::utf_encode_t::UTF_32BE);
         REQUIRE(begin == std::begin(input) + 4);
     }
@@ -166,7 +174,8 @@ TEST_CASE("UTFEncodeDetector_DetectEncodingAndSkipBom") {
         std::string input {char(0x60u), 0, 0, 0, char(0x61u), 0, 0, 0};
         auto begin = std::begin(input);
         auto end = std::end(input);
-        fkyaml::detail::utf_encode_t ret = fkyaml::detail::detect_encoding_and_skip_bom(begin, end);
+        using iterator_type = decltype(begin);
+        fkyaml::detail::utf_encode_t ret = fkyaml::detail::utf_encode_detector<iterator_type>::detect(begin, end);
         REQUIRE(ret == fkyaml::detail::utf_encode_t::UTF_32LE);
         REQUIRE(begin == std::begin(input));
     }
@@ -175,10 +184,57 @@ TEST_CASE("UTFEncodeDetector_DetectEncodingAndSkipBom") {
         std::string input {char(0xFFu), char(0xFEu), 0, 0, char(0x60u), 0, 0, 0};
         auto begin = std::begin(input);
         auto end = std::end(input);
-        fkyaml::detail::utf_encode_t ret = fkyaml::detail::detect_encoding_and_skip_bom(begin, end);
+        using iterator_type = decltype(begin);
+        fkyaml::detail::utf_encode_t ret = fkyaml::detail::utf_encode_detector<iterator_type>::detect(begin, end);
         REQUIRE(ret == fkyaml::detail::utf_encode_t::UTF_32LE);
         REQUIRE(begin == std::begin(input) + 4);
     }
+
+    ///////////////////////////
+    //   char8_t iterators   //
+    ///////////////////////////
+
+#ifdef FK_YAML_HAS_CHAR8_T
+
+    SECTION("char8_t iterators encoded in the UTF-8") {
+        std::u8string input {char8_t(0x60u), char8_t(0x61u), char8_t(0x62u), char8_t(0x63u)};
+        auto begin = std::begin(input);
+        auto end = std::end(input);
+        using iterator_type = decltype(begin);
+        fkyaml::detail::utf_encode_t ret = fkyaml::detail::utf_encode_detector<iterator_type>::detect(begin, end);
+        REQUIRE(ret == fkyaml::detail::utf_encode_t::UTF_8);
+        REQUIRE(begin == std::begin(input));
+    }
+
+    SECTION("char8_t iterators encoded in the UTF-8(BOM)") {
+        std::u8string input {char8_t(0xEFu), char8_t(0xBBu), char8_t(0xBFu), char8_t(0x60u)};
+        auto begin = std::begin(input);
+        auto end = std::end(input);
+        using iterator_type = decltype(begin);
+        fkyaml::detail::utf_encode_t ret = fkyaml::detail::utf_encode_detector<iterator_type>::detect(begin, end);
+        REQUIRE(ret == fkyaml::detail::utf_encode_t::UTF_8);
+        REQUIRE(begin == std::begin(input) + 3);
+    }
+
+    SECTION("empty char8_t iterators") {
+        std::u8string input = u8"";
+        auto begin = std::begin(input);
+        auto end = std::end(input);
+        using iterator_type = decltype(begin);
+        fkyaml::detail::utf_encode_t ret = fkyaml::detail::utf_encode_detector<iterator_type>::detect(begin, end);
+        REQUIRE(ret == fkyaml::detail::utf_encode_t::UTF_8);
+        REQUIRE(begin == std::begin(input));
+    }
+
+    SECTION("char8_t iterators with invalid encoding") {
+        std::u8string input {char8_t(0x00u), char8_t(0x00u), char8_t(0xFEu), char8_t(0xFFu)};
+        auto begin = std::begin(input);
+        auto end = std::end(input);
+        using iterator_type = decltype(begin);
+        REQUIRE_THROWS_AS(fkyaml::detail::utf_encode_detector<iterator_type>::detect(begin, end), fkyaml::exception);
+    }
+
+#endif // defined(FK_YAML_HAS_CHAR8_T)
 
     ////////////////////////////
     //   char16_t iterators   //
@@ -188,7 +244,8 @@ TEST_CASE("UTFEncodeDetector_DetectEncodingAndSkipBom") {
         std::u16string input {char16_t(0x0060u), char16_t(0x0061u)};
         auto begin = std::begin(input);
         auto end = std::end(input);
-        fkyaml::detail::utf_encode_t ret = fkyaml::detail::detect_encoding_and_skip_bom(begin, end);
+        using iterator_type = decltype(begin);
+        fkyaml::detail::utf_encode_t ret = fkyaml::detail::utf_encode_detector<iterator_type>::detect(begin, end);
         REQUIRE(ret == fkyaml::detail::utf_encode_t::UTF_16BE);
         REQUIRE(begin == std::begin(input));
     }
@@ -197,7 +254,8 @@ TEST_CASE("UTFEncodeDetector_DetectEncodingAndSkipBom") {
         std::u16string input {char16_t(0xFEFFu), char16_t(0x0060u)};
         auto begin = std::begin(input);
         auto end = std::end(input);
-        fkyaml::detail::utf_encode_t ret = fkyaml::detail::detect_encoding_and_skip_bom(begin, end);
+        using iterator_type = decltype(begin);
+        fkyaml::detail::utf_encode_t ret = fkyaml::detail::utf_encode_detector<iterator_type>::detect(begin, end);
         REQUIRE(ret == fkyaml::detail::utf_encode_t::UTF_16BE);
         REQUIRE(begin == std::begin(input) + 1);
     }
@@ -206,7 +264,8 @@ TEST_CASE("UTFEncodeDetector_DetectEncodingAndSkipBom") {
         std::u16string input {char16_t(0x6000u), char16_t(0x6100u)};
         auto begin = std::begin(input);
         auto end = std::end(input);
-        fkyaml::detail::utf_encode_t ret = fkyaml::detail::detect_encoding_and_skip_bom(begin, end);
+        using iterator_type = decltype(begin);
+        fkyaml::detail::utf_encode_t ret = fkyaml::detail::utf_encode_detector<iterator_type>::detect(begin, end);
         REQUIRE(ret == fkyaml::detail::utf_encode_t::UTF_16LE);
         REQUIRE(begin == std::begin(input));
     }
@@ -215,7 +274,8 @@ TEST_CASE("UTFEncodeDetector_DetectEncodingAndSkipBom") {
         std::u16string input {char16_t(0xFFFEu), char16_t(0x6000u)};
         auto begin = std::begin(input);
         auto end = std::end(input);
-        fkyaml::detail::utf_encode_t ret = fkyaml::detail::detect_encoding_and_skip_bom(begin, end);
+        using iterator_type = decltype(begin);
+        fkyaml::detail::utf_encode_t ret = fkyaml::detail::utf_encode_detector<iterator_type>::detect(begin, end);
         REQUIRE(ret == fkyaml::detail::utf_encode_t::UTF_16LE);
         REQUIRE(begin == std::begin(input) + 1);
     }
@@ -224,7 +284,8 @@ TEST_CASE("UTFEncodeDetector_DetectEncodingAndSkipBom") {
         std::u16string input = u"";
         auto begin = std::begin(input);
         auto end = std::end(input);
-        fkyaml::detail::utf_encode_t ret = fkyaml::detail::detect_encoding_and_skip_bom(begin, end);
+        using iterator_type = decltype(begin);
+        fkyaml::detail::utf_encode_t ret = fkyaml::detail::utf_encode_detector<iterator_type>::detect(begin, end);
         REQUIRE(ret == fkyaml::detail::utf_encode_t::UTF_16BE);
         REQUIRE(begin == std::begin(input));
     }
@@ -233,7 +294,8 @@ TEST_CASE("UTFEncodeDetector_DetectEncodingAndSkipBom") {
         std::u16string input {char16_t(0x0000u), char16_t(0xFEFFu)};
         auto begin = std::begin(input);
         auto end = std::end(input);
-        REQUIRE_THROWS_AS(fkyaml::detail::detect_encoding_and_skip_bom(begin, end), fkyaml::exception);
+        using iterator_type = decltype(begin);
+        REQUIRE_THROWS_AS(fkyaml::detail::utf_encode_detector<iterator_type>::detect(begin, end), fkyaml::exception);
     }
 
     ////////////////////////////
@@ -244,7 +306,8 @@ TEST_CASE("UTFEncodeDetector_DetectEncodingAndSkipBom") {
         std::u32string input {char32_t(0x00000060u), char32_t(0x00000061u)};
         auto begin = std::begin(input);
         auto end = std::end(input);
-        fkyaml::detail::utf_encode_t ret = fkyaml::detail::detect_encoding_and_skip_bom(begin, end);
+        using iterator_type = decltype(begin);
+        fkyaml::detail::utf_encode_t ret = fkyaml::detail::utf_encode_detector<iterator_type>::detect(begin, end);
         REQUIRE(ret == fkyaml::detail::utf_encode_t::UTF_32BE);
         REQUIRE(begin == std::begin(input));
     }
@@ -253,7 +316,8 @@ TEST_CASE("UTFEncodeDetector_DetectEncodingAndSkipBom") {
         std::u32string input {char32_t(0x0000FEFFu), char32_t(0x00000060u)};
         auto begin = std::begin(input);
         auto end = std::end(input);
-        fkyaml::detail::utf_encode_t ret = fkyaml::detail::detect_encoding_and_skip_bom(begin, end);
+        using iterator_type = decltype(begin);
+        fkyaml::detail::utf_encode_t ret = fkyaml::detail::utf_encode_detector<iterator_type>::detect(begin, end);
         REQUIRE(ret == fkyaml::detail::utf_encode_t::UTF_32BE);
         REQUIRE(begin == std::begin(input) + 1);
     }
@@ -262,7 +326,8 @@ TEST_CASE("UTFEncodeDetector_DetectEncodingAndSkipBom") {
         std::u32string input {char32_t(0x60000000u), char32_t(0x61000000u)};
         auto begin = std::begin(input);
         auto end = std::end(input);
-        fkyaml::detail::utf_encode_t ret = fkyaml::detail::detect_encoding_and_skip_bom(begin, end);
+        using iterator_type = decltype(begin);
+        fkyaml::detail::utf_encode_t ret = fkyaml::detail::utf_encode_detector<iterator_type>::detect(begin, end);
         REQUIRE(ret == fkyaml::detail::utf_encode_t::UTF_32LE);
         REQUIRE(begin == std::begin(input));
     }
@@ -271,7 +336,8 @@ TEST_CASE("UTFEncodeDetector_DetectEncodingAndSkipBom") {
         std::u32string input {char32_t(0xFFFE0000u), char32_t(0x60000000u)};
         auto begin = std::begin(input);
         auto end = std::end(input);
-        fkyaml::detail::utf_encode_t ret = fkyaml::detail::detect_encoding_and_skip_bom(begin, end);
+        using iterator_type = decltype(begin);
+        fkyaml::detail::utf_encode_t ret = fkyaml::detail::utf_encode_detector<iterator_type>::detect(begin, end);
         REQUIRE(ret == fkyaml::detail::utf_encode_t::UTF_32LE);
         REQUIRE(begin == std::begin(input) + 1);
     }
@@ -280,7 +346,8 @@ TEST_CASE("UTFEncodeDetector_DetectEncodingAndSkipBom") {
         std::u32string input = U"";
         auto begin = std::begin(input);
         auto end = std::end(input);
-        fkyaml::detail::utf_encode_t ret = fkyaml::detail::detect_encoding_and_skip_bom(begin, end);
+        using iterator_type = decltype(begin);
+        fkyaml::detail::utf_encode_t ret = fkyaml::detail::utf_encode_detector<iterator_type>::detect(begin, end);
         REQUIRE(ret == fkyaml::detail::utf_encode_t::UTF_32BE);
         REQUIRE(begin == std::begin(input));
     }
@@ -289,7 +356,8 @@ TEST_CASE("UTFEncodeDetector_DetectEncodingAndSkipBom") {
         std::u32string input {char32_t(0xFEFF0060u), char32_t(0x00610062u)};
         auto begin = std::begin(input);
         auto end = std::end(input);
-        REQUIRE_THROWS_AS(fkyaml::detail::detect_encoding_and_skip_bom(begin, end), fkyaml::exception);
+        using iterator_type = decltype(begin);
+        REQUIRE_THROWS_AS(fkyaml::detail::utf_encode_detector<iterator_type>::detect(begin, end), fkyaml::exception);
     }
 
     //////////////////////
@@ -302,7 +370,7 @@ TEST_CASE("UTFEncodeDetector_DetectEncodingAndSkipBom") {
         ENABLE_C4996
 
         REQUIRE(p_file != nullptr);
-        fkyaml::detail::utf_encode_t ret = fkyaml::detail::detect_encoding_and_skip_bom(p_file);
+        fkyaml::detail::utf_encode_t ret = fkyaml::detail::file_utf_encode_detector::detect(p_file);
         REQUIRE(ret == fkyaml::detail::utf_encode_t::UTF_8);
         REQUIRE(std::ftell(p_file) == 0);
 
@@ -315,7 +383,7 @@ TEST_CASE("UTFEncodeDetector_DetectEncodingAndSkipBom") {
         ENABLE_C4996
 
         REQUIRE(p_file != nullptr);
-        fkyaml::detail::utf_encode_t ret = fkyaml::detail::detect_encoding_and_skip_bom(p_file);
+        fkyaml::detail::utf_encode_t ret = fkyaml::detail::file_utf_encode_detector::detect(p_file);
         REQUIRE(ret == fkyaml::detail::utf_encode_t::UTF_8);
         REQUIRE(std::ftell(p_file) == 3);
 
@@ -328,7 +396,7 @@ TEST_CASE("UTFEncodeDetector_DetectEncodingAndSkipBom") {
         ENABLE_C4996
 
         REQUIRE(p_file != nullptr);
-        fkyaml::detail::utf_encode_t ret = fkyaml::detail::detect_encoding_and_skip_bom(p_file);
+        fkyaml::detail::utf_encode_t ret = fkyaml::detail::file_utf_encode_detector::detect(p_file);
         REQUIRE(ret == fkyaml::detail::utf_encode_t::UTF_16BE);
         REQUIRE(std::ftell(p_file) == 0);
 
@@ -341,7 +409,7 @@ TEST_CASE("UTFEncodeDetector_DetectEncodingAndSkipBom") {
         ENABLE_C4996
 
         REQUIRE(p_file != nullptr);
-        fkyaml::detail::utf_encode_t ret = fkyaml::detail::detect_encoding_and_skip_bom(p_file);
+        fkyaml::detail::utf_encode_t ret = fkyaml::detail::file_utf_encode_detector::detect(p_file);
         REQUIRE(ret == fkyaml::detail::utf_encode_t::UTF_16BE);
         REQUIRE(std::ftell(p_file) == 2);
 
@@ -354,7 +422,7 @@ TEST_CASE("UTFEncodeDetector_DetectEncodingAndSkipBom") {
         ENABLE_C4996
 
         REQUIRE(p_file != nullptr);
-        fkyaml::detail::utf_encode_t ret = fkyaml::detail::detect_encoding_and_skip_bom(p_file);
+        fkyaml::detail::utf_encode_t ret = fkyaml::detail::file_utf_encode_detector::detect(p_file);
         REQUIRE(ret == fkyaml::detail::utf_encode_t::UTF_16LE);
         REQUIRE(std::ftell(p_file) == 0);
 
@@ -367,7 +435,7 @@ TEST_CASE("UTFEncodeDetector_DetectEncodingAndSkipBom") {
         ENABLE_C4996
 
         REQUIRE(p_file != nullptr);
-        fkyaml::detail::utf_encode_t ret = fkyaml::detail::detect_encoding_and_skip_bom(p_file);
+        fkyaml::detail::utf_encode_t ret = fkyaml::detail::file_utf_encode_detector::detect(p_file);
         REQUIRE(ret == fkyaml::detail::utf_encode_t::UTF_16LE);
         REQUIRE(std::ftell(p_file) == 2);
 
@@ -380,7 +448,7 @@ TEST_CASE("UTFEncodeDetector_DetectEncodingAndSkipBom") {
         ENABLE_C4996
 
         REQUIRE(p_file != nullptr);
-        fkyaml::detail::utf_encode_t ret = fkyaml::detail::detect_encoding_and_skip_bom(p_file);
+        fkyaml::detail::utf_encode_t ret = fkyaml::detail::file_utf_encode_detector::detect(p_file);
         REQUIRE(ret == fkyaml::detail::utf_encode_t::UTF_32BE);
         REQUIRE(std::ftell(p_file) == 0);
 
@@ -393,7 +461,7 @@ TEST_CASE("UTFEncodeDetector_DetectEncodingAndSkipBom") {
         ENABLE_C4996
 
         REQUIRE(p_file != nullptr);
-        fkyaml::detail::utf_encode_t ret = fkyaml::detail::detect_encoding_and_skip_bom(p_file);
+        fkyaml::detail::utf_encode_t ret = fkyaml::detail::file_utf_encode_detector::detect(p_file);
         REQUIRE(ret == fkyaml::detail::utf_encode_t::UTF_32BE);
         REQUIRE(std::ftell(p_file) == 4);
 
@@ -406,7 +474,7 @@ TEST_CASE("UTFEncodeDetector_DetectEncodingAndSkipBom") {
         ENABLE_C4996
 
         REQUIRE(p_file != nullptr);
-        fkyaml::detail::utf_encode_t ret = fkyaml::detail::detect_encoding_and_skip_bom(p_file);
+        fkyaml::detail::utf_encode_t ret = fkyaml::detail::file_utf_encode_detector::detect(p_file);
         REQUIRE(ret == fkyaml::detail::utf_encode_t::UTF_32LE);
         REQUIRE(std::ftell(p_file) == 0);
 
@@ -419,7 +487,7 @@ TEST_CASE("UTFEncodeDetector_DetectEncodingAndSkipBom") {
         ENABLE_C4996
 
         REQUIRE(p_file != nullptr);
-        fkyaml::detail::utf_encode_t ret = fkyaml::detail::detect_encoding_and_skip_bom(p_file);
+        fkyaml::detail::utf_encode_t ret = fkyaml::detail::file_utf_encode_detector::detect(p_file);
         REQUIRE(ret == fkyaml::detail::utf_encode_t::UTF_32LE);
         REQUIRE(std::ftell(p_file) == 4);
 
@@ -432,7 +500,7 @@ TEST_CASE("UTFEncodeDetector_DetectEncodingAndSkipBom") {
         ENABLE_C4996
 
         REQUIRE(p_file != nullptr);
-        fkyaml::detail::utf_encode_t ret = fkyaml::detail::detect_encoding_and_skip_bom(p_file);
+        fkyaml::detail::utf_encode_t ret = fkyaml::detail::file_utf_encode_detector::detect(p_file);
         REQUIRE(ret == fkyaml::detail::utf_encode_t::UTF_8);
         REQUIRE(std::ftell(p_file) == 0);
 
@@ -445,77 +513,77 @@ TEST_CASE("UTFEncodeDetector_DetectEncodingAndSkipBom") {
 
     SECTION("std::istream with UTF-8 encoding") {
         std::ifstream ifs(FK_YAML_TEST_DATA_DIR "/input_adapter_test_data_utf8n.txt");
-        fkyaml::detail::utf_encode_t ret = fkyaml::detail::detect_encoding_and_skip_bom(ifs);
+        fkyaml::detail::utf_encode_t ret = fkyaml::detail::stream_utf_encode_detector::detect(ifs);
         REQUIRE(ret == fkyaml::detail::utf_encode_t::UTF_8);
         REQUIRE(ifs.tellg() == 0);
     }
 
     SECTION("std::istream with UTF-8(BOM) encoding") {
         std::ifstream ifs(FK_YAML_TEST_DATA_DIR "/input_adapter_test_data_utf8bom.txt");
-        fkyaml::detail::utf_encode_t ret = fkyaml::detail::detect_encoding_and_skip_bom(ifs);
+        fkyaml::detail::utf_encode_t ret = fkyaml::detail::stream_utf_encode_detector::detect(ifs);
         REQUIRE(ret == fkyaml::detail::utf_encode_t::UTF_8);
         REQUIRE(ifs.tellg() == 3);
     }
 
     SECTION("std::istream with UTF-16BE encoding") {
         std::ifstream ifs(FK_YAML_TEST_DATA_DIR "/input_adapter_test_data_utf16ben.txt");
-        fkyaml::detail::utf_encode_t ret = fkyaml::detail::detect_encoding_and_skip_bom(ifs);
+        fkyaml::detail::utf_encode_t ret = fkyaml::detail::stream_utf_encode_detector::detect(ifs);
         REQUIRE(ret == fkyaml::detail::utf_encode_t::UTF_16BE);
         REQUIRE(ifs.tellg() == 0);
     }
 
     SECTION("std::istream with UTF-16BE(BOM) encoding") {
         std::ifstream ifs(FK_YAML_TEST_DATA_DIR "/input_adapter_test_data_utf16bebom.txt");
-        fkyaml::detail::utf_encode_t ret = fkyaml::detail::detect_encoding_and_skip_bom(ifs);
+        fkyaml::detail::utf_encode_t ret = fkyaml::detail::stream_utf_encode_detector::detect(ifs);
         REQUIRE(ret == fkyaml::detail::utf_encode_t::UTF_16BE);
         REQUIRE(ifs.tellg() == 2);
     }
 
     SECTION("std::istream with UTF-16LE encoding") {
         std::ifstream ifs(FK_YAML_TEST_DATA_DIR "/input_adapter_test_data_utf16len.txt");
-        fkyaml::detail::utf_encode_t ret = fkyaml::detail::detect_encoding_and_skip_bom(ifs);
+        fkyaml::detail::utf_encode_t ret = fkyaml::detail::stream_utf_encode_detector::detect(ifs);
         REQUIRE(ret == fkyaml::detail::utf_encode_t::UTF_16LE);
         REQUIRE(ifs.tellg() == 0);
     }
 
     SECTION("std::istream with UTF-16LE(BOM) encoding") {
         std::ifstream ifs(FK_YAML_TEST_DATA_DIR "/input_adapter_test_data_utf16lebom.txt");
-        fkyaml::detail::utf_encode_t ret = fkyaml::detail::detect_encoding_and_skip_bom(ifs);
+        fkyaml::detail::utf_encode_t ret = fkyaml::detail::stream_utf_encode_detector::detect(ifs);
         REQUIRE(ret == fkyaml::detail::utf_encode_t::UTF_16LE);
         REQUIRE(ifs.tellg() == 2);
     }
 
     SECTION("std::istream with UTF-32BE encoding") {
         std::ifstream ifs(FK_YAML_TEST_DATA_DIR "/input_adapter_test_data_utf32ben.txt");
-        fkyaml::detail::utf_encode_t ret = fkyaml::detail::detect_encoding_and_skip_bom(ifs);
+        fkyaml::detail::utf_encode_t ret = fkyaml::detail::stream_utf_encode_detector::detect(ifs);
         REQUIRE(ret == fkyaml::detail::utf_encode_t::UTF_32BE);
         REQUIRE(ifs.tellg() == 0);
     }
 
     SECTION("std::istream with UTF-32BE(BOM) encoding") {
         std::ifstream ifs(FK_YAML_TEST_DATA_DIR "/input_adapter_test_data_utf32bebom.txt");
-        fkyaml::detail::utf_encode_t ret = fkyaml::detail::detect_encoding_and_skip_bom(ifs);
+        fkyaml::detail::utf_encode_t ret = fkyaml::detail::stream_utf_encode_detector::detect(ifs);
         REQUIRE(ret == fkyaml::detail::utf_encode_t::UTF_32BE);
         REQUIRE(ifs.tellg() == 4);
     }
 
     SECTION("std::istream with UTF-32LE encoding") {
         std::ifstream ifs(FK_YAML_TEST_DATA_DIR "/input_adapter_test_data_utf32len.txt");
-        fkyaml::detail::utf_encode_t ret = fkyaml::detail::detect_encoding_and_skip_bom(ifs);
+        fkyaml::detail::utf_encode_t ret = fkyaml::detail::stream_utf_encode_detector::detect(ifs);
         REQUIRE(ret == fkyaml::detail::utf_encode_t::UTF_32LE);
         REQUIRE(ifs.tellg() == 0);
     }
 
     SECTION("std::istream with UTF-32LE(BOM) encoding") {
         std::ifstream ifs(FK_YAML_TEST_DATA_DIR "/input_adapter_test_data_utf32lebom.txt");
-        fkyaml::detail::utf_encode_t ret = fkyaml::detail::detect_encoding_and_skip_bom(ifs);
+        fkyaml::detail::utf_encode_t ret = fkyaml::detail::stream_utf_encode_detector::detect(ifs);
         REQUIRE(ret == fkyaml::detail::utf_encode_t::UTF_32LE);
         REQUIRE(ifs.tellg() == 4);
     }
 
     SECTION("std::istream with an empty input file") {
         std::ifstream ifs(FK_YAML_TEST_DATA_DIR "/single_char_byte_input.txt");
-        fkyaml::detail::utf_encode_t ret = fkyaml::detail::detect_encoding_and_skip_bom(ifs);
+        fkyaml::detail::utf_encode_t ret = fkyaml::detail::stream_utf_encode_detector::detect(ifs);
         REQUIRE(ret == fkyaml::detail::utf_encode_t::UTF_8);
         REQUIRE(ifs.tellg() == 0);
     }


### PR DESCRIPTION
This PR has improved implementations for UTF encoding detection by separating detector impl classes accordingly to the given char type or by reducing an unnecessary number of array element accesses during the detection.  
No changes should appear to the library users since this is just a refactoring.  

---

## Pull Request Checklist

Read the [CONTRIBUTING.md](https://github.com/fktn-k/fkYAML/blob/develop/CONTRIBUTING.md) file for detailed information.  

- [x] Changes are described in the pull request or in a referenced [issue](https://github.com/fktn-k/fkYAML/issues).
- [x] The test suite compiles and runs without any error.
- [x] [The code coverage](https://coveralls.io/github/fktn-k/fkYAML) on your branch is 100%.
- [x] The documentation is updated if you added/changed a feature.

## Please don't

- The C++11 support varies between different **compilers** and versions. Please note the [list of supported compilers](https://github.com/fktn-k/fkYAML/blob/develop/README.md#supported-compilers). Some compilers like GCC 4.7 (and earlier), Clang 3.3 (and earlier), or Microsoft Visual Studio 13.0 and earlier are known not to work due to missing or incomplete C++11 support. Please refrain from proposing changes that work around these compiler's limitations with `#ifdef`s or other means.
- Please refrain from proposing changes that would **break [YAML](https://yaml.org/) specifications**. If you propose a conformant extension of YAML to be supported by the library, please motivate this extension.
- Please do not open pull requests that address **multiple issues**.
