### PR TITLE
Use _MSVC_LANG macro when compiled with MSVC for C++ standard detection

### DIFF
--- a/include/fkYAML/detail/macros/cpp_config_macros.hpp
+++ b/include/fkYAML/detail/macros/cpp_config_macros.hpp
@@ -14,18 +14,27 @@
 // This file is assumed to be included only by version_macros.hpp file.
 // To avoid redundant inclusion, do not include version_macros.hpp file as the other files do.
 
+// With the MSVC compilers, the value of __cplusplus is by default always "199611L"(C++98).
+// To avoid that, the library instead references _MSVC_LANG which is always set a correct value.
+// See https://devblogs.microsoft.com/cppblog/msvc-now-correctly-reports-__cplusplus/ for more details.
+#if defined(_MSVC_LANG) && !defined(__clang__)
+#define FK_YAML_CPLUSPLUS _MSVC_LANG
+#else
+#define FK_YAML_CPLUSPLUS __cplusplus
+#endif
+
 // C++ language standard detection (__cplusplus is not yet defined for C++23)
 // Skip detection if the definitions listed below already exist.
 #if !defined(FK_YAML_HAS_CXX_20) && !defined(FK_YAML_HAS_CXX_17) && !defined(FK_YAML_HAS_CXX_14) &&                    \
     !defined(FK_YAML_CXX_11)
-#if (defined(__cplusplus) && __cplusplus >= 202002L) || (defined(_MSVC_LANG) && MSVC_LANG >= 202002L)
+#if FK_YAML_CPLUSPLUS >= 202002L
 #define FK_YAML_HAS_CXX_20
 #define FK_YAML_HAS_CXX_17
 #define FK_YAML_HAS_CXX_14
-#elif (defined(__cplusplus) && __cplusplus >= 201703L) || (defined(_HAS_CXX17) && _HAS_CXX17 == 1)
+#elif FK_YAML_CPLUSPLUS >= 201703L
 #define FK_YAML_HAS_CXX_17
 #define FK_YAML_HAS_CXX_14
-#elif (defined(__cplusplus) && __cplusplus >= 201402L) || (defined(_HAS_CXX14) && _HAS_CXX14 == 1)
+#elif FK_YAML_CPLUSPLUS >= 201402L
 #define FK_YAML_HAS_CXX_14
 #endif
 

--- a/single_include/fkYAML/node.hpp
+++ b/single_include/fkYAML/node.hpp
@@ -88,18 +88,27 @@
 // This file is assumed to be included only by version_macros.hpp file.
 // To avoid redundant inclusion, do not include version_macros.hpp file as the other files do.
 
+// With the MSVC compilers, the value of __cplusplus is by default always "199611L"(C++98).
+// To avoid that, the library instead references _MSVC_LANG which is always set a correct value.
+// See https://devblogs.microsoft.com/cppblog/msvc-now-correctly-reports-__cplusplus/ for more details.
+#if defined(_MSVC_LANG) && !defined(__clang__)
+#define FK_YAML_CPLUSPLUS _MSVC_LANG
+#else
+#define FK_YAML_CPLUSPLUS __cplusplus
+#endif
+
 // C++ language standard detection (__cplusplus is not yet defined for C++23)
 // Skip detection if the definitions listed below already exist.
 #if !defined(FK_YAML_HAS_CXX_20) && !defined(FK_YAML_HAS_CXX_17) && !defined(FK_YAML_HAS_CXX_14) &&                    \
     !defined(FK_YAML_CXX_11)
-#if (defined(__cplusplus) && __cplusplus >= 202002L) || (defined(_MSVC_LANG) && MSVC_LANG >= 202002L)
+#if FK_YAML_CPLUSPLUS >= 202002L
 #define FK_YAML_HAS_CXX_20
 #define FK_YAML_HAS_CXX_17
 #define FK_YAML_HAS_CXX_14
-#elif (defined(__cplusplus) && __cplusplus >= 201703L) || (defined(_HAS_CXX17) && _HAS_CXX17 == 1)
+#elif FK_YAML_CPLUSPLUS >= 201703L
 #define FK_YAML_HAS_CXX_17
 #define FK_YAML_HAS_CXX_14
-#elif (defined(__cplusplus) && __cplusplus >= 201402L) || (defined(_HAS_CXX14) && _HAS_CXX14 == 1)
+#elif FK_YAML_CPLUSPLUS >= 201402L
 #define FK_YAML_HAS_CXX_14
 #endif
 


### PR DESCRIPTION
Although this library depends on C++11 by default, some implementations are switched based on the value of the `__cplusplus` macro to utilize some nice-to-have features available since C++14 or better.  
However, the MSVC compilers don't set an appropriate value to that macro if the `/Zc:__cplusplus` option isn't specified.  
That issue forces those who use this library with some MSVC compiler to stick to C++11 features even if they explicitly use C++14 or better by specifying options like `/std:c++14`.  

As explicitly described [here](https://devblogs.microsoft.com/cppblog/msvc-now-correctly-reports-__cplusplus/), the `_MSVC_LANG` macro is always set a correct value.  
So, as many other C++ libraries do, this library refers to `_MSVC_LANG` if some MSVC compiler is used to compile, and now detects a correct C++ standard.  
The updated behavior is tested in my local environment (Windows10, Visual Studio 2019).  

---

## Pull Request Checklist

Read the [CONTRIBUTING.md](https://github.com/fktn-k/fkYAML/blob/develop/CONTRIBUTING.md) file for detailed information.  

- [x] Changes are described in the pull request or in a referenced [issue](https://github.com/fktn-k/fkYAML/issues).
- [x] The test suite compiles and runs without any error.
- [x] [The code coverage](https://coveralls.io/github/fktn-k/fkYAML) on your branch is 100%.
- [x] The documentation is updated if you added/changed a feature.

## Please don't

- The C++11 support varies between different **compilers** and versions. Please note the [list of supported compilers](https://github.com/fktn-k/fkYAML/blob/develop/README.md#supported-compilers). Some compilers like GCC 4.7 (and earlier), Clang 3.3 (and earlier), or Microsoft Visual Studio 13.0 and earlier are known not to work due to missing or incomplete C++11 support. Please refrain from proposing changes that work around these compiler's limitations with `#ifdef`s or other means.
- Please refrain from proposing changes that would **break [YAML](https://yaml.org/) specifications**. If you propose a conformant extension of YAML to be supported by the library, please motivate this extension.
- Please do not open pull requests that address **multiple issues**.
