### PR TITLE
Fix detecting invalid contents of block scalar headers

### DIFF
--- a/include/fkYAML/detail/input/lexical_analyzer.hpp
+++ b/include/fkYAML/detail/input/lexical_analyzer.hpp
@@ -214,12 +214,14 @@ public:
         case '|': {
             chomping_indicator_t chomp_type = chomping_indicator_t::KEEP;
             uint32_t indent = 0;
+            ++m_cur_itr;
             get_block_style_metadata(chomp_type, indent);
             return scan_block_style_string_token(block_style_indicator_t::LITERAL, chomp_type, indent);
         }
         case '>': {
             chomping_indicator_t chomp_type = chomping_indicator_t::KEEP;
             uint32_t indent = 0;
+            ++m_cur_itr;
             get_block_style_metadata(chomp_type, indent);
             return scan_block_style_string_token(block_style_indicator_t::FOLDED, chomp_type, indent);
         }
@@ -1264,30 +1266,53 @@ private:
     /// @param indent A variable to store the retrieved indent size.
     void get_block_style_metadata(chomping_indicator_t& chomp_type, uint32_t& indent) {
         chomp_type = chomping_indicator_t::CLIP;
-        switch (*++m_cur_itr) {
-        case '-':
-            chomp_type = chomping_indicator_t::STRIP;
-            ++m_cur_itr;
-            break;
-        case '+':
-            chomp_type = chomping_indicator_t::KEEP;
-            ++m_cur_itr;
-            break;
-        default:
-            break;
-        }
-
-        if (*m_cur_itr == '0') {
-            emit_error("An indentation level for a block style scalar cannot be \'0\'");
-        }
-
         indent = 0;
-        if (std::isdigit(*m_cur_itr)) {
-            indent = static_cast<char>(*m_cur_itr++ - '0');
-        }
 
-        // skip characters including comments.
-        skip_until_line_end();
+        while (m_cur_itr != m_end_itr) {
+            switch (*m_cur_itr) {
+            case '-':
+                if (chomp_type != chomping_indicator_t::CLIP) {
+                    emit_error("Too many block chomping indicators specified.");
+                }
+                chomp_type = chomping_indicator_t::STRIP;
+                break;
+            case '+':
+                if (chomp_type != chomping_indicator_t::CLIP) {
+                    emit_error("Too many block chomping indicators specified.");
+                }
+                chomp_type = chomping_indicator_t::KEEP;
+                break;
+            case '0':
+                emit_error("An indentation level for a block scalar cannot be 0.");
+            case '1':
+            case '2':
+            case '3':
+            case '4':
+            case '5':
+            case '6':
+            case '7':
+            case '8':
+            case '9':
+                if (indent > 0) {
+                    emit_error("Invalid indentation level for a block scalar. It must be between 1 and 9.");
+                }
+                indent = static_cast<char>(*m_cur_itr - '0');
+                break;
+            case ' ':
+            case '\t':
+                break;
+            case '\n':
+                ++m_cur_itr;
+                return;
+            case '#':
+                skip_until_line_end();
+                return;
+            default:
+                emit_error("Invalid character found in a block scalar header.");
+            }
+
+            ++m_cur_itr;
+        }
     }
 
     /// @brief Skip white spaces (half-width spaces and tabs) from the current position.


### PR DESCRIPTION
The current library can't detect invalid contents specified in block scalar headers, like the followings:  

```yaml
foo: |10 # the indentation must be between 1 and 9.
```

```yaml
foo: >++ # too many chomping indicators
```

```yaml
foo: |invalid # neither chomping nor indentation indicators must be a comment.
```

So, this PR has fixed the implementation for parsing block scalar headers and also added some relevant test cases.  

---

## Pull Request Checklist

Read the [CONTRIBUTING.md](https://github.com/fktn-k/fkYAML/blob/develop/CONTRIBUTING.md) file for detailed information.  

- [x] Changes are described in the pull request or in a referenced [issue](https://github.com/fktn-k/fkYAML/issues).
- [x] The test suite compiles and runs without any error.
- [x] [The code coverage](https://coveralls.io/github/fktn-k/fkYAML) on your branch is 100%.
- [x] The documentation is updated if you added/changed a feature.

## Please don't

- The C++11 support varies between different **compilers** and versions. Please note the [list of supported compilers](https://github.com/fktn-k/fkYAML/blob/develop/README.md#supported-compilers). Some compilers like GCC 4.7 (and earlier), Clang 3.3 (and earlier), or Microsoft Visual Studio 13.0 and earlier are known not to work due to missing or incomplete C++11 support. Please refrain from proposing changes that work around these compiler's limitations with `#ifdef`s or other means.
- Please refrain from proposing changes that would **break [YAML](https://yaml.org/) specifications**. If you propose a conformant extension of YAML to be supported by the library, please motivate this extension.
- Please do not open pull requests that address **multiple issues**.
