### PR TITLE
Refactor lexical analysis

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -173,15 +173,21 @@ html-coverage: lcov-coverage
 #   Benchmark   #
 #################
 
-bm-debug:
+build-bm-debug:
 	cmake -B build_bm_debug -S . -DCMAKE_BUILD_TYPE=Debug -DFK_YAML_RUN_BENCHMARK=ON
 	cmake --build build_bm_debug --config Debug
-	./build_bm_debug/tool/benchmark/benchmarker ./tool/benchmark/macos.yml > ./tool/benchmark/result_debug.log
 
-bm-release:
+bm-debug: build-bm-debug
+	cmake -B build_bm_debug -S . -DCMAKE_BUILD_TYPE=Debug -DFK_YAML_RUN_BENCHMARK=ON
+	cmake --build build_bm_debug --config Debug
+	./build_bm_debug/tool/benchmark/benchmarker ./tool/benchmark/macos.yml
+
+build-bm-release:
 	cmake -B build_bm_release -S . -DCMAKE_BUILD_TYPE=Release -DFK_YAML_RUN_BENCHMARK=ON
 	cmake --build build_bm_release --config Release
-	./build_bm_release/tool/benchmark/benchmarker ./tool/benchmark/macos.yml > ./tool/benchmark/result_release.log
+
+bm-release: build-bm-release
+	./build_bm_release/tool/benchmark/benchmarker ./tool/benchmark/macos.yml
 
 ###################
 #   Maintenance   #

--- a/include/fkYAML/detail/input/deserializer.hpp
+++ b/include/fkYAML/detail/input/deserializer.hpp
@@ -1118,8 +1118,9 @@ private:
         case node_type::BOOLEAN:
             node = basic_node_type(from_string(token_str, type_tag<boolean_type> {}));
             break;
-        case node_type::INTEGER:
-            if (token_str.size() > 2 && token_str.rfind("0o", 0) != std::string::npos) {
+        case node_type::INTEGER: {
+            bool is_octal = (token_str.size() > 2) && (token_str.rfind("0o", 0) != std::string::npos);
+            if (is_octal) {
                 // Replace the prefix "0o" with "0" so STL functions can convert octal chars to an integer.
                 // Note that the YAML specifies octal values start with the prefix "0o", not "0".
                 // See https://yaml.org/spec/1.2.2/#1032-tag-resolution for more details.
@@ -1129,6 +1130,7 @@ private:
                 node = basic_node_type(from_string(token_str, type_tag<integer_type> {}));
             }
             break;
+        }
         case node_type::FLOAT:
             node = basic_node_type(from_string(token_str, type_tag<float_number_type> {}));
             break;

--- a/include/fkYAML/detail/input/input_adapter.hpp
+++ b/include/fkYAML/detail/input/input_adapter.hpp
@@ -126,6 +126,8 @@ private:
             }
         }
 
+        buffer.reserve(std::distance(m_current, m_end));
+
         do {
             IterType cr_or_end_itr = std::find(m_current, m_end, '\r');
             buffer.append(m_current, cr_or_end_itr);

--- a/include/fkYAML/detail/input/lexical_analyzer.hpp
+++ b/include/fkYAML/detail/input/lexical_analyzer.hpp
@@ -188,7 +188,8 @@ public:
 
             bool is_available = (std::distance(m_cur_itr, m_end_itr) > 2);
             if (is_available) {
-                if (std::equal(m_token_begin_itr, m_cur_itr + 3, "---")) {
+                bool is_dir_end = std::equal(m_token_begin_itr, m_cur_itr + 3, "---");
+                if (is_dir_end) {
                     m_cur_itr += 3;
                     token.type = lexical_token_t::END_OF_DIRECTIVES;
                     return token;
@@ -232,7 +233,8 @@ public:
         case '.': {
             bool is_available = (std::distance(m_cur_itr, m_end_itr) > 2);
             if (is_available) {
-                if (std::equal(m_cur_itr, m_cur_itr + 3, "...")) {
+                bool is_doc_end = std::equal(m_cur_itr, m_cur_itr + 3, "...");
+                if (is_doc_end) {
                     m_cur_itr += 3;
                     token.type = lexical_token_t::END_OF_DOCUMENT;
                     return token;
@@ -1035,9 +1037,6 @@ private:
             emit_error("Invalid end of input buffer in a single-quoted string token.");
         }
 
-        if (is_value_buffer_used) {
-            m_value_buffer.append(m_token_begin_itr, m_cur_itr);
-        }
         return is_value_buffer_used;
     }
 

--- a/include/fkYAML/detail/input/lexical_analyzer.hpp
+++ b/include/fkYAML/detail/input/lexical_analyzer.hpp
@@ -90,7 +90,9 @@ public:
             return {};
         }
 
-        lexical_token token {lexical_token_t::PLAIN_SCALAR, m_cur_itr, m_end_itr};
+        lexical_token token {};
+        token.type = lexical_token_t::PLAIN_SCALAR;
+        token.token_begin_itr = m_cur_itr;
 
         switch (char current = *m_cur_itr) {
         case '?':
@@ -1127,12 +1129,12 @@ private:
                             break;
                         }
 
-                        char current = *m_cur_itr;
-                        if (current == ' ') {
+                        char c = *m_cur_itr;
+                        if (c == ' ') {
                             continue;
                         }
 
-                        if (current == '\n') {
+                        if (c == '\n') {
                             is_next_empty = true;
                             break;
                         }

--- a/include/fkYAML/detail/input/lexical_analyzer.hpp
+++ b/include/fkYAML/detail/input/lexical_analyzer.hpp
@@ -95,7 +95,7 @@ public:
         switch (char current = *m_cur_itr) {
         case '?':
             if (++m_cur_itr == m_end_itr) {
-                token.token_end_itr == m_end_itr;
+                token.token_end_itr = m_end_itr;
                 return token;
             }
 
@@ -662,20 +662,30 @@ private:
             }
         }
 
-        extract_string_token(needs_last_single_quote, needs_last_double_quote);
+        bool is_value_buff_used = extract_string_token(needs_last_single_quote, needs_last_double_quote);
 
-        token.token_begin_itr = m_value_buffer.cbegin();
-        token.token_end_itr = m_value_buffer.cend();
+        if (is_value_buff_used) {
+            token.token_begin_itr = m_value_buffer.cbegin();
+            token.token_end_itr = m_value_buffer.cend();
+        }
+        else {
+            token.token_end_itr = m_cur_itr;
+            if (token.type != lexical_token_t::PLAIN_SCALAR) {
+                // If extract_string_token() didn't use m_value_buffer to store mutated scalar value, m_cur_itr is at
+                // the last quotation mark, which will cause infinite loops from the next get_next_token() call.
+                ++m_cur_itr;
+            }
+        }
     }
 
     /// @brief Check if the given character is allowed in a single-quoted scalar token.
     /// @param c The character to be checked.
     /// @return true if the given character is allowed, false otherwise.
-    bool is_allowed_single(char c) {
-        bool ret = false;
-
+    bool is_allowed_single(char c, bool& is_value_buffer_used) {
         switch (c) {
         case '\n': {
+            is_value_buffer_used = true;
+
             // discard trailing white spaces which preceeds the line break in the current line.
             auto before_trailing_spaces_itr = m_cur_itr - 1;
             bool ends_loop = false;
@@ -713,41 +723,46 @@ private:
             }
 
             m_token_begin_itr = (m_cur_itr == m_end_itr || *m_cur_itr == '\'') ? m_cur_itr-- : m_cur_itr;
-            ret = true;
-            break;
+            return true;
         }
 
         case '\'':
-            // If single quotation marks are repeated twice in a single-quoted string token,
-            // they are considered as an escaped single quotation mark.
             if (m_cur_itr + 1 == m_end_itr) {
-                m_value_buffer.append(m_token_begin_itr, m_cur_itr++);
-                m_token_begin_itr = m_cur_itr;
-                break;
+                if (is_value_buffer_used) {
+                    m_value_buffer.append(m_token_begin_itr, m_cur_itr++);
+                    m_token_begin_itr = m_cur_itr;
+                }
+                return false;
             }
 
             if (*(m_cur_itr + 1) != '\'') {
-                m_value_buffer.append(m_token_begin_itr, m_cur_itr++);
-                break;
+                if (is_value_buffer_used) {
+                    m_value_buffer.append(m_token_begin_itr, m_cur_itr++);
+                }
+                return false;
             }
+
+            // If single quotation marks are repeated twice in a single-quoted string token,
+            // they are considered as an escaped single quotation mark.
+            is_value_buffer_used = true;
 
             m_value_buffer.append(m_token_begin_itr, ++m_cur_itr);
             m_token_begin_itr = m_cur_itr + 1;
-            ret = true;
-            break;
-        }
+            return true;
 
-        return ret;
+        default:         // LCOV_EXCL_LINE
+            return true; // LCOV_EXCL_LINE
+        }
     }
 
     /// @brief Check if the given character is allowed in a double-quoted scalar token.
     /// @param c The character to be checked.
     /// @return true if the given character is allowed, false otherwise.
-    bool is_allowed_double(char c) {
-        bool ret = false;
-
+    bool is_allowed_double(char c, bool& is_value_buffer_used) {
         switch (c) {
         case '\n': {
+            is_value_buffer_used = true;
+
             // discard trailing white spaces which preceeds the line break in the current line.
             auto before_trailing_spaces_itr = m_cur_itr - 1;
             bool ends_loop = false;
@@ -785,15 +800,18 @@ private:
             }
 
             m_token_begin_itr = (m_cur_itr == m_end_itr || *m_cur_itr == '\"') ? m_cur_itr-- : m_cur_itr;
-            ret = true;
-            break;
+            return true;
         }
 
         case '\"':
-            m_value_buffer.append(m_token_begin_itr, m_cur_itr++);
-            break;
+            if (is_value_buffer_used) {
+                m_value_buffer.append(m_token_begin_itr, m_cur_itr++);
+            }
+            return false;
 
         case '\\':
+            is_value_buffer_used = true;
+
             m_value_buffer.append(m_token_begin_itr, m_cur_itr);
 
             // Handle escaped characters.
@@ -807,8 +825,7 @@ private:
                 }
 
                 m_token_begin_itr = m_cur_itr + 1;
-                ret = true;
-                break;
+                return true;
             }
 
             // move until the next non-space character is found.
@@ -816,29 +833,25 @@ private:
             skip_white_spaces();
 
             m_token_begin_itr = (m_cur_itr == m_end_itr || *m_cur_itr == '\"') ? m_cur_itr-- : m_cur_itr;
-            ret = true;
-            break;
-        }
+            return true;
 
-        return ret;
+        default:         // LCOV_EXCL_LINE
+            return true; // LCOV_EXCL_LINE
+        }
     }
 
     /// @brief Check if the given character is allowed in a plain scalar token.
     /// @param c The character to be checked.
     /// @return true if the given character is allowed, false otherwise.
-    bool is_allowed_plain(char c) {
-        bool ret = false;
-
+    bool is_allowed_plain(char c, bool& /*unused*/) {
         switch (c) {
         case '\n':
-            m_value_buffer.append(m_token_begin_itr, m_cur_itr);
-            break;
+            return false;
 
         case ' ': {
             // Allow a space in an unquoted string only if the space is surrounded by non-space characters.
             // See https://yaml.org/spec/1.2.2/#733-plain-style for more details.
             char next = *(m_cur_itr + 1);
-            bool is_appended = false;
 
             // These characters are permitted when not inside a flow collection, and not inside an implicit key.
             // TODO: Support detection of implicit key context for this check.
@@ -849,13 +862,7 @@ private:
                 case '[':
                 case ']':
                 case ',':
-                    m_value_buffer.append(m_token_begin_itr, m_cur_itr++);
-                    is_appended = true;
-                    break;
-                }
-
-                if (is_appended) {
-                    break;
+                    return false;
                 }
             }
 
@@ -863,12 +870,7 @@ private:
             if (next == ':') {
                 char peeked = *(m_cur_itr + 2);
                 if (peeked == ' ') {
-                    m_value_buffer.append(m_token_begin_itr, m_cur_itr++);
-                    is_appended = true;
-                }
-
-                if (is_appended) {
-                    break;
+                    return false;
                 }
             }
 
@@ -877,13 +879,10 @@ private:
             case '\n':
             case '#':
             case '\\':
-                m_value_buffer.append(m_token_begin_itr, m_cur_itr++);
-                is_appended = true;
-                break;
+                return false;
             }
 
-            ret = !is_appended;
-            break;
+            return true;
         }
 
         case ':': {
@@ -896,13 +895,9 @@ private:
             case ' ':
             case '\t':
             case '\n':
-                m_value_buffer.append(m_token_begin_itr, m_cur_itr);
-                break;
-            default:
-                ret = true;
-                break;
+                return false;
             }
-            break;
+            return true;
         }
 
         case '{':
@@ -912,26 +907,25 @@ private:
         case ',':
             // just regard the flow indicators as a normal character if plain but not inside a flow context.
             if (m_flow_context_depth == 0) {
-                ret = true;
-                break;
+                return true;
             }
 
-            m_value_buffer.append(m_token_begin_itr, m_cur_itr);
-            break;
-        }
+            return false;
 
-        return ret;
+        default:         // LCOV_EXCL_LINE
+            return true; // LCOV_EXCL_LINE
+        }
     }
 
     /// @brief Extracts a string token, either plain, single-quoted or double-quoted, from the input buffer.
-    void extract_string_token(bool needs_last_single_quote, bool needs_last_double_quote) {
+    bool extract_string_token(bool needs_last_single_quote, bool needs_last_double_quote) {
         // change behaviors depending on the type of a comming string scalar token.
         // * single quoted
         // * double quoted
         // * plain
 
         std::string check_filters {"\n"};
-        bool (lexical_analyzer::*pfn_is_allowed)(char) = nullptr;
+        bool (lexical_analyzer::*pfn_is_allowed)(char, bool&) = nullptr;
 
         if (needs_last_single_quote) {
             check_filters.append("\'");
@@ -943,21 +937,25 @@ private:
         }
         else // plain scalars
         {
-            check_filters.append(" :{}[],");
+            check_filters.append(" :");
+            if (m_flow_context_depth > 0) {
+                check_filters.append("{}[],");
+            }
             pfn_is_allowed = &lexical_analyzer::is_allowed_plain;
         }
 
         // scan the contents of a string scalar token.
 
+        bool is_value_buffer_used = false;
         for (; m_cur_itr != m_end_itr; m_cur_itr = (m_cur_itr == m_end_itr) ? m_cur_itr : ++m_cur_itr) {
             char current = *m_cur_itr;
             uint32_t num_bytes = utf8::get_num_bytes(static_cast<uint8_t>(current));
             if (num_bytes == 1) {
                 auto ret = check_filters.find(current);
                 if (ret != std::string::npos) {
-                    bool is_allowed = (this->*pfn_is_allowed)(current);
+                    bool is_allowed = (this->*pfn_is_allowed)(current, is_value_buffer_used);
                     if (!is_allowed) {
-                        return;
+                        return is_value_buffer_used;
                     }
 
                     continue;
@@ -987,7 +985,10 @@ private:
             emit_error("Invalid end of input buffer in a single-quoted string token.");
         }
 
-        m_value_buffer.append(m_token_begin_itr, m_cur_itr);
+        if (is_value_buffer_used) {
+            m_value_buffer.append(m_token_begin_itr, m_cur_itr);
+        }
+        return is_value_buffer_used;
     }
 
     /// @brief Scan a block style string token either in the literal or folded style.

--- a/include/fkYAML/detail/input/position_tracker.hpp
+++ b/include/fkYAML/detail/input/position_tracker.hpp
@@ -34,12 +34,18 @@ public:
     /// @note This function doesn't support cases where cur_pos has moved backward from the last call.
     /// @param cur_pos The iterator to the current element of the buffer.
     void update_position(std::string::const_iterator cur_pos) {
-        m_cur_pos = static_cast<uint32_t>(std::distance(m_begin, cur_pos));
+        uint32_t diff = static_cast<uint32_t>(std::distance(m_last, cur_pos));
+        if (diff == 0) {
+            return;
+        }
+
+        m_cur_pos += diff;
+        uint32_t prev_lines_read = m_lines_read;
         m_lines_read += static_cast<uint32_t>(std::count(m_last, cur_pos, '\n'));
         m_last = cur_pos;
 
-        if (m_lines_read == 0) {
-            m_cur_pos_in_line = m_cur_pos;
+        if (prev_lines_read == m_lines_read) {
+            m_cur_pos_in_line += diff;
             return;
         }
 

--- a/include/fkYAML/detail/output/serializer.hpp
+++ b/include/fkYAML/detail/output/serializer.hpp
@@ -246,9 +246,9 @@ private:
 
             auto adapter = input_adapter(str_val);
             lexical_analyzer<BasicNodeType> lexer(std::move(adapter));
-            lexical_token_t token_type = lexer.get_next_token();
+            lexical_token token = lexer.get_next_token();
 
-            if (token_type != lexical_token_t::STRING_VALUE) {
+            if (token.type != lexical_token_t::STRING_VALUE) {
                 // Surround a string value with double quotes to keep semantic equality.
                 // Without them, serialized values will become non-string. (e.g., "1" -> 1)
                 str += '\"';

--- a/include/fkYAML/detail/output/serializer.hpp
+++ b/include/fkYAML/detail/output/serializer.hpp
@@ -18,8 +18,7 @@
 #include <fkYAML/detail/macros/version_macros.hpp>
 #include <fkYAML/detail/conversions/to_string.hpp>
 #include <fkYAML/detail/encodings/yaml_escaper.hpp>
-#include <fkYAML/detail/input/input_adapter.hpp>
-#include <fkYAML/detail/input/lexical_analyzer.hpp>
+#include <fkYAML/detail/input/scalar_scanner.hpp>
 #include <fkYAML/detail/meta/node_traits.hpp>
 #include <fkYAML/exception.hpp>
 #include <fkYAML/node_type.hpp>
@@ -244,11 +243,7 @@ private:
                 break;
             }
 
-            auto adapter = input_adapter(str_val);
-            lexical_analyzer<BasicNodeType> lexer(std::move(adapter));
-            lexical_token token = lexer.get_next_token();
-
-            if (token.type != lexical_token_t::STRING_VALUE) {
+            if (scalar_scanner::scan(str_val) != node_type::STRING) {
                 // Surround a string value with double quotes to keep semantic equality.
                 // Without them, serialized values will become non-string. (e.g., "1" -> 1)
                 str += '\"';

--- a/include/fkYAML/detail/output/serializer.hpp
+++ b/include/fkYAML/detail/output/serializer.hpp
@@ -243,7 +243,8 @@ private:
                 break;
             }
 
-            if (scalar_scanner::scan(str_val) != node_type::STRING) {
+            node_type type_if_plain = scalar_scanner::scan(str_val); // LCOV_EXCL_LINE
+            if (type_if_plain != node_type::STRING) {
                 // Surround a string value with double quotes to keep semantic equality.
                 // Without them, serialized values will become non-string. (e.g., "1" -> 1)
                 str += '\"';

--- a/include/fkYAML/detail/types/lexical_token_t.hpp
+++ b/include/fkYAML/detail/types/lexical_token_t.hpp
@@ -32,11 +32,10 @@ enum class lexical_token_t {
     SEQUENCE_FLOW_END,     //!< the character for sequence flow end `]`
     MAPPING_FLOW_BEGIN,    //!< the character for mapping begin `{`
     MAPPING_FLOW_END,      //!< the character for mapping end `}`
-    NULL_VALUE,            //!< a null value found. use get_null() to get a value.
-    BOOLEAN_VALUE,         //!< a boolean value found. use get_boolean() to get a value.
-    INTEGER_VALUE,         //!< an integer value found. use get_integer() to get a value.
-    FLOAT_NUMBER_VALUE,    //!< a float number value found. use get_float_number() to get a value.
-    STRING_VALUE,          //!< the character for string begin `"` or any character except the above ones
+    PLAIN_SCALAR,          //!< plain (unquoted) scalars
+    SINGLE_QUOTED_SCALAR,  //!< single-quoted scalars
+    DOUBLE_QUOTED_SCALAR,  //!< double-quoted scalars
+    BLOCK_SCALAR,          //!< block style scalars
     END_OF_DIRECTIVES,     //!< the end of declaration of directives specified by `---`.
     END_OF_DOCUMENT,       //!< the end of a YAML document specified by `...`.
 };

--- a/single_include/fkYAML/node.hpp
+++ b/single_include/fkYAML/node.hpp
@@ -2944,7 +2944,9 @@ public:
             return {};
         }
 
-        lexical_token token {lexical_token_t::PLAIN_SCALAR, m_cur_itr, m_end_itr};
+        lexical_token token {};
+        token.type = lexical_token_t::PLAIN_SCALAR;
+        token.token_begin_itr = m_cur_itr;
 
         switch (char current = *m_cur_itr) {
         case '?':
@@ -3981,12 +3983,12 @@ private:
                             break;
                         }
 
-                        char current = *m_cur_itr;
-                        if (current == ' ') {
+                        char c = *m_cur_itr;
+                        if (c == ' ') {
                             continue;
                         }
 
-                        if (current == '\n') {
+                        if (c == '\n') {
                             is_next_empty = true;
                             break;
                         }

--- a/single_include/fkYAML/node.hpp
+++ b/single_include/fkYAML/node.hpp
@@ -2930,8 +2930,8 @@ public:
         m_pos_tracker.set_target_buffer(m_input_buffer);
     }
 
-    /// @brief Get the next lexical token type by scanning the left of the input buffer.
-    /// @return lexical_token_t The next lexical token type.
+    /// @brief Get the next lexical token by scanning the left of the input buffer.
+    /// @return lexical_token The next lexical token.
     lexical_token get_next_token() {
         skip_white_spaces_and_newline_codes();
 
@@ -3699,10 +3699,59 @@ private:
         }
     }
 
-    /// @brief Check if the given character is allowed in a plain scalar token.
+    /// @brief Check if the given character is allowed in a plain scalar token outside a flow context.
     /// @param c The character to be checked.
     /// @return true if the given character is allowed, false otherwise.
     bool is_allowed_plain(char c, bool& /*unused*/) {
+        switch (c) {
+        case '\n':
+            return false;
+
+        case ' ': {
+            // Allow a space in a plain scalar only if the space is surrounded by non-space characters.
+            // See https://yaml.org/spec/1.2.2/#733-plain-style for more details.
+
+            switch (*(m_cur_itr + 1)) {
+            case ':': {
+                // " :" is permitted in a plain style string token, but not when followed by a space.
+                char peeked = *(m_cur_itr + 2);
+                if (peeked == ' ') {
+                    return false;
+                }
+                return true;
+            }
+            case ' ':
+            case '\n':
+            case '#':
+            case '\\':
+                return false;
+            }
+
+            return true;
+        }
+
+        case ':': {
+            // A colon as a key separator must be followed by
+            // * a white space or
+            // * a newline code.
+            switch (*(m_cur_itr + 1)) {
+            case ' ':
+            case '\t':
+            case '\n':
+                return false;
+            }
+            return true;
+        }
+
+        default:         // LCOV_EXCL_LINE
+            return true; // LCOV_EXCL_LINE
+        }
+    }
+
+    /// @brief Check if the given character is allowed in a plain scalar token inside a flow context.
+    /// @param c The character to be checked.
+    /// @return true if the given character is allowed, false otherwise.
+    bool is_allowed_plain_flow(char c, bool& /*unused*/) {
         switch (c) {
         case '\n':
             return false;
@@ -3714,15 +3763,13 @@ private:
 
             // These characters are permitted when not inside a flow collection, and not inside an implicit key.
             // TODO: Support detection of implicit key context for this check.
-            if (m_flow_context_depth > 0) {
-                switch (next) {
-                case '{':
-                case '}':
-                case '[':
-                case ']':
-                case ',':
-                    return false;
-                }
+            switch (next) {
+            case '{':
+            case '}':
+            case '[':
+            case ']':
+            case ',':
+                return false;
             }
 
             // " :" is permitted in a plain style string token, but not when followed by a space.
@@ -3764,11 +3811,6 @@ private:
         case '[':
         case ']':
         case ',':
-            // just regard the flow indicators as a normal character if plain but not inside a flow context.
-            if (m_flow_context_depth == 0) {
-                return true;
-            }
-
             return false;
 
         default:         // LCOV_EXCL_LINE
@@ -3795,13 +3837,15 @@ private:
             check_filters.append("\"\\");
             pfn_is_allowed = &lexical_analyzer::is_allowed_double;
         }
-        else // plain scalars
-        {
+        else if (m_flow_context_depth == 0) {
+            // plain scalar outside flow contexts
             check_filters.append(" :");
-            if (m_flow_context_depth > 0) {
-                check_filters.append("{}[],");
-            }
             pfn_is_allowed = &lexical_analyzer::is_allowed_plain;
+        }
+        else {
+            // plain scalar inside flow contexts
+            check_filters.append(" :{}[],");
+            pfn_is_allowed = &lexical_analyzer::is_allowed_plain_flow;
         }
 
         // scan the contents of a string scalar token.
@@ -6393,6 +6437,8 @@ private:
                 break;
             }
         }
+
+        buffer.reserve(std::distance(m_current, m_end));
 
         do {
             IterType cr_or_end_itr = std::find(m_current, m_end, '\r');

--- a/single_include/fkYAML/node.hpp
+++ b/single_include/fkYAML/node.hpp
@@ -2770,12 +2770,18 @@ public:
     /// @note This function doesn't support cases where cur_pos has moved backward from the last call.
     /// @param cur_pos The iterator to the current element of the buffer.
     void update_position(std::string::const_iterator cur_pos) {
-        m_cur_pos = static_cast<uint32_t>(std::distance(m_begin, cur_pos));
+        uint32_t diff = static_cast<uint32_t>(std::distance(m_last, cur_pos));
+        if (diff == 0) {
+            return;
+        }
+
+        m_cur_pos += diff;
+        uint32_t prev_lines_read = m_lines_read;
         m_lines_read += static_cast<uint32_t>(std::count(m_last, cur_pos, '\n'));
         m_last = cur_pos;
 
-        if (m_lines_read == 0) {
-            m_cur_pos_in_line = m_cur_pos;
+        if (prev_lines_read == m_lines_read) {
+            m_cur_pos_in_line += diff;
             return;
         }
 
@@ -3348,7 +3354,8 @@ private:
         return lexical_token_t::YAML_VER_DIRECTIVE;
     }
 
-    /// @brief Extracts an anchor name from the input and assigns the result to `m_value_buffer`.
+    /// @brief Extracts an anchor name from the input.
+    /// @param token The token into which the extraction result is written.
     void extract_anchor_name(lexical_token& token) {
         FK_YAML_ASSERT(*m_cur_itr == '&' || *m_cur_itr == '*');
 
@@ -3382,7 +3389,8 @@ private:
         token.token_end_itr = m_cur_itr;
     }
 
-    /// @brief Extracts a tag name from the input and assigns the result to `m_value_buffer`.
+    /// @brief Extracts a tag name from the input.
+    /// @param token The token into which the extraction result is written.
     void extract_tag_name(lexical_token& token) {
         m_value_buffer.clear();
 
@@ -3489,7 +3497,8 @@ private:
         }
     }
 
-    /// @brief Scan a string token, either plain, single-quoted or double-quoted.
+    /// @brief Scan a scalar token, either plain, single-quoted or double-quoted.
+    /// @param token The token into which the scan result is written.
     /// @return lexical_token_t The lexical token type for strings.
     void scan_scalar(lexical_token& token) {
         m_value_buffer.clear();
@@ -3528,6 +3537,7 @@ private:
 
     /// @brief Check if the given character is allowed in a single-quoted scalar token.
     /// @param c The character to be checked.
+    /// @param is_value_buffer_used true is assigned when mutated scalar contents is written into m_value_buffer.
     /// @return true if the given character is allowed, false otherwise.
     bool is_allowed_single(char c, bool& is_value_buffer_used) {
         switch (c) {
@@ -3605,6 +3615,7 @@ private:
 
     /// @brief Check if the given character is allowed in a double-quoted scalar token.
     /// @param c The character to be checked.
+    /// @param is_value_buffer_used true is assigned when mutated scalar contents is written into m_value_buffer.
     /// @return true if the given character is allowed, false otherwise.
     bool is_allowed_double(char c, bool& is_value_buffer_used) {
         switch (c) {
@@ -3766,6 +3777,7 @@ private:
     }
 
     /// @brief Extracts a string token, either plain, single-quoted or double-quoted, from the input buffer.
+    /// @return true if mutated scalar contents is stored in m_value_buffer, false otherwise.
     bool extract_string_token(bool needs_last_single_quote, bool needs_last_double_quote) {
         // change behaviors depending on the type of a comming string scalar token.
         // * single quoted
@@ -3890,13 +3902,13 @@ private:
             }
 
             uint32_t diff = cur_indent - indent;
-            // m_value_buffer.append(diff, ' ');
             m_token_begin_itr -= diff;
-            chars_in_line += diff;
+            chars_in_line = diff;
         }
 
         for (; m_cur_itr != m_end_itr; ++m_cur_itr) {
-            if (*m_cur_itr == '\n') {
+            char current = *m_cur_itr;
+            if (current == '\n') {
                 if (style == block_style_indicator_t::LITERAL) {
                     if (chars_in_line == 0) {
                         m_value_buffer.push_back('\n');
@@ -3951,8 +3963,6 @@ private:
                         chars_in_line = 0;
                         continue;
                     }
-                    else {
-                    }
 
                     switch (char next = *(m_cur_itr + 1)) {
                     case '\n':
@@ -3981,7 +3991,7 @@ private:
                 m_pos_tracker.update_position(m_cur_itr);
                 cur_indent = m_pos_tracker.get_cur_pos_in_line();
                 if (cur_indent < indent) {
-                    if (*m_cur_itr != ' ') {
+                    if (current != ' ') {
                         // Interpret less indented non-space characters as the start of the next token.
                         break;
                     }
@@ -3989,7 +3999,7 @@ private:
                     continue;
                 }
 
-                if (*m_cur_itr == ' ' && style == block_style_indicator_t::FOLDED) {
+                if (current == ' ' && style == block_style_indicator_t::FOLDED) {
                     // A line being more indented is not folded.
                     m_value_buffer.push_back('\n');
                     is_extra_indented = true;
@@ -3997,7 +4007,6 @@ private:
                 m_token_begin_itr = m_cur_itr;
             }
 
-            // m_value_buffer.push_back(current);
             ++chars_in_line;
         }
 
@@ -4023,13 +4032,15 @@ private:
                 // No need to chomp the trailing newlines.
                 break;
             }
-            while (m_value_buffer.size() > 1) {
+            uint32_t buf_size = static_cast<uint32_t>(m_value_buffer.size());
+            while (buf_size > 1) {
                 // Strings with only newlines are handled above, so no check for the case.
-                char second_last = *(m_value_buffer.end() - 2);
+                char second_last = m_value_buffer[buf_size - 2];
                 if (second_last != '\n') {
                     break;
                 }
                 m_value_buffer.pop_back();
+                --buf_size;
             }
             break;
         }

--- a/test/unit_test/test_lexical_analyzer_class.cpp
+++ b/test/unit_test/test_lexical_analyzer_class.cpp
@@ -13,7 +13,7 @@
 using lexer_t = fkyaml::detail::lexical_analyzer<fkyaml::node>;
 
 TEST_CASE("LexicalAnalyzer_YamlVersionDirective") {
-    fkyaml::detail::lexical_token_t token;
+    fkyaml::detail::lexical_token token;
 
     SECTION("valid YAML directive") {
         using value_pair_t = std::pair<std::string, std::string>;
@@ -30,11 +30,11 @@ TEST_CASE("LexicalAnalyzer_YamlVersionDirective") {
         lexer_t lexer(fkyaml::detail::input_adapter(value_pair.first));
 
         REQUIRE_NOTHROW(token = lexer.get_next_token());
-        REQUIRE(token == fkyaml::detail::lexical_token_t::YAML_VER_DIRECTIVE);
+        REQUIRE(token.type == fkyaml::detail::lexical_token_t::YAML_VER_DIRECTIVE);
         REQUIRE(lexer.get_yaml_version() == value_pair.second);
 
         REQUIRE_NOTHROW(token = lexer.get_next_token());
-        REQUIRE(token == fkyaml::detail::lexical_token_t::END_OF_BUFFER);
+        REQUIRE(token.type == fkyaml::detail::lexical_token_t::END_OF_BUFFER);
     }
 
     SECTION("wrong YAML directive") {
@@ -42,10 +42,10 @@ TEST_CASE("LexicalAnalyzer_YamlVersionDirective") {
 
         lexer_t lexer(fkyaml::detail::input_adapter(buffer));
         REQUIRE_NOTHROW(token = lexer.get_next_token());
-        REQUIRE(token == fkyaml::detail::lexical_token_t::INVALID_DIRECTIVE);
+        REQUIRE(token.type == fkyaml::detail::lexical_token_t::INVALID_DIRECTIVE);
 
         REQUIRE_NOTHROW(token = lexer.get_next_token());
-        REQUIRE(token == fkyaml::detail::lexical_token_t::END_OF_BUFFER);
+        REQUIRE(token.type == fkyaml::detail::lexical_token_t::END_OF_BUFFER);
     }
 
     SECTION("invalid YAML directive value") {
@@ -65,18 +65,18 @@ TEST_CASE("LexicalAnalyzer_YamlVersionDirective") {
 }
 
 TEST_CASE("LexicalAnalyzer_TagDirective") {
-    fkyaml::detail::lexical_token_t token;
+    fkyaml::detail::lexical_token token;
 
     SECTION("primary tag handle") {
         auto input = GENERATE(std::string("%TAG ! foo"), std::string("%TAG\t!\tfoo"));
         lexer_t lexer(fkyaml::detail::input_adapter(input));
 
         REQUIRE_NOTHROW(token = lexer.get_next_token());
-        REQUIRE(token == fkyaml::detail::lexical_token_t::TAG_DIRECTIVE);
+        REQUIRE(token.type == fkyaml::detail::lexical_token_t::TAG_DIRECTIVE);
         REQUIRE(lexer.get_tag_handle() == "!");
         REQUIRE(lexer.get_tag_prefix() == "foo");
         REQUIRE_NOTHROW(token = lexer.get_next_token());
-        REQUIRE(token == fkyaml::detail::lexical_token_t::END_OF_BUFFER);
+        REQUIRE(token.type == fkyaml::detail::lexical_token_t::END_OF_BUFFER);
     }
 
     SECTION("secondary tag handle") {
@@ -84,11 +84,11 @@ TEST_CASE("LexicalAnalyzer_TagDirective") {
         lexer_t lexer(fkyaml::detail::input_adapter(input));
 
         REQUIRE_NOTHROW(token = lexer.get_next_token());
-        REQUIRE(token == fkyaml::detail::lexical_token_t::TAG_DIRECTIVE);
+        REQUIRE(token.type == fkyaml::detail::lexical_token_t::TAG_DIRECTIVE);
         REQUIRE(lexer.get_tag_handle() == "!!");
         REQUIRE(lexer.get_tag_prefix() == "foo");
         REQUIRE_NOTHROW(token = lexer.get_next_token());
-        REQUIRE(token == fkyaml::detail::lexical_token_t::END_OF_BUFFER);
+        REQUIRE(token.type == fkyaml::detail::lexical_token_t::END_OF_BUFFER);
     }
 
     SECTION("named tag handle") {
@@ -96,11 +96,11 @@ TEST_CASE("LexicalAnalyzer_TagDirective") {
         lexer_t lexer(fkyaml::detail::input_adapter(input));
 
         REQUIRE_NOTHROW(token = lexer.get_next_token());
-        REQUIRE(token == fkyaml::detail::lexical_token_t::TAG_DIRECTIVE);
+        REQUIRE(token.type == fkyaml::detail::lexical_token_t::TAG_DIRECTIVE);
         REQUIRE(lexer.get_tag_handle() == "!va1id-ta9!");
         REQUIRE(lexer.get_tag_prefix() == "foo");
         REQUIRE_NOTHROW(token = lexer.get_next_token());
-        REQUIRE(token == fkyaml::detail::lexical_token_t::END_OF_BUFFER);
+        REQUIRE(token.type == fkyaml::detail::lexical_token_t::END_OF_BUFFER);
     }
 
     SECTION("invalid TAG directive") {
@@ -108,9 +108,9 @@ TEST_CASE("LexicalAnalyzer_TagDirective") {
 
         lexer_t lexer(fkyaml::detail::input_adapter(buffer));
         REQUIRE_NOTHROW(token = lexer.get_next_token());
-        REQUIRE(token == fkyaml::detail::lexical_token_t::INVALID_DIRECTIVE);
+        REQUIRE(token.type == fkyaml::detail::lexical_token_t::INVALID_DIRECTIVE);
         REQUIRE_NOTHROW(token = lexer.get_next_token());
-        REQUIRE(token == fkyaml::detail::lexical_token_t::END_OF_BUFFER);
+        REQUIRE(token.type == fkyaml::detail::lexical_token_t::END_OF_BUFFER);
     }
 
     SECTION("invalid tag handle") {
@@ -156,106 +156,106 @@ TEST_CASE("LexicalAnalyzer_ReservedDirective") {
     auto buffer =
         GENERATE(std::string("%TEST\n"), std::string("%1984\n "), std::string("%TEST4LIB\n"), std::string("%%ERROR"));
 
-    fkyaml::detail::lexical_token_t token;
+    fkyaml::detail::lexical_token token;
     lexer_t lexer(fkyaml::detail::input_adapter(buffer));
     REQUIRE_NOTHROW(token = lexer.get_next_token());
-    REQUIRE(token == fkyaml::detail::lexical_token_t::INVALID_DIRECTIVE);
+    REQUIRE(token.type == fkyaml::detail::lexical_token_t::INVALID_DIRECTIVE);
 
     REQUIRE_NOTHROW(token = lexer.get_next_token());
-    REQUIRE(token == fkyaml::detail::lexical_token_t::END_OF_BUFFER);
+    REQUIRE(token.type == fkyaml::detail::lexical_token_t::END_OF_BUFFER);
 }
 
 TEST_CASE("LexicalAnalyzer_EmptyDirective") {
     lexer_t lexer(fkyaml::detail::input_adapter("%"));
-    REQUIRE(lexer.get_next_token() == fkyaml::detail::lexical_token_t::INVALID_DIRECTIVE);
+    REQUIRE(lexer.get_next_token().type == fkyaml::detail::lexical_token_t::INVALID_DIRECTIVE);
 }
 
 TEST_CASE("LexicalAnalyzer_EndOfDirectives") {
     lexer_t lexer(fkyaml::detail::input_adapter("%YAML 1.2\n---\nfoo: bar"));
-    fkyaml::detail::lexical_token_t token;
+    fkyaml::detail::lexical_token token;
 
     REQUIRE_NOTHROW(token = lexer.get_next_token());
-    REQUIRE(token == fkyaml::detail::lexical_token_t::YAML_VER_DIRECTIVE);
+    REQUIRE(token.type == fkyaml::detail::lexical_token_t::YAML_VER_DIRECTIVE);
     REQUIRE(lexer.get_yaml_version() == "1.2");
     REQUIRE_NOTHROW(token = lexer.get_next_token());
-    REQUIRE(token == fkyaml::detail::lexical_token_t::END_OF_DIRECTIVES);
+    REQUIRE(token.type == fkyaml::detail::lexical_token_t::END_OF_DIRECTIVES);
     REQUIRE_NOTHROW(token = lexer.get_next_token());
-    REQUIRE(token == fkyaml::detail::lexical_token_t::STRING_VALUE);
-    REQUIRE(lexer.get_string() == "foo");
+    REQUIRE(token.type == fkyaml::detail::lexical_token_t::STRING_VALUE);
+    REQUIRE(std::string(token.token_begin_itr, token.token_end_itr) == "foo");
     REQUIRE_NOTHROW(token = lexer.get_next_token());
-    REQUIRE(token == fkyaml::detail::lexical_token_t::KEY_SEPARATOR);
+    REQUIRE(token.type == fkyaml::detail::lexical_token_t::KEY_SEPARATOR);
     REQUIRE_NOTHROW(token = lexer.get_next_token());
-    REQUIRE(token == fkyaml::detail::lexical_token_t::STRING_VALUE);
-    REQUIRE(lexer.get_string() == "bar");
+    REQUIRE(token.type == fkyaml::detail::lexical_token_t::STRING_VALUE);
+    REQUIRE(std::string(token.token_begin_itr, token.token_end_itr) == "bar");
     REQUIRE_NOTHROW(token = lexer.get_next_token());
-    REQUIRE(token == fkyaml::detail::lexical_token_t::END_OF_BUFFER);
+    REQUIRE(token.type == fkyaml::detail::lexical_token_t::END_OF_BUFFER);
 }
 
 TEST_CASE("LexicalAnalyzer_EndOfDocuments") {
     lexer_t lexer(fkyaml::detail::input_adapter("%YAML 1.2\n---\n..."));
-    fkyaml::detail::lexical_token_t token;
+    fkyaml::detail::lexical_token token;
 
     REQUIRE_NOTHROW(token = lexer.get_next_token());
-    REQUIRE(token == fkyaml::detail::lexical_token_t::YAML_VER_DIRECTIVE);
+    REQUIRE(token.type == fkyaml::detail::lexical_token_t::YAML_VER_DIRECTIVE);
     REQUIRE(lexer.get_yaml_version() == "1.2");
     REQUIRE_NOTHROW(token = lexer.get_next_token());
-    REQUIRE(token == fkyaml::detail::lexical_token_t::END_OF_DIRECTIVES);
+    REQUIRE(token.type == fkyaml::detail::lexical_token_t::END_OF_DIRECTIVES);
     REQUIRE_NOTHROW(token = lexer.get_next_token());
-    REQUIRE(token == fkyaml::detail::lexical_token_t::END_OF_DOCUMENT);
+    REQUIRE(token.type == fkyaml::detail::lexical_token_t::END_OF_DOCUMENT);
     REQUIRE_NOTHROW(token = lexer.get_next_token());
-    REQUIRE(token == fkyaml::detail::lexical_token_t::END_OF_BUFFER);
+    REQUIRE(token.type == fkyaml::detail::lexical_token_t::END_OF_BUFFER);
 }
 
 TEST_CASE("LexicalAnalyzer_Colon") {
-    fkyaml::detail::lexical_token_t token;
+    fkyaml::detail::lexical_token token;
 
     SECTION("colon with half-width space") {
         lexer_t lexer(fkyaml::detail::input_adapter(": "));
         REQUIRE_NOTHROW(token = lexer.get_next_token());
-        REQUIRE(token == fkyaml::detail::lexical_token_t::KEY_SEPARATOR);
+        REQUIRE(token.type == fkyaml::detail::lexical_token_t::KEY_SEPARATOR);
     }
 
     SECTION("colon with LF newline code") {
         lexer_t lexer(fkyaml::detail::input_adapter(":\n"));
         REQUIRE_NOTHROW(token = lexer.get_next_token());
-        REQUIRE(token == fkyaml::detail::lexical_token_t::KEY_SEPARATOR);
+        REQUIRE(token.type == fkyaml::detail::lexical_token_t::KEY_SEPARATOR);
     }
 
     SECTION("colon with the end of the buffer") {
         lexer_t lexer(fkyaml::detail::input_adapter(":"));
         REQUIRE_NOTHROW(token = lexer.get_next_token());
-        REQUIRE(token == fkyaml::detail::lexical_token_t::KEY_SEPARATOR);
+        REQUIRE(token.type == fkyaml::detail::lexical_token_t::KEY_SEPARATOR);
     }
 
     SECTION("colon with a comment and a LF newline code") {
         lexer_t lexer(fkyaml::detail::input_adapter(": # comment\n"));
         REQUIRE_NOTHROW(token = lexer.get_next_token());
-        REQUIRE(token == fkyaml::detail::lexical_token_t::KEY_SEPARATOR);
+        REQUIRE(token.type == fkyaml::detail::lexical_token_t::KEY_SEPARATOR);
     }
 
     SECTION("colon with a comment and no newline code") {
         lexer_t lexer(fkyaml::detail::input_adapter(": # comment"));
         REQUIRE_NOTHROW(token = lexer.get_next_token());
-        REQUIRE(token == fkyaml::detail::lexical_token_t::KEY_SEPARATOR);
+        REQUIRE(token.type == fkyaml::detail::lexical_token_t::KEY_SEPARATOR);
     }
 
     SECTION("colon with many spaces and a LF newline code") {
         lexer_t lexer(fkyaml::detail::input_adapter(":                         \n"));
         REQUIRE_NOTHROW(token = lexer.get_next_token());
-        REQUIRE(token == fkyaml::detail::lexical_token_t::KEY_SEPARATOR);
+        REQUIRE(token.type == fkyaml::detail::lexical_token_t::KEY_SEPARATOR);
     }
 
     SECTION("colon with many spaces and no newline code") {
         lexer_t lexer(fkyaml::detail::input_adapter(":                         "));
         REQUIRE_NOTHROW(token = lexer.get_next_token());
-        REQUIRE(token == fkyaml::detail::lexical_token_t::KEY_SEPARATOR);
+        REQUIRE(token.type == fkyaml::detail::lexical_token_t::KEY_SEPARATOR);
     }
 
     SECTION("colon with an always-safe character") {
         lexer_t lexer(fkyaml::detail::input_adapter(":test"));
         REQUIRE_NOTHROW(token = lexer.get_next_token());
-        REQUIRE(token == fkyaml::detail::lexical_token_t::STRING_VALUE);
-        REQUIRE(lexer.get_string() == ":test");
+        REQUIRE(token.type == fkyaml::detail::lexical_token_t::STRING_VALUE);
+        REQUIRE(std::string(token.token_begin_itr, token.token_end_itr) == ":test");
     }
 
     SECTION("colon with a flow indicator in a non-flow context") {
@@ -263,8 +263,8 @@ TEST_CASE("LexicalAnalyzer_Colon") {
             GENERATE(std::string(":,"), std::string(":{"), std::string(":}"), std::string(":["), std::string(":]"));
         lexer_t lexer(fkyaml::detail::input_adapter(input));
         REQUIRE_NOTHROW(token = lexer.get_next_token());
-        REQUIRE(token == fkyaml::detail::lexical_token_t::STRING_VALUE);
-        REQUIRE(lexer.get_string() == input);
+        REQUIRE(token.type == fkyaml::detail::lexical_token_t::STRING_VALUE);
+        REQUIRE(std::string(token.token_begin_itr, token.token_end_itr) == input);
     }
 
     SECTION("colon with a flow indicator in a flow context") {
@@ -272,204 +272,116 @@ TEST_CASE("LexicalAnalyzer_Colon") {
             std::string("{:,"), std::string("{:{"), std::string("{:}"), std::string("{:["), std::string("{:]"));
         lexer_t lexer(fkyaml::detail::input_adapter(input));
         REQUIRE_NOTHROW(token = lexer.get_next_token());
-        REQUIRE(token == fkyaml::detail::lexical_token_t::MAPPING_FLOW_BEGIN);
+        REQUIRE(token.type == fkyaml::detail::lexical_token_t::MAPPING_FLOW_BEGIN);
         REQUIRE_NOTHROW(token = lexer.get_next_token());
-        REQUIRE(token == fkyaml::detail::lexical_token_t::KEY_SEPARATOR);
+        REQUIRE(token.type == fkyaml::detail::lexical_token_t::KEY_SEPARATOR);
     }
 }
 
 TEST_CASE("LexicalAnalzer_BlockSequenceEntryPrefix") {
     auto input = GENERATE(std::string("- foo"), std::string("-\tfoo"), std::string("-\n  foo"));
 
-    fkyaml::detail::lexical_token_t token;
+    fkyaml::detail::lexical_token token;
     lexer_t lexer(fkyaml::detail::input_adapter(input));
     REQUIRE_NOTHROW(token = lexer.get_next_token());
-    REQUIRE(token == fkyaml::detail::lexical_token_t::SEQUENCE_BLOCK_PREFIX);
+    REQUIRE(token.type == fkyaml::detail::lexical_token_t::SEQUENCE_BLOCK_PREFIX);
     REQUIRE_NOTHROW(token = lexer.get_next_token());
-    REQUIRE(token == fkyaml::detail::lexical_token_t::STRING_VALUE);
-    REQUIRE(lexer.get_string() == "foo");
+    REQUIRE(token.type == fkyaml::detail::lexical_token_t::STRING_VALUE);
+    REQUIRE(std::string(token.token_begin_itr, token.token_end_itr) == "foo");
 }
 
 TEST_CASE("LexicalAnalyzer_Null") {
-    fkyaml::detail::lexical_token_t token;
+    fkyaml::detail::lexical_token token;
 
     SECTION("valid null scalar token") {
         auto buffer = GENERATE(std::string("null"), std::string("Null"), std::string("NULL"), std::string("~"));
         lexer_t lexer(fkyaml::detail::input_adapter(buffer));
 
         REQUIRE_NOTHROW(token = lexer.get_next_token());
-        REQUIRE(token == fkyaml::detail::lexical_token_t::NULL_VALUE);
-        REQUIRE_NOTHROW(lexer.get_null());
-        REQUIRE(lexer.get_null() == nullptr);
-    }
-
-    SECTION("invalid token for null scalar") {
-        lexer_t lexer(fkyaml::detail::input_adapter("test"));
-        REQUIRE_NOTHROW(lexer.get_next_token());
-        REQUIRE_THROWS_AS(lexer.get_null(), fkyaml::exception);
+        REQUIRE(token.type == fkyaml::detail::lexical_token_t::NULL_VALUE);
     }
 }
 
-TEST_CASE("LexicalAnalyzer_BooleanTrue") {
-    fkyaml::detail::lexical_token_t token;
+TEST_CASE("LexicalAnalyzer_Boolean") {
+    fkyaml::detail::lexical_token token;
 
-    SECTION("valid boolean true scalar token") {
-        auto buffer = GENERATE(std::string("true"), std::string("True"), std::string("TRUE"));
-        lexer_t lexer(fkyaml::detail::input_adapter(buffer));
+    auto buffer = GENERATE(
+        std::string("true"),
+        std::string("True"),
+        std::string("TRUE"),
+        std::string("false"),
+        std::string("False"),
+        std::string("FALSE"));
+    lexer_t lexer(fkyaml::detail::input_adapter(buffer));
 
-        REQUIRE_NOTHROW(token = lexer.get_next_token());
-        REQUIRE(token == fkyaml::detail::lexical_token_t::BOOLEAN_VALUE);
-        REQUIRE_NOTHROW(lexer.get_boolean());
-        REQUIRE(lexer.get_boolean() == true);
-    }
-
-    SECTION("invalid token for boolean true scalar") {
-        lexer_t lexer(fkyaml::detail::input_adapter("test"));
-        REQUIRE_NOTHROW(lexer.get_next_token());
-        REQUIRE_THROWS_AS(lexer.get_boolean(), fkyaml::exception);
-    }
-}
-
-TEST_CASE("LexicalAnalyzer_BooleanFalse") {
-    fkyaml::detail::lexical_token_t token;
-
-    SECTION("valid boolean false scalar token") {
-        auto buffer = GENERATE(std::string("false"), std::string("False"), std::string("FALSE"));
-        lexer_t lexer(fkyaml::detail::input_adapter(buffer));
-
-        REQUIRE_NOTHROW(token = lexer.get_next_token());
-        REQUIRE(token == fkyaml::detail::lexical_token_t::BOOLEAN_VALUE);
-        REQUIRE_NOTHROW(lexer.get_boolean());
-        REQUIRE(lexer.get_boolean() == false);
-    }
-
-    SECTION("invalid token for boolean true scalar") {
-        lexer_t lexer(fkyaml::detail::input_adapter("test"));
-        REQUIRE_NOTHROW(lexer.get_next_token());
-        REQUIRE_THROWS_AS(lexer.get_boolean(), fkyaml::exception);
-    }
+    REQUIRE_NOTHROW(token = lexer.get_next_token());
+    REQUIRE(token.type == fkyaml::detail::lexical_token_t::BOOLEAN_VALUE);
 }
 
 TEST_CASE("LexicalAnalyzer_Integer") {
-    fkyaml::detail::lexical_token_t token;
+    fkyaml::detail::lexical_token token;
 
-    SECTION("valid integer scalar token") {
-        using value_pair_t = std::pair<std::string, fkyaml::node::integer_type>;
-        auto value_pair = GENERATE(
-            value_pair_t(std::string("-1234"), -1234),
-            value_pair_t(std::string("-853255"), -853255),
-            value_pair_t(std::string("-1"), -1),
-            value_pair_t(std::string("0"), 0),
-            value_pair_t(std::string("643"), 643),
-            value_pair_t(std::string("+123"), 123));
+    auto buffer = GENERATE(
+        std::string("-1234"),
+        std::string("-853255"),
+        std::string("-1"),
+        std::string("0"),
+        std::string("643"),
+        std::string("+123"));
 
-        lexer_t lexer(fkyaml::detail::input_adapter(value_pair.first));
+    lexer_t lexer(fkyaml::detail::input_adapter(buffer));
 
-        REQUIRE_NOTHROW(token = lexer.get_next_token());
-        REQUIRE(token == fkyaml::detail::lexical_token_t::INTEGER_VALUE);
-        REQUIRE_NOTHROW(lexer.get_integer());
-        REQUIRE(lexer.get_integer() == value_pair.second);
-    }
-
-    SECTION("invalid token for integer scalar") {
-        lexer_t lexer(fkyaml::detail::input_adapter("test"));
-        REQUIRE_NOTHROW(lexer.get_next_token());
-        REQUIRE_THROWS_AS(lexer.get_integer(), fkyaml::exception);
-    }
+    REQUIRE_NOTHROW(token = lexer.get_next_token());
+    REQUIRE(token.type == fkyaml::detail::lexical_token_t::INTEGER_VALUE);
 }
 
 TEST_CASE("LexicalAnalyzer_OctalInteger") {
-    using value_pair_t = std::pair<std::string, fkyaml::node::integer_type>;
-    auto value_pair = GENERATE(
-        value_pair_t(std::string("0o27"), 027),
-        value_pair_t(std::string("0o5"), 05),
-        value_pair_t(std::string("0o77772"), 077772),
-        value_pair_t(std::string("0o672"), 0672));
+    auto buffer = GENERATE(std::string("0o27"), std::string("0o5"), std::string("0o77772"), std::string("0o672"));
 
-    lexer_t lexer(fkyaml::detail::input_adapter(value_pair.first));
-    fkyaml::detail::lexical_token_t token;
+    lexer_t lexer(fkyaml::detail::input_adapter(buffer));
+    fkyaml::detail::lexical_token token;
 
     REQUIRE_NOTHROW(token = lexer.get_next_token());
-    REQUIRE(token == fkyaml::detail::lexical_token_t::INTEGER_VALUE);
-    REQUIRE_NOTHROW(lexer.get_integer());
-    REQUIRE(lexer.get_integer() == value_pair.second);
+    REQUIRE(token.type == fkyaml::detail::lexical_token_t::INTEGER_VALUE);
 }
 
 TEST_CASE("LexicalAnalyzer_HexadecimalInteger") {
-    using value_pair_t = std::pair<std::string, fkyaml::node::integer_type>;
-    auto value_pair = GENERATE(
-        value_pair_t(std::string("0xA04F"), 0xA04F),
-        value_pair_t(std::string("0xa7F3"), 0xa7F3),
-        value_pair_t(std::string("0xFf29Bc"), 0xFf29Bc));
+    auto buffer = GENERATE(std::string("0xA04F"), std::string("0xa7F3"), std::string("0xFf29Bc"));
 
-    lexer_t lexer(fkyaml::detail::input_adapter(value_pair.first));
-    fkyaml::detail::lexical_token_t token;
+    lexer_t lexer(fkyaml::detail::input_adapter(buffer));
+    fkyaml::detail::lexical_token token;
 
     REQUIRE_NOTHROW(token = lexer.get_next_token());
-    REQUIRE(token == fkyaml::detail::lexical_token_t::INTEGER_VALUE);
-    REQUIRE_NOTHROW(lexer.get_integer());
-    REQUIRE(lexer.get_integer() == value_pair.second);
+    REQUIRE(token.type == fkyaml::detail::lexical_token_t::INTEGER_VALUE);
 }
 
 TEST_CASE("LexicalAnalyzer_FloatingPointNumber") {
-    fkyaml::detail::lexical_token_t token;
+    fkyaml::detail::lexical_token token;
 
-    SECTION("valid floating point number scalar token") {
-        using value_pair_t = std::pair<std::string, fkyaml::node::float_number_type>;
-        auto value_pair = GENERATE(
-            value_pair_t(std::string("-1.234"), -1.234),
-            value_pair_t(std::string("-21."), -21.),
-            value_pair_t(std::string("0."), 0.),
-            value_pair_t(std::string("12."), 12.),
-            value_pair_t(std::string("567.8"), 567.8),
-            value_pair_t(std::string("0.24"), 0.24),
-            value_pair_t(std::string("9.8e-3"), 9.8e-3),
-            value_pair_t(std::string("3.95E3"), 3.95e3),
-            value_pair_t(std::string("1.863e+3"), 1.863e+3));
-
-        lexer_t lexer(fkyaml::detail::input_adapter(value_pair.first));
-
-        REQUIRE_NOTHROW(token = lexer.get_next_token());
-        REQUIRE(token == fkyaml::detail::lexical_token_t::FLOAT_NUMBER_VALUE);
-        REQUIRE_NOTHROW(lexer.get_float_number());
-        REQUIRE(lexer.get_float_number() == value_pair.second);
-    }
-
-    SECTION("valid floating point number scalar token edge cases") {
-        auto input = GENERATE(std::string("1.23e"), std::string("1.2e-z"));
-        lexer_t lexer(fkyaml::detail::input_adapter(input));
-        REQUIRE_FALSE(lexer.get_next_token() == fkyaml::detail::lexical_token_t::FLOAT_NUMBER_VALUE);
-    }
-
-    SECTION("invalid token for floating point number scalar") {
-        lexer_t lexer(fkyaml::detail::input_adapter("test"));
-        REQUIRE_NOTHROW(lexer.get_next_token());
-        REQUIRE_THROWS_AS(lexer.get_float_number(), fkyaml::exception);
-    }
-}
-
-TEST_CASE("LexicalAnalyzer_Infinity") {
     auto buffer = GENERATE(
+        std::string("-1.234"),
+        std::string("-21."),
+        std::string("0."),
+        std::string("12."),
+        std::string("567.8"),
+        std::string("0.24"),
+        std::string("9.8e-3"),
+        std::string("3.95E3"),
+        std::string("1.863e+3"),
         std::string(".inf"),
         std::string(".Inf"),
         std::string(".INF"),
         std::string("-.inf"),
         std::string("-.Inf"),
-        std::string("-.INF"));
+        std::string("-.INF"),
+        std::string(".nan"),
+        std::string(".NaN"),
+        std::string(".NAN"));
+
     lexer_t lexer(fkyaml::detail::input_adapter(buffer));
 
-    REQUIRE(lexer.get_next_token() == fkyaml::detail::lexical_token_t::FLOAT_NUMBER_VALUE);
-    REQUIRE_NOTHROW(lexer.get_float_number());
-    REQUIRE(std::isinf(lexer.get_float_number()) == true);
-}
-
-TEST_CASE("LexicalAnalyzer_NaN") {
-    auto buffer = GENERATE(std::string(".nan"), std::string(".NaN"), std::string(".NAN"));
-    lexer_t lexer(fkyaml::detail::input_adapter(buffer));
-
-    REQUIRE(lexer.get_next_token() == fkyaml::detail::lexical_token_t::FLOAT_NUMBER_VALUE);
-    REQUIRE_NOTHROW(lexer.get_float_number());
-    REQUIRE(std::isnan(lexer.get_float_number()) == true);
+    REQUIRE_NOTHROW(token = lexer.get_next_token());
+    REQUIRE(token.type == fkyaml::detail::lexical_token_t::FLOAT_NUMBER_VALUE);
 }
 
 TEST_CASE("LexicalAnalyzer_PlainString") {
@@ -518,12 +430,11 @@ TEST_CASE("LexicalAnalyzer_PlainString") {
         value_pair_t(std::string(".NAN_VALUE"), fkyaml::node::string_type(".NAN_VALUE")));
 
     lexer_t lexer(fkyaml::detail::input_adapter(value_pair.first));
-    fkyaml::detail::lexical_token_t token;
+    fkyaml::detail::lexical_token token;
 
     REQUIRE_NOTHROW(token = lexer.get_next_token());
-    REQUIRE(token == fkyaml::detail::lexical_token_t::STRING_VALUE);
-    REQUIRE_NOTHROW(lexer.get_string());
-    REQUIRE(lexer.get_string() == value_pair.second);
+    REQUIRE(token.type == fkyaml::detail::lexical_token_t::STRING_VALUE);
+    REQUIRE(std::string(token.token_begin_itr, token.token_end_itr) == value_pair.second);
 }
 
 TEST_CASE("LexicalAnalyzer_SingleQuotedString") {
@@ -547,12 +458,11 @@ TEST_CASE("LexicalAnalyzer_SingleQuotedString") {
         value_pair_t(std::string("\'foo\nbar\n\'"), fkyaml::node::string_type("foo bar ")));
 
     lexer_t lexer(fkyaml::detail::input_adapter(value_pair.first));
-    fkyaml::detail::lexical_token_t token;
+    fkyaml::detail::lexical_token token;
 
     REQUIRE_NOTHROW(token = lexer.get_next_token());
-    REQUIRE(token == fkyaml::detail::lexical_token_t::STRING_VALUE);
-    REQUIRE_NOTHROW(lexer.get_string());
-    REQUIRE(lexer.get_string() == value_pair.second);
+    REQUIRE(token.type == fkyaml::detail::lexical_token_t::STRING_VALUE);
+    REQUIRE(std::string(token.token_begin_itr, token.token_end_itr) == value_pair.second);
 }
 
 TEST_CASE("LexicalAnalyzer_DoubleQuotedString") {
@@ -578,12 +488,11 @@ TEST_CASE("LexicalAnalyzer_DoubleQuotedString") {
         value_pair_t(std::string("\"\\\n  foo \t\\\n\tbar\t  \t\\\n\""), fkyaml::node::string_type("foo \tbar\t  \t")));
 
     lexer_t lexer(fkyaml::detail::input_adapter(value_pair.first));
-    fkyaml::detail::lexical_token_t token;
+    fkyaml::detail::lexical_token token;
 
     REQUIRE_NOTHROW(token = lexer.get_next_token());
-    REQUIRE(token == fkyaml::detail::lexical_token_t::STRING_VALUE);
-    REQUIRE_NOTHROW(lexer.get_string());
-    REQUIRE(lexer.get_string() == value_pair.second);
+    REQUIRE(token.type == fkyaml::detail::lexical_token_t::STRING_VALUE);
+    REQUIRE(std::string(token.token_begin_itr, token.token_end_itr) == value_pair.second);
 }
 
 TEST_CASE("LexicalAnalyzer_MultiByteCharString") {
@@ -635,12 +544,11 @@ TEST_CASE("LexicalAnalyzer_MultiByteCharString") {
             char_traits_t::to_char_type(0xBF)});
 
     lexer_t lexer(fkyaml::detail::input_adapter(mb_char));
-    fkyaml::detail::lexical_token_t token;
+    fkyaml::detail::lexical_token token;
 
     REQUIRE_NOTHROW(token = lexer.get_next_token());
-    REQUIRE(token == fkyaml::detail::lexical_token_t::STRING_VALUE);
-    REQUIRE_NOTHROW(lexer.get_string());
-    REQUIRE(lexer.get_string() == mb_char);
+    REQUIRE(token.type == fkyaml::detail::lexical_token_t::STRING_VALUE);
+    REQUIRE(std::string(token.token_begin_itr, token.token_end_itr) == mb_char);
 }
 
 TEST_CASE("LexicalAnalyzer_EscapedUnicodeCharacter") {
@@ -733,12 +641,11 @@ TEST_CASE("LexicalAnalyzer_EscapedUnicodeCharacter") {
                 char_traits_t::to_char_type(0xBF)}));
 
     lexer_t lexer(fkyaml::detail::input_adapter(value_pair.first));
-    fkyaml::detail::lexical_token_t token;
+    fkyaml::detail::lexical_token token;
 
     REQUIRE_NOTHROW(token = lexer.get_next_token());
-    REQUIRE(token == fkyaml::detail::lexical_token_t::STRING_VALUE);
-    REQUIRE_NOTHROW(lexer.get_string());
-    REQUIRE(lexer.get_string() == value_pair.second);
+    REQUIRE(token.type == fkyaml::detail::lexical_token_t::STRING_VALUE);
+    REQUIRE(std::string(token.token_begin_itr, token.token_end_itr) == value_pair.second);
 }
 
 TEST_CASE("LexicalAnalyzer_InvalidString") {
@@ -933,7 +840,7 @@ TEST_CASE("LexicalAnalyzer_UnescapedControlCharacter") {
 }
 
 TEST_CASE("LexicalAnalyzer_LiteralStringScalar") {
-    fkyaml::detail::lexical_token_t token;
+    fkyaml::detail::lexical_token token;
 
     SECTION("empty literal string scalar with strip chomping") {
         const char input[] = "|-\n"
@@ -941,8 +848,8 @@ TEST_CASE("LexicalAnalyzer_LiteralStringScalar") {
         lexer_t lexer(fkyaml::detail::input_adapter(input));
 
         REQUIRE_NOTHROW(token = lexer.get_next_token());
-        REQUIRE(token == fkyaml::detail::lexical_token_t::STRING_VALUE);
-        REQUIRE(lexer.get_string() == "");
+        REQUIRE(token.type == fkyaml::detail::lexical_token_t::STRING_VALUE);
+        REQUIRE(std::string(token.token_begin_itr, token.token_end_itr) == "");
     }
 
     SECTION("empty literal string scalar with clip chomping") {
@@ -951,8 +858,8 @@ TEST_CASE("LexicalAnalyzer_LiteralStringScalar") {
         lexer_t lexer(fkyaml::detail::input_adapter(input));
 
         REQUIRE_NOTHROW(token = lexer.get_next_token());
-        REQUIRE(token == fkyaml::detail::lexical_token_t::STRING_VALUE);
-        REQUIRE(lexer.get_string() == "");
+        REQUIRE(token.type == fkyaml::detail::lexical_token_t::STRING_VALUE);
+        REQUIRE(std::string(token.token_begin_itr, token.token_end_itr) == "");
     }
 
     SECTION("empty literal string scalar with keep chomping") {
@@ -961,8 +868,8 @@ TEST_CASE("LexicalAnalyzer_LiteralStringScalar") {
         lexer_t lexer(fkyaml::detail::input_adapter(input));
 
         REQUIRE_NOTHROW(token = lexer.get_next_token());
-        REQUIRE(token == fkyaml::detail::lexical_token_t::STRING_VALUE);
-        REQUIRE(lexer.get_string() == "\n");
+        REQUIRE(token.type == fkyaml::detail::lexical_token_t::STRING_VALUE);
+        REQUIRE(std::string(token.token_begin_itr, token.token_end_itr) == "\n");
     }
 
     SECTION("literal string scalar with 0 indent level.") {
@@ -988,8 +895,8 @@ TEST_CASE("LexicalAnalyzer_LiteralStringScalar") {
         lexer_t lexer(fkyaml::detail::input_adapter(input));
 
         REQUIRE_NOTHROW(token = lexer.get_next_token());
-        REQUIRE(token == fkyaml::detail::lexical_token_t::STRING_VALUE);
-        REQUIRE(lexer.get_string() == "  foo\nbar\n");
+        REQUIRE(token.type == fkyaml::detail::lexical_token_t::STRING_VALUE);
+        REQUIRE(std::string(token.token_begin_itr, token.token_end_itr) == "  foo\nbar\n");
     }
 
     SECTION("literal string scalar") {
@@ -999,8 +906,8 @@ TEST_CASE("LexicalAnalyzer_LiteralStringScalar") {
         lexer_t lexer(fkyaml::detail::input_adapter(input));
 
         REQUIRE_NOTHROW(token = lexer.get_next_token());
-        REQUIRE(token == fkyaml::detail::lexical_token_t::STRING_VALUE);
-        REQUIRE(lexer.get_string() == "foo\nbar\n");
+        REQUIRE(token.type == fkyaml::detail::lexical_token_t::STRING_VALUE);
+        REQUIRE(std::string(token.token_begin_itr, token.token_end_itr) == "foo\nbar\n");
     }
 
     SECTION("literal string scalar with implicit indentation and strip chomping") {
@@ -1014,8 +921,8 @@ TEST_CASE("LexicalAnalyzer_LiteralStringScalar") {
         lexer_t lexer(fkyaml::detail::input_adapter(input));
 
         REQUIRE_NOTHROW(token = lexer.get_next_token());
-        REQUIRE(token == fkyaml::detail::lexical_token_t::STRING_VALUE);
-        REQUIRE(lexer.get_string() == "\nfoo\nbar\n\nbaz");
+        REQUIRE(token.type == fkyaml::detail::lexical_token_t::STRING_VALUE);
+        REQUIRE(std::string(token.token_begin_itr, token.token_end_itr) == "\nfoo\nbar\n\nbaz");
     }
 
     SECTION("literal string scalar with explicit indentation and strip chomping") {
@@ -1028,8 +935,8 @@ TEST_CASE("LexicalAnalyzer_LiteralStringScalar") {
         lexer_t lexer(fkyaml::detail::input_adapter(input));
 
         REQUIRE_NOTHROW(token = lexer.get_next_token());
-        REQUIRE(token == fkyaml::detail::lexical_token_t::STRING_VALUE);
-        REQUIRE(lexer.get_string() == "foo\n  bar\n\nbaz");
+        REQUIRE(token.type == fkyaml::detail::lexical_token_t::STRING_VALUE);
+        REQUIRE(std::string(token.token_begin_itr, token.token_end_itr) == "foo\n  bar\n\nbaz");
     }
 
     SECTION("literal string scalar with implicit indentation and clip chomping") {
@@ -1043,8 +950,8 @@ TEST_CASE("LexicalAnalyzer_LiteralStringScalar") {
         lexer_t lexer(fkyaml::detail::input_adapter(input));
 
         REQUIRE_NOTHROW(token = lexer.get_next_token());
-        REQUIRE(token == fkyaml::detail::lexical_token_t::STRING_VALUE);
-        REQUIRE(lexer.get_string() == "\nfoo\nbar\n\nbaz\n");
+        REQUIRE(token.type == fkyaml::detail::lexical_token_t::STRING_VALUE);
+        REQUIRE(std::string(token.token_begin_itr, token.token_end_itr) == "\nfoo\nbar\n\nbaz\n");
     }
 
     SECTION("literal string scalar with explicit indentation and clip chomping") {
@@ -1057,8 +964,8 @@ TEST_CASE("LexicalAnalyzer_LiteralStringScalar") {
         lexer_t lexer(fkyaml::detail::input_adapter(input));
 
         REQUIRE_NOTHROW(token = lexer.get_next_token());
-        REQUIRE(token == fkyaml::detail::lexical_token_t::STRING_VALUE);
-        REQUIRE(lexer.get_string() == "foo\n  bar\n\nbaz\n");
+        REQUIRE(token.type == fkyaml::detail::lexical_token_t::STRING_VALUE);
+        REQUIRE(std::string(token.token_begin_itr, token.token_end_itr) == "foo\n  bar\n\nbaz\n");
     }
 
     SECTION("literal string scalar with clip chomping and no trailing newlines") {
@@ -1070,8 +977,8 @@ TEST_CASE("LexicalAnalyzer_LiteralStringScalar") {
         lexer_t lexer(fkyaml::detail::input_adapter(input));
 
         REQUIRE_NOTHROW(token = lexer.get_next_token());
-        REQUIRE(token == fkyaml::detail::lexical_token_t::STRING_VALUE);
-        REQUIRE(lexer.get_string() == "foo\n  bar\n\nbaz");
+        REQUIRE(token.type == fkyaml::detail::lexical_token_t::STRING_VALUE);
+        REQUIRE(std::string(token.token_begin_itr, token.token_end_itr) == "foo\n  bar\n\nbaz");
     }
 
     SECTION("literal string scalar with implicit indentation and keep chomping") {
@@ -1085,8 +992,8 @@ TEST_CASE("LexicalAnalyzer_LiteralStringScalar") {
         lexer_t lexer(fkyaml::detail::input_adapter(input));
 
         REQUIRE_NOTHROW(token = lexer.get_next_token());
-        REQUIRE(token == fkyaml::detail::lexical_token_t::STRING_VALUE);
-        REQUIRE(lexer.get_string() == "\nfoo\nbar\n\nbaz\n\n");
+        REQUIRE(token.type == fkyaml::detail::lexical_token_t::STRING_VALUE);
+        REQUIRE(std::string(token.token_begin_itr, token.token_end_itr) == "\nfoo\nbar\n\nbaz\n\n");
     }
 
     SECTION("literal string scalar with explicit indentation and keep chomping") {
@@ -1099,8 +1006,8 @@ TEST_CASE("LexicalAnalyzer_LiteralStringScalar") {
         lexer_t lexer(fkyaml::detail::input_adapter(input));
 
         REQUIRE_NOTHROW(token = lexer.get_next_token());
-        REQUIRE(token == fkyaml::detail::lexical_token_t::STRING_VALUE);
-        REQUIRE(lexer.get_string() == "foo\n  bar\n\nbaz\n\n");
+        REQUIRE(token.type == fkyaml::detail::lexical_token_t::STRING_VALUE);
+        REQUIRE(std::string(token.token_begin_itr, token.token_end_itr) == "foo\n  bar\n\nbaz\n\n");
     }
 
     SECTION("literal string scalar with trailing spaces/tabs after the block scalar header.") {
@@ -1109,8 +1016,8 @@ TEST_CASE("LexicalAnalyzer_LiteralStringScalar") {
         lexer_t lexer(fkyaml::detail::input_adapter(input));
 
         REQUIRE_NOTHROW(token = lexer.get_next_token());
-        REQUIRE(token == fkyaml::detail::lexical_token_t::STRING_VALUE);
-        REQUIRE(lexer.get_string() == "foo\n");
+        REQUIRE(token.type == fkyaml::detail::lexical_token_t::STRING_VALUE);
+        REQUIRE(std::string(token.token_begin_itr, token.token_end_itr) == "foo\n");
     }
 
     SECTION("literal string scalar with invalid block scalar headers") {
@@ -1129,7 +1036,7 @@ TEST_CASE("LexicalAnalyzer_LiteralStringScalar") {
 }
 
 TEST_CASE("LexicalAnalyzer_FoldedString") {
-    fkyaml::detail::lexical_token_t token;
+    fkyaml::detail::lexical_token token;
 
     SECTION("empty folded string scalar with strip chomping") {
         const char input[] = ">-\n"
@@ -1137,8 +1044,8 @@ TEST_CASE("LexicalAnalyzer_FoldedString") {
         lexer_t lexer(fkyaml::detail::input_adapter(input));
 
         REQUIRE_NOTHROW(token = lexer.get_next_token());
-        REQUIRE(token == fkyaml::detail::lexical_token_t::STRING_VALUE);
-        REQUIRE(lexer.get_string() == "");
+        REQUIRE(token.type == fkyaml::detail::lexical_token_t::STRING_VALUE);
+        REQUIRE(std::string(token.token_begin_itr, token.token_end_itr) == "");
     }
 
     SECTION("empty folded string scalar with clip chomping") {
@@ -1147,8 +1054,8 @@ TEST_CASE("LexicalAnalyzer_FoldedString") {
         lexer_t lexer(fkyaml::detail::input_adapter(input));
 
         REQUIRE_NOTHROW(token = lexer.get_next_token());
-        REQUIRE(token == fkyaml::detail::lexical_token_t::STRING_VALUE);
-        REQUIRE(lexer.get_string() == "");
+        REQUIRE(token.type == fkyaml::detail::lexical_token_t::STRING_VALUE);
+        REQUIRE(std::string(token.token_begin_itr, token.token_end_itr) == "");
     }
 
     SECTION("empty folded string scalar with keep chomping") {
@@ -1157,8 +1064,8 @@ TEST_CASE("LexicalAnalyzer_FoldedString") {
         lexer_t lexer(fkyaml::detail::input_adapter(input));
 
         REQUIRE_NOTHROW(token = lexer.get_next_token());
-        REQUIRE(token == fkyaml::detail::lexical_token_t::STRING_VALUE);
-        REQUIRE(lexer.get_string() == "\n");
+        REQUIRE(token.type == fkyaml::detail::lexical_token_t::STRING_VALUE);
+        REQUIRE(std::string(token.token_begin_itr, token.token_end_itr) == "\n");
     }
 
     SECTION("folded string scalar with 0 indent level") {
@@ -1184,8 +1091,8 @@ TEST_CASE("LexicalAnalyzer_FoldedString") {
         lexer_t lexer(fkyaml::detail::input_adapter(input));
 
         REQUIRE_NOTHROW(token = lexer.get_next_token());
-        REQUIRE(token == fkyaml::detail::lexical_token_t::STRING_VALUE);
-        REQUIRE(lexer.get_string() == "\n  foo\nbar\n");
+        REQUIRE(token.type == fkyaml::detail::lexical_token_t::STRING_VALUE);
+        REQUIRE(std::string(token.token_begin_itr, token.token_end_itr) == "\n  foo\nbar\n");
     }
 
     SECTION("folded string scalar with the non-first line being more indented than the indicated level") {
@@ -1195,8 +1102,8 @@ TEST_CASE("LexicalAnalyzer_FoldedString") {
         lexer_t lexer(fkyaml::detail::input_adapter(input));
 
         REQUIRE_NOTHROW(token = lexer.get_next_token());
-        REQUIRE(token == fkyaml::detail::lexical_token_t::STRING_VALUE);
-        REQUIRE(lexer.get_string() == "foo\n  bar\n");
+        REQUIRE(token.type == fkyaml::detail::lexical_token_t::STRING_VALUE);
+        REQUIRE(std::string(token.token_begin_itr, token.token_end_itr) == "foo\n  bar\n");
     }
 
     SECTION("folded string scalar") {
@@ -1209,8 +1116,8 @@ TEST_CASE("LexicalAnalyzer_FoldedString") {
         lexer_t lexer(fkyaml::detail::input_adapter(input));
 
         REQUIRE_NOTHROW(token = lexer.get_next_token());
-        REQUIRE(token == fkyaml::detail::lexical_token_t::STRING_VALUE);
-        REQUIRE(lexer.get_string() == "foo\n\nbar\n");
+        REQUIRE(token.type == fkyaml::detail::lexical_token_t::STRING_VALUE);
+        REQUIRE(std::string(token.token_begin_itr, token.token_end_itr) == "foo\n\nbar\n");
     }
 
     SECTION("folded string scalar with implicit indentation and strip chomping") {
@@ -1222,8 +1129,8 @@ TEST_CASE("LexicalAnalyzer_FoldedString") {
         lexer_t lexer(fkyaml::detail::input_adapter(input));
 
         REQUIRE_NOTHROW(token = lexer.get_next_token());
-        REQUIRE(token == fkyaml::detail::lexical_token_t::STRING_VALUE);
-        REQUIRE(lexer.get_string() == "foo bar");
+        REQUIRE(token.type == fkyaml::detail::lexical_token_t::STRING_VALUE);
+        REQUIRE(std::string(token.token_begin_itr, token.token_end_itr) == "foo bar");
     }
 
     SECTION("folded string scalar with implicit indentation and clip chomping") {
@@ -1235,8 +1142,8 @@ TEST_CASE("LexicalAnalyzer_FoldedString") {
         lexer_t lexer(fkyaml::detail::input_adapter(input));
 
         REQUIRE_NOTHROW(token = lexer.get_next_token());
-        REQUIRE(token == fkyaml::detail::lexical_token_t::STRING_VALUE);
-        REQUIRE(lexer.get_string() == "foo bar\n");
+        REQUIRE(token.type == fkyaml::detail::lexical_token_t::STRING_VALUE);
+        REQUIRE(std::string(token.token_begin_itr, token.token_end_itr) == "foo bar\n");
     }
 
     SECTION("folded string scalar with implicit indentation and keep chomping") {
@@ -1248,8 +1155,8 @@ TEST_CASE("LexicalAnalyzer_FoldedString") {
         lexer_t lexer(fkyaml::detail::input_adapter(input));
 
         REQUIRE_NOTHROW(token = lexer.get_next_token());
-        REQUIRE(token == fkyaml::detail::lexical_token_t::STRING_VALUE);
-        REQUIRE(lexer.get_string() == "foo bar\n\n");
+        REQUIRE(token.type == fkyaml::detail::lexical_token_t::STRING_VALUE);
+        REQUIRE(std::string(token.token_begin_itr, token.token_end_itr) == "foo bar\n\n");
     }
 
     SECTION("folded string scalar with trailing spaces/tabs/comments after the block scalar header.") {
@@ -1258,8 +1165,8 @@ TEST_CASE("LexicalAnalyzer_FoldedString") {
         lexer_t lexer(fkyaml::detail::input_adapter(input));
 
         REQUIRE_NOTHROW(token = lexer.get_next_token());
-        REQUIRE(token == fkyaml::detail::lexical_token_t::STRING_VALUE);
-        REQUIRE(lexer.get_string() == "foo\n");
+        REQUIRE(token.type == fkyaml::detail::lexical_token_t::STRING_VALUE);
+        REQUIRE(std::string(token.token_begin_itr, token.token_end_itr) == "foo\n");
     }
 
     SECTION("folded string scalar with invalid block scalar headers") {
@@ -1278,7 +1185,7 @@ TEST_CASE("LexicalAnalyzer_FoldedString") {
 }
 
 TEST_CASE("LexicalAnalyzer_Anchor") {
-    fkyaml::detail::lexical_token_t token;
+    fkyaml::detail::lexical_token token;
 
     SECTION("valid anchor name") {
         using test_data_t = std::pair<std::string, std::string>;
@@ -1298,8 +1205,8 @@ TEST_CASE("LexicalAnalyzer_Anchor") {
         lexer_t lexer(fkyaml::detail::input_adapter(test_data.first));
 
         REQUIRE_NOTHROW(token = lexer.get_next_token());
-        REQUIRE(token == fkyaml::detail::lexical_token_t::ANCHOR_PREFIX);
-        REQUIRE_NOTHROW(lexer.get_string() == test_data.second);
+        REQUIRE(token.type == fkyaml::detail::lexical_token_t::ANCHOR_PREFIX);
+        REQUIRE_NOTHROW(std::string(token.token_begin_itr, token.token_end_itr) == test_data.second);
     }
 
     SECTION("invalid anchor name") {
@@ -1320,7 +1227,7 @@ TEST_CASE("LexicalAnalyzer_Anchor") {
 }
 
 TEST_CASE("LexicalAnalyzer_Alias") {
-    fkyaml::detail::lexical_token_t token;
+    fkyaml::detail::lexical_token token;
 
     SECTION("valid anchor name") {
         using test_data_t = std::pair<std::string, std::string>;
@@ -1340,8 +1247,8 @@ TEST_CASE("LexicalAnalyzer_Alias") {
         lexer_t lexer(fkyaml::detail::input_adapter(test_data.first));
 
         REQUIRE_NOTHROW(token = lexer.get_next_token());
-        REQUIRE(token == fkyaml::detail::lexical_token_t::ALIAS_PREFIX);
-        REQUIRE_NOTHROW(lexer.get_string() == test_data.second);
+        REQUIRE(token.type == fkyaml::detail::lexical_token_t::ALIAS_PREFIX);
+        REQUIRE_NOTHROW(std::string(token.token_begin_itr, token.token_end_itr) == test_data.second);
     }
 
     SECTION("invalid anchor name") {
@@ -1362,7 +1269,7 @@ TEST_CASE("LexicalAnalyzer_Alias") {
 }
 
 TEST_CASE("LexicalAnalyzer_Tag") {
-    fkyaml::detail::lexical_token_t token;
+    fkyaml::detail::lexical_token token;
 
     SECTION("valid tag names") {
         auto input = GENERATE(
@@ -1380,12 +1287,12 @@ TEST_CASE("LexicalAnalyzer_Tag") {
 
         lexer_t lexer(fkyaml::detail::input_adapter(input));
         REQUIRE_NOTHROW(token = lexer.get_next_token());
-        REQUIRE(token == fkyaml::detail::lexical_token_t::TAG_PREFIX);
-        REQUIRE(lexer.get_string() == input.substr(0, input.size() - 4));
+        REQUIRE(token.type == fkyaml::detail::lexical_token_t::TAG_PREFIX);
+        REQUIRE(std::string(token.token_begin_itr, token.token_end_itr) == input.substr(0, input.size() - 4));
 
         REQUIRE_NOTHROW(token = lexer.get_next_token());
-        REQUIRE(token == fkyaml::detail::lexical_token_t::STRING_VALUE);
-        REQUIRE(lexer.get_string() == "tag");
+        REQUIRE(token.type == fkyaml::detail::lexical_token_t::STRING_VALUE);
+        REQUIRE(std::string(token.token_begin_itr, token.token_end_itr) == "tag");
     }
 
     SECTION("valid tag name (not followed by a value)") {
@@ -1393,8 +1300,8 @@ TEST_CASE("LexicalAnalyzer_Tag") {
 
         lexer_t lexer(fkyaml::detail::input_adapter(input));
         REQUIRE_NOTHROW(token = lexer.get_next_token());
-        REQUIRE(token == fkyaml::detail::lexical_token_t::TAG_PREFIX);
-        REQUIRE(lexer.get_string() == input);
+        REQUIRE(token.type == fkyaml::detail::lexical_token_t::TAG_PREFIX);
+        REQUIRE(std::string(token.token_begin_itr, token.token_end_itr) == input);
     }
 
     SECTION("invalid tag names") {
@@ -1421,357 +1328,325 @@ TEST_CASE("LexicalAnalyzer_ReservedIndicator") {
 
 TEST_CASE("LexicalAnalyzer_KeyBooleanValuePair") {
     lexer_t lexer(fkyaml::detail::input_adapter("test: true"));
-    fkyaml::detail::lexical_token_t token;
+    fkyaml::detail::lexical_token token;
 
     REQUIRE_NOTHROW(token = lexer.get_next_token());
-    REQUIRE(token == fkyaml::detail::lexical_token_t::STRING_VALUE);
-    REQUIRE_NOTHROW(lexer.get_string());
-    REQUIRE(lexer.get_string().compare("test") == 0);
+    REQUIRE(token.type == fkyaml::detail::lexical_token_t::STRING_VALUE);
+    REQUIRE(std::string(token.token_begin_itr, token.token_end_itr) == "test");
 
     REQUIRE_NOTHROW(token = lexer.get_next_token());
-    REQUIRE(token == fkyaml::detail::lexical_token_t::KEY_SEPARATOR);
+    REQUIRE(token.type == fkyaml::detail::lexical_token_t::KEY_SEPARATOR);
 
     REQUIRE_NOTHROW(token = lexer.get_next_token());
-    REQUIRE(token == fkyaml::detail::lexical_token_t::BOOLEAN_VALUE);
-    REQUIRE_NOTHROW(lexer.get_boolean());
-    REQUIRE(lexer.get_boolean() == true);
+    REQUIRE(token.type == fkyaml::detail::lexical_token_t::BOOLEAN_VALUE);
+    REQUIRE(std::string(token.token_begin_itr, token.token_end_itr) == "true");
 
     REQUIRE_NOTHROW(token = lexer.get_next_token());
-    REQUIRE(token == fkyaml::detail::lexical_token_t::END_OF_BUFFER);
+    REQUIRE(token.type == fkyaml::detail::lexical_token_t::END_OF_BUFFER);
 }
 
 TEST_CASE("LexicalAnalyzer_KeyIntegerValuePair") {
     lexer_t lexer(fkyaml::detail::input_adapter("test: -5784"));
-    fkyaml::detail::lexical_token_t token;
+    fkyaml::detail::lexical_token token;
 
     REQUIRE_NOTHROW(token = lexer.get_next_token());
-    REQUIRE(token == fkyaml::detail::lexical_token_t::STRING_VALUE);
-    REQUIRE_NOTHROW(lexer.get_string());
-    REQUIRE(lexer.get_string().compare("test") == 0);
+    REQUIRE(token.type == fkyaml::detail::lexical_token_t::STRING_VALUE);
+    REQUIRE(std::string(token.token_begin_itr, token.token_end_itr) == "test");
 
     REQUIRE_NOTHROW(token = lexer.get_next_token());
-    REQUIRE(token == fkyaml::detail::lexical_token_t::KEY_SEPARATOR);
+    REQUIRE(token.type == fkyaml::detail::lexical_token_t::KEY_SEPARATOR);
 
     REQUIRE_NOTHROW(token = lexer.get_next_token());
-    REQUIRE(token == fkyaml::detail::lexical_token_t::INTEGER_VALUE);
-    REQUIRE_NOTHROW(lexer.get_integer());
-    REQUIRE(lexer.get_integer() == -5784);
+    REQUIRE(token.type == fkyaml::detail::lexical_token_t::INTEGER_VALUE);
+    REQUIRE(std::string(token.token_begin_itr, token.token_end_itr) == "-5784");
 
     REQUIRE_NOTHROW(token = lexer.get_next_token());
-    REQUIRE(token == fkyaml::detail::lexical_token_t::END_OF_BUFFER);
+    REQUIRE(token.type == fkyaml::detail::lexical_token_t::END_OF_BUFFER);
 }
 
 TEST_CASE("LexicalAnalyzer_KeyFloatNumberValuePair") {
     lexer_t lexer(fkyaml::detail::input_adapter("test: -5.58e-3"));
-    fkyaml::detail::lexical_token_t token;
+    fkyaml::detail::lexical_token token;
 
     REQUIRE_NOTHROW(token = lexer.get_next_token());
-    REQUIRE(token == fkyaml::detail::lexical_token_t::STRING_VALUE);
-    REQUIRE_NOTHROW(lexer.get_string());
-    REQUIRE(lexer.get_string().compare("test") == 0);
+    REQUIRE(token.type == fkyaml::detail::lexical_token_t::STRING_VALUE);
+    REQUIRE(std::string(token.token_begin_itr, token.token_end_itr) == "test");
 
     REQUIRE_NOTHROW(token = lexer.get_next_token());
-    REQUIRE(token == fkyaml::detail::lexical_token_t::KEY_SEPARATOR);
+    REQUIRE(token.type == fkyaml::detail::lexical_token_t::KEY_SEPARATOR);
 
     REQUIRE_NOTHROW(token = lexer.get_next_token());
-    REQUIRE(token == fkyaml::detail::lexical_token_t::FLOAT_NUMBER_VALUE);
-    REQUIRE_NOTHROW(lexer.get_float_number());
-    REQUIRE(lexer.get_float_number() == -5.58e-3);
+    REQUIRE(token.type == fkyaml::detail::lexical_token_t::FLOAT_NUMBER_VALUE);
+    REQUIRE(std::string(token.token_begin_itr, token.token_end_itr) == "-5.58e-3");
 
     REQUIRE_NOTHROW(token = lexer.get_next_token());
-    REQUIRE(token == fkyaml::detail::lexical_token_t::END_OF_BUFFER);
+    REQUIRE(token.type == fkyaml::detail::lexical_token_t::END_OF_BUFFER);
 }
 
 TEST_CASE("LexicalAnalyzer_KeyStringValuePair") {
     lexer_t lexer(fkyaml::detail::input_adapter("test: \"some value\""));
-    fkyaml::detail::lexical_token_t token;
+    fkyaml::detail::lexical_token token;
 
     REQUIRE_NOTHROW(token = lexer.get_next_token());
-    REQUIRE(token == fkyaml::detail::lexical_token_t::STRING_VALUE);
-    REQUIRE_NOTHROW(lexer.get_string());
-    REQUIRE(lexer.get_string().compare("test") == 0);
+    REQUIRE(token.type == fkyaml::detail::lexical_token_t::STRING_VALUE);
+    REQUIRE(std::string(token.token_begin_itr, token.token_end_itr) == "test");
 
     REQUIRE_NOTHROW(token = lexer.get_next_token());
-    REQUIRE(token == fkyaml::detail::lexical_token_t::KEY_SEPARATOR);
+    REQUIRE(token.type == fkyaml::detail::lexical_token_t::KEY_SEPARATOR);
 
     REQUIRE_NOTHROW(token = lexer.get_next_token());
-    REQUIRE(token == fkyaml::detail::lexical_token_t::STRING_VALUE);
-    REQUIRE_NOTHROW(lexer.get_string());
-    REQUIRE(lexer.get_string().compare("some value") == 0);
+    REQUIRE(token.type == fkyaml::detail::lexical_token_t::STRING_VALUE);
+    REQUIRE(std::string(token.token_begin_itr, token.token_end_itr) == "some value");
 
     REQUIRE_NOTHROW(token = lexer.get_next_token());
-    REQUIRE(token == fkyaml::detail::lexical_token_t::END_OF_BUFFER);
+    REQUIRE(token.type == fkyaml::detail::lexical_token_t::END_OF_BUFFER);
 }
 
 TEST_CASE("LexicalAnalyzer_FlowSequence") {
-    fkyaml::detail::lexical_token_t token;
+    fkyaml::detail::lexical_token token;
 
     SECTION("simple flow sequence") {
         lexer_t lexer(fkyaml::detail::input_adapter("test: [ foo, bar ]"));
 
         REQUIRE_NOTHROW(token = lexer.get_next_token());
-        REQUIRE(token == fkyaml::detail::lexical_token_t::STRING_VALUE);
-        REQUIRE_NOTHROW(lexer.get_string());
-        REQUIRE(lexer.get_string().compare("test") == 0);
+        REQUIRE(token.type == fkyaml::detail::lexical_token_t::STRING_VALUE);
+        REQUIRE(std::string(token.token_begin_itr, token.token_end_itr) == "test");
 
         REQUIRE_NOTHROW(token = lexer.get_next_token());
-        REQUIRE(token == fkyaml::detail::lexical_token_t::KEY_SEPARATOR);
+        REQUIRE(token.type == fkyaml::detail::lexical_token_t::KEY_SEPARATOR);
 
         REQUIRE_NOTHROW(token = lexer.get_next_token());
-        REQUIRE(token == fkyaml::detail::lexical_token_t::SEQUENCE_FLOW_BEGIN);
+        REQUIRE(token.type == fkyaml::detail::lexical_token_t::SEQUENCE_FLOW_BEGIN);
 
         REQUIRE_NOTHROW(token = lexer.get_next_token());
-        REQUIRE(token == fkyaml::detail::lexical_token_t::STRING_VALUE);
-        REQUIRE_NOTHROW(lexer.get_string());
-        REQUIRE(lexer.get_string().compare("foo") == 0);
+        REQUIRE(token.type == fkyaml::detail::lexical_token_t::STRING_VALUE);
+        REQUIRE(std::string(token.token_begin_itr, token.token_end_itr) == "foo");
 
         REQUIRE_NOTHROW(token = lexer.get_next_token());
-        REQUIRE(token == fkyaml::detail::lexical_token_t::VALUE_SEPARATOR);
+        REQUIRE(token.type == fkyaml::detail::lexical_token_t::VALUE_SEPARATOR);
 
         REQUIRE_NOTHROW(token = lexer.get_next_token());
-        REQUIRE(token == fkyaml::detail::lexical_token_t::STRING_VALUE);
-        REQUIRE_NOTHROW(lexer.get_string());
-        REQUIRE(lexer.get_string().compare("bar") == 0);
+        REQUIRE(token.type == fkyaml::detail::lexical_token_t::STRING_VALUE);
+        REQUIRE(std::string(token.token_begin_itr, token.token_end_itr) == "bar");
 
         REQUIRE_NOTHROW(token = lexer.get_next_token());
-        REQUIRE(token == fkyaml::detail::lexical_token_t::SEQUENCE_FLOW_END);
+        REQUIRE(token.type == fkyaml::detail::lexical_token_t::SEQUENCE_FLOW_END);
 
         REQUIRE_NOTHROW(token = lexer.get_next_token());
-        REQUIRE(token == fkyaml::detail::lexical_token_t::END_OF_BUFFER);
+        REQUIRE(token.type == fkyaml::detail::lexical_token_t::END_OF_BUFFER);
     }
 
     SECTION("flow sequence with flow mapping child nodes") {
         lexer_t lexer(fkyaml::detail::input_adapter("test: [ { foo: one, bar: false }, { foo: two, bar: true } ]"));
 
         REQUIRE_NOTHROW(token = lexer.get_next_token());
-        REQUIRE(token == fkyaml::detail::lexical_token_t::STRING_VALUE);
-        REQUIRE_NOTHROW(lexer.get_string());
-        REQUIRE(lexer.get_string().compare("test") == 0);
+        REQUIRE(token.type == fkyaml::detail::lexical_token_t::STRING_VALUE);
+        REQUIRE(std::string(token.token_begin_itr, token.token_end_itr) == "test");
 
         REQUIRE_NOTHROW(token = lexer.get_next_token());
-        REQUIRE(token == fkyaml::detail::lexical_token_t::KEY_SEPARATOR);
+        REQUIRE(token.type == fkyaml::detail::lexical_token_t::KEY_SEPARATOR);
 
         REQUIRE_NOTHROW(token = lexer.get_next_token());
-        REQUIRE(token == fkyaml::detail::lexical_token_t::SEQUENCE_FLOW_BEGIN);
+        REQUIRE(token.type == fkyaml::detail::lexical_token_t::SEQUENCE_FLOW_BEGIN);
 
         REQUIRE_NOTHROW(token = lexer.get_next_token());
-        REQUIRE(token == fkyaml::detail::lexical_token_t::MAPPING_FLOW_BEGIN);
+        REQUIRE(token.type == fkyaml::detail::lexical_token_t::MAPPING_FLOW_BEGIN);
 
         REQUIRE_NOTHROW(token = lexer.get_next_token());
-        REQUIRE(token == fkyaml::detail::lexical_token_t::STRING_VALUE);
-        REQUIRE_NOTHROW(lexer.get_string());
-        REQUIRE(lexer.get_string().compare("foo") == 0);
+        REQUIRE(token.type == fkyaml::detail::lexical_token_t::STRING_VALUE);
+        REQUIRE(std::string(token.token_begin_itr, token.token_end_itr) == "foo");
 
         REQUIRE_NOTHROW(token = lexer.get_next_token());
-        REQUIRE(token == fkyaml::detail::lexical_token_t::KEY_SEPARATOR);
+        REQUIRE(token.type == fkyaml::detail::lexical_token_t::KEY_SEPARATOR);
 
         REQUIRE_NOTHROW(token = lexer.get_next_token());
-        REQUIRE(token == fkyaml::detail::lexical_token_t::STRING_VALUE);
-        REQUIRE_NOTHROW(lexer.get_string());
-        REQUIRE(lexer.get_string().compare("one") == 0);
+        REQUIRE(token.type == fkyaml::detail::lexical_token_t::STRING_VALUE);
+        REQUIRE(std::string(token.token_begin_itr, token.token_end_itr) == "one");
 
         REQUIRE_NOTHROW(token = lexer.get_next_token());
-        REQUIRE(token == fkyaml::detail::lexical_token_t::VALUE_SEPARATOR);
+        REQUIRE(token.type == fkyaml::detail::lexical_token_t::VALUE_SEPARATOR);
 
         REQUIRE_NOTHROW(token = lexer.get_next_token());
-        REQUIRE(token == fkyaml::detail::lexical_token_t::STRING_VALUE);
-        REQUIRE_NOTHROW(lexer.get_string());
-        REQUIRE(lexer.get_string().compare("bar") == 0);
+        REQUIRE(token.type == fkyaml::detail::lexical_token_t::STRING_VALUE);
+        REQUIRE(std::string(token.token_begin_itr, token.token_end_itr) == "bar");
 
         REQUIRE_NOTHROW(token = lexer.get_next_token());
-        REQUIRE(token == fkyaml::detail::lexical_token_t::KEY_SEPARATOR);
+        REQUIRE(token.type == fkyaml::detail::lexical_token_t::KEY_SEPARATOR);
 
         REQUIRE_NOTHROW(token = lexer.get_next_token());
-        REQUIRE(token == fkyaml::detail::lexical_token_t::BOOLEAN_VALUE);
-        REQUIRE_NOTHROW(lexer.get_boolean());
-        REQUIRE(lexer.get_boolean() == false);
+        REQUIRE(token.type == fkyaml::detail::lexical_token_t::BOOLEAN_VALUE);
+        REQUIRE(std::string(token.token_begin_itr, token.token_end_itr) == "false");
 
         REQUIRE_NOTHROW(token = lexer.get_next_token());
-        REQUIRE(token == fkyaml::detail::lexical_token_t::MAPPING_FLOW_END);
+        REQUIRE(token.type == fkyaml::detail::lexical_token_t::MAPPING_FLOW_END);
 
         REQUIRE_NOTHROW(token = lexer.get_next_token());
-        REQUIRE(token == fkyaml::detail::lexical_token_t::VALUE_SEPARATOR);
+        REQUIRE(token.type == fkyaml::detail::lexical_token_t::VALUE_SEPARATOR);
 
         REQUIRE_NOTHROW(token = lexer.get_next_token());
-        REQUIRE(token == fkyaml::detail::lexical_token_t::MAPPING_FLOW_BEGIN);
+        REQUIRE(token.type == fkyaml::detail::lexical_token_t::MAPPING_FLOW_BEGIN);
 
         REQUIRE_NOTHROW(token = lexer.get_next_token());
-        REQUIRE(token == fkyaml::detail::lexical_token_t::STRING_VALUE);
-        REQUIRE_NOTHROW(lexer.get_string());
-        REQUIRE(lexer.get_string().compare("foo") == 0);
+        REQUIRE(token.type == fkyaml::detail::lexical_token_t::STRING_VALUE);
+        REQUIRE(std::string(token.token_begin_itr, token.token_end_itr) == "foo");
 
         REQUIRE_NOTHROW(token = lexer.get_next_token());
-        REQUIRE(token == fkyaml::detail::lexical_token_t::KEY_SEPARATOR);
+        REQUIRE(token.type == fkyaml::detail::lexical_token_t::KEY_SEPARATOR);
 
         REQUIRE_NOTHROW(token = lexer.get_next_token());
-        REQUIRE(token == fkyaml::detail::lexical_token_t::STRING_VALUE);
-        REQUIRE_NOTHROW(lexer.get_string());
-        REQUIRE(lexer.get_string().compare("two") == 0);
+        REQUIRE(token.type == fkyaml::detail::lexical_token_t::STRING_VALUE);
+        REQUIRE(std::string(token.token_begin_itr, token.token_end_itr) == "two");
 
         REQUIRE_NOTHROW(token = lexer.get_next_token());
-        REQUIRE(token == fkyaml::detail::lexical_token_t::VALUE_SEPARATOR);
+        REQUIRE(token.type == fkyaml::detail::lexical_token_t::VALUE_SEPARATOR);
 
         REQUIRE_NOTHROW(token = lexer.get_next_token());
-        REQUIRE(token == fkyaml::detail::lexical_token_t::STRING_VALUE);
-        REQUIRE_NOTHROW(lexer.get_string());
-        REQUIRE(lexer.get_string().compare("bar") == 0);
+        REQUIRE(token.type == fkyaml::detail::lexical_token_t::STRING_VALUE);
+        REQUIRE(std::string(token.token_begin_itr, token.token_end_itr) == "bar");
 
         REQUIRE_NOTHROW(token = lexer.get_next_token());
-        REQUIRE(token == fkyaml::detail::lexical_token_t::KEY_SEPARATOR);
+        REQUIRE(token.type == fkyaml::detail::lexical_token_t::KEY_SEPARATOR);
 
         REQUIRE_NOTHROW(token = lexer.get_next_token());
-        REQUIRE(token == fkyaml::detail::lexical_token_t::BOOLEAN_VALUE);
-        REQUIRE_NOTHROW(lexer.get_boolean());
-        REQUIRE(lexer.get_boolean() == true);
+        REQUIRE(token.type == fkyaml::detail::lexical_token_t::BOOLEAN_VALUE);
+        REQUIRE(std::string(token.token_begin_itr, token.token_end_itr) == "true");
 
         REQUIRE_NOTHROW(token = lexer.get_next_token());
-        REQUIRE(token == fkyaml::detail::lexical_token_t::MAPPING_FLOW_END);
+        REQUIRE(token.type == fkyaml::detail::lexical_token_t::MAPPING_FLOW_END);
 
         REQUIRE_NOTHROW(token = lexer.get_next_token());
-        REQUIRE(token == fkyaml::detail::lexical_token_t::SEQUENCE_FLOW_END);
+        REQUIRE(token.type == fkyaml::detail::lexical_token_t::SEQUENCE_FLOW_END);
 
         REQUIRE_NOTHROW(token = lexer.get_next_token());
-        REQUIRE(token == fkyaml::detail::lexical_token_t::END_OF_BUFFER);
+        REQUIRE(token.type == fkyaml::detail::lexical_token_t::END_OF_BUFFER);
     }
 }
 
 TEST_CASE("LexicalAnalyzer_FlowMapping") {
-    fkyaml::detail::lexical_token_t token;
+    fkyaml::detail::lexical_token token;
 
     SECTION("simple flow mapping") {
         lexer_t lexer(fkyaml::detail::input_adapter("test: { bool: true, foo: bar, pi: 3.14 }"));
 
         REQUIRE_NOTHROW(token = lexer.get_next_token());
-        REQUIRE(token == fkyaml::detail::lexical_token_t::STRING_VALUE);
-        REQUIRE_NOTHROW(lexer.get_string());
-        REQUIRE(lexer.get_string().compare("test") == 0);
+        REQUIRE(token.type == fkyaml::detail::lexical_token_t::STRING_VALUE);
+        REQUIRE(std::string(token.token_begin_itr, token.token_end_itr) == "test");
 
         REQUIRE_NOTHROW(token = lexer.get_next_token());
-        REQUIRE(token == fkyaml::detail::lexical_token_t::KEY_SEPARATOR);
+        REQUIRE(token.type == fkyaml::detail::lexical_token_t::KEY_SEPARATOR);
 
         REQUIRE_NOTHROW(token = lexer.get_next_token());
-        REQUIRE(token == fkyaml::detail::lexical_token_t::MAPPING_FLOW_BEGIN);
+        REQUIRE(token.type == fkyaml::detail::lexical_token_t::MAPPING_FLOW_BEGIN);
 
         REQUIRE_NOTHROW(token = lexer.get_next_token());
-        REQUIRE(token == fkyaml::detail::lexical_token_t::STRING_VALUE);
-        REQUIRE_NOTHROW(lexer.get_string());
-        REQUIRE(lexer.get_string().compare("bool") == 0);
+        REQUIRE(token.type == fkyaml::detail::lexical_token_t::STRING_VALUE);
+        REQUIRE(std::string(token.token_begin_itr, token.token_end_itr) == "bool");
 
         REQUIRE_NOTHROW(token = lexer.get_next_token());
-        REQUIRE(token == fkyaml::detail::lexical_token_t::KEY_SEPARATOR);
+        REQUIRE(token.type == fkyaml::detail::lexical_token_t::KEY_SEPARATOR);
 
         REQUIRE_NOTHROW(token = lexer.get_next_token());
-        REQUIRE(token == fkyaml::detail::lexical_token_t::BOOLEAN_VALUE);
-        REQUIRE_NOTHROW(lexer.get_boolean());
-        REQUIRE(lexer.get_boolean() == true);
+        REQUIRE(token.type == fkyaml::detail::lexical_token_t::BOOLEAN_VALUE);
+        REQUIRE(std::string(token.token_begin_itr, token.token_end_itr) == "true");
 
         REQUIRE_NOTHROW(token = lexer.get_next_token());
-        REQUIRE(token == fkyaml::detail::lexical_token_t::VALUE_SEPARATOR);
+        REQUIRE(token.type == fkyaml::detail::lexical_token_t::VALUE_SEPARATOR);
 
         REQUIRE_NOTHROW(token = lexer.get_next_token());
-        REQUIRE(token == fkyaml::detail::lexical_token_t::STRING_VALUE);
-        REQUIRE_NOTHROW(lexer.get_string());
-        REQUIRE(lexer.get_string().compare("foo") == 0);
+        REQUIRE(token.type == fkyaml::detail::lexical_token_t::STRING_VALUE);
+        REQUIRE(std::string(token.token_begin_itr, token.token_end_itr) == "foo");
 
         REQUIRE_NOTHROW(token = lexer.get_next_token());
-        REQUIRE(token == fkyaml::detail::lexical_token_t::KEY_SEPARATOR);
+        REQUIRE(token.type == fkyaml::detail::lexical_token_t::KEY_SEPARATOR);
 
         REQUIRE_NOTHROW(token = lexer.get_next_token());
-        REQUIRE(token == fkyaml::detail::lexical_token_t::STRING_VALUE);
-        REQUIRE_NOTHROW(lexer.get_string());
-        REQUIRE(lexer.get_string().compare("bar") == 0);
+        REQUIRE(token.type == fkyaml::detail::lexical_token_t::STRING_VALUE);
+        REQUIRE(std::string(token.token_begin_itr, token.token_end_itr) == "bar");
 
         REQUIRE_NOTHROW(token = lexer.get_next_token());
-        REQUIRE(token == fkyaml::detail::lexical_token_t::VALUE_SEPARATOR);
+        REQUIRE(token.type == fkyaml::detail::lexical_token_t::VALUE_SEPARATOR);
 
         REQUIRE_NOTHROW(token = lexer.get_next_token());
-        REQUIRE(token == fkyaml::detail::lexical_token_t::STRING_VALUE);
-        REQUIRE_NOTHROW(lexer.get_string());
-        REQUIRE(lexer.get_string().compare("pi") == 0);
+        REQUIRE(token.type == fkyaml::detail::lexical_token_t::STRING_VALUE);
+        REQUIRE(std::string(token.token_begin_itr, token.token_end_itr) == "pi");
 
         REQUIRE_NOTHROW(token = lexer.get_next_token());
-        REQUIRE(token == fkyaml::detail::lexical_token_t::KEY_SEPARATOR);
+        REQUIRE(token.type == fkyaml::detail::lexical_token_t::KEY_SEPARATOR);
 
         REQUIRE_NOTHROW(token = lexer.get_next_token());
-        REQUIRE(token == fkyaml::detail::lexical_token_t::FLOAT_NUMBER_VALUE);
-        REQUIRE_NOTHROW(lexer.get_float_number());
-        REQUIRE(lexer.get_float_number() == 3.14);
+        REQUIRE(token.type == fkyaml::detail::lexical_token_t::FLOAT_NUMBER_VALUE);
+        REQUIRE_NOTHROW(std::string(token.token_begin_itr, token.token_end_itr));
+        REQUIRE(std::string(token.token_begin_itr, token.token_end_itr) == "3.14");
 
         REQUIRE_NOTHROW(token = lexer.get_next_token());
-        REQUIRE(token == fkyaml::detail::lexical_token_t::MAPPING_FLOW_END);
+        REQUIRE(token.type == fkyaml::detail::lexical_token_t::MAPPING_FLOW_END);
 
         REQUIRE_NOTHROW(token = lexer.get_next_token());
-        REQUIRE(token == fkyaml::detail::lexical_token_t::END_OF_BUFFER);
+        REQUIRE(token.type == fkyaml::detail::lexical_token_t::END_OF_BUFFER);
     }
 
     SECTION("flow maping with a child mapping node") {
         lexer_t lexer(fkyaml::detail::input_adapter("test: {foo: bar baz}"));
 
         REQUIRE_NOTHROW(token = lexer.get_next_token());
-        REQUIRE(token == fkyaml::detail::lexical_token_t::STRING_VALUE);
-        REQUIRE_NOTHROW(lexer.get_string());
-        REQUIRE(lexer.get_string().compare("test") == 0);
+        REQUIRE(token.type == fkyaml::detail::lexical_token_t::STRING_VALUE);
+        REQUIRE(std::string(token.token_begin_itr, token.token_end_itr) == "test");
 
         REQUIRE_NOTHROW(token = lexer.get_next_token());
-        REQUIRE(token == fkyaml::detail::lexical_token_t::KEY_SEPARATOR);
+        REQUIRE(token.type == fkyaml::detail::lexical_token_t::KEY_SEPARATOR);
 
         REQUIRE_NOTHROW(token = lexer.get_next_token());
-        REQUIRE(token == fkyaml::detail::lexical_token_t::MAPPING_FLOW_BEGIN);
+        REQUIRE(token.type == fkyaml::detail::lexical_token_t::MAPPING_FLOW_BEGIN);
 
         REQUIRE_NOTHROW(token = lexer.get_next_token());
-        REQUIRE(token == fkyaml::detail::lexical_token_t::STRING_VALUE);
-        REQUIRE_NOTHROW(lexer.get_string());
-        REQUIRE(lexer.get_string().compare("foo") == 0);
+        REQUIRE(token.type == fkyaml::detail::lexical_token_t::STRING_VALUE);
+        REQUIRE(std::string(token.token_begin_itr, token.token_end_itr) == "foo");
 
         REQUIRE_NOTHROW(token = lexer.get_next_token());
-        REQUIRE(token == fkyaml::detail::lexical_token_t::KEY_SEPARATOR);
+        REQUIRE(token.type == fkyaml::detail::lexical_token_t::KEY_SEPARATOR);
 
         REQUIRE_NOTHROW(token = lexer.get_next_token());
-        REQUIRE(token == fkyaml::detail::lexical_token_t::STRING_VALUE);
-        REQUIRE_NOTHROW(lexer.get_string());
-        REQUIRE(lexer.get_string().compare("bar baz") == 0);
+        REQUIRE(token.type == fkyaml::detail::lexical_token_t::STRING_VALUE);
+        REQUIRE(std::string(token.token_begin_itr, token.token_end_itr) == "bar baz");
 
         REQUIRE_NOTHROW(token = lexer.get_next_token());
-        REQUIRE(token == fkyaml::detail::lexical_token_t::MAPPING_FLOW_END);
+        REQUIRE(token.type == fkyaml::detail::lexical_token_t::MAPPING_FLOW_END);
 
         REQUIRE_NOTHROW(token = lexer.get_next_token());
-        REQUIRE(token == fkyaml::detail::lexical_token_t::END_OF_BUFFER);
+        REQUIRE(token.type == fkyaml::detail::lexical_token_t::END_OF_BUFFER);
     }
 }
 
 TEST_CASE("LexicalAnalyzer_BlockSequence") {
-    fkyaml::detail::lexical_token_t token;
+    fkyaml::detail::lexical_token token;
 
     SECTION("simple block sequence") {
         std::string buffer = "test:\n  - foo\n  - bar";
         lexer_t lexer(fkyaml::detail::input_adapter(buffer));
 
         REQUIRE_NOTHROW(token = lexer.get_next_token());
-        REQUIRE(token == fkyaml::detail::lexical_token_t::STRING_VALUE);
-        REQUIRE_NOTHROW(lexer.get_string());
-        REQUIRE(lexer.get_string() == "test");
+        REQUIRE(token.type == fkyaml::detail::lexical_token_t::STRING_VALUE);
+        REQUIRE(std::string(token.token_begin_itr, token.token_end_itr) == "test");
 
         REQUIRE_NOTHROW(token = lexer.get_next_token());
-        REQUIRE(token == fkyaml::detail::lexical_token_t::KEY_SEPARATOR);
+        REQUIRE(token.type == fkyaml::detail::lexical_token_t::KEY_SEPARATOR);
 
         REQUIRE_NOTHROW(token = lexer.get_next_token());
-        REQUIRE(token == fkyaml::detail::lexical_token_t::SEQUENCE_BLOCK_PREFIX);
+        REQUIRE(token.type == fkyaml::detail::lexical_token_t::SEQUENCE_BLOCK_PREFIX);
 
         REQUIRE_NOTHROW(token = lexer.get_next_token());
-        REQUIRE(token == fkyaml::detail::lexical_token_t::STRING_VALUE);
-        REQUIRE_NOTHROW(lexer.get_string());
-        REQUIRE(lexer.get_string() == "foo");
+        REQUIRE(token.type == fkyaml::detail::lexical_token_t::STRING_VALUE);
+        REQUIRE(std::string(token.token_begin_itr, token.token_end_itr) == "foo");
 
         REQUIRE_NOTHROW(token = lexer.get_next_token());
-        REQUIRE(token == fkyaml::detail::lexical_token_t::SEQUENCE_BLOCK_PREFIX);
+        REQUIRE(token.type == fkyaml::detail::lexical_token_t::SEQUENCE_BLOCK_PREFIX);
 
         REQUIRE_NOTHROW(token = lexer.get_next_token());
-        REQUIRE(token == fkyaml::detail::lexical_token_t::STRING_VALUE);
-        REQUIRE_NOTHROW(lexer.get_string());
-        REQUIRE(lexer.get_string() == "bar");
+        REQUIRE(token.type == fkyaml::detail::lexical_token_t::STRING_VALUE);
+        REQUIRE(std::string(token.token_begin_itr, token.token_end_itr) == "bar");
 
         REQUIRE_NOTHROW(token = lexer.get_next_token());
-        REQUIRE(token == fkyaml::detail::lexical_token_t::END_OF_BUFFER);
+        REQUIRE(token.type == fkyaml::detail::lexical_token_t::END_OF_BUFFER);
     }
 
     SECTION("block sequence with block mapping child nodes") {
@@ -1779,222 +1654,197 @@ TEST_CASE("LexicalAnalyzer_BlockSequence") {
         lexer_t lexer(fkyaml::detail::input_adapter(buffer));
 
         REQUIRE_NOTHROW(token = lexer.get_next_token());
-        REQUIRE(token == fkyaml::detail::lexical_token_t::STRING_VALUE);
-        REQUIRE_NOTHROW(lexer.get_string());
-        REQUIRE(lexer.get_string() == "test");
+        REQUIRE(token.type == fkyaml::detail::lexical_token_t::STRING_VALUE);
+        REQUIRE(std::string(token.token_begin_itr, token.token_end_itr) == "test");
 
         REQUIRE_NOTHROW(token = lexer.get_next_token());
-        REQUIRE(token == fkyaml::detail::lexical_token_t::KEY_SEPARATOR);
+        REQUIRE(token.type == fkyaml::detail::lexical_token_t::KEY_SEPARATOR);
 
         REQUIRE_NOTHROW(token = lexer.get_next_token());
-        REQUIRE(token == fkyaml::detail::lexical_token_t::SEQUENCE_BLOCK_PREFIX);
+        REQUIRE(token.type == fkyaml::detail::lexical_token_t::SEQUENCE_BLOCK_PREFIX);
 
         REQUIRE_NOTHROW(token = lexer.get_next_token());
-        REQUIRE(token == fkyaml::detail::lexical_token_t::STRING_VALUE);
-        REQUIRE_NOTHROW(lexer.get_string());
-        REQUIRE(lexer.get_string() == "foo");
+        REQUIRE(token.type == fkyaml::detail::lexical_token_t::STRING_VALUE);
+        REQUIRE(std::string(token.token_begin_itr, token.token_end_itr) == "foo");
 
         REQUIRE_NOTHROW(token = lexer.get_next_token());
-        REQUIRE(token == fkyaml::detail::lexical_token_t::KEY_SEPARATOR);
+        REQUIRE(token.type == fkyaml::detail::lexical_token_t::KEY_SEPARATOR);
 
         REQUIRE_NOTHROW(token = lexer.get_next_token());
-        REQUIRE(token == fkyaml::detail::lexical_token_t::STRING_VALUE);
-        REQUIRE_NOTHROW(lexer.get_string());
-        REQUIRE(lexer.get_string() == "one");
+        REQUIRE(token.type == fkyaml::detail::lexical_token_t::STRING_VALUE);
+        REQUIRE(std::string(token.token_begin_itr, token.token_end_itr) == "one");
 
         REQUIRE_NOTHROW(token = lexer.get_next_token());
-        REQUIRE(token == fkyaml::detail::lexical_token_t::STRING_VALUE);
-        REQUIRE_NOTHROW(lexer.get_string());
-        REQUIRE(lexer.get_string() == "bar");
+        REQUIRE(token.type == fkyaml::detail::lexical_token_t::STRING_VALUE);
+        REQUIRE(std::string(token.token_begin_itr, token.token_end_itr) == "bar");
 
         REQUIRE_NOTHROW(token = lexer.get_next_token());
-        REQUIRE(token == fkyaml::detail::lexical_token_t::KEY_SEPARATOR);
+        REQUIRE(token.type == fkyaml::detail::lexical_token_t::KEY_SEPARATOR);
 
         REQUIRE_NOTHROW(token = lexer.get_next_token());
-        REQUIRE(token == fkyaml::detail::lexical_token_t::BOOLEAN_VALUE);
-        REQUIRE_NOTHROW(lexer.get_boolean());
-        REQUIRE(lexer.get_boolean() == false);
+        REQUIRE(token.type == fkyaml::detail::lexical_token_t::BOOLEAN_VALUE);
+        REQUIRE(std::string(token.token_begin_itr, token.token_end_itr) == "false");
 
         REQUIRE_NOTHROW(token = lexer.get_next_token());
-        REQUIRE(token == fkyaml::detail::lexical_token_t::SEQUENCE_BLOCK_PREFIX);
+        REQUIRE(token.type == fkyaml::detail::lexical_token_t::SEQUENCE_BLOCK_PREFIX);
 
         REQUIRE_NOTHROW(token = lexer.get_next_token());
-        REQUIRE(token == fkyaml::detail::lexical_token_t::STRING_VALUE);
-        REQUIRE_NOTHROW(lexer.get_string());
-        REQUIRE(lexer.get_string() == "foo");
+        REQUIRE(token.type == fkyaml::detail::lexical_token_t::STRING_VALUE);
+        REQUIRE(std::string(token.token_begin_itr, token.token_end_itr) == "foo");
 
         REQUIRE_NOTHROW(token = lexer.get_next_token());
-        REQUIRE(token == fkyaml::detail::lexical_token_t::KEY_SEPARATOR);
+        REQUIRE(token.type == fkyaml::detail::lexical_token_t::KEY_SEPARATOR);
 
         REQUIRE_NOTHROW(token = lexer.get_next_token());
-        REQUIRE(token == fkyaml::detail::lexical_token_t::STRING_VALUE);
-        REQUIRE_NOTHROW(lexer.get_string());
-        REQUIRE(lexer.get_string() == "two");
+        REQUIRE(token.type == fkyaml::detail::lexical_token_t::STRING_VALUE);
+        REQUIRE(std::string(token.token_begin_itr, token.token_end_itr) == "two");
 
         REQUIRE_NOTHROW(token = lexer.get_next_token());
-        REQUIRE(token == fkyaml::detail::lexical_token_t::STRING_VALUE);
-        REQUIRE_NOTHROW(lexer.get_string());
-        REQUIRE(lexer.get_string() == "bar");
+        REQUIRE(token.type == fkyaml::detail::lexical_token_t::STRING_VALUE);
+        REQUIRE(std::string(token.token_begin_itr, token.token_end_itr) == "bar");
 
         REQUIRE_NOTHROW(token = lexer.get_next_token());
-        REQUIRE(token == fkyaml::detail::lexical_token_t::KEY_SEPARATOR);
+        REQUIRE(token.type == fkyaml::detail::lexical_token_t::KEY_SEPARATOR);
 
         REQUIRE_NOTHROW(token = lexer.get_next_token());
-        REQUIRE(token == fkyaml::detail::lexical_token_t::BOOLEAN_VALUE);
-        REQUIRE_NOTHROW(lexer.get_boolean());
-        REQUIRE(lexer.get_boolean() == true);
+        REQUIRE(token.type == fkyaml::detail::lexical_token_t::BOOLEAN_VALUE);
+        REQUIRE(std::string(token.token_begin_itr, token.token_end_itr) == "true");
 
         REQUIRE_NOTHROW(token = lexer.get_next_token());
-        REQUIRE(token == fkyaml::detail::lexical_token_t::END_OF_BUFFER);
+        REQUIRE(token.type == fkyaml::detail::lexical_token_t::END_OF_BUFFER);
     }
 }
 
 TEST_CASE("LexicalAnalyzer_BlockMapping") {
-    fkyaml::detail::lexical_token_t token;
+    fkyaml::detail::lexical_token token;
 
     SECTION("simple block mapping") {
         lexer_t lexer(fkyaml::detail::input_adapter("test:\n  bool: true\n  foo: \'bar\'\n  pi: 3.14"));
 
         REQUIRE_NOTHROW(token = lexer.get_next_token());
-        REQUIRE(token == fkyaml::detail::lexical_token_t::STRING_VALUE);
-        REQUIRE_NOTHROW(lexer.get_string());
-        REQUIRE(lexer.get_string().compare("test") == 0);
+        REQUIRE(token.type == fkyaml::detail::lexical_token_t::STRING_VALUE);
+        REQUIRE(std::string(token.token_begin_itr, token.token_end_itr) == "test");
 
         REQUIRE_NOTHROW(token = lexer.get_next_token());
-        REQUIRE(token == fkyaml::detail::lexical_token_t::KEY_SEPARATOR);
+        REQUIRE(token.type == fkyaml::detail::lexical_token_t::KEY_SEPARATOR);
 
         REQUIRE_NOTHROW(token = lexer.get_next_token());
-        REQUIRE(token == fkyaml::detail::lexical_token_t::STRING_VALUE);
-        REQUIRE_NOTHROW(lexer.get_string());
-        REQUIRE(lexer.get_string().compare("bool") == 0);
+        REQUIRE(token.type == fkyaml::detail::lexical_token_t::STRING_VALUE);
+        REQUIRE(std::string(token.token_begin_itr, token.token_end_itr) == "bool");
 
         REQUIRE_NOTHROW(token = lexer.get_next_token());
-        REQUIRE(token == fkyaml::detail::lexical_token_t::KEY_SEPARATOR);
+        REQUIRE(token.type == fkyaml::detail::lexical_token_t::KEY_SEPARATOR);
 
         REQUIRE_NOTHROW(token = lexer.get_next_token());
-        REQUIRE(token == fkyaml::detail::lexical_token_t::BOOLEAN_VALUE);
-        REQUIRE_NOTHROW(lexer.get_boolean());
-        REQUIRE(lexer.get_boolean() == true);
+        REQUIRE(token.type == fkyaml::detail::lexical_token_t::BOOLEAN_VALUE);
+        REQUIRE(std::string(token.token_begin_itr, token.token_end_itr) == "true");
 
         REQUIRE_NOTHROW(token = lexer.get_next_token());
-        REQUIRE(token == fkyaml::detail::lexical_token_t::STRING_VALUE);
-        REQUIRE_NOTHROW(lexer.get_string());
-        REQUIRE(lexer.get_string().compare("foo") == 0);
+        REQUIRE(token.type == fkyaml::detail::lexical_token_t::STRING_VALUE);
+        REQUIRE(std::string(token.token_begin_itr, token.token_end_itr) == "foo");
 
         REQUIRE_NOTHROW(token = lexer.get_next_token());
-        REQUIRE(token == fkyaml::detail::lexical_token_t::KEY_SEPARATOR);
+        REQUIRE(token.type == fkyaml::detail::lexical_token_t::KEY_SEPARATOR);
 
         REQUIRE_NOTHROW(token = lexer.get_next_token());
-        REQUIRE(token == fkyaml::detail::lexical_token_t::STRING_VALUE);
-        REQUIRE_NOTHROW(lexer.get_string());
-        REQUIRE(lexer.get_string().compare("bar") == 0);
+        REQUIRE(token.type == fkyaml::detail::lexical_token_t::STRING_VALUE);
+        REQUIRE(std::string(token.token_begin_itr, token.token_end_itr) == "bar");
 
         REQUIRE_NOTHROW(token = lexer.get_next_token());
-        REQUIRE(token == fkyaml::detail::lexical_token_t::STRING_VALUE);
-        REQUIRE_NOTHROW(lexer.get_string());
-        REQUIRE(lexer.get_string().compare("pi") == 0);
+        REQUIRE(token.type == fkyaml::detail::lexical_token_t::STRING_VALUE);
+        REQUIRE(std::string(token.token_begin_itr, token.token_end_itr) == "pi");
 
         REQUIRE_NOTHROW(token = lexer.get_next_token());
-        REQUIRE(token == fkyaml::detail::lexical_token_t::KEY_SEPARATOR);
+        REQUIRE(token.type == fkyaml::detail::lexical_token_t::KEY_SEPARATOR);
 
         REQUIRE_NOTHROW(token = lexer.get_next_token());
-        REQUIRE(token == fkyaml::detail::lexical_token_t::FLOAT_NUMBER_VALUE);
-        REQUIRE_NOTHROW(lexer.get_float_number());
-        REQUIRE(lexer.get_float_number() == 3.14);
+        REQUIRE(token.type == fkyaml::detail::lexical_token_t::FLOAT_NUMBER_VALUE);
+        REQUIRE_NOTHROW(std::string(token.token_begin_itr, token.token_end_itr));
+        REQUIRE(std::string(token.token_begin_itr, token.token_end_itr) == "3.14");
 
         REQUIRE_NOTHROW(token = lexer.get_next_token());
-        REQUIRE(token == fkyaml::detail::lexical_token_t::END_OF_BUFFER);
+        REQUIRE(token.type == fkyaml::detail::lexical_token_t::END_OF_BUFFER);
     }
 
     SECTION("block mapping with a literal string scalar value") {
         lexer_t lexer(fkyaml::detail::input_adapter("test: |\n  a literal scalar.\nfoo: \'bar\'\npi: 3.14"));
 
         REQUIRE_NOTHROW(token = lexer.get_next_token());
-        REQUIRE(token == fkyaml::detail::lexical_token_t::STRING_VALUE);
-        REQUIRE_NOTHROW(lexer.get_string());
-        REQUIRE(lexer.get_string() == "test");
+        REQUIRE(token.type == fkyaml::detail::lexical_token_t::STRING_VALUE);
+        REQUIRE(std::string(token.token_begin_itr, token.token_end_itr) == "test");
 
         REQUIRE_NOTHROW(token = lexer.get_next_token());
-        REQUIRE(token == fkyaml::detail::lexical_token_t::KEY_SEPARATOR);
+        REQUIRE(token.type == fkyaml::detail::lexical_token_t::KEY_SEPARATOR);
 
         REQUIRE_NOTHROW(token = lexer.get_next_token());
-        REQUIRE(token == fkyaml::detail::lexical_token_t::STRING_VALUE);
-        REQUIRE_NOTHROW(lexer.get_string());
-        REQUIRE(lexer.get_string() == "a literal scalar.\n");
+        REQUIRE(token.type == fkyaml::detail::lexical_token_t::STRING_VALUE);
+        REQUIRE(std::string(token.token_begin_itr, token.token_end_itr) == "a literal scalar.\n");
 
         REQUIRE_NOTHROW(token = lexer.get_next_token());
-        REQUIRE(token == fkyaml::detail::lexical_token_t::STRING_VALUE);
-        REQUIRE_NOTHROW(lexer.get_string());
-        REQUIRE(lexer.get_string() == "foo");
+        REQUIRE(token.type == fkyaml::detail::lexical_token_t::STRING_VALUE);
+        REQUIRE(std::string(token.token_begin_itr, token.token_end_itr) == "foo");
 
         REQUIRE_NOTHROW(token = lexer.get_next_token());
-        REQUIRE(token == fkyaml::detail::lexical_token_t::KEY_SEPARATOR);
+        REQUIRE(token.type == fkyaml::detail::lexical_token_t::KEY_SEPARATOR);
 
         REQUIRE_NOTHROW(token = lexer.get_next_token());
-        REQUIRE(token == fkyaml::detail::lexical_token_t::STRING_VALUE);
-        REQUIRE_NOTHROW(lexer.get_string());
-        REQUIRE(lexer.get_string() == "bar");
+        REQUIRE(token.type == fkyaml::detail::lexical_token_t::STRING_VALUE);
+        REQUIRE(std::string(token.token_begin_itr, token.token_end_itr) == "bar");
 
         REQUIRE_NOTHROW(token = lexer.get_next_token());
-        REQUIRE(token == fkyaml::detail::lexical_token_t::STRING_VALUE);
-        REQUIRE_NOTHROW(lexer.get_string());
-        REQUIRE(lexer.get_string() == "pi");
+        REQUIRE(token.type == fkyaml::detail::lexical_token_t::STRING_VALUE);
+        REQUIRE(std::string(token.token_begin_itr, token.token_end_itr) == "pi");
 
         REQUIRE_NOTHROW(token = lexer.get_next_token());
-        REQUIRE(token == fkyaml::detail::lexical_token_t::KEY_SEPARATOR);
+        REQUIRE(token.type == fkyaml::detail::lexical_token_t::KEY_SEPARATOR);
 
         REQUIRE_NOTHROW(token = lexer.get_next_token());
-        REQUIRE(token == fkyaml::detail::lexical_token_t::FLOAT_NUMBER_VALUE);
-        REQUIRE_NOTHROW(lexer.get_float_number());
-        REQUIRE(lexer.get_float_number() == 3.14);
+        REQUIRE(token.type == fkyaml::detail::lexical_token_t::FLOAT_NUMBER_VALUE);
+        REQUIRE_NOTHROW(std::string(token.token_begin_itr, token.token_end_itr));
+        REQUIRE(std::string(token.token_begin_itr, token.token_end_itr) == "3.14");
 
         REQUIRE_NOTHROW(token = lexer.get_next_token());
-        REQUIRE(token == fkyaml::detail::lexical_token_t::END_OF_BUFFER);
+        REQUIRE(token.type == fkyaml::detail::lexical_token_t::END_OF_BUFFER);
     }
 
     SECTION("block mapping with a folded string scalar value") {
         lexer_t lexer(fkyaml::detail::input_adapter("test: >\n  a literal scalar.\nfoo: \'bar\'\npi: 3.14"));
 
         REQUIRE_NOTHROW(token = lexer.get_next_token());
-        REQUIRE(token == fkyaml::detail::lexical_token_t::STRING_VALUE);
-        REQUIRE_NOTHROW(lexer.get_string());
-        REQUIRE(lexer.get_string() == "test");
+        REQUIRE(token.type == fkyaml::detail::lexical_token_t::STRING_VALUE);
+        REQUIRE(std::string(token.token_begin_itr, token.token_end_itr) == "test");
 
         REQUIRE_NOTHROW(token = lexer.get_next_token());
-        REQUIRE(token == fkyaml::detail::lexical_token_t::KEY_SEPARATOR);
+        REQUIRE(token.type == fkyaml::detail::lexical_token_t::KEY_SEPARATOR);
 
         REQUIRE_NOTHROW(token = lexer.get_next_token());
-        REQUIRE(token == fkyaml::detail::lexical_token_t::STRING_VALUE);
-        REQUIRE_NOTHROW(lexer.get_string());
-        REQUIRE(lexer.get_string() == "a literal scalar.\n");
+        REQUIRE(token.type == fkyaml::detail::lexical_token_t::STRING_VALUE);
+        REQUIRE(std::string(token.token_begin_itr, token.token_end_itr) == "a literal scalar.\n");
 
         REQUIRE_NOTHROW(token = lexer.get_next_token());
-        REQUIRE(token == fkyaml::detail::lexical_token_t::STRING_VALUE);
-        REQUIRE_NOTHROW(lexer.get_string());
-        REQUIRE(lexer.get_string() == "foo");
+        REQUIRE(token.type == fkyaml::detail::lexical_token_t::STRING_VALUE);
+        REQUIRE(std::string(token.token_begin_itr, token.token_end_itr) == "foo");
 
         REQUIRE_NOTHROW(token = lexer.get_next_token());
-        REQUIRE(token == fkyaml::detail::lexical_token_t::KEY_SEPARATOR);
+        REQUIRE(token.type == fkyaml::detail::lexical_token_t::KEY_SEPARATOR);
 
         REQUIRE_NOTHROW(token = lexer.get_next_token());
-        REQUIRE(token == fkyaml::detail::lexical_token_t::STRING_VALUE);
-        REQUIRE_NOTHROW(lexer.get_string());
-        REQUIRE(lexer.get_string() == "bar");
+        REQUIRE(token.type == fkyaml::detail::lexical_token_t::STRING_VALUE);
+        REQUIRE(std::string(token.token_begin_itr, token.token_end_itr) == "bar");
 
         REQUIRE_NOTHROW(token = lexer.get_next_token());
-        REQUIRE(token == fkyaml::detail::lexical_token_t::STRING_VALUE);
-        REQUIRE_NOTHROW(lexer.get_string());
-        REQUIRE(lexer.get_string() == "pi");
+        REQUIRE(token.type == fkyaml::detail::lexical_token_t::STRING_VALUE);
+        REQUIRE(std::string(token.token_begin_itr, token.token_end_itr) == "pi");
 
         REQUIRE_NOTHROW(token = lexer.get_next_token());
-        REQUIRE(token == fkyaml::detail::lexical_token_t::KEY_SEPARATOR);
+        REQUIRE(token.type == fkyaml::detail::lexical_token_t::KEY_SEPARATOR);
 
         REQUIRE_NOTHROW(token = lexer.get_next_token());
-        REQUIRE(token == fkyaml::detail::lexical_token_t::FLOAT_NUMBER_VALUE);
-        REQUIRE_NOTHROW(lexer.get_float_number());
-        REQUIRE(lexer.get_float_number() == 3.14);
+        REQUIRE(token.type == fkyaml::detail::lexical_token_t::FLOAT_NUMBER_VALUE);
+        REQUIRE_NOTHROW(std::string(token.token_begin_itr, token.token_end_itr));
+        REQUIRE(std::string(token.token_begin_itr, token.token_end_itr) == "3.14");
 
         REQUIRE_NOTHROW(token = lexer.get_next_token());
-        REQUIRE(token == fkyaml::detail::lexical_token_t::END_OF_BUFFER);
+        REQUIRE(token.type == fkyaml::detail::lexical_token_t::END_OF_BUFFER);
     }
 }

--- a/test/unit_test/test_lexical_analyzer_class.cpp
+++ b/test/unit_test/test_lexical_analyzer_class.cpp
@@ -180,12 +180,12 @@ TEST_CASE("LexicalAnalyzer_EndOfDirectives") {
     REQUIRE_NOTHROW(token = lexer.get_next_token());
     REQUIRE(token.type == fkyaml::detail::lexical_token_t::END_OF_DIRECTIVES);
     REQUIRE_NOTHROW(token = lexer.get_next_token());
-    REQUIRE(token.type == fkyaml::detail::lexical_token_t::STRING_VALUE);
+    REQUIRE(token.type == fkyaml::detail::lexical_token_t::PLAIN_SCALAR);
     REQUIRE(std::string(token.token_begin_itr, token.token_end_itr) == "foo");
     REQUIRE_NOTHROW(token = lexer.get_next_token());
     REQUIRE(token.type == fkyaml::detail::lexical_token_t::KEY_SEPARATOR);
     REQUIRE_NOTHROW(token = lexer.get_next_token());
-    REQUIRE(token.type == fkyaml::detail::lexical_token_t::STRING_VALUE);
+    REQUIRE(token.type == fkyaml::detail::lexical_token_t::PLAIN_SCALAR);
     REQUIRE(std::string(token.token_begin_itr, token.token_end_itr) == "bar");
     REQUIRE_NOTHROW(token = lexer.get_next_token());
     REQUIRE(token.type == fkyaml::detail::lexical_token_t::END_OF_BUFFER);
@@ -254,7 +254,7 @@ TEST_CASE("LexicalAnalyzer_Colon") {
     SECTION("colon with an always-safe character") {
         lexer_t lexer(fkyaml::detail::input_adapter(":test"));
         REQUIRE_NOTHROW(token = lexer.get_next_token());
-        REQUIRE(token.type == fkyaml::detail::lexical_token_t::STRING_VALUE);
+        REQUIRE(token.type == fkyaml::detail::lexical_token_t::PLAIN_SCALAR);
         REQUIRE(std::string(token.token_begin_itr, token.token_end_itr) == ":test");
     }
 
@@ -263,7 +263,7 @@ TEST_CASE("LexicalAnalyzer_Colon") {
             GENERATE(std::string(":,"), std::string(":{"), std::string(":}"), std::string(":["), std::string(":]"));
         lexer_t lexer(fkyaml::detail::input_adapter(input));
         REQUIRE_NOTHROW(token = lexer.get_next_token());
-        REQUIRE(token.type == fkyaml::detail::lexical_token_t::STRING_VALUE);
+        REQUIRE(token.type == fkyaml::detail::lexical_token_t::PLAIN_SCALAR);
         REQUIRE(std::string(token.token_begin_itr, token.token_end_itr) == input);
     }
 
@@ -286,102 +286,8 @@ TEST_CASE("LexicalAnalzer_BlockSequenceEntryPrefix") {
     REQUIRE_NOTHROW(token = lexer.get_next_token());
     REQUIRE(token.type == fkyaml::detail::lexical_token_t::SEQUENCE_BLOCK_PREFIX);
     REQUIRE_NOTHROW(token = lexer.get_next_token());
-    REQUIRE(token.type == fkyaml::detail::lexical_token_t::STRING_VALUE);
+    REQUIRE(token.type == fkyaml::detail::lexical_token_t::PLAIN_SCALAR);
     REQUIRE(std::string(token.token_begin_itr, token.token_end_itr) == "foo");
-}
-
-TEST_CASE("LexicalAnalyzer_Null") {
-    fkyaml::detail::lexical_token token;
-
-    SECTION("valid null scalar token") {
-        auto buffer = GENERATE(std::string("null"), std::string("Null"), std::string("NULL"), std::string("~"));
-        lexer_t lexer(fkyaml::detail::input_adapter(buffer));
-
-        REQUIRE_NOTHROW(token = lexer.get_next_token());
-        REQUIRE(token.type == fkyaml::detail::lexical_token_t::NULL_VALUE);
-    }
-}
-
-TEST_CASE("LexicalAnalyzer_Boolean") {
-    fkyaml::detail::lexical_token token;
-
-    auto buffer = GENERATE(
-        std::string("true"),
-        std::string("True"),
-        std::string("TRUE"),
-        std::string("false"),
-        std::string("False"),
-        std::string("FALSE"));
-    lexer_t lexer(fkyaml::detail::input_adapter(buffer));
-
-    REQUIRE_NOTHROW(token = lexer.get_next_token());
-    REQUIRE(token.type == fkyaml::detail::lexical_token_t::BOOLEAN_VALUE);
-}
-
-TEST_CASE("LexicalAnalyzer_Integer") {
-    fkyaml::detail::lexical_token token;
-
-    auto buffer = GENERATE(
-        std::string("-1234"),
-        std::string("-853255"),
-        std::string("-1"),
-        std::string("0"),
-        std::string("643"),
-        std::string("+123"));
-
-    lexer_t lexer(fkyaml::detail::input_adapter(buffer));
-
-    REQUIRE_NOTHROW(token = lexer.get_next_token());
-    REQUIRE(token.type == fkyaml::detail::lexical_token_t::INTEGER_VALUE);
-}
-
-TEST_CASE("LexicalAnalyzer_OctalInteger") {
-    auto buffer = GENERATE(std::string("0o27"), std::string("0o5"), std::string("0o77772"), std::string("0o672"));
-
-    lexer_t lexer(fkyaml::detail::input_adapter(buffer));
-    fkyaml::detail::lexical_token token;
-
-    REQUIRE_NOTHROW(token = lexer.get_next_token());
-    REQUIRE(token.type == fkyaml::detail::lexical_token_t::INTEGER_VALUE);
-}
-
-TEST_CASE("LexicalAnalyzer_HexadecimalInteger") {
-    auto buffer = GENERATE(std::string("0xA04F"), std::string("0xa7F3"), std::string("0xFf29Bc"));
-
-    lexer_t lexer(fkyaml::detail::input_adapter(buffer));
-    fkyaml::detail::lexical_token token;
-
-    REQUIRE_NOTHROW(token = lexer.get_next_token());
-    REQUIRE(token.type == fkyaml::detail::lexical_token_t::INTEGER_VALUE);
-}
-
-TEST_CASE("LexicalAnalyzer_FloatingPointNumber") {
-    fkyaml::detail::lexical_token token;
-
-    auto buffer = GENERATE(
-        std::string("-1.234"),
-        std::string("-21."),
-        std::string("0."),
-        std::string("12."),
-        std::string("567.8"),
-        std::string("0.24"),
-        std::string("9.8e-3"),
-        std::string("3.95E3"),
-        std::string("1.863e+3"),
-        std::string(".inf"),
-        std::string(".Inf"),
-        std::string(".INF"),
-        std::string("-.inf"),
-        std::string("-.Inf"),
-        std::string("-.INF"),
-        std::string(".nan"),
-        std::string(".NaN"),
-        std::string(".NAN"));
-
-    lexer_t lexer(fkyaml::detail::input_adapter(buffer));
-
-    REQUIRE_NOTHROW(token = lexer.get_next_token());
-    REQUIRE(token.type == fkyaml::detail::lexical_token_t::FLOAT_NUMBER_VALUE);
 }
 
 TEST_CASE("LexicalAnalyzer_PlainString") {
@@ -433,7 +339,7 @@ TEST_CASE("LexicalAnalyzer_PlainString") {
     fkyaml::detail::lexical_token token;
 
     REQUIRE_NOTHROW(token = lexer.get_next_token());
-    REQUIRE(token.type == fkyaml::detail::lexical_token_t::STRING_VALUE);
+    REQUIRE(token.type == fkyaml::detail::lexical_token_t::PLAIN_SCALAR);
     REQUIRE(std::string(token.token_begin_itr, token.token_end_itr) == value_pair.second);
 }
 
@@ -461,7 +367,7 @@ TEST_CASE("LexicalAnalyzer_SingleQuotedString") {
     fkyaml::detail::lexical_token token;
 
     REQUIRE_NOTHROW(token = lexer.get_next_token());
-    REQUIRE(token.type == fkyaml::detail::lexical_token_t::STRING_VALUE);
+    REQUIRE(token.type == fkyaml::detail::lexical_token_t::SINGLE_QUOTED_SCALAR);
     REQUIRE(std::string(token.token_begin_itr, token.token_end_itr) == value_pair.second);
 }
 
@@ -491,7 +397,7 @@ TEST_CASE("LexicalAnalyzer_DoubleQuotedString") {
     fkyaml::detail::lexical_token token;
 
     REQUIRE_NOTHROW(token = lexer.get_next_token());
-    REQUIRE(token.type == fkyaml::detail::lexical_token_t::STRING_VALUE);
+    REQUIRE(token.type == fkyaml::detail::lexical_token_t::DOUBLE_QUOTED_SCALAR);
     REQUIRE(std::string(token.token_begin_itr, token.token_end_itr) == value_pair.second);
 }
 
@@ -547,7 +453,7 @@ TEST_CASE("LexicalAnalyzer_MultiByteCharString") {
     fkyaml::detail::lexical_token token;
 
     REQUIRE_NOTHROW(token = lexer.get_next_token());
-    REQUIRE(token.type == fkyaml::detail::lexical_token_t::STRING_VALUE);
+    REQUIRE(token.type == fkyaml::detail::lexical_token_t::PLAIN_SCALAR);
     REQUIRE(std::string(token.token_begin_itr, token.token_end_itr) == mb_char);
 }
 
@@ -644,7 +550,7 @@ TEST_CASE("LexicalAnalyzer_EscapedUnicodeCharacter") {
     fkyaml::detail::lexical_token token;
 
     REQUIRE_NOTHROW(token = lexer.get_next_token());
-    REQUIRE(token.type == fkyaml::detail::lexical_token_t::STRING_VALUE);
+    REQUIRE(token.type == fkyaml::detail::lexical_token_t::DOUBLE_QUOTED_SCALAR);
     REQUIRE(std::string(token.token_begin_itr, token.token_end_itr) == value_pair.second);
 }
 
@@ -848,7 +754,7 @@ TEST_CASE("LexicalAnalyzer_LiteralStringScalar") {
         lexer_t lexer(fkyaml::detail::input_adapter(input));
 
         REQUIRE_NOTHROW(token = lexer.get_next_token());
-        REQUIRE(token.type == fkyaml::detail::lexical_token_t::STRING_VALUE);
+        REQUIRE(token.type == fkyaml::detail::lexical_token_t::BLOCK_SCALAR);
         REQUIRE(std::string(token.token_begin_itr, token.token_end_itr) == "");
     }
 
@@ -858,7 +764,7 @@ TEST_CASE("LexicalAnalyzer_LiteralStringScalar") {
         lexer_t lexer(fkyaml::detail::input_adapter(input));
 
         REQUIRE_NOTHROW(token = lexer.get_next_token());
-        REQUIRE(token.type == fkyaml::detail::lexical_token_t::STRING_VALUE);
+        REQUIRE(token.type == fkyaml::detail::lexical_token_t::BLOCK_SCALAR);
         REQUIRE(std::string(token.token_begin_itr, token.token_end_itr) == "");
     }
 
@@ -868,7 +774,7 @@ TEST_CASE("LexicalAnalyzer_LiteralStringScalar") {
         lexer_t lexer(fkyaml::detail::input_adapter(input));
 
         REQUIRE_NOTHROW(token = lexer.get_next_token());
-        REQUIRE(token.type == fkyaml::detail::lexical_token_t::STRING_VALUE);
+        REQUIRE(token.type == fkyaml::detail::lexical_token_t::BLOCK_SCALAR);
         REQUIRE(std::string(token.token_begin_itr, token.token_end_itr) == "\n");
     }
 
@@ -895,7 +801,7 @@ TEST_CASE("LexicalAnalyzer_LiteralStringScalar") {
         lexer_t lexer(fkyaml::detail::input_adapter(input));
 
         REQUIRE_NOTHROW(token = lexer.get_next_token());
-        REQUIRE(token.type == fkyaml::detail::lexical_token_t::STRING_VALUE);
+        REQUIRE(token.type == fkyaml::detail::lexical_token_t::BLOCK_SCALAR);
         REQUIRE(std::string(token.token_begin_itr, token.token_end_itr) == "  foo\nbar\n");
     }
 
@@ -906,7 +812,7 @@ TEST_CASE("LexicalAnalyzer_LiteralStringScalar") {
         lexer_t lexer(fkyaml::detail::input_adapter(input));
 
         REQUIRE_NOTHROW(token = lexer.get_next_token());
-        REQUIRE(token.type == fkyaml::detail::lexical_token_t::STRING_VALUE);
+        REQUIRE(token.type == fkyaml::detail::lexical_token_t::BLOCK_SCALAR);
         REQUIRE(std::string(token.token_begin_itr, token.token_end_itr) == "foo\nbar\n");
     }
 
@@ -921,7 +827,7 @@ TEST_CASE("LexicalAnalyzer_LiteralStringScalar") {
         lexer_t lexer(fkyaml::detail::input_adapter(input));
 
         REQUIRE_NOTHROW(token = lexer.get_next_token());
-        REQUIRE(token.type == fkyaml::detail::lexical_token_t::STRING_VALUE);
+        REQUIRE(token.type == fkyaml::detail::lexical_token_t::BLOCK_SCALAR);
         REQUIRE(std::string(token.token_begin_itr, token.token_end_itr) == "\nfoo\nbar\n\nbaz");
     }
 
@@ -935,7 +841,7 @@ TEST_CASE("LexicalAnalyzer_LiteralStringScalar") {
         lexer_t lexer(fkyaml::detail::input_adapter(input));
 
         REQUIRE_NOTHROW(token = lexer.get_next_token());
-        REQUIRE(token.type == fkyaml::detail::lexical_token_t::STRING_VALUE);
+        REQUIRE(token.type == fkyaml::detail::lexical_token_t::BLOCK_SCALAR);
         REQUIRE(std::string(token.token_begin_itr, token.token_end_itr) == "foo\n  bar\n\nbaz");
     }
 
@@ -950,7 +856,7 @@ TEST_CASE("LexicalAnalyzer_LiteralStringScalar") {
         lexer_t lexer(fkyaml::detail::input_adapter(input));
 
         REQUIRE_NOTHROW(token = lexer.get_next_token());
-        REQUIRE(token.type == fkyaml::detail::lexical_token_t::STRING_VALUE);
+        REQUIRE(token.type == fkyaml::detail::lexical_token_t::BLOCK_SCALAR);
         REQUIRE(std::string(token.token_begin_itr, token.token_end_itr) == "\nfoo\nbar\n\nbaz\n");
     }
 
@@ -964,7 +870,7 @@ TEST_CASE("LexicalAnalyzer_LiteralStringScalar") {
         lexer_t lexer(fkyaml::detail::input_adapter(input));
 
         REQUIRE_NOTHROW(token = lexer.get_next_token());
-        REQUIRE(token.type == fkyaml::detail::lexical_token_t::STRING_VALUE);
+        REQUIRE(token.type == fkyaml::detail::lexical_token_t::BLOCK_SCALAR);
         REQUIRE(std::string(token.token_begin_itr, token.token_end_itr) == "foo\n  bar\n\nbaz\n");
     }
 
@@ -977,7 +883,7 @@ TEST_CASE("LexicalAnalyzer_LiteralStringScalar") {
         lexer_t lexer(fkyaml::detail::input_adapter(input));
 
         REQUIRE_NOTHROW(token = lexer.get_next_token());
-        REQUIRE(token.type == fkyaml::detail::lexical_token_t::STRING_VALUE);
+        REQUIRE(token.type == fkyaml::detail::lexical_token_t::BLOCK_SCALAR);
         REQUIRE(std::string(token.token_begin_itr, token.token_end_itr) == "foo\n  bar\n\nbaz");
     }
 
@@ -992,7 +898,7 @@ TEST_CASE("LexicalAnalyzer_LiteralStringScalar") {
         lexer_t lexer(fkyaml::detail::input_adapter(input));
 
         REQUIRE_NOTHROW(token = lexer.get_next_token());
-        REQUIRE(token.type == fkyaml::detail::lexical_token_t::STRING_VALUE);
+        REQUIRE(token.type == fkyaml::detail::lexical_token_t::BLOCK_SCALAR);
         REQUIRE(std::string(token.token_begin_itr, token.token_end_itr) == "\nfoo\nbar\n\nbaz\n\n");
     }
 
@@ -1006,7 +912,7 @@ TEST_CASE("LexicalAnalyzer_LiteralStringScalar") {
         lexer_t lexer(fkyaml::detail::input_adapter(input));
 
         REQUIRE_NOTHROW(token = lexer.get_next_token());
-        REQUIRE(token.type == fkyaml::detail::lexical_token_t::STRING_VALUE);
+        REQUIRE(token.type == fkyaml::detail::lexical_token_t::BLOCK_SCALAR);
         REQUIRE(std::string(token.token_begin_itr, token.token_end_itr) == "foo\n  bar\n\nbaz\n\n");
     }
 
@@ -1016,7 +922,7 @@ TEST_CASE("LexicalAnalyzer_LiteralStringScalar") {
         lexer_t lexer(fkyaml::detail::input_adapter(input));
 
         REQUIRE_NOTHROW(token = lexer.get_next_token());
-        REQUIRE(token.type == fkyaml::detail::lexical_token_t::STRING_VALUE);
+        REQUIRE(token.type == fkyaml::detail::lexical_token_t::BLOCK_SCALAR);
         REQUIRE(std::string(token.token_begin_itr, token.token_end_itr) == "foo\n");
     }
 
@@ -1044,7 +950,7 @@ TEST_CASE("LexicalAnalyzer_FoldedString") {
         lexer_t lexer(fkyaml::detail::input_adapter(input));
 
         REQUIRE_NOTHROW(token = lexer.get_next_token());
-        REQUIRE(token.type == fkyaml::detail::lexical_token_t::STRING_VALUE);
+        REQUIRE(token.type == fkyaml::detail::lexical_token_t::BLOCK_SCALAR);
         REQUIRE(std::string(token.token_begin_itr, token.token_end_itr) == "");
     }
 
@@ -1054,7 +960,7 @@ TEST_CASE("LexicalAnalyzer_FoldedString") {
         lexer_t lexer(fkyaml::detail::input_adapter(input));
 
         REQUIRE_NOTHROW(token = lexer.get_next_token());
-        REQUIRE(token.type == fkyaml::detail::lexical_token_t::STRING_VALUE);
+        REQUIRE(token.type == fkyaml::detail::lexical_token_t::BLOCK_SCALAR);
         REQUIRE(std::string(token.token_begin_itr, token.token_end_itr) == "");
     }
 
@@ -1064,7 +970,7 @@ TEST_CASE("LexicalAnalyzer_FoldedString") {
         lexer_t lexer(fkyaml::detail::input_adapter(input));
 
         REQUIRE_NOTHROW(token = lexer.get_next_token());
-        REQUIRE(token.type == fkyaml::detail::lexical_token_t::STRING_VALUE);
+        REQUIRE(token.type == fkyaml::detail::lexical_token_t::BLOCK_SCALAR);
         REQUIRE(std::string(token.token_begin_itr, token.token_end_itr) == "\n");
     }
 
@@ -1091,7 +997,7 @@ TEST_CASE("LexicalAnalyzer_FoldedString") {
         lexer_t lexer(fkyaml::detail::input_adapter(input));
 
         REQUIRE_NOTHROW(token = lexer.get_next_token());
-        REQUIRE(token.type == fkyaml::detail::lexical_token_t::STRING_VALUE);
+        REQUIRE(token.type == fkyaml::detail::lexical_token_t::BLOCK_SCALAR);
         REQUIRE(std::string(token.token_begin_itr, token.token_end_itr) == "\n  foo\nbar\n");
     }
 
@@ -1102,7 +1008,7 @@ TEST_CASE("LexicalAnalyzer_FoldedString") {
         lexer_t lexer(fkyaml::detail::input_adapter(input));
 
         REQUIRE_NOTHROW(token = lexer.get_next_token());
-        REQUIRE(token.type == fkyaml::detail::lexical_token_t::STRING_VALUE);
+        REQUIRE(token.type == fkyaml::detail::lexical_token_t::BLOCK_SCALAR);
         REQUIRE(std::string(token.token_begin_itr, token.token_end_itr) == "foo\n  bar\n");
     }
 
@@ -1116,7 +1022,7 @@ TEST_CASE("LexicalAnalyzer_FoldedString") {
         lexer_t lexer(fkyaml::detail::input_adapter(input));
 
         REQUIRE_NOTHROW(token = lexer.get_next_token());
-        REQUIRE(token.type == fkyaml::detail::lexical_token_t::STRING_VALUE);
+        REQUIRE(token.type == fkyaml::detail::lexical_token_t::BLOCK_SCALAR);
         REQUIRE(std::string(token.token_begin_itr, token.token_end_itr) == "foo\n\nbar\n");
     }
 
@@ -1129,7 +1035,7 @@ TEST_CASE("LexicalAnalyzer_FoldedString") {
         lexer_t lexer(fkyaml::detail::input_adapter(input));
 
         REQUIRE_NOTHROW(token = lexer.get_next_token());
-        REQUIRE(token.type == fkyaml::detail::lexical_token_t::STRING_VALUE);
+        REQUIRE(token.type == fkyaml::detail::lexical_token_t::BLOCK_SCALAR);
         REQUIRE(std::string(token.token_begin_itr, token.token_end_itr) == "foo bar");
     }
 
@@ -1142,7 +1048,7 @@ TEST_CASE("LexicalAnalyzer_FoldedString") {
         lexer_t lexer(fkyaml::detail::input_adapter(input));
 
         REQUIRE_NOTHROW(token = lexer.get_next_token());
-        REQUIRE(token.type == fkyaml::detail::lexical_token_t::STRING_VALUE);
+        REQUIRE(token.type == fkyaml::detail::lexical_token_t::BLOCK_SCALAR);
         REQUIRE(std::string(token.token_begin_itr, token.token_end_itr) == "foo bar\n");
     }
 
@@ -1155,7 +1061,7 @@ TEST_CASE("LexicalAnalyzer_FoldedString") {
         lexer_t lexer(fkyaml::detail::input_adapter(input));
 
         REQUIRE_NOTHROW(token = lexer.get_next_token());
-        REQUIRE(token.type == fkyaml::detail::lexical_token_t::STRING_VALUE);
+        REQUIRE(token.type == fkyaml::detail::lexical_token_t::BLOCK_SCALAR);
         REQUIRE(std::string(token.token_begin_itr, token.token_end_itr) == "foo bar\n\n");
     }
 
@@ -1165,7 +1071,7 @@ TEST_CASE("LexicalAnalyzer_FoldedString") {
         lexer_t lexer(fkyaml::detail::input_adapter(input));
 
         REQUIRE_NOTHROW(token = lexer.get_next_token());
-        REQUIRE(token.type == fkyaml::detail::lexical_token_t::STRING_VALUE);
+        REQUIRE(token.type == fkyaml::detail::lexical_token_t::BLOCK_SCALAR);
         REQUIRE(std::string(token.token_begin_itr, token.token_end_itr) == "foo\n");
     }
 
@@ -1291,7 +1197,7 @@ TEST_CASE("LexicalAnalyzer_Tag") {
         REQUIRE(std::string(token.token_begin_itr, token.token_end_itr) == input.substr(0, input.size() - 4));
 
         REQUIRE_NOTHROW(token = lexer.get_next_token());
-        REQUIRE(token.type == fkyaml::detail::lexical_token_t::STRING_VALUE);
+        REQUIRE(token.type == fkyaml::detail::lexical_token_t::PLAIN_SCALAR);
         REQUIRE(std::string(token.token_begin_itr, token.token_end_itr) == "tag");
     }
 
@@ -1331,14 +1237,14 @@ TEST_CASE("LexicalAnalyzer_KeyBooleanValuePair") {
     fkyaml::detail::lexical_token token;
 
     REQUIRE_NOTHROW(token = lexer.get_next_token());
-    REQUIRE(token.type == fkyaml::detail::lexical_token_t::STRING_VALUE);
+    REQUIRE(token.type == fkyaml::detail::lexical_token_t::PLAIN_SCALAR);
     REQUIRE(std::string(token.token_begin_itr, token.token_end_itr) == "test");
 
     REQUIRE_NOTHROW(token = lexer.get_next_token());
     REQUIRE(token.type == fkyaml::detail::lexical_token_t::KEY_SEPARATOR);
 
     REQUIRE_NOTHROW(token = lexer.get_next_token());
-    REQUIRE(token.type == fkyaml::detail::lexical_token_t::BOOLEAN_VALUE);
+    REQUIRE(token.type == fkyaml::detail::lexical_token_t::PLAIN_SCALAR);
     REQUIRE(std::string(token.token_begin_itr, token.token_end_itr) == "true");
 
     REQUIRE_NOTHROW(token = lexer.get_next_token());
@@ -1350,14 +1256,14 @@ TEST_CASE("LexicalAnalyzer_KeyIntegerValuePair") {
     fkyaml::detail::lexical_token token;
 
     REQUIRE_NOTHROW(token = lexer.get_next_token());
-    REQUIRE(token.type == fkyaml::detail::lexical_token_t::STRING_VALUE);
+    REQUIRE(token.type == fkyaml::detail::lexical_token_t::PLAIN_SCALAR);
     REQUIRE(std::string(token.token_begin_itr, token.token_end_itr) == "test");
 
     REQUIRE_NOTHROW(token = lexer.get_next_token());
     REQUIRE(token.type == fkyaml::detail::lexical_token_t::KEY_SEPARATOR);
 
     REQUIRE_NOTHROW(token = lexer.get_next_token());
-    REQUIRE(token.type == fkyaml::detail::lexical_token_t::INTEGER_VALUE);
+    REQUIRE(token.type == fkyaml::detail::lexical_token_t::PLAIN_SCALAR);
     REQUIRE(std::string(token.token_begin_itr, token.token_end_itr) == "-5784");
 
     REQUIRE_NOTHROW(token = lexer.get_next_token());
@@ -1369,14 +1275,14 @@ TEST_CASE("LexicalAnalyzer_KeyFloatNumberValuePair") {
     fkyaml::detail::lexical_token token;
 
     REQUIRE_NOTHROW(token = lexer.get_next_token());
-    REQUIRE(token.type == fkyaml::detail::lexical_token_t::STRING_VALUE);
+    REQUIRE(token.type == fkyaml::detail::lexical_token_t::PLAIN_SCALAR);
     REQUIRE(std::string(token.token_begin_itr, token.token_end_itr) == "test");
 
     REQUIRE_NOTHROW(token = lexer.get_next_token());
     REQUIRE(token.type == fkyaml::detail::lexical_token_t::KEY_SEPARATOR);
 
     REQUIRE_NOTHROW(token = lexer.get_next_token());
-    REQUIRE(token.type == fkyaml::detail::lexical_token_t::FLOAT_NUMBER_VALUE);
+    REQUIRE(token.type == fkyaml::detail::lexical_token_t::PLAIN_SCALAR);
     REQUIRE(std::string(token.token_begin_itr, token.token_end_itr) == "-5.58e-3");
 
     REQUIRE_NOTHROW(token = lexer.get_next_token());
@@ -1388,14 +1294,14 @@ TEST_CASE("LexicalAnalyzer_KeyStringValuePair") {
     fkyaml::detail::lexical_token token;
 
     REQUIRE_NOTHROW(token = lexer.get_next_token());
-    REQUIRE(token.type == fkyaml::detail::lexical_token_t::STRING_VALUE);
+    REQUIRE(token.type == fkyaml::detail::lexical_token_t::PLAIN_SCALAR);
     REQUIRE(std::string(token.token_begin_itr, token.token_end_itr) == "test");
 
     REQUIRE_NOTHROW(token = lexer.get_next_token());
     REQUIRE(token.type == fkyaml::detail::lexical_token_t::KEY_SEPARATOR);
 
     REQUIRE_NOTHROW(token = lexer.get_next_token());
-    REQUIRE(token.type == fkyaml::detail::lexical_token_t::STRING_VALUE);
+    REQUIRE(token.type == fkyaml::detail::lexical_token_t::DOUBLE_QUOTED_SCALAR);
     REQUIRE(std::string(token.token_begin_itr, token.token_end_itr) == "some value");
 
     REQUIRE_NOTHROW(token = lexer.get_next_token());
@@ -1409,7 +1315,7 @@ TEST_CASE("LexicalAnalyzer_FlowSequence") {
         lexer_t lexer(fkyaml::detail::input_adapter("test: [ foo, bar ]"));
 
         REQUIRE_NOTHROW(token = lexer.get_next_token());
-        REQUIRE(token.type == fkyaml::detail::lexical_token_t::STRING_VALUE);
+        REQUIRE(token.type == fkyaml::detail::lexical_token_t::PLAIN_SCALAR);
         REQUIRE(std::string(token.token_begin_itr, token.token_end_itr) == "test");
 
         REQUIRE_NOTHROW(token = lexer.get_next_token());
@@ -1419,14 +1325,14 @@ TEST_CASE("LexicalAnalyzer_FlowSequence") {
         REQUIRE(token.type == fkyaml::detail::lexical_token_t::SEQUENCE_FLOW_BEGIN);
 
         REQUIRE_NOTHROW(token = lexer.get_next_token());
-        REQUIRE(token.type == fkyaml::detail::lexical_token_t::STRING_VALUE);
+        REQUIRE(token.type == fkyaml::detail::lexical_token_t::PLAIN_SCALAR);
         REQUIRE(std::string(token.token_begin_itr, token.token_end_itr) == "foo");
 
         REQUIRE_NOTHROW(token = lexer.get_next_token());
         REQUIRE(token.type == fkyaml::detail::lexical_token_t::VALUE_SEPARATOR);
 
         REQUIRE_NOTHROW(token = lexer.get_next_token());
-        REQUIRE(token.type == fkyaml::detail::lexical_token_t::STRING_VALUE);
+        REQUIRE(token.type == fkyaml::detail::lexical_token_t::PLAIN_SCALAR);
         REQUIRE(std::string(token.token_begin_itr, token.token_end_itr) == "bar");
 
         REQUIRE_NOTHROW(token = lexer.get_next_token());
@@ -1440,7 +1346,7 @@ TEST_CASE("LexicalAnalyzer_FlowSequence") {
         lexer_t lexer(fkyaml::detail::input_adapter("test: [ { foo: one, bar: false }, { foo: two, bar: true } ]"));
 
         REQUIRE_NOTHROW(token = lexer.get_next_token());
-        REQUIRE(token.type == fkyaml::detail::lexical_token_t::STRING_VALUE);
+        REQUIRE(token.type == fkyaml::detail::lexical_token_t::PLAIN_SCALAR);
         REQUIRE(std::string(token.token_begin_itr, token.token_end_itr) == "test");
 
         REQUIRE_NOTHROW(token = lexer.get_next_token());
@@ -1453,28 +1359,28 @@ TEST_CASE("LexicalAnalyzer_FlowSequence") {
         REQUIRE(token.type == fkyaml::detail::lexical_token_t::MAPPING_FLOW_BEGIN);
 
         REQUIRE_NOTHROW(token = lexer.get_next_token());
-        REQUIRE(token.type == fkyaml::detail::lexical_token_t::STRING_VALUE);
+        REQUIRE(token.type == fkyaml::detail::lexical_token_t::PLAIN_SCALAR);
         REQUIRE(std::string(token.token_begin_itr, token.token_end_itr) == "foo");
 
         REQUIRE_NOTHROW(token = lexer.get_next_token());
         REQUIRE(token.type == fkyaml::detail::lexical_token_t::KEY_SEPARATOR);
 
         REQUIRE_NOTHROW(token = lexer.get_next_token());
-        REQUIRE(token.type == fkyaml::detail::lexical_token_t::STRING_VALUE);
+        REQUIRE(token.type == fkyaml::detail::lexical_token_t::PLAIN_SCALAR);
         REQUIRE(std::string(token.token_begin_itr, token.token_end_itr) == "one");
 
         REQUIRE_NOTHROW(token = lexer.get_next_token());
         REQUIRE(token.type == fkyaml::detail::lexical_token_t::VALUE_SEPARATOR);
 
         REQUIRE_NOTHROW(token = lexer.get_next_token());
-        REQUIRE(token.type == fkyaml::detail::lexical_token_t::STRING_VALUE);
+        REQUIRE(token.type == fkyaml::detail::lexical_token_t::PLAIN_SCALAR);
         REQUIRE(std::string(token.token_begin_itr, token.token_end_itr) == "bar");
 
         REQUIRE_NOTHROW(token = lexer.get_next_token());
         REQUIRE(token.type == fkyaml::detail::lexical_token_t::KEY_SEPARATOR);
 
         REQUIRE_NOTHROW(token = lexer.get_next_token());
-        REQUIRE(token.type == fkyaml::detail::lexical_token_t::BOOLEAN_VALUE);
+        REQUIRE(token.type == fkyaml::detail::lexical_token_t::PLAIN_SCALAR);
         REQUIRE(std::string(token.token_begin_itr, token.token_end_itr) == "false");
 
         REQUIRE_NOTHROW(token = lexer.get_next_token());
@@ -1487,28 +1393,28 @@ TEST_CASE("LexicalAnalyzer_FlowSequence") {
         REQUIRE(token.type == fkyaml::detail::lexical_token_t::MAPPING_FLOW_BEGIN);
 
         REQUIRE_NOTHROW(token = lexer.get_next_token());
-        REQUIRE(token.type == fkyaml::detail::lexical_token_t::STRING_VALUE);
+        REQUIRE(token.type == fkyaml::detail::lexical_token_t::PLAIN_SCALAR);
         REQUIRE(std::string(token.token_begin_itr, token.token_end_itr) == "foo");
 
         REQUIRE_NOTHROW(token = lexer.get_next_token());
         REQUIRE(token.type == fkyaml::detail::lexical_token_t::KEY_SEPARATOR);
 
         REQUIRE_NOTHROW(token = lexer.get_next_token());
-        REQUIRE(token.type == fkyaml::detail::lexical_token_t::STRING_VALUE);
+        REQUIRE(token.type == fkyaml::detail::lexical_token_t::PLAIN_SCALAR);
         REQUIRE(std::string(token.token_begin_itr, token.token_end_itr) == "two");
 
         REQUIRE_NOTHROW(token = lexer.get_next_token());
         REQUIRE(token.type == fkyaml::detail::lexical_token_t::VALUE_SEPARATOR);
 
         REQUIRE_NOTHROW(token = lexer.get_next_token());
-        REQUIRE(token.type == fkyaml::detail::lexical_token_t::STRING_VALUE);
+        REQUIRE(token.type == fkyaml::detail::lexical_token_t::PLAIN_SCALAR);
         REQUIRE(std::string(token.token_begin_itr, token.token_end_itr) == "bar");
 
         REQUIRE_NOTHROW(token = lexer.get_next_token());
         REQUIRE(token.type == fkyaml::detail::lexical_token_t::KEY_SEPARATOR);
 
         REQUIRE_NOTHROW(token = lexer.get_next_token());
-        REQUIRE(token.type == fkyaml::detail::lexical_token_t::BOOLEAN_VALUE);
+        REQUIRE(token.type == fkyaml::detail::lexical_token_t::PLAIN_SCALAR);
         REQUIRE(std::string(token.token_begin_itr, token.token_end_itr) == "true");
 
         REQUIRE_NOTHROW(token = lexer.get_next_token());
@@ -1529,7 +1435,7 @@ TEST_CASE("LexicalAnalyzer_FlowMapping") {
         lexer_t lexer(fkyaml::detail::input_adapter("test: { bool: true, foo: bar, pi: 3.14 }"));
 
         REQUIRE_NOTHROW(token = lexer.get_next_token());
-        REQUIRE(token.type == fkyaml::detail::lexical_token_t::STRING_VALUE);
+        REQUIRE(token.type == fkyaml::detail::lexical_token_t::PLAIN_SCALAR);
         REQUIRE(std::string(token.token_begin_itr, token.token_end_itr) == "test");
 
         REQUIRE_NOTHROW(token = lexer.get_next_token());
@@ -1539,42 +1445,42 @@ TEST_CASE("LexicalAnalyzer_FlowMapping") {
         REQUIRE(token.type == fkyaml::detail::lexical_token_t::MAPPING_FLOW_BEGIN);
 
         REQUIRE_NOTHROW(token = lexer.get_next_token());
-        REQUIRE(token.type == fkyaml::detail::lexical_token_t::STRING_VALUE);
+        REQUIRE(token.type == fkyaml::detail::lexical_token_t::PLAIN_SCALAR);
         REQUIRE(std::string(token.token_begin_itr, token.token_end_itr) == "bool");
 
         REQUIRE_NOTHROW(token = lexer.get_next_token());
         REQUIRE(token.type == fkyaml::detail::lexical_token_t::KEY_SEPARATOR);
 
         REQUIRE_NOTHROW(token = lexer.get_next_token());
-        REQUIRE(token.type == fkyaml::detail::lexical_token_t::BOOLEAN_VALUE);
+        REQUIRE(token.type == fkyaml::detail::lexical_token_t::PLAIN_SCALAR);
         REQUIRE(std::string(token.token_begin_itr, token.token_end_itr) == "true");
 
         REQUIRE_NOTHROW(token = lexer.get_next_token());
         REQUIRE(token.type == fkyaml::detail::lexical_token_t::VALUE_SEPARATOR);
 
         REQUIRE_NOTHROW(token = lexer.get_next_token());
-        REQUIRE(token.type == fkyaml::detail::lexical_token_t::STRING_VALUE);
+        REQUIRE(token.type == fkyaml::detail::lexical_token_t::PLAIN_SCALAR);
         REQUIRE(std::string(token.token_begin_itr, token.token_end_itr) == "foo");
 
         REQUIRE_NOTHROW(token = lexer.get_next_token());
         REQUIRE(token.type == fkyaml::detail::lexical_token_t::KEY_SEPARATOR);
 
         REQUIRE_NOTHROW(token = lexer.get_next_token());
-        REQUIRE(token.type == fkyaml::detail::lexical_token_t::STRING_VALUE);
+        REQUIRE(token.type == fkyaml::detail::lexical_token_t::PLAIN_SCALAR);
         REQUIRE(std::string(token.token_begin_itr, token.token_end_itr) == "bar");
 
         REQUIRE_NOTHROW(token = lexer.get_next_token());
         REQUIRE(token.type == fkyaml::detail::lexical_token_t::VALUE_SEPARATOR);
 
         REQUIRE_NOTHROW(token = lexer.get_next_token());
-        REQUIRE(token.type == fkyaml::detail::lexical_token_t::STRING_VALUE);
+        REQUIRE(token.type == fkyaml::detail::lexical_token_t::PLAIN_SCALAR);
         REQUIRE(std::string(token.token_begin_itr, token.token_end_itr) == "pi");
 
         REQUIRE_NOTHROW(token = lexer.get_next_token());
         REQUIRE(token.type == fkyaml::detail::lexical_token_t::KEY_SEPARATOR);
 
         REQUIRE_NOTHROW(token = lexer.get_next_token());
-        REQUIRE(token.type == fkyaml::detail::lexical_token_t::FLOAT_NUMBER_VALUE);
+        REQUIRE(token.type == fkyaml::detail::lexical_token_t::PLAIN_SCALAR);
         REQUIRE_NOTHROW(std::string(token.token_begin_itr, token.token_end_itr));
         REQUIRE(std::string(token.token_begin_itr, token.token_end_itr) == "3.14");
 
@@ -1589,7 +1495,7 @@ TEST_CASE("LexicalAnalyzer_FlowMapping") {
         lexer_t lexer(fkyaml::detail::input_adapter("test: {foo: bar baz}"));
 
         REQUIRE_NOTHROW(token = lexer.get_next_token());
-        REQUIRE(token.type == fkyaml::detail::lexical_token_t::STRING_VALUE);
+        REQUIRE(token.type == fkyaml::detail::lexical_token_t::PLAIN_SCALAR);
         REQUIRE(std::string(token.token_begin_itr, token.token_end_itr) == "test");
 
         REQUIRE_NOTHROW(token = lexer.get_next_token());
@@ -1599,14 +1505,14 @@ TEST_CASE("LexicalAnalyzer_FlowMapping") {
         REQUIRE(token.type == fkyaml::detail::lexical_token_t::MAPPING_FLOW_BEGIN);
 
         REQUIRE_NOTHROW(token = lexer.get_next_token());
-        REQUIRE(token.type == fkyaml::detail::lexical_token_t::STRING_VALUE);
+        REQUIRE(token.type == fkyaml::detail::lexical_token_t::PLAIN_SCALAR);
         REQUIRE(std::string(token.token_begin_itr, token.token_end_itr) == "foo");
 
         REQUIRE_NOTHROW(token = lexer.get_next_token());
         REQUIRE(token.type == fkyaml::detail::lexical_token_t::KEY_SEPARATOR);
 
         REQUIRE_NOTHROW(token = lexer.get_next_token());
-        REQUIRE(token.type == fkyaml::detail::lexical_token_t::STRING_VALUE);
+        REQUIRE(token.type == fkyaml::detail::lexical_token_t::PLAIN_SCALAR);
         REQUIRE(std::string(token.token_begin_itr, token.token_end_itr) == "bar baz");
 
         REQUIRE_NOTHROW(token = lexer.get_next_token());
@@ -1625,7 +1531,7 @@ TEST_CASE("LexicalAnalyzer_BlockSequence") {
         lexer_t lexer(fkyaml::detail::input_adapter(buffer));
 
         REQUIRE_NOTHROW(token = lexer.get_next_token());
-        REQUIRE(token.type == fkyaml::detail::lexical_token_t::STRING_VALUE);
+        REQUIRE(token.type == fkyaml::detail::lexical_token_t::PLAIN_SCALAR);
         REQUIRE(std::string(token.token_begin_itr, token.token_end_itr) == "test");
 
         REQUIRE_NOTHROW(token = lexer.get_next_token());
@@ -1635,14 +1541,14 @@ TEST_CASE("LexicalAnalyzer_BlockSequence") {
         REQUIRE(token.type == fkyaml::detail::lexical_token_t::SEQUENCE_BLOCK_PREFIX);
 
         REQUIRE_NOTHROW(token = lexer.get_next_token());
-        REQUIRE(token.type == fkyaml::detail::lexical_token_t::STRING_VALUE);
+        REQUIRE(token.type == fkyaml::detail::lexical_token_t::PLAIN_SCALAR);
         REQUIRE(std::string(token.token_begin_itr, token.token_end_itr) == "foo");
 
         REQUIRE_NOTHROW(token = lexer.get_next_token());
         REQUIRE(token.type == fkyaml::detail::lexical_token_t::SEQUENCE_BLOCK_PREFIX);
 
         REQUIRE_NOTHROW(token = lexer.get_next_token());
-        REQUIRE(token.type == fkyaml::detail::lexical_token_t::STRING_VALUE);
+        REQUIRE(token.type == fkyaml::detail::lexical_token_t::PLAIN_SCALAR);
         REQUIRE(std::string(token.token_begin_itr, token.token_end_itr) == "bar");
 
         REQUIRE_NOTHROW(token = lexer.get_next_token());
@@ -1654,7 +1560,7 @@ TEST_CASE("LexicalAnalyzer_BlockSequence") {
         lexer_t lexer(fkyaml::detail::input_adapter(buffer));
 
         REQUIRE_NOTHROW(token = lexer.get_next_token());
-        REQUIRE(token.type == fkyaml::detail::lexical_token_t::STRING_VALUE);
+        REQUIRE(token.type == fkyaml::detail::lexical_token_t::PLAIN_SCALAR);
         REQUIRE(std::string(token.token_begin_itr, token.token_end_itr) == "test");
 
         REQUIRE_NOTHROW(token = lexer.get_next_token());
@@ -1664,50 +1570,50 @@ TEST_CASE("LexicalAnalyzer_BlockSequence") {
         REQUIRE(token.type == fkyaml::detail::lexical_token_t::SEQUENCE_BLOCK_PREFIX);
 
         REQUIRE_NOTHROW(token = lexer.get_next_token());
-        REQUIRE(token.type == fkyaml::detail::lexical_token_t::STRING_VALUE);
+        REQUIRE(token.type == fkyaml::detail::lexical_token_t::PLAIN_SCALAR);
         REQUIRE(std::string(token.token_begin_itr, token.token_end_itr) == "foo");
 
         REQUIRE_NOTHROW(token = lexer.get_next_token());
         REQUIRE(token.type == fkyaml::detail::lexical_token_t::KEY_SEPARATOR);
 
         REQUIRE_NOTHROW(token = lexer.get_next_token());
-        REQUIRE(token.type == fkyaml::detail::lexical_token_t::STRING_VALUE);
+        REQUIRE(token.type == fkyaml::detail::lexical_token_t::PLAIN_SCALAR);
         REQUIRE(std::string(token.token_begin_itr, token.token_end_itr) == "one");
 
         REQUIRE_NOTHROW(token = lexer.get_next_token());
-        REQUIRE(token.type == fkyaml::detail::lexical_token_t::STRING_VALUE);
+        REQUIRE(token.type == fkyaml::detail::lexical_token_t::PLAIN_SCALAR);
         REQUIRE(std::string(token.token_begin_itr, token.token_end_itr) == "bar");
 
         REQUIRE_NOTHROW(token = lexer.get_next_token());
         REQUIRE(token.type == fkyaml::detail::lexical_token_t::KEY_SEPARATOR);
 
         REQUIRE_NOTHROW(token = lexer.get_next_token());
-        REQUIRE(token.type == fkyaml::detail::lexical_token_t::BOOLEAN_VALUE);
+        REQUIRE(token.type == fkyaml::detail::lexical_token_t::PLAIN_SCALAR);
         REQUIRE(std::string(token.token_begin_itr, token.token_end_itr) == "false");
 
         REQUIRE_NOTHROW(token = lexer.get_next_token());
         REQUIRE(token.type == fkyaml::detail::lexical_token_t::SEQUENCE_BLOCK_PREFIX);
 
         REQUIRE_NOTHROW(token = lexer.get_next_token());
-        REQUIRE(token.type == fkyaml::detail::lexical_token_t::STRING_VALUE);
+        REQUIRE(token.type == fkyaml::detail::lexical_token_t::PLAIN_SCALAR);
         REQUIRE(std::string(token.token_begin_itr, token.token_end_itr) == "foo");
 
         REQUIRE_NOTHROW(token = lexer.get_next_token());
         REQUIRE(token.type == fkyaml::detail::lexical_token_t::KEY_SEPARATOR);
 
         REQUIRE_NOTHROW(token = lexer.get_next_token());
-        REQUIRE(token.type == fkyaml::detail::lexical_token_t::STRING_VALUE);
+        REQUIRE(token.type == fkyaml::detail::lexical_token_t::PLAIN_SCALAR);
         REQUIRE(std::string(token.token_begin_itr, token.token_end_itr) == "two");
 
         REQUIRE_NOTHROW(token = lexer.get_next_token());
-        REQUIRE(token.type == fkyaml::detail::lexical_token_t::STRING_VALUE);
+        REQUIRE(token.type == fkyaml::detail::lexical_token_t::PLAIN_SCALAR);
         REQUIRE(std::string(token.token_begin_itr, token.token_end_itr) == "bar");
 
         REQUIRE_NOTHROW(token = lexer.get_next_token());
         REQUIRE(token.type == fkyaml::detail::lexical_token_t::KEY_SEPARATOR);
 
         REQUIRE_NOTHROW(token = lexer.get_next_token());
-        REQUIRE(token.type == fkyaml::detail::lexical_token_t::BOOLEAN_VALUE);
+        REQUIRE(token.type == fkyaml::detail::lexical_token_t::PLAIN_SCALAR);
         REQUIRE(std::string(token.token_begin_itr, token.token_end_itr) == "true");
 
         REQUIRE_NOTHROW(token = lexer.get_next_token());
@@ -1722,43 +1628,43 @@ TEST_CASE("LexicalAnalyzer_BlockMapping") {
         lexer_t lexer(fkyaml::detail::input_adapter("test:\n  bool: true\n  foo: \'bar\'\n  pi: 3.14"));
 
         REQUIRE_NOTHROW(token = lexer.get_next_token());
-        REQUIRE(token.type == fkyaml::detail::lexical_token_t::STRING_VALUE);
+        REQUIRE(token.type == fkyaml::detail::lexical_token_t::PLAIN_SCALAR);
         REQUIRE(std::string(token.token_begin_itr, token.token_end_itr) == "test");
 
         REQUIRE_NOTHROW(token = lexer.get_next_token());
         REQUIRE(token.type == fkyaml::detail::lexical_token_t::KEY_SEPARATOR);
 
         REQUIRE_NOTHROW(token = lexer.get_next_token());
-        REQUIRE(token.type == fkyaml::detail::lexical_token_t::STRING_VALUE);
+        REQUIRE(token.type == fkyaml::detail::lexical_token_t::PLAIN_SCALAR);
         REQUIRE(std::string(token.token_begin_itr, token.token_end_itr) == "bool");
 
         REQUIRE_NOTHROW(token = lexer.get_next_token());
         REQUIRE(token.type == fkyaml::detail::lexical_token_t::KEY_SEPARATOR);
 
         REQUIRE_NOTHROW(token = lexer.get_next_token());
-        REQUIRE(token.type == fkyaml::detail::lexical_token_t::BOOLEAN_VALUE);
+        REQUIRE(token.type == fkyaml::detail::lexical_token_t::PLAIN_SCALAR);
         REQUIRE(std::string(token.token_begin_itr, token.token_end_itr) == "true");
 
         REQUIRE_NOTHROW(token = lexer.get_next_token());
-        REQUIRE(token.type == fkyaml::detail::lexical_token_t::STRING_VALUE);
+        REQUIRE(token.type == fkyaml::detail::lexical_token_t::PLAIN_SCALAR);
         REQUIRE(std::string(token.token_begin_itr, token.token_end_itr) == "foo");
 
         REQUIRE_NOTHROW(token = lexer.get_next_token());
         REQUIRE(token.type == fkyaml::detail::lexical_token_t::KEY_SEPARATOR);
 
         REQUIRE_NOTHROW(token = lexer.get_next_token());
-        REQUIRE(token.type == fkyaml::detail::lexical_token_t::STRING_VALUE);
+        REQUIRE(token.type == fkyaml::detail::lexical_token_t::SINGLE_QUOTED_SCALAR);
         REQUIRE(std::string(token.token_begin_itr, token.token_end_itr) == "bar");
 
         REQUIRE_NOTHROW(token = lexer.get_next_token());
-        REQUIRE(token.type == fkyaml::detail::lexical_token_t::STRING_VALUE);
+        REQUIRE(token.type == fkyaml::detail::lexical_token_t::PLAIN_SCALAR);
         REQUIRE(std::string(token.token_begin_itr, token.token_end_itr) == "pi");
 
         REQUIRE_NOTHROW(token = lexer.get_next_token());
         REQUIRE(token.type == fkyaml::detail::lexical_token_t::KEY_SEPARATOR);
 
         REQUIRE_NOTHROW(token = lexer.get_next_token());
-        REQUIRE(token.type == fkyaml::detail::lexical_token_t::FLOAT_NUMBER_VALUE);
+        REQUIRE(token.type == fkyaml::detail::lexical_token_t::PLAIN_SCALAR);
         REQUIRE_NOTHROW(std::string(token.token_begin_itr, token.token_end_itr));
         REQUIRE(std::string(token.token_begin_itr, token.token_end_itr) == "3.14");
 
@@ -1770,36 +1676,36 @@ TEST_CASE("LexicalAnalyzer_BlockMapping") {
         lexer_t lexer(fkyaml::detail::input_adapter("test: |\n  a literal scalar.\nfoo: \'bar\'\npi: 3.14"));
 
         REQUIRE_NOTHROW(token = lexer.get_next_token());
-        REQUIRE(token.type == fkyaml::detail::lexical_token_t::STRING_VALUE);
+        REQUIRE(token.type == fkyaml::detail::lexical_token_t::PLAIN_SCALAR);
         REQUIRE(std::string(token.token_begin_itr, token.token_end_itr) == "test");
 
         REQUIRE_NOTHROW(token = lexer.get_next_token());
         REQUIRE(token.type == fkyaml::detail::lexical_token_t::KEY_SEPARATOR);
 
         REQUIRE_NOTHROW(token = lexer.get_next_token());
-        REQUIRE(token.type == fkyaml::detail::lexical_token_t::STRING_VALUE);
+        REQUIRE(token.type == fkyaml::detail::lexical_token_t::BLOCK_SCALAR);
         REQUIRE(std::string(token.token_begin_itr, token.token_end_itr) == "a literal scalar.\n");
 
         REQUIRE_NOTHROW(token = lexer.get_next_token());
-        REQUIRE(token.type == fkyaml::detail::lexical_token_t::STRING_VALUE);
+        REQUIRE(token.type == fkyaml::detail::lexical_token_t::PLAIN_SCALAR);
         REQUIRE(std::string(token.token_begin_itr, token.token_end_itr) == "foo");
 
         REQUIRE_NOTHROW(token = lexer.get_next_token());
         REQUIRE(token.type == fkyaml::detail::lexical_token_t::KEY_SEPARATOR);
 
         REQUIRE_NOTHROW(token = lexer.get_next_token());
-        REQUIRE(token.type == fkyaml::detail::lexical_token_t::STRING_VALUE);
+        REQUIRE(token.type == fkyaml::detail::lexical_token_t::SINGLE_QUOTED_SCALAR);
         REQUIRE(std::string(token.token_begin_itr, token.token_end_itr) == "bar");
 
         REQUIRE_NOTHROW(token = lexer.get_next_token());
-        REQUIRE(token.type == fkyaml::detail::lexical_token_t::STRING_VALUE);
+        REQUIRE(token.type == fkyaml::detail::lexical_token_t::PLAIN_SCALAR);
         REQUIRE(std::string(token.token_begin_itr, token.token_end_itr) == "pi");
 
         REQUIRE_NOTHROW(token = lexer.get_next_token());
         REQUIRE(token.type == fkyaml::detail::lexical_token_t::KEY_SEPARATOR);
 
         REQUIRE_NOTHROW(token = lexer.get_next_token());
-        REQUIRE(token.type == fkyaml::detail::lexical_token_t::FLOAT_NUMBER_VALUE);
+        REQUIRE(token.type == fkyaml::detail::lexical_token_t::PLAIN_SCALAR);
         REQUIRE_NOTHROW(std::string(token.token_begin_itr, token.token_end_itr));
         REQUIRE(std::string(token.token_begin_itr, token.token_end_itr) == "3.14");
 
@@ -1811,36 +1717,36 @@ TEST_CASE("LexicalAnalyzer_BlockMapping") {
         lexer_t lexer(fkyaml::detail::input_adapter("test: >\n  a literal scalar.\nfoo: \'bar\'\npi: 3.14"));
 
         REQUIRE_NOTHROW(token = lexer.get_next_token());
-        REQUIRE(token.type == fkyaml::detail::lexical_token_t::STRING_VALUE);
+        REQUIRE(token.type == fkyaml::detail::lexical_token_t::PLAIN_SCALAR);
         REQUIRE(std::string(token.token_begin_itr, token.token_end_itr) == "test");
 
         REQUIRE_NOTHROW(token = lexer.get_next_token());
         REQUIRE(token.type == fkyaml::detail::lexical_token_t::KEY_SEPARATOR);
 
         REQUIRE_NOTHROW(token = lexer.get_next_token());
-        REQUIRE(token.type == fkyaml::detail::lexical_token_t::STRING_VALUE);
+        REQUIRE(token.type == fkyaml::detail::lexical_token_t::BLOCK_SCALAR);
         REQUIRE(std::string(token.token_begin_itr, token.token_end_itr) == "a literal scalar.\n");
 
         REQUIRE_NOTHROW(token = lexer.get_next_token());
-        REQUIRE(token.type == fkyaml::detail::lexical_token_t::STRING_VALUE);
+        REQUIRE(token.type == fkyaml::detail::lexical_token_t::PLAIN_SCALAR);
         REQUIRE(std::string(token.token_begin_itr, token.token_end_itr) == "foo");
 
         REQUIRE_NOTHROW(token = lexer.get_next_token());
         REQUIRE(token.type == fkyaml::detail::lexical_token_t::KEY_SEPARATOR);
 
         REQUIRE_NOTHROW(token = lexer.get_next_token());
-        REQUIRE(token.type == fkyaml::detail::lexical_token_t::STRING_VALUE);
+        REQUIRE(token.type == fkyaml::detail::lexical_token_t::SINGLE_QUOTED_SCALAR);
         REQUIRE(std::string(token.token_begin_itr, token.token_end_itr) == "bar");
 
         REQUIRE_NOTHROW(token = lexer.get_next_token());
-        REQUIRE(token.type == fkyaml::detail::lexical_token_t::STRING_VALUE);
+        REQUIRE(token.type == fkyaml::detail::lexical_token_t::PLAIN_SCALAR);
         REQUIRE(std::string(token.token_begin_itr, token.token_end_itr) == "pi");
 
         REQUIRE_NOTHROW(token = lexer.get_next_token());
         REQUIRE(token.type == fkyaml::detail::lexical_token_t::KEY_SEPARATOR);
 
         REQUIRE_NOTHROW(token = lexer.get_next_token());
-        REQUIRE(token.type == fkyaml::detail::lexical_token_t::FLOAT_NUMBER_VALUE);
+        REQUIRE(token.type == fkyaml::detail::lexical_token_t::PLAIN_SCALAR);
         REQUIRE_NOTHROW(std::string(token.token_begin_itr, token.token_end_itr));
         REQUIRE(std::string(token.token_begin_itr, token.token_end_itr) == "3.14");
 

--- a/test/unit_test/test_lexical_analyzer_class.cpp
+++ b/test/unit_test/test_lexical_analyzer_class.cpp
@@ -290,7 +290,7 @@ TEST_CASE("LexicalAnalzer_BlockSequenceEntryPrefix") {
     REQUIRE(std::string(token.token_begin_itr, token.token_end_itr) == "foo");
 }
 
-TEST_CASE("LexicalAnalyzer_PlainString") {
+TEST_CASE("LexicalAnalyzer_PlainScalar") {
     using value_pair_t = std::pair<std::string, fkyaml::node::string_type>;
     auto value_pair = GENERATE(
         value_pair_t(std::string("test"), fkyaml::node::string_type("test")),
@@ -304,6 +304,8 @@ TEST_CASE("LexicalAnalyzer_PlainString") {
         value_pair_t(std::string("-foo"), fkyaml::node::string_type("-foo")),
         value_pair_t(std::string("-.test"), fkyaml::node::string_type("-.test")),
         value_pair_t(std::string("?"), fkyaml::node::string_type("?")),
+        value_pair_t(std::string("--foo"), fkyaml::node::string_type("--foo")),
+        value_pair_t(std::string("+123"), fkyaml::node::string_type("+123")),
         value_pair_t(std::string("1.2.3"), fkyaml::node::string_type("1.2.3")),
         value_pair_t(std::string("foo,bar"), fkyaml::node::string_type("foo,bar")),
         value_pair_t(std::string("foo[bar"), fkyaml::node::string_type("foo[bar")),
@@ -343,13 +345,14 @@ TEST_CASE("LexicalAnalyzer_PlainString") {
     REQUIRE(std::string(token.token_begin_itr, token.token_end_itr) == value_pair.second);
 }
 
-TEST_CASE("LexicalAnalyzer_SingleQuotedString") {
+TEST_CASE("LexicalAnalyzer_SingleQuotedScalar") {
     using value_pair_t = std::pair<std::string, fkyaml::node::string_type>;
     auto value_pair = GENERATE(
         value_pair_t(std::string("\'\'"), fkyaml::node::string_type("")),
         value_pair_t(std::string("\'foo\"bar\'"), fkyaml::node::string_type("foo\"bar")),
         value_pair_t(std::string("\'foo bar\'"), fkyaml::node::string_type("foo bar")),
         value_pair_t(std::string("\'foo\'\'bar\'"), fkyaml::node::string_type("foo\'bar")),
+        value_pair_t(std::string("\'foo\'\'bar\' "), fkyaml::node::string_type("foo\'bar")),
         value_pair_t(std::string("\'foo,bar\'"), fkyaml::node::string_type("foo,bar")),
         value_pair_t(std::string("\'foo]bar\'"), fkyaml::node::string_type("foo]bar")),
         value_pair_t(std::string("\'foo}bar\'"), fkyaml::node::string_type("foo}bar")),
@@ -371,7 +374,7 @@ TEST_CASE("LexicalAnalyzer_SingleQuotedString") {
     REQUIRE(std::string(token.token_begin_itr, token.token_end_itr) == value_pair.second);
 }
 
-TEST_CASE("LexicalAnalyzer_DoubleQuotedString") {
+TEST_CASE("LexicalAnalyzer_DoubleQuotedScalar") {
     using value_pair_t = std::pair<std::string, fkyaml::node::string_type>;
     auto value_pair = GENERATE(
         value_pair_t(std::string("\"\""), fkyaml::node::string_type("")),
@@ -1432,7 +1435,7 @@ TEST_CASE("LexicalAnalyzer_FlowMapping") {
     fkyaml::detail::lexical_token token;
 
     SECTION("simple flow mapping") {
-        lexer_t lexer(fkyaml::detail::input_adapter("test: { bool: true, foo: bar, pi: 3.14 }"));
+        lexer_t lexer(fkyaml::detail::input_adapter("test: { bool : true, foo :b: bar, pi: 3.14 }"));
 
         REQUIRE_NOTHROW(token = lexer.get_next_token());
         REQUIRE(token.type == fkyaml::detail::lexical_token_t::PLAIN_SCALAR);
@@ -1460,7 +1463,7 @@ TEST_CASE("LexicalAnalyzer_FlowMapping") {
 
         REQUIRE_NOTHROW(token = lexer.get_next_token());
         REQUIRE(token.type == fkyaml::detail::lexical_token_t::PLAIN_SCALAR);
-        REQUIRE(std::string(token.token_begin_itr, token.token_end_itr) == "foo");
+        REQUIRE(std::string(token.token_begin_itr, token.token_end_itr) == "foo :b");
 
         REQUIRE_NOTHROW(token = lexer.get_next_token());
         REQUIRE(token.type == fkyaml::detail::lexical_token_t::KEY_SEPARATOR);

--- a/test/unit_test/test_scalar_scanner_class.cpp
+++ b/test/unit_test/test_scalar_scanner_class.cpp
@@ -76,6 +76,8 @@ TEST_CASE("ScalarScanner_StringValue") {
         std::string("0th"),
         std::string("0123"),
         std::string("1.2.3"),
+        std::string("1.23e"),
+        std::string("1.2e-z"),
         std::string("1.non-digit"),
         std::string("-.foo"),
         std::string("1exe"),

--- a/test/unit_test/test_scalar_scanner_class.cpp
+++ b/test/unit_test/test_scalar_scanner_class.cpp
@@ -92,6 +92,7 @@ TEST_CASE("ScalarScanner_StringValue") {
         std::string("-.infValue"),
         std::string("-.InfValue"),
         std::string("-.INFValue"),
+        std::string(".foo"),
         std::string("abc"),
         std::string("0th"),
         std::string("0123"),

--- a/test/unit_test/test_scalar_scanner_class.cpp
+++ b/test/unit_test/test_scalar_scanner_class.cpp
@@ -11,12 +11,12 @@
 #include <fkYAML/node.hpp>
 
 TEST_CASE("ScalarScanner_Empty") {
-    REQUIRE(fkyaml::detail::scalar_scanner::scan("") == fkyaml::detail::lexical_token_t::STRING_VALUE);
+    REQUIRE(fkyaml::detail::scalar_scanner::scan("") == fkyaml::node_type::STRING);
 }
 
 TEST_CASE("ScalarScanner_NullValue") {
     auto token = GENERATE(std::string("~"), std::string("null"), std::string("Null"), std::string("NULL"));
-    REQUIRE(fkyaml::detail::scalar_scanner::scan(token) == fkyaml::detail::lexical_token_t::NULL_VALUE);
+    REQUIRE(fkyaml::detail::scalar_scanner::scan(token) == fkyaml::node_type::NULL_OBJECT);
 }
 
 TEST_CASE("ScalarScanner_BooleanValue") {
@@ -27,7 +27,7 @@ TEST_CASE("ScalarScanner_BooleanValue") {
         std::string("false"),
         std::string("False"),
         std::string("FALSE"));
-    REQUIRE(fkyaml::detail::scalar_scanner::scan(token) == fkyaml::detail::lexical_token_t::BOOLEAN_VALUE);
+    REQUIRE(fkyaml::detail::scalar_scanner::scan(token) == fkyaml::node_type::BOOLEAN);
 }
 
 TEST_CASE("ScalarScanner_IntegerNumberValue") {
@@ -45,7 +45,7 @@ TEST_CASE("ScalarScanner_IntegerNumberValue") {
         std::string("0xA04F"),
         std::string("0xa7F3"),
         std::string("0xFf29Bc"));
-    REQUIRE(fkyaml::detail::scalar_scanner::scan(token) == fkyaml::detail::lexical_token_t::INTEGER_VALUE);
+    REQUIRE(fkyaml::detail::scalar_scanner::scan(token) == fkyaml::node_type::INTEGER);
 }
 
 TEST_CASE("ScalarScanner_FloatNumberValue") {
@@ -60,6 +60,7 @@ TEST_CASE("ScalarScanner_FloatNumberValue") {
         std::string("-.Inf"),
         std::string("-.INF"),
         std::string("-1.234"),
+        std::string("-21."),
         std::string("567.8"),
         std::string("123."),
         std::string("0.24"),
@@ -67,11 +68,30 @@ TEST_CASE("ScalarScanner_FloatNumberValue") {
         std::string("9.8e-3"),
         std::string("3.95E3"),
         std::string("1.863e+3"));
-    REQUIRE(fkyaml::detail::scalar_scanner::scan(token) == fkyaml::detail::lexical_token_t::FLOAT_NUMBER_VALUE);
+    REQUIRE(fkyaml::detail::scalar_scanner::scan(token) == fkyaml::node_type::FLOAT);
 }
 
 TEST_CASE("ScalarScanner_StringValue") {
     auto token = GENERATE(
+        std::string("nullValue"),
+        std::string("NullValue"),
+        std::string("NULL_VALUE"),
+        std::string("~Value"),
+        std::string("trueValue"),
+        std::string("TrueValue"),
+        std::string("TRUE_VALUE"),
+        std::string("falseValue"),
+        std::string("FalseValue"),
+        std::string("FALSE_VALUE"),
+        std::string(".infValue"),
+        std::string(".InfValue"),
+        std::string(".INFValue"),
+        std::string(".nanValue"),
+        std::string(".NaNValue"),
+        std::string(".NANValue"),
+        std::string("-.infValue"),
+        std::string("-.InfValue"),
+        std::string("-.INFValue"),
         std::string("abc"),
         std::string("0th"),
         std::string("0123"),
@@ -83,5 +103,5 @@ TEST_CASE("ScalarScanner_StringValue") {
         std::string("1exe"),
         std::string("0oabc"),
         std::string("0xyz"));
-    REQUIRE(fkyaml::detail::scalar_scanner::scan(token) == fkyaml::detail::lexical_token_t::STRING_VALUE);
+    REQUIRE(fkyaml::detail::scalar_scanner::scan(token) == fkyaml::node_type::STRING);
 }


### PR DESCRIPTION
In this PR, the lexer implementation has been refactored by:  
* reducing the number of string copies during lexical analysis
* improving the ways of block/flow scalar scannings
  
No changes have been made regarding public APIs.  

---

## Pull Request Checklist

Read the [CONTRIBUTING.md](https://github.com/fktn-k/fkYAML/blob/develop/CONTRIBUTING.md) file for detailed information.  

- [x] Changes are described in the pull request or in a referenced [issue](https://github.com/fktn-k/fkYAML/issues).
- [x] The test suite compiles and runs without any error.
- [x] [The code coverage](https://coveralls.io/github/fktn-k/fkYAML) on your branch is 100%.
- [x] The documentation is updated if you added/changed a feature.

## Please don't

- The C++11 support varies between different **compilers** and versions. Please note the [list of supported compilers](https://github.com/fktn-k/fkYAML/blob/develop/README.md#supported-compilers). Some compilers like GCC 4.7 (and earlier), Clang 3.3 (and earlier), or Microsoft Visual Studio 13.0 and earlier are known not to work due to missing or incomplete C++11 support. Please refrain from proposing changes that work around these compiler's limitations with `#ifdef`s or other means.
- Please refrain from proposing changes that would **break [YAML](https://yaml.org/) specifications**. If you propose a conformant extension of YAML to be supported by the library, please motivate this extension.
- Please do not open pull requests that address **multiple issues**.
