### PR TITLE
Reduce string copies in parse

### DIFF
--- a/README.md
+++ b/README.md
@@ -92,13 +92,13 @@ On an AMD Ryzen 7 5800H @3.20GHz with g++11.4.0 in Ubuntu22.04 (WSL2), fkYAML pa
 
 | Benchmark                          | Release (MB/s) |
 | ---------------------------------- | -------------- |
-| fkYAML                             | 40.491         |
+| fkYAML                             | 41.051         |
 | libfyaml                           | 31.110         |
 | rapidyaml<br>(with mutable buff)   | 147.221        |
 | rapidyaml<br>(with immutable buff) | 144.904        |
 | yaml-cpp                           | 7.397          |
 
-Although [rapidyaml](https://github.com/biojppm/rapidyaml) is in general 4x faster than fkYAML as it focuses on high performance, fkYAML is 30% faster than [libfyaml](https://github.com/pantoniou/libfyaml) and also 5.4x faster than [yaml-cpp](https://github.com/jbeder/yaml-cpp).  
+Although [rapidyaml](https://github.com/biojppm/rapidyaml) is in general 4x faster than fkYAML as it focuses on high performance, fkYAML is 30% faster than [libfyaml](https://github.com/pantoniou/libfyaml) and also 5.5x faster than [yaml-cpp](https://github.com/jbeder/yaml-cpp).  
 Note that, since fkYAML deserializes scalars into native booleans or integers during the parsing, the performance could be more faster in some real use cases.  
 
 ## Supported compilers

--- a/include/fkYAML/detail/encodings/uri_encoding.hpp
+++ b/include/fkYAML/detail/encodings/uri_encoding.hpp
@@ -25,12 +25,12 @@ public:
     /// @param begin An iterator to the first element of the character sequence.
     /// @param end An iterator to the past-the-end element of the character sequence.
     /// @return true if all the characters are valid, false otherwise.
-    static bool validate(std::string::const_iterator begin, std::string::const_iterator end) noexcept {
+    static bool validate(const char* begin, const char* end) noexcept {
         if (begin == end) {
             return true;
         }
 
-        std::string::const_iterator current = begin;
+        const char* current = begin;
 
         for (; current != end; ++current) {
             if (*current == '%') {
@@ -56,7 +56,7 @@ private:
     /// @param begin An iterator to the first octet.
     /// @param end An iterator to the past-the-end element of the whole character sequence.
     /// @return true if the octets are valid, false otherwise.
-    static bool validate_octets(std::string::const_iterator& begin, std::string::const_iterator& end) {
+    static bool validate_octets(const char*& begin, const char*& end) {
         for (int i = 0; i < 2; i++, ++begin) {
             if (begin == end) {
                 return false;

--- a/include/fkYAML/detail/encodings/yaml_escaper.hpp
+++ b/include/fkYAML/detail/encodings/yaml_escaper.hpp
@@ -24,7 +24,7 @@ class yaml_escaper {
     using iterator = ::std::string::const_iterator;
 
 public:
-    static bool unescape(iterator& begin, iterator end, std::string& buff) {
+    static bool unescape(const char*& begin, const char* end, std::string& buff) {
         FK_YAML_ASSERT(*begin == '\\' && std::distance(begin, end) > 0);
         bool ret = true;
 
@@ -111,7 +111,7 @@ public:
         return ret;
     }
 
-    static ::std::string escape(iterator begin, iterator end, bool& is_escaped) {
+    static ::std::string escape(const char* begin, const char* end, bool& is_escaped) {
         ::std::string escaped {};
         escaped.reserve(std::distance(begin, end));
         for (; begin != end; ++begin) {
@@ -310,7 +310,7 @@ private:
         return false;
     }
 
-    static bool extract_codepoint(iterator& begin, iterator end, int bytes_to_read, char32_t& codepoint) {
+    static bool extract_codepoint(const char*& begin, const char* end, int bytes_to_read, char32_t& codepoint) {
         bool has_enough_room = static_cast<int>(std::distance(begin, end)) >= (bytes_to_read - 1);
         if (!has_enough_room) {
             return false;

--- a/include/fkYAML/detail/input/deserializer.hpp
+++ b/include/fkYAML/detail/input/deserializer.hpp
@@ -924,7 +924,7 @@ private:
                         lexer.get_last_token_begin_pos());
                 }
 
-                m_anchor_name.assign(token.token_begin_itr, token.token_end_itr);
+                m_anchor_name.assign(token.str.begin(), token.str.end());
                 m_needs_anchor_impl = true;
 
                 if (!m_needs_tag_impl) {
@@ -942,7 +942,7 @@ private:
                         lexer.get_last_token_begin_pos());
                 }
 
-                m_tag_name.assign(token.token_begin_itr, token.token_end_itr);
+                m_tag_name.assign(token.str.begin(), token.str.end());
                 m_needs_tag_impl = true;
 
                 if (!m_needs_anchor_impl) {
@@ -1063,7 +1063,7 @@ private:
 
         node_type value_type {node_type::STRING};
         if (type == lexical_token_t::PLAIN_SCALAR) {
-            value_type = scalar_scanner::scan(token.token_begin_itr, token.token_end_itr);
+            value_type = scalar_scanner::scan(token.str.begin(), token.str.end());
         }
 
         if (m_needs_tag_impl) {
@@ -1105,7 +1105,7 @@ private:
         basic_node_type node {};
 
         if (type == lexical_token_t::ALIAS_PREFIX) {
-            const std::string token_str = std::string(token.token_begin_itr, token.token_end_itr);
+            const std::string token_str = std::string(token.str.begin(), token.str.end());
 
             uint32_t anchor_counts = static_cast<uint32_t>(mp_meta->anchor_table.count(token_str));
             if (anchor_counts == 0) {
@@ -1125,7 +1125,7 @@ private:
         switch (value_type) {
         case node_type::NULL_OBJECT: {
             std::nullptr_t null = nullptr;
-            bool converted = detail::aton(token.token_begin_itr, token.token_end_itr, null);
+            bool converted = detail::aton(token.str.begin(), token.str.end(), null);
             if (!converted) {
                 throw parse_error("Failed to convert a scalar to a null.", line, indent);
             }
@@ -1134,7 +1134,7 @@ private:
         }
         case node_type::BOOLEAN: {
             boolean_type boolean = static_cast<boolean_type>(false);
-            bool converted = detail::atob(token.token_begin_itr, token.token_end_itr, boolean);
+            bool converted = detail::atob(token.str.begin(), token.str.end(), boolean);
             if (!converted) {
                 throw parse_error("Failed to convert a scalar to a boolean.", line, indent);
             }
@@ -1143,7 +1143,7 @@ private:
         }
         case node_type::INTEGER: {
             integer_type integer = 0;
-            bool converted = detail::atoi(token.token_begin_itr, token.token_end_itr, integer);
+            bool converted = detail::atoi(token.str.begin(), token.str.end(), integer);
             if (!converted) {
                 throw parse_error("Failed to convert a scalar to an integer.", line, indent);
             }
@@ -1152,7 +1152,7 @@ private:
         }
         case node_type::FLOAT: {
             float_number_type float_val = 0;
-            bool converted = detail::atof(token.token_begin_itr, token.token_end_itr, float_val);
+            bool converted = detail::atof(token.str.begin(), token.str.end(), float_val);
             if (!converted) {
                 throw parse_error("Failed to convert a scalar to a floating point value", line, indent);
             }
@@ -1160,7 +1160,7 @@ private:
             break;
         }
         case node_type::STRING:
-            node = basic_node_type(std::string(token.token_begin_itr, token.token_end_itr));
+            node = basic_node_type(std::string(token.str.begin(), token.str.end()));
             break;
         default:   // LCOV_EXCL_LINE
             break; // LCOV_EXCL_LINE

--- a/include/fkYAML/detail/input/deserializer.hpp
+++ b/include/fkYAML/detail/input/deserializer.hpp
@@ -132,8 +132,8 @@ public:
     /// @return basic_node_type A root YAML node deserialized from the source string.
     template <typename InputAdapterType, enable_if_t<is_input_adapter<InputAdapterType>::value, int> = 0>
     basic_node_type deserialize(InputAdapterType&& input_adapter) {
-        input_adapter.fill_buffer();
-        lexer_type lexer(input_adapter.get_buffer());
+        str_view input_view = input_adapter.get_buffer_view();
+        lexer_type lexer(input_view);
 
         lexical_token_t type {lexical_token_t::END_OF_BUFFER};
         return deserialize_document(lexer, type);
@@ -145,8 +145,8 @@ public:
     /// @return std::vector<basic_node_type> Root YAML nodes for deserialized YAML documents.
     template <typename InputAdapterType, enable_if_t<is_input_adapter<InputAdapterType>::value, int> = 0>
     std::vector<basic_node_type> deserialize_docs(InputAdapterType&& input_adapter) {
-        input_adapter.fill_buffer();
-        lexer_type lexer(input_adapter.get_buffer());
+        str_view input_view = input_adapter.get_buffer_view();
+        lexer_type lexer(input_view);
 
         std::vector<basic_node_type> nodes {};
         lexical_token_t type {lexical_token_t::END_OF_BUFFER};

--- a/include/fkYAML/detail/input/deserializer.hpp
+++ b/include/fkYAML/detail/input/deserializer.hpp
@@ -12,9 +12,7 @@
 #define FK_YAML_DETAIL_INPUT_DESERIALIZER_HPP_
 
 #include <algorithm>
-#include <cstdint>
 #include <deque>
-#include <unordered_map>
 #include <vector>
 
 #include <fkYAML/detail/macros/version_macros.hpp>
@@ -24,6 +22,7 @@
 #include <fkYAML/detail/input/tag_resolver.hpp>
 #include <fkYAML/detail/meta/input_adapter_traits.hpp>
 #include <fkYAML/detail/meta/node_traits.hpp>
+#include <fkYAML/detail/input/scalar_scanner.hpp>
 #include <fkYAML/detail/meta/stl_supplement.hpp>
 #include <fkYAML/detail/node_attrs.hpp>
 #include <fkYAML/detail/node_property.hpp>
@@ -41,7 +40,7 @@ class basic_deserializer {
     /** A type for the target basic_node. */
     using basic_node_type = BasicNodeType;
     /** A type for the lexical analyzer. */
-    using lexer_type = lexical_analyzer<basic_node_type>;
+    using lexer_type = lexical_analyzer;
     /** A type for the document metainfo. */
     using doc_metainfo_type = document_metainfo<basic_node_type>;
     /** A type for the tag resolver. */

--- a/include/fkYAML/detail/input/deserializer.hpp
+++ b/include/fkYAML/detail/input/deserializer.hpp
@@ -133,8 +133,10 @@ public:
     /// @return basic_node_type A root YAML node deserialized from the source string.
     template <typename InputAdapterType, enable_if_t<is_input_adapter<InputAdapterType>::value, int> = 0>
     basic_node_type deserialize(InputAdapterType&& input_adapter) {
+        input_adapter.fill_buffer();
+        lexer_type lexer(input_adapter.get_buffer());
+
         lexical_token_t type {lexical_token_t::END_OF_BUFFER};
-        lexer_type lexer(std::forward<InputAdapterType>(input_adapter));
         return deserialize_document(lexer, type);
     }
 
@@ -144,7 +146,9 @@ public:
     /// @return std::vector<basic_node_type> Root YAML nodes for deserialized YAML documents.
     template <typename InputAdapterType, enable_if_t<is_input_adapter<InputAdapterType>::value, int> = 0>
     std::vector<basic_node_type> deserialize_docs(InputAdapterType&& input_adapter) {
-        lexer_type lexer(std::forward<InputAdapterType>(input_adapter));
+        input_adapter.fill_buffer();
+        lexer_type lexer(input_adapter.get_buffer());
+
         std::vector<basic_node_type> nodes {};
         lexical_token_t type {lexical_token_t::END_OF_BUFFER};
 

--- a/include/fkYAML/detail/input/input_adapter.hpp
+++ b/include/fkYAML/detail/input/input_adapter.hpp
@@ -950,12 +950,11 @@ inline iterator_input_adapter<ItrType> input_adapter(ItrType begin, ItrType end)
     bool is_contiguous = false;
     if (is_random_access_itr) {
         ptrdiff_t size = static_cast<ptrdiff_t>(std::distance(begin, end - 1));
-        if (size > 0) {
-            using CharPtr = remove_cvref_t<typename std::iterator_traits<ItrType>::pointer>;
-            CharPtr p_begin = &*begin;
-            CharPtr p_second_last = &*(end - 1);
-            is_contiguous = (p_second_last - p_begin == size);
-        }
+
+        using CharPtr = remove_cvref_t<typename std::iterator_traits<ItrType>::pointer>;
+        CharPtr p_begin = &*begin;
+        CharPtr p_second_last = &*(end - 1);
+        is_contiguous = (p_second_last - p_begin == size);
     }
     return create_iterator_input_adapter(begin, end, is_contiguous);
 }

--- a/include/fkYAML/detail/input/input_adapter.hpp
+++ b/include/fkYAML/detail/input/input_adapter.hpp
@@ -264,7 +264,7 @@ public:
     /// @param encode_type The encoding type for this input adapter.
     /// @param is_contiguous Whether iterators are contiguous or not.
     iterator_input_adapter(IterType begin, IterType end, utf_encode_t encode_type, bool is_contiguous) noexcept
-        : m_current(begin),
+        : m_begin(begin),
           m_end(end),
           m_encode_type(encode_type),
           m_is_contiguous(is_contiguous) {

--- a/include/fkYAML/detail/input/lexical_analyzer.hpp
+++ b/include/fkYAML/detail/input/lexical_analyzer.hpp
@@ -45,8 +45,6 @@ struct lexical_token {
 template <typename BasicNodeType, enable_if_t<is_basic_node<BasicNodeType>::value, int> = 0>
 class lexical_analyzer {
 private:
-    using char_traits_type = typename std::char_traits<char>;
-
     enum class block_style_indicator_t {
         LITERAL, //!< keeps newlines inside the block as they are indicated by a pipe `|`.
         FOLDED,  //!< replaces newlines inside the block with spaces indicated by a right angle bracket `>`.
@@ -59,11 +57,6 @@ private:
     };
 
 public:
-    using boolean_type = typename BasicNodeType::boolean_type;
-    using integer_type = typename BasicNodeType::integer_type;
-    using float_number_type = typename BasicNodeType::float_number_type;
-    using string_type = typename BasicNodeType::string_type;
-
     /// @brief Construct a new lexical_analyzer object.
     /// @tparam InputAdapterType The type of the input adapter.
     /// @param input_adapter An input adapter object.

--- a/include/fkYAML/detail/input/lexical_analyzer.hpp
+++ b/include/fkYAML/detail/input/lexical_analyzer.hpp
@@ -977,10 +977,6 @@ private:
                         return is_value_buffer_used;
                     }
 
-                    if (m_cur_itr == m_end_itr) {
-                        break;
-                    }
-
                     continue;
                 }
 

--- a/include/fkYAML/detail/input/lexical_analyzer.hpp
+++ b/include/fkYAML/detail/input/lexical_analyzer.hpp
@@ -11,6 +11,7 @@
 #ifndef FK_YAML_DETAIL_INPUT_LEXICAL_ANALIZER_HPP_
 #define FK_YAML_DETAIL_INPUT_LEXICAL_ANALIZER_HPP_
 
+#include <algorithm>
 #include <cctype>
 #include <cstdlib>
 

--- a/include/fkYAML/detail/input/lexical_analyzer.hpp
+++ b/include/fkYAML/detail/input/lexical_analyzer.hpp
@@ -12,21 +12,14 @@
 #define FK_YAML_DETAIL_INPUT_LEXICAL_ANALIZER_HPP_
 
 #include <cctype>
-#include <cmath>
-#include <cstdint>
 #include <cstdlib>
-#include <limits>
-#include <type_traits>
-#include <vector>
 
 #include <fkYAML/detail/macros/version_macros.hpp>
 #include <fkYAML/detail/assert.hpp>
 #include <fkYAML/detail/encodings/uri_encoding.hpp>
 #include <fkYAML/detail/encodings/utf_encodings.hpp>
 #include <fkYAML/detail/encodings/yaml_escaper.hpp>
-#include <fkYAML/detail/input/scalar_scanner.hpp>
 #include <fkYAML/detail/input/position_tracker.hpp>
-#include <fkYAML/detail/meta/node_traits.hpp>
 #include <fkYAML/detail/meta/stl_supplement.hpp>
 #include <fkYAML/detail/str_view.hpp>
 #include <fkYAML/detail/types/lexical_token_t.hpp>
@@ -40,8 +33,6 @@ struct lexical_token {
 };
 
 /// @brief A class which lexically analizes YAML formatted inputs.
-/// @tparam BasicNodeType A type of the container for YAML values.
-template <typename BasicNodeType, enable_if_t<is_basic_node<BasicNodeType>::value, int> = 0>
 class lexical_analyzer {
 private:
     enum class block_style_indicator_t {
@@ -83,7 +74,7 @@ public:
         lexical_token token {};
         token.type = lexical_token_t::PLAIN_SCALAR;
 
-        switch (char current = *m_cur_itr) {
+        switch (*m_cur_itr) {
         case '?':
             if (++m_cur_itr == m_end_itr) {
                 token.str = str_view {m_token_begin_itr, m_end_itr};

--- a/include/fkYAML/detail/input/position_tracker.hpp
+++ b/include/fkYAML/detail/input/position_tracker.hpp
@@ -12,13 +12,8 @@
 #define FK_YAML_DETAIL_INPUT_POSITION_TRACKER_HPP_
 
 #include <algorithm>
-#include <string>
-#include <utility>
-#include <vector>
 
 #include <fkYAML/detail/macros/version_macros.hpp>
-#include <fkYAML/detail/meta/input_adapter_traits.hpp>
-#include <fkYAML/detail/meta/stl_supplement.hpp>
 #include <fkYAML/detail/str_view.hpp>
 
 FK_YAML_DETAIL_NAMESPACE_BEGIN
@@ -35,7 +30,7 @@ public:
     /// @note This function doesn't support cases where cur_pos has moved backward from the last call.
     /// @param cur_pos The iterator to the current element of the buffer.
     void update_position(const char* p_current) {
-        uint32_t diff = static_cast<uint32_t>(std::distance(m_last, p_current));
+        uint32_t diff = static_cast<uint32_t>(p_current - m_last);
         if (diff == 0) {
             return;
         }
@@ -51,7 +46,8 @@ public:
         }
 
         uint32_t count = 0;
-        while (--p_current != m_begin) {
+        const char* p_begin = m_begin;
+        while (--p_current != p_begin) {
             if (*p_current == '\n') {
                 break;
             }

--- a/include/fkYAML/detail/input/position_tracker.hpp
+++ b/include/fkYAML/detail/input/position_tracker.hpp
@@ -19,13 +19,14 @@
 #include <fkYAML/detail/macros/version_macros.hpp>
 #include <fkYAML/detail/meta/input_adapter_traits.hpp>
 #include <fkYAML/detail/meta/stl_supplement.hpp>
+#include <fkYAML/detail/str_view.hpp>
 
 FK_YAML_DETAIL_NAMESPACE_BEGIN
 
 /// @brief A position tracker of the target buffer.
 class position_tracker {
 public:
-    void set_target_buffer(const std::string& buffer) {
+    void set_target_buffer(str_view buffer) noexcept {
         m_begin = m_last = buffer.begin();
         m_end = buffer.end();
     }
@@ -33,16 +34,16 @@ public:
     /// @brief Update the set of the current position informations.
     /// @note This function doesn't support cases where cur_pos has moved backward from the last call.
     /// @param cur_pos The iterator to the current element of the buffer.
-    void update_position(std::string::const_iterator cur_pos) {
-        uint32_t diff = static_cast<uint32_t>(std::distance(m_last, cur_pos));
+    void update_position(const char* p_current) {
+        uint32_t diff = static_cast<uint32_t>(std::distance(m_last, p_current));
         if (diff == 0) {
             return;
         }
 
         m_cur_pos += diff;
         uint32_t prev_lines_read = m_lines_read;
-        m_lines_read += static_cast<uint32_t>(std::count(m_last, cur_pos, '\n'));
-        m_last = cur_pos;
+        m_lines_read += static_cast<uint32_t>(std::count(m_last, p_current, '\n'));
+        m_last = p_current;
 
         if (prev_lines_read == m_lines_read) {
             m_cur_pos_in_line += diff;
@@ -50,8 +51,8 @@ public:
         }
 
         uint32_t count = 0;
-        while (--cur_pos != m_begin) {
-            if (*cur_pos == '\n') {
+        while (--p_current != m_begin) {
+            if (*p_current == '\n') {
                 break;
             }
             count++;
@@ -77,11 +78,11 @@ public:
 
 private:
     /// The iterator to the beginning element in the target buffer.
-    std::string::const_iterator m_begin {};
+    const char* m_begin {};
     /// The iterator to the past-the-end element in the target buffer.
-    std::string::const_iterator m_end {};
+    const char* m_end {};
     /// The iterator to the last updated element in the target buffer.
-    std::string::const_iterator m_last {};
+    const char* m_last {};
     /// The current position from the beginning of an input buffer.
     uint32_t m_cur_pos {0};
     /// The current position in the current line.

--- a/include/fkYAML/detail/input/scalar_scanner.hpp
+++ b/include/fkYAML/detail/input/scalar_scanner.hpp
@@ -47,7 +47,7 @@ public:
     /// @param begin The iterator to the first element of the scalar.
     /// @param end The iterator to the past-the-end element of the scalar.
     /// @return A detected scalar value type.
-    static node_type scan(std::string::const_iterator begin, std::string::const_iterator end) {
+    static node_type scan(const char* begin, const char* end) {
         if (begin == end) {
             return node_type::STRING;
         }
@@ -132,7 +132,7 @@ private:
     /// @param itr The iterator to the first element of the scalar.
     /// @param len The length of the scalar contents.
     /// @return A detected scalar value type.
-    static node_type scan_possible_number_token(std::string::const_iterator itr, uint32_t len) {
+    static node_type scan_possible_number_token(const char* itr, uint32_t len) {
         FK_YAML_ASSERT(len > 0);
 
         switch (*itr) {
@@ -161,7 +161,7 @@ private:
     /// @param itr The iterator to the past-the-negative-sign element of the scalar.
     /// @param len The length of the scalar contents left unscanned.
     /// @return A detected scalar value type.
-    static node_type scan_negative_number(std::string::const_iterator itr, uint32_t len) {
+    static node_type scan_negative_number(const char* itr, uint32_t len) {
         FK_YAML_ASSERT(len > 0);
 
         if (is_digit(*itr)) {
@@ -175,7 +175,7 @@ private:
     /// @param itr The iterator to the past-the-zero element of the scalar.
     /// @param len The length of the scalar left unscanned.
     /// @return A detected scalar value type.
-    static node_type scan_after_zero_at_first(std::string::const_iterator itr, uint32_t len) {
+    static node_type scan_after_zero_at_first(const char* itr, uint32_t len) {
         FK_YAML_ASSERT(len > 0);
 
         if (is_digit(*itr)) {
@@ -207,7 +207,7 @@ private:
     /// @param len The length of the scalar left unscanned.
     /// @param has_decimal_point Whether a decimal point has already been found in the previous part.
     /// @return A detected scalar value type.
-    static node_type scan_decimal_number(std::string::const_iterator itr, uint32_t len, bool has_decimal_point) {
+    static node_type scan_decimal_number(const char* itr, uint32_t len, bool has_decimal_point) {
         FK_YAML_ASSERT(len > 0);
 
         if (is_digit(*itr)) {
@@ -240,7 +240,7 @@ private:
     /// @param len The length of the scalar left unscanned.
     /// @param has_decimal_point Whether the decimal point has already been found in the previous part.
     /// @return A detected scalar value type.
-    static node_type scan_after_decimal_point(std::string::const_iterator itr, uint32_t len, bool has_decimal_point) {
+    static node_type scan_after_decimal_point(const char* itr, uint32_t len, bool has_decimal_point) {
         FK_YAML_ASSERT(len > 0);
 
         if (is_digit(*itr)) {
@@ -255,7 +255,7 @@ private:
     /// @param len The length of the scalar left unscanned.
     /// @param has_decimal_point Whether the decimal point has already been found in the previous part.
     /// @return A detected scalar value type.
-    static node_type scan_after_exponent(std::string::const_iterator itr, uint32_t len, bool has_decimal_point) {
+    static node_type scan_after_exponent(const char* itr, uint32_t len, bool has_decimal_point) {
         FK_YAML_ASSERT(len > 0);
 
         if (is_digit(*itr)) {
@@ -275,7 +275,7 @@ private:
     /// @param itr The iterator to the octal-number element of the scalar.
     /// @param len The length of the scalar left unscanned.
     /// @return A detected scalar value type.
-    static node_type scan_octal_number(std::string::const_iterator itr, uint32_t len) {
+    static node_type scan_octal_number(const char* itr, uint32_t len) {
         FK_YAML_ASSERT(len > 0);
 
         switch (*itr) {
@@ -297,7 +297,7 @@ private:
     /// @param itr The iterator to the hexadecimal-number element of the scalar.
     /// @param len The length of the scalar left unscanned.
     /// @return A detected scalar value type.
-    static node_type scan_hexadecimal_number(std::string::const_iterator itr, uint32_t len) {
+    static node_type scan_hexadecimal_number(const char* itr, uint32_t len) {
         FK_YAML_ASSERT(len > 0);
 
         if (is_xdigit(*itr)) {

--- a/include/fkYAML/detail/meta/input_adapter_traits.hpp
+++ b/include/fkYAML/detail/meta/input_adapter_traits.hpp
@@ -11,12 +11,18 @@
 #ifndef FK_YAML_DETAIL_META_INPUT_ADAPTER_TRAITS_HPP_
 #define FK_YAML_DETAIL_META_INPUT_ADAPTER_TRAITS_HPP_
 
+#include <array>
 #include <string>
 #include <type_traits>
+#include <vector>
 
 #include <fkYAML/detail/macros/version_macros.hpp>
 #include <fkYAML/detail/meta/detect.hpp>
 #include <fkYAML/detail/meta/stl_supplement.hpp>
+
+#ifdef FK_YAML_HAS_CXX_17
+#include <string_view>
+#endif
 
 FK_YAML_DETAIL_NAMESPACE_BEGIN
 
@@ -55,6 +61,44 @@ struct is_input_adapter : std::false_type {};
 /// @tparam InputAdapterType
 template <typename InputAdapterType>
 struct is_input_adapter<InputAdapterType, enable_if_t<has_fill_buffer<InputAdapterType>::value>> : std::true_type {};
+
+/////////////////////////////////////////////////
+//   traits for contiguous iterator detection
+/////////////////////////////////////////////////
+
+/// @brief Type traits to check if T is a container which has contiguous bytes.
+/// @tparam T A target type.
+template <typename T>
+struct is_contiguous_container : std::false_type {};
+
+/// @brief A partial specialization of is_contiguous_container if T is a std::array.
+/// @tparam T Element type.
+/// @tparam N Maximum number of elements.
+template <typename T, std::size_t N>
+struct is_contiguous_container<std::array<T, N>> : std::true_type {};
+
+/// @brief A partial specialization of is_contiguous_container if T is a std::basic_string.
+/// @tparam CharT Character type.
+/// @tparam Traits Character traits type.
+/// @tparam Alloc Allocator type.
+template <typename CharT, typename Traits, typename Alloc>
+struct is_contiguous_container<std::basic_string<CharT, Traits, Alloc>> : std::true_type {};
+
+#ifdef FK_YAML_HAS_CXX_17
+
+/// @brief A partial specialization of is_contiguous_container if T is a std::basic_string_view.
+/// @tparam CharT Character type.
+/// @tparam Traits Character traits type.
+template <typename CharT, typename Traits>
+struct is_contiguous_container<std::basic_string_view<CharT, Traits>> : std::true_type {};
+
+#endif // defined(FK_YAML_HAS_CXX_20)
+
+/// @brief A partial specialization of is_contiguous_container if T is a std::vector.
+/// @tparam T Element type.
+/// @tparam Alloc Allocator type.
+template <typename T, typename Alloc>
+struct is_contiguous_container<std::vector<T, Alloc>> : std::true_type {};
 
 FK_YAML_DETAIL_NAMESPACE_END
 

--- a/include/fkYAML/detail/meta/input_adapter_traits.hpp
+++ b/include/fkYAML/detail/meta/input_adapter_traits.hpp
@@ -30,21 +30,21 @@ FK_YAML_DETAIL_NAMESPACE_BEGIN
 //   Input Adapter API detection traits
 ///////////////////////////////////////////
 
-/// @brief A type which represents get_character function.
+/// @brief A type which represents get_buffer_view function.
 /// @tparam T A target type.
 template <typename T>
-using fill_buffer_fn_t = decltype(std::declval<T>().fill_buffer());
+using get_buffer_view_fn_t = decltype(std::declval<T>().get_buffer_view());
 
-/// @brief Type traits to check if InputAdapterType has get_character member function.
-/// @tparam InputAdapterType An input adapter type to check if it has get_character function.
+/// @brief Type traits to check if InputAdapterType has get_buffer_view member function.
+/// @tparam InputAdapterType An input adapter type to check if it has get_buffer_view function.
 /// @tparam typename N/A
 template <typename InputAdapterType, typename = void>
-struct has_fill_buffer : std::false_type {};
+struct has_get_buffer_view : std::false_type {};
 
-/// @brief A partial specialization of has_fill_buffer if InputAdapterType has get_character member function.
+/// @brief A partial specialization of has_get_buffer_view if InputAdapterType has get_buffer_view member function.
 /// @tparam InputAdapterType A type of a target input adapter.
 template <typename InputAdapterType>
-struct has_fill_buffer<InputAdapterType, enable_if_t<is_detected<fill_buffer_fn_t, InputAdapterType>::value>>
+struct has_get_buffer_view<InputAdapterType, enable_if_t<is_detected<get_buffer_view_fn_t, InputAdapterType>::value>>
     : std::true_type {};
 
 ////////////////////////////////
@@ -60,7 +60,8 @@ struct is_input_adapter : std::false_type {};
 /// @brief A partial specialization of is_input_adapter if T is an input adapter type.
 /// @tparam InputAdapterType
 template <typename InputAdapterType>
-struct is_input_adapter<InputAdapterType, enable_if_t<has_fill_buffer<InputAdapterType>::value>> : std::true_type {};
+struct is_input_adapter<InputAdapterType, enable_if_t<has_get_buffer_view<InputAdapterType>::value>> : std::true_type {
+};
 
 /////////////////////////////////////////////////
 //   traits for contiguous iterator detection

--- a/include/fkYAML/detail/meta/input_adapter_traits.hpp
+++ b/include/fkYAML/detail/meta/input_adapter_traits.hpp
@@ -27,7 +27,7 @@ FK_YAML_DETAIL_NAMESPACE_BEGIN
 /// @brief A type which represents get_character function.
 /// @tparam T A target type.
 template <typename T>
-using fill_buffer_fn_t = decltype(std::declval<T>().fill_buffer(std::declval<std::string&>()));
+using fill_buffer_fn_t = decltype(std::declval<T>().fill_buffer());
 
 /// @brief Type traits to check if InputAdapterType has get_character member function.
 /// @tparam InputAdapterType An input adapter type to check if it has get_character function.

--- a/include/fkYAML/detail/output/serializer.hpp
+++ b/include/fkYAML/detail/output/serializer.hpp
@@ -247,7 +247,8 @@ private:
             // The next line is intentionally excluded from the LCOV coverage target since the next line is somehow
             // misrecognized as it has a binary branch. Possibly begin() or end() has some conditional branch(es)
             // internally. Confirmed with LCOV 1.14 on Ubuntu22.04.
-            node_type type_if_plain = scalar_scanner::scan(str_val.begin(), str_val.end()); // LCOV_EXCL_LINE
+            node_type type_if_plain =
+                scalar_scanner::scan(str_val.c_str(), str_val.c_str() + str_val.size()); // LCOV_EXCL_LINE
 
             if (type_if_plain != node_type::STRING) {
                 // Surround a string value with double quotes to keep semantic equality.
@@ -344,7 +345,7 @@ private:
 
         using string_type = typename BasicNodeType::string_type;
         const string_type& s = node.template get_value_ref<const string_type&>();
-        return yaml_escaper::escape(s.begin(), s.end(), is_escaped);
+        return yaml_escaper::escape(s.c_str(), s.c_str() + s.size(), is_escaped);
     } // LCOV_EXCL_LINE
 
 private:

--- a/include/fkYAML/detail/str_view.hpp
+++ b/include/fkYAML/detail/str_view.hpp
@@ -495,8 +495,47 @@ bool operator==(basic_str_view<CharT, Traits> lhs, basic_str_view<CharT, Traits>
 }
 
 template <typename CharT, typename Traits>
+bool operator==(basic_str_view<CharT, Traits> lhs, const std::basic_string<CharT, Traits>& rhs) noexcept {
+    return lhs == basic_str_view<CharT, Traits>(rhs);
+}
+
+template <typename CharT, typename Traits>
+bool operator==(const std::basic_string<CharT, Traits>& lhs, basic_str_view<CharT, Traits> rhs) noexcept {
+    return basic_str_view<CharT, Traits>(lhs) == rhs;
+}
+
+template <typename CharT, typename Traits, std::size_t N>
+bool operator==(basic_str_view<CharT, Traits> lhs, const CharT (&rhs)[N]) noexcept {
+    // assume `rhs` is null terminated
+    return lhs == basic_str_view<CharT, Traits>(rhs, N - 1);
+}
+
+template <typename CharT, typename Traits, std::size_t N>
+bool operator==(const CharT (&lhs)[N], basic_str_view<CharT, Traits> rhs) noexcept {
+    // assume `lhs` is null terminated
+    return basic_str_view<CharT, Traits>(lhs, N - 1) == rhs;
+}
+
+template <typename CharT, typename Traits>
 bool operator!=(basic_str_view<CharT, Traits> lhs, basic_str_view<CharT, Traits> rhs) noexcept {
     return !(lhs == rhs);
+}
+
+template <typename CharT, typename Traits>
+bool operator!=(basic_str_view<CharT, Traits> lhs, const std::basic_string<CharT, Traits>& rhs) noexcept {
+    return !(lhs == basic_str_view<CharT, Traits>(rhs));
+}
+
+template <typename CharT, typename Traits, std::size_t N>
+bool operator!=(basic_str_view<CharT, Traits> lhs, const CharT (&rhs)[N]) noexcept {
+    // assume `rhs` is null terminated.
+    return !(lhs == basic_str_view<CharT, Traits>(rhs, N - 1));
+}
+
+template <typename CharT, typename Traits, std::size_t N>
+bool operator!=(const CharT (&lhs)[N], basic_str_view<CharT, Traits> rhs) noexcept {
+    // assume `lhs` is null terminate
+    return !(basic_str_view<CharT, Traits>(lhs, N - 1) == rhs);
 }
 
 template <typename CharT, typename Traits>

--- a/include/fkYAML/detail/str_view.hpp
+++ b/include/fkYAML/detail/str_view.hpp
@@ -221,7 +221,7 @@ public:
     /// @return The element at the given position.
     const_reference at(size_type pos) const {
         if (pos >= m_len) {
-            throw fkyaml::out_of_range(pos);
+            throw fkyaml::out_of_range(static_cast<int>(pos));
         }
         return *(mp_str + pos);
     }
@@ -266,13 +266,14 @@ public:
     }
 
     /// @brief Copys the referenced character sequence values from `pos` by `n` size.
+    /// @warning Throws an fkyaml::out_of_range exception if the given `pos` is bigger than the lenth.
     /// @param p_str The pointer to a character sequence buffer for output.
     /// @param n The number of elements to write into `p_str`.
     /// @param pos The offset of the beginning position to copy values.
     /// @return The number of elements to be written into `p_str`.
     size_type copy(CharT* p_str, size_type n, size_type pos = 0) const {
         if (pos > m_len) {
-            throw fkyaml::out_of_range(pos);
+            throw fkyaml::out_of_range(static_cast<int>(pos));
         }
         const size_type rlen = std::min(n, m_len - pos);
         traits_type::copy(p_str, mp_str + pos, rlen);
@@ -286,7 +287,7 @@ public:
     /// @return A newly created sub basic_str_view object.
     basic_str_view substr(size_type pos = 0, size_type n = npos) const {
         if (pos > m_len) {
-            throw fkyaml::out_of_range(pos);
+            throw fkyaml::out_of_range(static_cast<int>(pos));
         }
         const size_type rlen = std::min(n, m_len - pos);
         return basic_str_view(mp_str + pos, rlen);

--- a/include/fkYAML/detail/str_view.hpp
+++ b/include/fkYAML/detail/str_view.hpp
@@ -21,6 +21,15 @@
 
 FK_YAML_DETAIL_NAMESPACE_BEGIN
 
+/// @brief Non owning view into constant character sequence.
+/// @note
+/// This class is a minimal implementation of std::basic_string_view which has been available since C++17
+/// but pretty useful and efficient for referencing/investigating character sequences.
+/// @warning
+/// This class intentionally omits a lot of value checks to improve efficiency. Necessary checks should be
+/// made before calling this class' APIs for safety.
+/// @tparam CharT Character type
+/// @tparam Traits Character traits type which defaults to std::char_traits<CharT>.
 template <typename CharT, typename Traits = std::char_traits<CharT>>
 class basic_str_view {
     static_assert(!std::is_array<CharT>::value, "CharT must not be an array type.");
@@ -31,38 +40,72 @@ class basic_str_view {
         std::is_same<CharT, typename Traits::char_type>::value, "CharT & Traits::char_type must be the same type.");
 
 public:
+    /// Character traits type.
     using traits_type = Traits;
+    /// Character type.
     using value_type = CharT;
+    /// Pointer type to a character.
     using pointer = value_type*;
+    /// Constant pointer type to a character.
     using const_pointer = const value_type*;
+    /// Reference type to a character.
     using reference = value_type&;
+    /// Constant reference type to a character.
     using const_reference = const value_type&;
+    /// Constant iterator type to a character.
     using const_iterator = const value_type*;
+    /// Iterator type to a character.
+    /// (Always constant since this class isn't meant to provide any mutating features.)
     using iterator = const_iterator;
+    /// Constant reverse iterator type to a character.
     using const_reverse_iterator = std::reverse_iterator<const_iterator>;
+    /// Reverse iterator type to a character.
+    /// (Always constant since this class isn't meant to provide any mutating features.)
     using reverse_iterator = const_reverse_iterator;
+    /// Size type for character sequence sizes.
     using size_type = std::size_t;
+    /// Difference type for distances between characters.
     using difference_type = std::ptrdiff_t;
 
+    /// Invalid position value.
     static constexpr size_type npos = static_cast<size_type>(-1);
 
+    /// Constructs a basic_str_view object.
     basic_str_view() noexcept = default;
+
+    /// Destroys a basic_str_view object.
     ~basic_str_view() noexcept = default;
+
+    /// @brief Copy constructs a basic_str_view object.
+    /// @param _ A basic_str_view object to copy from.
     basic_str_view(const basic_str_view&) noexcept = default;
+
+    /// @brief Move constructs a basic_str_view object.
+    /// @param _ A basic_str_view object to move from.
     basic_str_view(basic_str_view&&) noexcept = default;
 
+    /// @brief Constructs a basic_str_view object from a pointer to a character sequence.
+    /// @param p_str A pointer to a character sequence. (Must be null-terminated, or an undefined behavior.)
     basic_str_view(const value_type* p_str) noexcept
         : m_len(traits_type::length(p_str)),
           mp_str(p_str) {
     }
 
+    /// @brief Construction from a null pointer is forbidden.
     basic_str_view(std::nullptr_t) = delete;
 
+    /// @brief Constructs a basic_str_view object from a poineter to a character sequence and its size.
+    /// @param p_str A pointer to a character sequence. (May or may not be null-terminated.)
+    /// @param len The length of a character sequence.
     basic_str_view(const value_type* p_str, size_type len) noexcept
         : m_len(len),
           mp_str(p_str) {
     }
 
+    /// @brief Constructs a basic_str_view object from compatible begin/end iterators
+    /// @tparam ItrType Iterator type to a character.
+    /// @param first The iterator to the first element of a character sequence.
+    /// @param last The iterator to the past-the-end of a character sequence.
     template <
         typename ItrType,
         enable_if_t<
@@ -76,66 +119,106 @@ public:
           mp_str(m_len > 0 ? &*first : nullptr) {
     }
 
+    /// @brief Constructs a basic_str_view object from a compatible std::basic_string object.
+    /// @param str A compatible character sequence container.
     basic_str_view(const std::basic_string<CharT>& str) noexcept
         : m_len(str.length()),
           mp_str(str.data()) {
     }
 
+    /// @brief Copy assignment operator for this basic_str_view class.
+    /// @param _ A basic_str_view object to copy from.
+    /// @return Reference to this basic_str_view object.
     basic_str_view& operator=(const basic_str_view&) noexcept = default;
+
+    /// @brief Move assignment operator for this basic_str_view class.
+    /// @param _ A basic_str_view object to move from.
+    /// @return Reference to this basic_str_view object.
     basic_str_view& operator=(basic_str_view&&) noexcept = default;
 
+    /// @brief Get the iterator to the first element. (Always constant)
+    /// @return The iterator to the first element.
     const_iterator begin() const noexcept {
         return mp_str;
     }
 
+    /// @brief Get the iterator to the past-the-end element. (Always constant)
+    /// @return The iterator to the past-the-end element.
     const_iterator end() const noexcept {
         return mp_str + m_len;
     }
 
+    /// @brief Get the iterator to the first element. (Always constant)
+    /// @return The iterator to the first element.
     const_iterator cbegin() const noexcept {
         return mp_str;
     }
 
+    /// @brief Get the iterator to the past-the-end element. (Always constant)
+    /// @return The iterator to the past-the-end element.
     const_iterator cend() const noexcept {
         return mp_str + m_len;
     }
 
+    /// @brief Get the iterator to the first element in the reverse order. (Always constant)
+    /// @return The iterator to the first element in the reverse order.
     const_reverse_iterator rbegin() const noexcept {
         return const_reverse_iterator(end());
     }
 
+    /// @brief Get the iterator to the past-the-end element in the reverse order. (Always constant)
+    /// @return The iterator to the past-the-end element in the reverse order.
     const_reverse_iterator rend() const noexcept {
         return const_reverse_iterator(begin());
     }
 
+    /// @brief Get the iterator to the first element in the reverse order. (Always constant)
+    /// @return The iterator to the first element in the reverse order.
     const_reverse_iterator crbegin() const noexcept {
         return const_reverse_iterator(end());
     }
 
+    /// @brief Get the iterator to the past-the-end element in the reverse order. (Always constant)
+    /// @return The iterator to the past-the-end element in the reverse order.
     const_reverse_iterator crend() const noexcept {
         return const_reverse_iterator(begin());
     }
 
+    /// @brief Get the size of the referenced character sequence.
+    /// @return The size of the referenced character sequence.
     size_type size() const noexcept {
         return m_len;
     }
 
+    /// @brief Get the size of the referenced character sequence.
+    /// @return The size of the referenced character sequence.
     size_type length() const noexcept {
         return m_len;
     }
 
+    /// @brief Get the maximum number of the character sequence size.
+    /// @return The maximum number of the character sequence size.
     constexpr size_type max_size() const noexcept {
         return std::numeric_limits<difference_type>::max();
     }
 
+    /// @brief Checks if the referenced character sequence is empty.
+    /// @return true if empty, false otherwise.
     bool empty() const noexcept {
         return m_len == 0;
     }
 
+    /// @brief Get the element at the given position.
+    /// @param pos The position of the target element.
+    /// @return The element at the given position.
     const_reference operator[](size_type pos) const noexcept {
         return *(mp_str + pos);
     }
 
+    /// @brief Get the element at the given position with bounds checks.
+    /// @warning Throws an fkyaml::out_of_range exception if the position exceeds the character sequence size.
+    /// @param pos The position of the target element.
+    /// @return The element at the given position.
     const_reference at(size_type pos) const {
         if (pos >= m_len) {
             throw fkyaml::out_of_range(pos);
@@ -143,33 +226,50 @@ public:
         return *(mp_str + pos);
     }
 
+    /// @brief Get the first element.
+    /// @return The first element.
     const_reference front() const noexcept {
         return *mp_str;
     }
 
+    /// @brief Get the last element.
+    /// @return The last element.
     const_reference back() const {
         return *(mp_str + m_len - 1);
     }
 
+    /// @brief Get the pointer to the raw data of referenced character sequence.
+    /// @return The pointer to the raw data of referenced character sequence.
     const_pointer data() const noexcept {
         return mp_str;
     }
 
+    /// @brief Moves the beginning position by `n` elements.
+    /// @param n The number of elements by which to move the beginning position.
     void remove_prefix(size_type n) noexcept {
         mp_str += n;
         m_len -= n;
     }
 
+    /// @brief Shrinks the referenced character sequence from the last by `n` elements.
+    /// @param n The number of elements by which to shrink the sequence from the last.
     void remove_suffix(size_type n) noexcept {
         m_len -= n;
     }
 
+    /// @brief Swaps data with the given basic_str_view object.
+    /// @param other A basic_str_view object to swap data with.
     void swap(basic_str_view& other) noexcept {
         auto tmp = *this;
         *this = other;
         other = tmp;
     }
 
+    /// @brief Copys the referenced character sequence values from `pos` by `n` size.
+    /// @param p_str The pointer to a character sequence buffer for output.
+    /// @param n The number of elements to write into `p_str`.
+    /// @param pos The offset of the beginning position to copy values.
+    /// @return The number of elements to be written into `p_str`.
     size_type copy(CharT* p_str, size_type n, size_type pos = 0) const {
         if (pos > m_len) {
             throw fkyaml::out_of_range(pos);
@@ -179,6 +279,11 @@ public:
         return rlen;
     }
 
+    /// @brief Constructs a sub basic_str_view object from `pos` by `n` size.
+    /// @warning Throws an fkyaml::out_of_range exception if the given `pos` is bigger than the lenth.
+    /// @param pos The offset of the beginning position.
+    /// @param n The number of elements to the end of a new sub basic_str_view object.
+    /// @return A newly created sub basic_str_view object.
     basic_str_view substr(size_type pos = 0, size_type n = npos) const {
         if (pos > m_len) {
             throw fkyaml::out_of_range(pos);
@@ -187,6 +292,9 @@ public:
         return basic_str_view(mp_str + pos, rlen);
     }
 
+    /// @brief Compares the referenced character sequence values with the given basic_str_view object.
+    /// @param sv The basic_str_view object to compare with.
+    /// @return The lexicographical comparison result. The values are same as std::strncmp().
     int compare(basic_str_view sv) const noexcept {
         const size_type rlen = std::min(m_len, sv.m_len);
         int ret = traits_type::compare(mp_str, sv.mp_str, rlen);
@@ -209,68 +317,131 @@ public:
         return ret;
     }
 
+    /// @brief Compares the referenced character sequence values from `pos1` by `n1` characters with `sv`.
+    /// @param pos1 The offset of the beginning element.
+    /// @param n1 The length of character sequence used for comparison.
+    /// @param sv A basic_str_view object to compare with.
+    /// @return The lexicographical comparison result. The values are same as std::strncmp().
     int compare(size_type pos1, size_type n1, basic_str_view sv) const {
         return substr(pos1, n1).compare(sv);
     }
 
+    /// @brief Compares the referenced character sequence value from `pos1` by `n1` characters with `sv` from `pos2` by
+    /// `n2` characters.
+    /// @param pos1 The offset of the beginning element in this character sequence.
+    /// @param n1 The length of this character sequence used for comparison.
+    /// @param sv A basic_str_view object to compare with.
+    /// @param pos2 The offset of the beginning element in `sv`.
+    /// @param n2 The length of `sv` used for comparison.
+    /// @return The lexicographical comparison result. The values are same as std::strncmp().
     int compare(size_type pos1, size_type n1, basic_str_view sv, size_type pos2, size_type n2) const {
         return substr(pos1, n1).compare(sv.substr(pos2, n2));
     }
 
+    /// @brief Compares the referenced character sequence with `s` character sequence.
+    /// @param s The pointer to a character sequence to compare with.
+    /// @return The lexicolographical comparison result. The values are same as std::strncmp().
     int compare(const CharT* s) const {
         return compare(basic_str_view(s));
     }
 
+    /// @brief Compares the referenced character sequence from `pos1` by `n1` characters with `s` character sequence.
+    /// @param pos1 The offset of the beginning element in this character sequence.
+    /// @param n1 The length of this character sequence used fo comparison.
+    /// @param s The pointer to a character sequence to compare with.
+    /// @return The lexicographical comparison result. The values are same as std::strncmp().
     int compare(size_type pos1, size_type n1, const CharT* s) const {
         return substr(pos1, n1).compare(basic_str_view(s));
     }
 
+    /// @brief Compares the referenced character sequence from `pos1` by `n1` characters with `s` character sequence by
+    /// `n2` characters.
+    /// @param pos1 The offset of the beginning element in this character sequence.
+    /// @param n1 The length of this character sequence used fo comparison.
+    /// @param s The pointer to a character sequence to compare with.
+    /// @param n2 The length of `s` used fo comparison.
+    /// @return
     int compare(size_type pos1, size_type n1, const CharT* s, size_type n2) const {
         return substr(pos1, n1).compare(basic_str_view(s, n2));
     }
 
+    /// @brief Checks if this character sequence starts with `sv` characters.
+    /// @param sv The character sequence to compare with.
+    /// @return true if the character sequence starts with `sv` characters, false otherwise.
     bool starts_with(basic_str_view sv) const noexcept {
         return substr(0, sv.size()) == sv;
     }
 
+    /// @brief Checks if this character sequence starts with `c` character.
+    /// @param c The character to compare with.
+    /// @return true if the character sequence starts with `c` character, false otherwise.
     bool starts_with(CharT c) const noexcept {
         return !empty() && traits_type::eq(front(), c);
     }
 
+    /// @brief Checks if this character sequence starts with `s` characters.
+    /// @param s The character sequence to compare with.
+    /// @return true if the character sequence starts with `s` characters, false otherwise.
     bool starts_with(const CharT* s) const noexcept {
         return starts_with(basic_str_view(s));
     }
 
+    /// @brief Checks if this character sequence ends with `sv` characters.
+    /// @param sv The character sequence to compare with.
+    /// @return true if the character sequence ends with `sv` characters, false otherwise.
     bool ends_with(basic_str_view sv) const noexcept {
         const size_type size = m_len;
         const size_type sv_size = sv.size();
         return size >= sv_size && traits_type::compare(end() - sv_size, sv.data(), sv_size) == 0;
     }
 
+    /// @brief Checks if this character sequence ends with `c` character.
+    /// @param c The character to compare with.
+    /// @return true if the character sequence ends with `c` character, false otherwise.
     bool ends_with(CharT c) const noexcept {
         return !empty() && traits_type::eq(back(), c);
     }
 
+    /// @brief Checks if this character sequence ends with `s` characters.
+    /// @param s The character sequence to compare with.
+    /// @return true if the character sequence ends with `s` characters, false otherwise.
     bool ends_with(const CharT* s) const noexcept {
         return ends_with(basic_str_view(s));
     }
 
+    /// @brief Checks if this character sequence contains `sv` characters.
+    /// @param sv The character sequence to compare with.
+    /// @return true if the character sequence contains `sv` characters, false otherwise.
     bool contains(basic_str_view sv) const noexcept {
         return find(sv) != npos;
     }
 
+    /// @brief Checks if this character sequence contains `c` character.
+    /// @param c The character to compare with.
+    /// @return true if the character sequence contains `c` character, false otherwise.
     bool contains(CharT c) const noexcept {
         return find(c) != npos;
     }
 
+    /// @brief Checks if this character sequence contains `s` characters.
+    /// @param s The character sequence to compare with.
+    /// @return true if the character sequence contains `s` characters, false otherwise.
     bool contains(const CharT* s) const noexcept {
         return find(s) != npos;
     }
 
+    /// @brief Finds the beginning position of `sv` characters in this referenced character sequence.
+    /// @param sv The character sequence to compare with.
+    /// @param pos The offset of the search beginning position in this referenced character sequence.
+    /// @return The beginning position of `sv` characters, `npos` otherwise.
     size_type find(basic_str_view sv, size_type pos = 0) const noexcept {
         return find(sv.mp_str, pos, sv.m_len);
     }
 
+    /// @brief Finds the beginning position of `c` character in this referenced character sequence.
+    /// @param sv The character to compare with.
+    /// @param pos The offset of the search beginning position in this referenced character sequence.
+    /// @return The beginning position of `c` character, `npos` otherwise.
     size_type find(CharT c, size_type pos = 0) const noexcept {
         size_type ret = npos;
 
@@ -285,6 +456,12 @@ public:
         return ret;
     }
 
+    /// @brief Finds the beginning position of `s` character sequence by `n` characters in this referenced character
+    /// sequence.
+    /// @param s The character sequence to compare with.
+    /// @param pos The offset of the search beginning position in this referenced character sequence.
+    /// @param n The length of `s` character sequence used for comparison.
+    /// @return The beginning position of `s` characters, `npos` otherwise.
     size_type find(const CharT* s, size_type pos, size_type n) const noexcept {
         if (n == 0) {
             return pos <= m_len ? pos : npos;
@@ -317,14 +494,26 @@ public:
         return npos;
     }
 
+    /// @brief Finds the beginning position of `s` character sequence in this referenced character sequence.
+    /// @param s The character sequence to compare with.
+    /// @param pos The offset of the search beginning position in this referenced character sequence.
+    /// @return The beginning position of `s` characters, `npos` otherwise.
     size_type find(const CharT* s, size_type pos = 0) const noexcept {
         return find(basic_str_view(s), pos);
     }
 
+    /// @brief Retrospectively finds the beginning position of `sv` characters in this referenced character sequence.
+    /// @param sv The character sequence to compare with.
+    /// @param pos The offset of the search beginning position in this referenced character sequence.
+    /// @return The beginning position of `sv` characters, `npos` otherwise.
     size_type rfind(basic_str_view sv, size_type pos = npos) const noexcept {
         return rfind(sv.mp_str, pos, sv.m_len);
     }
 
+    /// @brief Retrospectively finds the beginning position of `c` character in this referenced character sequence.
+    /// @param sv The character to compare with.
+    /// @param pos The offset of the search beginning position in this referenced character sequence.
+    /// @return The beginning position of `c` character, `npos` otherwise.
     size_type rfind(CharT c, size_type pos = npos) const noexcept {
         if (m_len == 0) {
             return npos;
@@ -345,6 +534,12 @@ public:
         return npos;
     }
 
+    /// @brief Retrospectively finds the beginning position of `s` character sequence by `n` characters in this
+    /// referenced character sequence.
+    /// @param s The character sequence to compare with.
+    /// @param pos The offset of the search beginning position in this referenced character sequence.
+    /// @param n The length of `s` character sequence used for comparison.
+    /// @return The beginning position of `s` characters, `npos` otherwise.
     size_type rfind(const CharT* s, size_type pos, size_type n) const noexcept {
         if (n <= m_len) {
             pos = std::min(m_len - n, pos) + 1;
@@ -359,18 +554,37 @@ public:
         return npos;
     }
 
+    /// @brief Retrospectively finds the beginning position of `s` character sequence in this referenced character
+    /// sequence.
+    /// @param s The character sequence to compare with.
+    /// @param pos The offset of the search beginning position in this referenced character sequence.
+    /// @return The beginning position of `s` characters, `npos` otherwise.
     size_type rfind(const CharT* s, size_type pos = npos) const noexcept {
         return rfind(basic_str_view(s), pos);
     }
 
+    /// @brief Finds the first occurence of `sv` character sequence in this referenced character sequence.
+    /// @param sv The character sequence to compare with.
+    /// @param pos The offset of the search beginning position in this referenced character sequence.
+    /// @return The beginning position of `sv` characters, `npos` otherwise.
     size_type find_first_of(basic_str_view sv, size_type pos = 0) const noexcept {
         return find_first_of(sv.mp_str, pos, sv.m_len);
     }
 
+    /// @brief Finds the first occurence of `c` character in this referenced character sequence.
+    /// @param c The character to compare with.
+    /// @param pos The offset of the search beginning position in this referenced character sequence.
+    /// @return The beginning position of `c` character, `npos` otherwise.
     size_type find_first_of(CharT c, size_type pos = 0) const noexcept {
         return find(c, pos);
     }
 
+    /// @brief Finds the first occurence of `s` character sequence by `n` characters in this referenced character
+    /// sequence.
+    /// @param s The character sequence to compare with.
+    /// @param pos The offset of the search beginning position in this referenced character sequence.
+    /// @param n The length of `s` character sequence used for comparison.
+    /// @return The beginning position of `s` characters, `npos` otherwise.
     size_type find_first_of(const CharT* s, size_type pos, size_type n) const noexcept {
         if (n == 0) {
             return npos;
@@ -386,18 +600,36 @@ public:
         return npos;
     }
 
+    /// @brief Finds the first occurence of `s` character sequence in this referenced character sequence.
+    /// @param s The character sequence to compare with.
+    /// @param pos The offset of the search beginning position in this referenced character sequence.
+    /// @return The beginning position of `s` characters, `npos` otherwise.
     size_type find_first_of(const CharT* s, size_type pos = 0) const noexcept {
         return find_first_of(basic_str_view(s), pos);
     }
 
+    /// @brief Finds the last occurence of `sv` character sequence in this referenced character sequence.
+    /// @param sv The character sequence to compare with.
+    /// @param pos The offset of the search beginning position in this referenced character sequence.
+    /// @return The beginning position of `sv` characters, `npos` otherwise.
     size_type find_last_of(basic_str_view sv, size_type pos = npos) const noexcept {
         return find_last_of(sv.mp_str, pos, sv.m_len);
     }
 
+    /// @brief Finds the last occurence of `c` character in this referenced character sequence.
+    /// @param c The character to compare with.
+    /// @param pos The offset of the search beginning position in this referenced character sequence.
+    /// @return The beginning position of `c` character, `npos` otherwise.
     size_type find_last_of(CharT c, size_type pos = npos) const noexcept {
         return rfind(c, pos);
     }
 
+    /// @brief Finds the last occurence of `s` character sequence by `n` characters in this referenced character
+    /// sequence.
+    /// @param s The character sequence to compare with.
+    /// @param pos The offset of the search beginning position in this referenced character sequence.
+    /// @param n The length of `s` character sequence used for comparison.
+    /// @return The beginning position of `s` characters, `npos` otherwise.
     size_type find_last_of(const CharT* s, size_type pos, size_type n) const noexcept {
         if (n <= m_len) {
             pos = std::min(m_len - n, pos) + 1;
@@ -413,14 +645,26 @@ public:
         return npos;
     }
 
+    /// @brief Finds the last occurence of `s` character sequence in this referenced character sequence.
+    /// @param s The character sequence to compare with.
+    /// @param pos The offset of the search beginning position in this referenced character sequence.
+    /// @return The beginning position of `s` characters, `npos` otherwise.
     size_type find_last_of(const CharT* s, size_type pos = npos) const noexcept {
         return find_last_of(basic_str_view(s), pos);
     }
 
+    /// @brief Finds the first absence of `sv` character sequence in this referenced character sequence.
+    /// @param sv The character sequence to compare with.
+    /// @param pos The offset of the search beginning position in this referenced character sequence.
+    /// @return The beginning position of non `sv` characters, `npos` otherwise.
     size_type find_first_not_of(basic_str_view sv, size_type pos = npos) const noexcept {
         return find_first_not_of(sv.mp_str, pos, sv.m_len);
     }
 
+    /// @brief Finds the first absence of `c` character in this referenced character sequence.
+    /// @param c The character to compare with.
+    /// @param pos The offset of the search beginning position in this referenced character sequence.
+    /// @return The beginning position of non `c` character, `npos` otherwise.
     size_type find_first_not_of(CharT c, size_type pos = npos) const noexcept {
         for (; pos < m_len; ++pos) {
             if (!traits_type::eq(mp_str[pos], c)) {
@@ -431,6 +675,12 @@ public:
         return npos;
     }
 
+    /// @brief Finds the first absence of `s` character sequence by `n` characters in this referenced character
+    /// sequence.
+    /// @param s The character sequence to compare with.
+    /// @param pos The offset of the search beginning position in this referenced character sequence.
+    /// @param n The length of `s` character sequence used for comparison.
+    /// @return The beginning position of non `s` characters, `npos` otherwise.
     size_type find_first_not_of(const CharT* s, size_type pos, size_type n) const noexcept {
         for (; pos < m_len; ++pos) {
             const CharT* p_found = traits_type::find(s, n, mp_str[pos]);
@@ -442,14 +692,26 @@ public:
         return npos;
     }
 
+    /// @brief Finds the first absence of `s` character sequence in this referenced character sequence.
+    /// @param s The character sequence to compare with.
+    /// @param pos The offset of the search beginning position in this referenced character sequence.
+    /// @return The beginning position of non `s` characters, `npos` otherwise.
     size_type find_first_not_of(const CharT* s, size_type pos = npos) const noexcept {
         return find_first_not_of(basic_str_view(s), pos);
     }
 
+    /// @brief Finds the last absence of `sv` character sequence in this referenced character sequence.
+    /// @param sv The character sequence to compare with.
+    /// @param pos The offset of the search beginning position in this referenced character sequence.
+    /// @return The beginning position of non `sv` characters, `npos` otherwise.
     size_type find_last_not_of(basic_str_view sv, size_type pos = npos) const noexcept {
         return find_last_not_of(sv.mp_str, pos, sv.m_len);
     }
 
+    /// @brief Finds the last absence of `c` character in this referenced character sequence.
+    /// @param c The character to compare with.
+    /// @param pos The offset of the search beginning position in this referenced character sequence.
+    /// @return The beginning position of non `c` character, `npos` otherwise.
     size_type find_last_not_of(CharT c, size_type pos = npos) const noexcept {
         if (m_len > 0) {
             pos = std::min(m_len, pos);
@@ -464,6 +726,12 @@ public:
         return npos;
     }
 
+    /// @brief Finds the last absence of `s` character sequence by `n` characters in this referenced character
+    /// sequence.
+    /// @param s The character sequence to compare with.
+    /// @param pos The offset of the search beginning position in this referenced character sequence.
+    /// @param n The length of `s` character sequence used for comparison.
+    /// @return The beginning position of non `s` characters, `npos` otherwise.
     size_type find_last_not_of(const CharT* s, size_type pos, size_type n) const noexcept {
         if (n <= m_len) {
             pos = std::min(m_len - n, pos) + 1;
@@ -479,6 +747,10 @@ public:
         return npos;
     }
 
+    /// @brief Finds the last absence of `s` character sequence in this referenced character sequence.
+    /// @param s The character sequence to compare with.
+    /// @param pos The offset of the search beginning position in this referenced character sequence.
+    /// @return The beginning position of non `s` characters, `npos` otherwise.
     size_type find_last_not_of(const CharT* s, size_type pos = npos) const noexcept {
         return find_last_not_of(basic_str_view(s), pos);
     }
@@ -488,82 +760,193 @@ private:
     const value_type* mp_str {nullptr};
 };
 
+/// @brief An equal-to operator of the basic_str_view class.
+/// @tparam CharT Character type
+/// @tparam Traits Character traits type.
+/// @param lhs A basic_str_view object for comparison.
+/// @param rhs A basic_str_view object to compare with.
+/// @return true if the two objects are the same, false otherwise.
 template <typename CharT, typename Traits>
 bool operator==(basic_str_view<CharT, Traits> lhs, basic_str_view<CharT, Traits> rhs) noexcept {
     // Comparing the lengths first will omit unnecessary value comparison in compare().
     return lhs.size() == rhs.size() && lhs.compare(rhs) == 0;
 }
 
+/// @brief An equal-to operator of the basic_str_view class.
+/// @tparam CharT Character type
+/// @tparam Traits Character traits type.
+/// @param lhs A basic_str_view object for comparison.
+/// @param rhs A basic_string object to compare with.
+/// @return true if the two objects are the same, false otherwise.
 template <typename CharT, typename Traits>
 bool operator==(basic_str_view<CharT, Traits> lhs, const std::basic_string<CharT, Traits>& rhs) noexcept {
     return lhs == basic_str_view<CharT, Traits>(rhs);
 }
 
+/// @brief An equal-to operator of the basic_str_view class.
+/// @tparam CharT Character type
+/// @tparam Traits Character traits type.
+/// @param lhs A basic_string object for comparison.
+/// @param rhs A basic_str_view object to compare with.
+/// @return true if the two objects are the same, false otherwise.
 template <typename CharT, typename Traits>
 bool operator==(const std::basic_string<CharT, Traits>& lhs, basic_str_view<CharT, Traits> rhs) noexcept {
     return basic_str_view<CharT, Traits>(lhs) == rhs;
 }
 
+/// @brief An equal-to operator of the basic_str_view class.
+/// @tparam CharT Character type
+/// @tparam Traits Character traits type.
+/// @tparam N The length of the character array.
+/// @param lhs A basic_str_view object for comparison.
+/// @param rhs A character array to compare with.
+/// @return true if the two objects are the same, false otherwise.
 template <typename CharT, typename Traits, std::size_t N>
 bool operator==(basic_str_view<CharT, Traits> lhs, const CharT (&rhs)[N]) noexcept {
     // assume `rhs` is null terminated
     return lhs == basic_str_view<CharT, Traits>(rhs, N - 1);
 }
 
+/// @brief An equal-to operator of the basic_str_view class.
+/// @tparam CharT Character type
+/// @tparam Traits Character traits type.
+/// @tparam N The length of the character array.
+/// @param rhs A character array for comparison.
+/// @param lhs A basic_str_view object to compare with.
+/// @return true if the two objects are the same, false otherwise.
 template <typename CharT, typename Traits, std::size_t N>
 bool operator==(const CharT (&lhs)[N], basic_str_view<CharT, Traits> rhs) noexcept {
     // assume `lhs` is null terminated
     return basic_str_view<CharT, Traits>(lhs, N - 1) == rhs;
 }
 
+/// @brief An not-equal-to operator of the basic_str_view class.
+/// @tparam CharT Character type
+/// @tparam Traits Character traits type.
+/// @param lhs A basic_str_view object for comparison.
+/// @param rhs A basic_str_view object to compare with.
+/// @return true if the two objects are different, false otherwise.
 template <typename CharT, typename Traits>
 bool operator!=(basic_str_view<CharT, Traits> lhs, basic_str_view<CharT, Traits> rhs) noexcept {
     return !(lhs == rhs);
 }
 
+/// @brief An not-equal-to operator of the basic_str_view class.
+/// @tparam CharT Character type
+/// @tparam Traits Character traits type.
+/// @param lhs A basic_str_view object for comparison.
+/// @param rhs A basic_string object to compare with.
+/// @return true if the two objects are different, false otherwise.
 template <typename CharT, typename Traits>
 bool operator!=(basic_str_view<CharT, Traits> lhs, const std::basic_string<CharT, Traits>& rhs) noexcept {
     return !(lhs == basic_str_view<CharT, Traits>(rhs));
 }
 
+/// @brief An not-equal-to operator of the basic_str_view class.
+/// @tparam CharT Character type
+/// @tparam Traits Character traits type.
+/// @param lhs A basic_string object for comparison.
+/// @param rhs A basic_str_view object to compare with.
+/// @return true if the two objects are different, false otherwise.
+template <typename CharT, typename Traits>
+bool operator!=(const std::basic_string<CharT, Traits>& lhs, basic_str_view<CharT, Traits> rhs) noexcept {
+    return !(basic_str_view<CharT, Traits>(lhs) == rhs);
+}
+
+/// @brief An not-equal-to operator of the basic_str_view class.
+/// @tparam CharT Character type
+/// @tparam Traits Character traits type.
+/// @tparam N The length of the character array.
+/// @param lhs A basic_str_view object for comparison.
+/// @param rhs A character array to compare with.
+/// @return true if the two objects are different, false otherwise.
 template <typename CharT, typename Traits, std::size_t N>
 bool operator!=(basic_str_view<CharT, Traits> lhs, const CharT (&rhs)[N]) noexcept {
     // assume `rhs` is null terminated.
     return !(lhs == basic_str_view<CharT, Traits>(rhs, N - 1));
 }
 
+/// @brief An not-equal-to operator of the basic_str_view class.
+/// @tparam CharT Character type
+/// @tparam Traits Character traits type.
+/// @tparam N The length of the character array.
+/// @param rhs A character array for comparison.
+/// @param lhs A basic_str_view object to compare with.
+/// @return true if the two objects are different, false otherwise.
 template <typename CharT, typename Traits, std::size_t N>
 bool operator!=(const CharT (&lhs)[N], basic_str_view<CharT, Traits> rhs) noexcept {
     // assume `lhs` is null terminate
     return !(basic_str_view<CharT, Traits>(lhs, N - 1) == rhs);
 }
 
+/// @brief An less-than operator of the basic_str_view class.
+/// @tparam CharT Character type
+/// @tparam Traits Character traits type.
+/// @param lhs A basic_str_view object for comparison.
+/// @param rhs A basic_str_view object to compare with.
+/// @return true if `lhs` is less than `rhs`, false otherwise.
 template <typename CharT, typename Traits>
 bool operator<(basic_str_view<CharT, Traits> lhs, basic_str_view<CharT, Traits> rhs) noexcept {
     return lhs.compare(rhs) < 0;
 }
 
+/// @brief An less-than-or-equal-to operator of the basic_str_view class.
+/// @tparam CharT Character type
+/// @tparam Traits Character traits type.
+/// @param lhs A basic_str_view object for comparison.
+/// @param rhs A basic_str_view object to compare with.
+/// @return true if `lhs` is less than or equal to `rhs`, false otherwise.
 template <typename CharT, typename Traits>
 bool operator<=(basic_str_view<CharT, Traits> lhs, basic_str_view<CharT, Traits> rhs) noexcept {
     return lhs.compare(rhs) <= 0;
 }
 
+/// @brief An greater-than operator of the basic_str_view class.
+/// @tparam CharT Character type
+/// @tparam Traits Character traits type.
+/// @param lhs A basic_str_view object for comparison.
+/// @param rhs A basic_str_view object to compare with.
+/// @return true if `lhs` is greater than `rhs`, false otherwise.
 template <typename CharT, typename Traits>
 bool operator>(basic_str_view<CharT, Traits> lhs, basic_str_view<CharT, Traits> rhs) noexcept {
     return lhs.compare(rhs) > 0;
 }
 
+/// @brief An greater-than-or-equal-to operator of the basic_str_view class.
+/// @tparam CharT Character type
+/// @tparam Traits Character traits type.
+/// @param lhs A basic_str_view object for comparison.
+/// @param rhs A basic_str_view object to compare with.
+/// @return true if `lhs` is greater than or equal to `rhs`, false otherwise.
 template <typename CharT, typename Traits>
 bool operator>=(basic_str_view<CharT, Traits> lhs, basic_str_view<CharT, Traits> rhs) noexcept {
     return lhs.compare(rhs) >= 0;
 }
 
+/// @brief Insertion operator of the basic_str_view class.
+/// @tparam CharT Character type.
+/// @tparam Traits Character traits type.
+/// @param os An output stream object.
+/// @param sv A basic_str_view object.
+/// @return Reference to the output stream object `os`.
 template <typename CharT, typename Traits>
 std::basic_ostream<CharT, Traits>& operator<<(std::basic_ostream<CharT, Traits>& os, basic_str_view<CharT, Traits> sv) {
     return os.write(sv.data(), static_cast<std::streamsize>(sv.size()));
 }
 
+/// @brief view into `char` sequence.
 using str_view = basic_str_view<char>;
+
+#ifdef FK_YAML_HAS_CHAR8_T
+/// @brief view into `char8_t` sequence.
+using u8str_view = basic_str_view<char8_t>;
+#endif
+
+/// @brief view into `char16_t` sequence.
+using u16str_view = basic_str_view<char16_t>;
+
+/// @brief view into `char32_t` sequence.
+using u32str_view = basic_str_view<char32_t>;
 
 FK_YAML_DETAIL_NAMESPACE_END
 

--- a/include/fkYAML/detail/str_view.hpp
+++ b/include/fkYAML/detail/str_view.hpp
@@ -1,0 +1,531 @@
+///  _______   __ __   __  _____   __  __  __
+/// |   __| |_/  |  \_/  |/  _  \ /  \/  \|  |     fkYAML: A C++ header-only YAML library
+/// |   __|  _  < \_   _/|  ___  |    _   |  |___  version 0.3.11
+/// |__|  |_| \__|  |_|  |_|   |_|___||___|______| https://github.com/fktn-k/fkYAML
+///
+/// SPDX-FileCopyrightText: 2023-2024 Kensuke Fukutani <fktn.dev@gmail.com>
+/// SPDX-License-Identifier: MIT
+///
+/// @file
+
+#ifndef FK_YAML_DETAIL_STR_VIEW_HPP_
+#define FK_YAML_DETAIL_STR_VIEW_HPP_
+
+#include <limits>
+#include <string>
+
+#include <fkYAML/detail/macros/version_macros.hpp>
+#include <fkYAML/detail/meta/stl_supplement.hpp>
+#include <fkYAML/detail/meta/type_traits.hpp>
+#include <fkYAML/exception.hpp>
+
+FK_YAML_DETAIL_NAMESPACE_BEGIN
+
+template <typename CharT, typename Traits = std::char_traits<CharT>>
+class basic_str_view {
+    static_assert(!std::is_array<CharT>::value, "CharT must not be an array type.");
+    static_assert(
+        std::is_trivial<CharT>::value && std::is_standard_layout<CharT>::value,
+        "CharT must be a trivial, standard layout type.");
+    static_assert(
+        std::is_same<CharT, typename Traits::char_type>::value, "CharT & Traits::char_type must be the same type.");
+
+public:
+    using traits_type = Traits;
+    using value_type = CharT;
+    using pointer = value_type*;
+    using const_pointer = const value_type*;
+    using reference = value_type&;
+    using const_reference = const value_type&;
+    using const_iterator = const value_type*;
+    using iterator = const_iterator;
+    using const_reverse_iterator = std::reverse_iterator<const_iterator>;
+    using reverse_iterator = const_reverse_iterator;
+    using size_type = std::size_t;
+    using difference_type = std::ptrdiff_t;
+
+    static constexpr size_type npos = static_cast<size_type>(-1);
+
+    basic_str_view() noexcept = default;
+    ~basic_str_view() noexcept = default;
+    basic_str_view(const basic_str_view&) noexcept = default;
+    basic_str_view(basic_str_view&&) noexcept = default;
+
+    basic_str_view(const value_type* p_str) noexcept
+        : m_len(traits_type::length(p_str)),
+          mp_str(p_str) {
+    }
+
+    basic_str_view(std::nullptr_t) = delete;
+
+    basic_str_view(const value_type* p_str, size_type len) noexcept
+        : m_len(len),
+          mp_str(p_str) {
+    }
+
+    template <
+        typename ItrType,
+        enable_if_t<
+            conjunction<
+                is_iterator_of<ItrType, CharT>,
+                std::is_base_of<
+                    std::random_access_iterator_tag, typename std::iterator_traits<ItrType>::iterator_category>>::value,
+            int> = 0>
+    basic_str_view(ItrType first, ItrType last) noexcept
+        : m_len(last - first),
+          mp_str(m_len > 0 ? &*first : nullptr) {
+    }
+
+    basic_str_view(const std::basic_string<CharT>& str) noexcept
+        : m_len(str.length()),
+          mp_str(str.data()) {
+    }
+
+    basic_str_view& operator=(const basic_str_view&) noexcept = default;
+    basic_str_view& operator=(basic_str_view&&) noexcept = default;
+
+    const_iterator begin() const noexcept {
+        return mp_str;
+    }
+
+    const_iterator end() const noexcept {
+        return mp_str + m_len;
+    }
+
+    const_iterator cbegin() const noexcept {
+        return mp_str;
+    }
+
+    const_iterator cend() const noexcept {
+        return mp_str + m_len;
+    }
+
+    const_reverse_iterator rbegin() const noexcept {
+        return const_reverse_iterator(end());
+    }
+
+    const_reverse_iterator rend() const noexcept {
+        return const_reverse_iterator(begin());
+    }
+
+    const_reverse_iterator crbegin() const noexcept {
+        return const_reverse_iterator(end());
+    }
+
+    const_reverse_iterator crend() const noexcept {
+        return const_reverse_iterator(begin());
+    }
+
+    size_type size() const noexcept {
+        return m_len;
+    }
+
+    size_type length() const noexcept {
+        return m_len;
+    }
+
+    constexpr size_type max_size() const noexcept {
+        return std::numeric_limits<difference_type>::max();
+    }
+
+    bool empty() const noexcept {
+        return m_len == 0;
+    }
+
+    const_reference operator[](size_type pos) const noexcept {
+        return *(mp_str + pos);
+    }
+
+    const_reference at(size_type pos) const {
+        if (pos >= m_len) {
+            throw fkyaml::out_of_range(pos);
+        }
+        return *(mp_str + pos);
+    }
+
+    const_reference front() const noexcept {
+        return *mp_str;
+    }
+
+    const_reference back() const {
+        return *(mp_str + m_len - 1);
+    }
+
+    const_pointer data() const noexcept {
+        return mp_str;
+    }
+
+    void remove_prefix(size_type n) noexcept {
+        mp_str += n;
+        m_len -= n;
+    }
+
+    void remove_suffix(size_type n) noexcept {
+        m_len -= n;
+    }
+
+    void swap(basic_str_view& other) noexcept {
+        auto tmp = *this;
+        *this = other;
+        other = tmp;
+    }
+
+    size_type copy(CharT* p_str, size_type n, size_type pos = 0) const {
+        if (pos > m_len) {
+            throw fkyaml::out_of_range(pos);
+        }
+        const size_type rlen = std::min(n, m_len - pos);
+        traits_type::copy(p_str, mp_str + pos, rlen);
+        return rlen;
+    }
+
+    basic_str_view substr(size_type pos = 0, size_type n = npos) const {
+        if (pos > m_len) {
+            throw fkyaml::out_of_range(pos);
+        }
+        const size_type rlen = std::min(n, m_len - pos);
+        return basic_str_view(mp_str + pos, rlen);
+    }
+
+    int compare(basic_str_view sv) const noexcept {
+        const size_type rlen = std::min(m_len, sv.m_len);
+        int ret = traits_type::compare(mp_str, sv.mp_str, rlen);
+
+        if (ret == 0) {
+            using int_limits = std::numeric_limits<int>;
+            difference_type diff = m_len - sv.m_len;
+
+            if (diff > int_limits::max()) {
+                ret = int_limits::max();
+            }
+            else if (diff < int_limits::min()) {
+                ret = int_limits::min();
+            }
+            else {
+                ret = static_cast<int>(diff);
+            }
+        }
+
+        return ret;
+    }
+
+    int compare(size_type pos1, size_type n1, basic_str_view sv) const {
+        return substr(pos1, n1).compare(sv);
+    }
+
+    int compare(size_type pos1, size_type n1, basic_str_view sv, size_type pos2, size_type n2) const {
+        return substr(pos1, n1).compare(sv.substr(pos2, n2));
+    }
+
+    int compare(const CharT* s) const {
+        return compare(basic_str_view(s));
+    }
+
+    int compare(size_type pos1, size_type n1, const CharT* s) const {
+        return substr(pos1, n1).compare(basic_str_view(s));
+    }
+
+    int compare(size_type pos1, size_type n1, const CharT* s, size_type n2) const {
+        return substr(pos1, n1).compare(basic_str_view(s, n2));
+    }
+
+    bool starts_with(basic_str_view sv) const noexcept {
+        return substr(0, sv.size()) == sv;
+    }
+
+    bool starts_with(CharT c) const noexcept {
+        return !empty() && traits_type::eq(front(), c);
+    }
+
+    bool starts_with(const CharT* s) const noexcept {
+        return starts_with(basic_str_view(s));
+    }
+
+    bool ends_with(basic_str_view sv) const noexcept {
+        const size_type size = m_len;
+        const size_type sv_size = sv.size();
+        return size >= sv_size && traits_type::compare(end() - sv_size, sv.data(), sv_size) == 0;
+    }
+
+    bool ends_with(CharT c) const noexcept {
+        return !empty() && traits_type::eq(back(), c);
+    }
+
+    bool ends_with(const CharT* s) const noexcept {
+        return ends_with(basic_str_view(s));
+    }
+
+    bool contains(basic_str_view sv) const noexcept {
+        return find(sv) != npos;
+    }
+
+    bool contains(CharT c) const noexcept {
+        return find(c) != npos;
+    }
+
+    bool contains(const CharT* s) const noexcept {
+        return find(s) != npos;
+    }
+
+    size_type find(basic_str_view sv, size_type pos = 0) const noexcept {
+        return find(sv.mp_str, pos, sv.m_len);
+    }
+
+    size_type find(CharT c, size_type pos = 0) const noexcept {
+        size_type ret = npos;
+
+        if (pos < m_len) {
+            const size_type n = m_len - pos;
+            const CharT* p_found = traits_type::find(mp_str + pos, n, c);
+            if (p_found) {
+                ret = p_found - mp_str;
+            }
+        }
+
+        return ret;
+    }
+
+    size_type find(const CharT* s, size_type pos, size_type n) const noexcept {
+        if (n == 0) {
+            return pos <= m_len ? pos : npos;
+        }
+
+        if (pos >= m_len) {
+            return npos;
+        }
+
+        CharT s0 = s[0];
+        const CharT* p_first = mp_str + pos;
+        const CharT* p_last = mp_str + m_len;
+        size_type len = m_len - pos;
+
+        while (len >= n) {
+            // find the first occurence of s0
+            p_first = traits_type::find(p_first, len - n + 1, s0);
+            if (!p_first) {
+                return npos;
+            }
+
+            // compare the full strings from the first occurence of s0
+            if (traits_type::compare(p_first, s, n) == 0) {
+                return p_first - mp_str;
+            }
+
+            len = p_last - (++p_first);
+        }
+
+        return npos;
+    }
+
+    size_type find(const CharT* s, size_type pos = 0) const noexcept {
+        return find(basic_str_view(s), pos);
+    }
+
+    size_type rfind(basic_str_view sv, size_type pos = npos) const noexcept {
+        return rfind(sv.mp_str, pos, sv.m_len);
+    }
+
+    size_type rfind(CharT c, size_type pos = npos) const noexcept {
+        if (m_len == 0) {
+            return npos;
+        }
+
+        size_type idx = pos;
+        if (pos >= m_len) {
+            idx = m_len - 1;
+        }
+
+        while (idx > 0) {
+            if (traits_type::eq(mp_str[idx], c)) {
+                return idx;
+            }
+            --idx;
+        }
+
+        return npos;
+    }
+
+    size_type rfind(const CharT* s, size_type pos, size_type n) const noexcept {
+        if (n <= m_len) {
+            pos = std::min(m_len - n, pos) + 1;
+
+            do {
+                if (traits_type::compare(mp_str + --pos, s, n) == 0) {
+                    return pos;
+                }
+            } while (pos > 0);
+        }
+
+        return npos;
+    }
+
+    size_type rfind(const CharT* s, size_type pos = npos) const noexcept {
+        return rfind(basic_str_view(s), pos);
+    }
+
+    size_type find_first_of(basic_str_view sv, size_type pos = 0) const noexcept {
+        return find_first_of(sv.mp_str, pos, sv.m_len);
+    }
+
+    size_type find_first_of(CharT c, size_type pos = 0) const noexcept {
+        return find(c, pos);
+    }
+
+    size_type find_first_of(const CharT* s, size_type pos, size_type n) const noexcept {
+        if (n == 0) {
+            return npos;
+        }
+
+        for (size_type idx = pos; idx < m_len; ++idx) {
+            const CharT* p_found = traits_type::find(s, n, mp_str[idx]);
+            if (p_found) {
+                return idx;
+            }
+        }
+
+        return npos;
+    }
+
+    size_type find_first_of(const CharT* s, size_type pos = 0) const noexcept {
+        return find_first_of(basic_str_view(s), pos);
+    }
+
+    size_type find_last_of(basic_str_view sv, size_type pos = npos) const noexcept {
+        return find_last_of(sv.mp_str, pos, sv.m_len);
+    }
+
+    size_type find_last_of(CharT c, size_type pos = npos) const noexcept {
+        return rfind(c, pos);
+    }
+
+    size_type find_last_of(const CharT* s, size_type pos, size_type n) const noexcept {
+        if (n <= m_len) {
+            pos = std::min(m_len - n, pos) + 1;
+
+            do {
+                const CharT* p_found = traits_type::find(s, n, mp_str[--pos]);
+                if (p_found) {
+                    return pos;
+                }
+            } while (pos > 0);
+        }
+
+        return npos;
+    }
+
+    size_type find_last_of(const CharT* s, size_type pos = npos) const noexcept {
+        return find_last_of(basic_str_view(s), pos);
+    }
+
+    size_type find_first_not_of(basic_str_view sv, size_type pos = npos) const noexcept {
+        return find_first_not_of(sv.mp_str, pos, sv.m_len);
+    }
+
+    size_type find_first_not_of(CharT c, size_type pos = npos) const noexcept {
+        for (; pos < m_len; ++pos) {
+            if (!traits_type::eq(mp_str[pos], c)) {
+                return pos;
+            }
+        }
+
+        return npos;
+    }
+
+    size_type find_first_not_of(const CharT* s, size_type pos, size_type n) const noexcept {
+        for (; pos < m_len; ++pos) {
+            const CharT* p_found = traits_type::find(s, n, mp_str[pos]);
+            if (!p_found) {
+                return pos;
+            }
+        }
+
+        return npos;
+    }
+
+    size_type find_first_not_of(const CharT* s, size_type pos = npos) const noexcept {
+        return find_first_not_of(basic_str_view(s), pos);
+    }
+
+    size_type find_last_not_of(basic_str_view sv, size_type pos = npos) const noexcept {
+        return find_last_not_of(sv.mp_str, pos, sv.m_len);
+    }
+
+    size_type find_last_not_of(CharT c, size_type pos = npos) const noexcept {
+        if (m_len > 0) {
+            pos = std::min(m_len, pos);
+
+            do {
+                if (!traits_type::eq(mp_str[--pos], c)) {
+                    return pos;
+                }
+            } while (pos > 0);
+        }
+
+        return npos;
+    }
+
+    size_type find_last_not_of(const CharT* s, size_type pos, size_type n) const noexcept {
+        if (n <= m_len) {
+            pos = std::min(m_len - n, pos) + 1;
+
+            do {
+                const CharT* p_found = traits_type::find(s, n, mp_str[--pos]);
+                if (!p_found) {
+                    return pos;
+                }
+            } while (pos > 0);
+        }
+
+        return npos;
+    }
+
+    size_type find_last_not_of(const CharT* s, size_type pos = npos) const noexcept {
+        return find_last_not_of(basic_str_view(s), pos);
+    }
+
+private:
+    size_type m_len {0};
+    const value_type* mp_str {nullptr};
+};
+
+template <typename CharT, typename Traits>
+bool operator==(basic_str_view<CharT, Traits> lhs, basic_str_view<CharT, Traits> rhs) noexcept {
+    // Comparing the lengths first will omit unnecessary value comparison in compare().
+    return lhs.size() == rhs.size() && lhs.compare(rhs) == 0;
+}
+
+template <typename CharT, typename Traits>
+bool operator!=(basic_str_view<CharT, Traits> lhs, basic_str_view<CharT, Traits> rhs) noexcept {
+    return !(lhs == rhs);
+}
+
+template <typename CharT, typename Traits>
+bool operator<(basic_str_view<CharT, Traits> lhs, basic_str_view<CharT, Traits> rhs) noexcept {
+    return lhs.compare(rhs) < 0;
+}
+
+template <typename CharT, typename Traits>
+bool operator<=(basic_str_view<CharT, Traits> lhs, basic_str_view<CharT, Traits> rhs) noexcept {
+    return lhs.compare(rhs) <= 0;
+}
+
+template <typename CharT, typename Traits>
+bool operator>(basic_str_view<CharT, Traits> lhs, basic_str_view<CharT, Traits> rhs) noexcept {
+    return lhs.compare(rhs) > 0;
+}
+
+template <typename CharT, typename Traits>
+bool operator>=(basic_str_view<CharT, Traits> lhs, basic_str_view<CharT, Traits> rhs) noexcept {
+    return lhs.compare(rhs) >= 0;
+}
+
+template <typename CharT, typename Traits>
+std::basic_ostream<CharT, Traits>& operator<<(std::basic_ostream<CharT, Traits>& os, basic_str_view<CharT, Traits> sv) {
+    return os.write(sv.data(), static_cast<std::streamsize>(sv.size()));
+}
+
+using str_view = basic_str_view<char>;
+
+FK_YAML_DETAIL_NAMESPACE_END
+
+#endif /* FK_YAML_DETAIL_STR_VIEW_HPP_ */

--- a/include/fkYAML/detail/str_view.hpp
+++ b/include/fkYAML/detail/str_view.hpp
@@ -199,7 +199,7 @@ public:
     /// @brief Get the maximum number of the character sequence size.
     /// @return The maximum number of the character sequence size.
     constexpr size_type max_size() const noexcept {
-        return std::numeric_limits<difference_type>::max();
+        return static_cast<size_type>(std::numeric_limits<difference_type>::max());
     }
 
     /// @brief Checks if the referenced character sequence is empty.

--- a/single_include/fkYAML/node.hpp
+++ b/single_include/fkYAML/node.hpp
@@ -890,9 +890,7 @@ FK_YAML_DETAIL_NAMESPACE_END
 #define FK_YAML_DETAIL_INPUT_DESERIALIZER_HPP_
 
 #include <algorithm>
-#include <cstdint>
 #include <deque>
-#include <unordered_map>
 #include <vector>
 
 // #include <fkYAML/detail/macros/version_macros.hpp>
@@ -1752,12 +1750,7 @@ FK_YAML_DETAIL_NAMESPACE_END
 #define FK_YAML_DETAIL_INPUT_LEXICAL_ANALIZER_HPP_
 
 #include <cctype>
-#include <cmath>
-#include <cstdint>
 #include <cstdlib>
-#include <limits>
-#include <type_traits>
-#include <vector>
 
 // #include <fkYAML/detail/macros/version_macros.hpp>
 
@@ -2931,323 +2924,6 @@ FK_YAML_DETAIL_NAMESPACE_END
 
 #endif /* FK_YAML_DETAIL_ENCODINGS_YAML_ESCAPER_HPP_ */
 
-// #include <fkYAML/detail/input/scalar_scanner.hpp>
-///  _______   __ __   __  _____   __  __  __
-/// |   __| |_/  |  \_/  |/  _  \ /  \/  \|  |     fkYAML: A C++ header-only YAML library
-/// |   __|  _  < \_   _/|  ___  |    _   |  |___  version 0.3.11
-/// |__|  |_| \__|  |_|  |_|   |_|___||___|______| https://github.com/fktn-k/fkYAML
-///
-/// SPDX-FileCopyrightText: 2023-2024 Kensuke Fukutani <fktn.dev@gmail.com>
-/// SPDX-License-Identifier: MIT
-///
-/// @file
-
-#ifndef FK_YAML_DETAIL_INPUT_SCALAR_SCANNER_HPP_
-#define FK_YAML_DETAIL_INPUT_SCALAR_SCANNER_HPP_
-
-#include <cstring>
-#include <string>
-
-// #include <fkYAML/detail/macros/version_macros.hpp>
-
-// #include <fkYAML/detail/assert.hpp>
-
-// #include <fkYAML/node_type.hpp>
-
-
-FK_YAML_DETAIL_NAMESPACE_BEGIN
-
-namespace {
-
-/// @brief Check if the given character is a digit.
-/// @note This function is needed to avoid assertion failures in `std::isdigit()` especially when compiled with MSVC.
-/// @param c A character to be checked.
-/// @return true if the given character is a digit, false otherwise.
-inline bool is_digit(char c) {
-    return ('0' <= c && c <= '9');
-}
-
-/// @brief Check if the given character is a hex-digit.
-/// @note This function is needed to avoid assertion failures in `std::isxdigit()` especially when compiled with MSVC.
-/// @param c A character to be checked.
-/// @return true if the given character is a hex-digit, false otherwise.
-inline bool is_xdigit(char c) {
-    return (('0' <= c && c <= '9') || ('A' <= c && c <= 'F') || ('a' <= c && c <= 'f'));
-}
-
-} // namespace
-
-/// @brief The class which detects a scalar value type by scanning contents.
-class scalar_scanner {
-public:
-    /// @brief Detects a scalar value type by scanning the contents ranged by the given iterators.
-    /// @param begin The iterator to the first element of the scalar.
-    /// @param end The iterator to the past-the-end element of the scalar.
-    /// @return A detected scalar value type.
-    static node_type scan(const char* begin, const char* end) {
-        if (begin == end) {
-            return node_type::STRING;
-        }
-
-        uint32_t len = static_cast<uint32_t>(std::distance(begin, end));
-        if (len > 5) {
-            return scan_possible_number_token(begin, len);
-        }
-
-        const char* p_begin = &*begin;
-
-        switch (len) {
-        case 1:
-            if (*p_begin == '~') {
-                return node_type::NULL_OBJECT;
-            }
-            break;
-        case 4:
-            switch (*p_begin) {
-            case 'n':
-                // no possible case of begin a number otherwise.
-                return (std::strncmp(p_begin + 1, "ull", 3) == 0) ? node_type::NULL_OBJECT : node_type::STRING;
-            case 'N':
-                // no possible case of begin a number otherwise.
-                return ((std::strncmp(p_begin + 1, "ull", 3) == 0) || (std::strncmp(p_begin + 1, "ULL", 3) == 0))
-                           ? node_type::NULL_OBJECT
-                           : node_type::STRING;
-            case 't':
-                // no possible case of being a number otherwise.
-                return (std::strncmp(p_begin + 1, "rue", 3) == 0) ? node_type::BOOLEAN : node_type::STRING;
-            case 'T':
-                // no possible case of being a number otherwise.
-                return ((std::strncmp(p_begin + 1, "rue", 3) == 0) || (std::strncmp(p_begin + 1, "RUE", 3) == 0))
-                           ? node_type::BOOLEAN
-                           : node_type::STRING;
-            case '.': {
-                const char* p_from_second = p_begin + 1;
-                bool is_inf_or_nan_scalar =
-                    (std::strncmp(p_from_second, "inf", 3) == 0) || (std::strncmp(p_from_second, "Inf", 3) == 0) ||
-                    (std::strncmp(p_from_second, "INF", 3) == 0) || (std::strncmp(p_from_second, "nan", 3) == 0) ||
-                    (std::strncmp(p_from_second, "NaN", 3) == 0) || (std::strncmp(p_from_second, "NAN", 3) == 0);
-                if (is_inf_or_nan_scalar) {
-                    return node_type::FLOAT;
-                }
-                // maybe a number.
-                break;
-            }
-            }
-            break;
-        case 5:
-            switch (*p_begin) {
-            case 'f':
-                // no possible case of being a number otherwise.
-                return (std::strncmp(p_begin + 1, "alse", 4) == 0) ? node_type::BOOLEAN : node_type::STRING;
-            case 'F':
-                // no possible case of being a number otherwise.
-                return ((std::strncmp(p_begin + 1, "alse", 4) == 0) || (std::strncmp(p_begin + 1, "ALSE", 4) == 0))
-                           ? node_type::BOOLEAN
-                           : node_type::STRING;
-            case '+':
-            case '-':
-                if (*(p_begin + 1) == '.') {
-                    const char* p_from_third = p_begin + 2;
-                    bool is_min_inf_scalar = (std::strncmp(p_from_third, "inf", 3) == 0) ||
-                                             (std::strncmp(p_from_third, "Inf", 3) == 0) ||
-                                             (std::strncmp(p_from_third, "INF", 3) == 0);
-                    if (is_min_inf_scalar) {
-                        return node_type::FLOAT;
-                    }
-                }
-                // maybe a number.
-                break;
-            }
-            break;
-        }
-
-        return scan_possible_number_token(begin, len);
-    }
-
-private:
-    /// @brief Detects a scalar value type from the contents (possibly an integer or a floating-point value).
-    /// @param itr The iterator to the first element of the scalar.
-    /// @param len The length of the scalar contents.
-    /// @return A detected scalar value type.
-    static node_type scan_possible_number_token(const char* itr, uint32_t len) {
-        FK_YAML_ASSERT(len > 0);
-
-        switch (*itr) {
-        case '-':
-            return (len > 1) ? scan_negative_number(++itr, --len) : node_type::STRING;
-        case '+':
-            return (len > 1) ? scan_decimal_number(++itr, --len, false) : node_type::STRING;
-        case '0':
-            return (len > 1) ? scan_after_zero_at_first(++itr, --len) : node_type::INTEGER;
-        case '1':
-        case '2':
-        case '3':
-        case '4':
-        case '5':
-        case '6':
-        case '7':
-        case '8':
-        case '9':
-            return (len > 1) ? scan_decimal_number(++itr, --len, false) : node_type::INTEGER;
-        default:
-            return node_type::STRING;
-        }
-    }
-
-    /// @brief Detects a scalar value type by scanning the contents right after the negative sign.
-    /// @param itr The iterator to the past-the-negative-sign element of the scalar.
-    /// @param len The length of the scalar contents left unscanned.
-    /// @return A detected scalar value type.
-    static node_type scan_negative_number(const char* itr, uint32_t len) {
-        FK_YAML_ASSERT(len > 0);
-
-        if (is_digit(*itr)) {
-            return (len > 1) ? scan_decimal_number(++itr, --len, false) : node_type::INTEGER;
-        }
-
-        return node_type::STRING;
-    }
-
-    /// @brief Detects a scalar value type by scanning the contents right after the beginning 0.
-    /// @param itr The iterator to the past-the-zero element of the scalar.
-    /// @param len The length of the scalar left unscanned.
-    /// @return A detected scalar value type.
-    static node_type scan_after_zero_at_first(const char* itr, uint32_t len) {
-        FK_YAML_ASSERT(len > 0);
-
-        if (is_digit(*itr)) {
-            // a token consisting of the beginning '0' and some following numbers, e.g., `0123`, is not an integer
-            // according to https://yaml.org/spec/1.2.2/#10213-integer.
-            return node_type::STRING;
-        }
-
-        switch (*itr) {
-        case '.': {
-            if (len == 1) {
-                // 0 is omitted after `0.`.
-                return node_type::FLOAT;
-            }
-            node_type ret = scan_after_decimal_point(++itr, --len, true);
-            return (ret == node_type::STRING) ? node_type::STRING : node_type::FLOAT;
-        }
-        case 'o':
-            return (len > 1) ? scan_octal_number(++itr, --len) : node_type::STRING;
-        case 'x':
-            return (len > 1) ? scan_hexadecimal_number(++itr, --len) : node_type::STRING;
-        default:
-            return node_type::STRING;
-        }
-    }
-
-    /// @brief Detects a scalar value type by scanning the contents part starting with a decimal.
-    /// @param itr The iterator to the beginning decimal element of the scalar.
-    /// @param len The length of the scalar left unscanned.
-    /// @param has_decimal_point Whether a decimal point has already been found in the previous part.
-    /// @return A detected scalar value type.
-    static node_type scan_decimal_number(const char* itr, uint32_t len, bool has_decimal_point) {
-        FK_YAML_ASSERT(len > 0);
-
-        if (is_digit(*itr)) {
-            return (len > 1) ? scan_decimal_number(++itr, --len, has_decimal_point) : node_type::INTEGER;
-        }
-
-        switch (*itr) {
-        case '.': {
-            if (has_decimal_point) {
-                // the token has more than one period, e.g., a semantic version `1.2.3`.
-                return node_type::STRING;
-            }
-            if (len == 1) {
-                // 0 is omitted after the decimal point
-                return node_type::FLOAT;
-            }
-            node_type ret = scan_after_decimal_point(++itr, --len, true);
-            return (ret == node_type::STRING) ? node_type::STRING : node_type::FLOAT;
-        }
-        case 'e':
-        case 'E':
-            return (len > 1) ? scan_after_exponent(++itr, --len, has_decimal_point) : node_type::STRING;
-        default:
-            return node_type::STRING;
-        }
-    }
-
-    /// @brief Detects a scalar value type by scanning the contents right after a decimal point.
-    /// @param itr The iterator to the past-the-decimal-point element of the scalar.
-    /// @param len The length of the scalar left unscanned.
-    /// @param has_decimal_point Whether the decimal point has already been found in the previous part.
-    /// @return A detected scalar value type.
-    static node_type scan_after_decimal_point(const char* itr, uint32_t len, bool has_decimal_point) {
-        FK_YAML_ASSERT(len > 0);
-
-        if (is_digit(*itr)) {
-            return (len > 1) ? scan_decimal_number(++itr, --len, has_decimal_point) : node_type::FLOAT;
-        }
-
-        return node_type::STRING;
-    }
-
-    /// @brief Detects a scalar value type by scanning the contents right after the exponent prefix ("e" or "E").
-    /// @param itr The iterator to the past-the-exponent-prefix element of the scalar.
-    /// @param len The length of the scalar left unscanned.
-    /// @param has_decimal_point Whether the decimal point has already been found in the previous part.
-    /// @return A detected scalar value type.
-    static node_type scan_after_exponent(const char* itr, uint32_t len, bool has_decimal_point) {
-        FK_YAML_ASSERT(len > 0);
-
-        if (is_digit(*itr)) {
-            return (len > 1) ? scan_decimal_number(++itr, --len, has_decimal_point) : node_type::FLOAT;
-        }
-
-        switch (*itr) {
-        case '+':
-        case '-':
-            return (len > 1) ? scan_decimal_number(++itr, --len, has_decimal_point) : node_type::STRING;
-        default:
-            return node_type::STRING;
-        }
-    }
-
-    /// @brief Detects a scalar value type by scanning the contents assuming octal numbers.
-    /// @param itr The iterator to the octal-number element of the scalar.
-    /// @param len The length of the scalar left unscanned.
-    /// @return A detected scalar value type.
-    static node_type scan_octal_number(const char* itr, uint32_t len) {
-        FK_YAML_ASSERT(len > 0);
-
-        switch (*itr) {
-        case '0':
-        case '1':
-        case '2':
-        case '3':
-        case '4':
-        case '5':
-        case '6':
-        case '7':
-            return (len > 1) ? scan_octal_number(++itr, --len) : node_type::INTEGER;
-        default:
-            return node_type::STRING;
-        }
-    }
-
-    /// @brief Detects a scalar value type by scanning the contents assuming hexadecimal numbers.
-    /// @param itr The iterator to the hexadecimal-number element of the scalar.
-    /// @param len The length of the scalar left unscanned.
-    /// @return A detected scalar value type.
-    static node_type scan_hexadecimal_number(const char* itr, uint32_t len) {
-        FK_YAML_ASSERT(len > 0);
-
-        if (is_xdigit(*itr)) {
-            return (len > 1) ? scan_hexadecimal_number(++itr, --len) : node_type::INTEGER;
-        }
-        return node_type::STRING;
-    }
-};
-
-FK_YAML_DETAIL_NAMESPACE_END
-
-#endif /* FK_YAML_DETAIL_INPUT_SCALAR_SCANNER_HPP_ */
-
 // #include <fkYAML/detail/input/position_tracker.hpp>
 ///  _______   __ __   __  _____   __  __  __
 /// |   __| |_/  |  \_/  |/  _  \ /  \/  \|  |     fkYAML: A C++ header-only YAML library
@@ -4290,7 +3966,7 @@ using u8str_view = basic_str_view<char8_t>;
 using u16str_view = basic_str_view<char16_t>;
 
 /// @brief view into `char32_t` sequence.
-using u16str_view = basic_str_view<char32_t>;
+using u32str_view = basic_str_view<char32_t>;
 
 FK_YAML_DETAIL_NAMESPACE_END
 
@@ -4371,8 +4047,6 @@ FK_YAML_DETAIL_NAMESPACE_END
 
 #endif /* FK_YAML_DETAIL_INPUT_POSITION_TRACKER_HPP_ */
 
-// #include <fkYAML/detail/meta/node_traits.hpp>
-
 // #include <fkYAML/detail/meta/stl_supplement.hpp>
 
 // #include <fkYAML/detail/str_view.hpp>
@@ -4436,8 +4110,6 @@ struct lexical_token {
 };
 
 /// @brief A class which lexically analizes YAML formatted inputs.
-/// @tparam BasicNodeType A type of the container for YAML values.
-template <typename BasicNodeType, enable_if_t<is_basic_node<BasicNodeType>::value, int> = 0>
 class lexical_analyzer {
 private:
     enum class block_style_indicator_t {
@@ -4479,7 +4151,7 @@ public:
         lexical_token token {};
         token.type = lexical_token_t::PLAIN_SCALAR;
 
-        switch (char current = *m_cur_itr) {
+        switch (*m_cur_itr) {
         case '?':
             if (++m_cur_itr == m_end_itr) {
                 token.str = str_view {m_token_begin_itr, m_end_itr};
@@ -6037,6 +5709,323 @@ FK_YAML_DETAIL_NAMESPACE_END
 
 // #include <fkYAML/detail/meta/node_traits.hpp>
 
+// #include <fkYAML/detail/input/scalar_scanner.hpp>
+///  _______   __ __   __  _____   __  __  __
+/// |   __| |_/  |  \_/  |/  _  \ /  \/  \|  |     fkYAML: A C++ header-only YAML library
+/// |   __|  _  < \_   _/|  ___  |    _   |  |___  version 0.3.11
+/// |__|  |_| \__|  |_|  |_|   |_|___||___|______| https://github.com/fktn-k/fkYAML
+///
+/// SPDX-FileCopyrightText: 2023-2024 Kensuke Fukutani <fktn.dev@gmail.com>
+/// SPDX-License-Identifier: MIT
+///
+/// @file
+
+#ifndef FK_YAML_DETAIL_INPUT_SCALAR_SCANNER_HPP_
+#define FK_YAML_DETAIL_INPUT_SCALAR_SCANNER_HPP_
+
+#include <cstring>
+#include <string>
+
+// #include <fkYAML/detail/macros/version_macros.hpp>
+
+// #include <fkYAML/detail/assert.hpp>
+
+// #include <fkYAML/node_type.hpp>
+
+
+FK_YAML_DETAIL_NAMESPACE_BEGIN
+
+namespace {
+
+/// @brief Check if the given character is a digit.
+/// @note This function is needed to avoid assertion failures in `std::isdigit()` especially when compiled with MSVC.
+/// @param c A character to be checked.
+/// @return true if the given character is a digit, false otherwise.
+inline bool is_digit(char c) {
+    return ('0' <= c && c <= '9');
+}
+
+/// @brief Check if the given character is a hex-digit.
+/// @note This function is needed to avoid assertion failures in `std::isxdigit()` especially when compiled with MSVC.
+/// @param c A character to be checked.
+/// @return true if the given character is a hex-digit, false otherwise.
+inline bool is_xdigit(char c) {
+    return (('0' <= c && c <= '9') || ('A' <= c && c <= 'F') || ('a' <= c && c <= 'f'));
+}
+
+} // namespace
+
+/// @brief The class which detects a scalar value type by scanning contents.
+class scalar_scanner {
+public:
+    /// @brief Detects a scalar value type by scanning the contents ranged by the given iterators.
+    /// @param begin The iterator to the first element of the scalar.
+    /// @param end The iterator to the past-the-end element of the scalar.
+    /// @return A detected scalar value type.
+    static node_type scan(const char* begin, const char* end) {
+        if (begin == end) {
+            return node_type::STRING;
+        }
+
+        uint32_t len = static_cast<uint32_t>(std::distance(begin, end));
+        if (len > 5) {
+            return scan_possible_number_token(begin, len);
+        }
+
+        const char* p_begin = &*begin;
+
+        switch (len) {
+        case 1:
+            if (*p_begin == '~') {
+                return node_type::NULL_OBJECT;
+            }
+            break;
+        case 4:
+            switch (*p_begin) {
+            case 'n':
+                // no possible case of begin a number otherwise.
+                return (std::strncmp(p_begin + 1, "ull", 3) == 0) ? node_type::NULL_OBJECT : node_type::STRING;
+            case 'N':
+                // no possible case of begin a number otherwise.
+                return ((std::strncmp(p_begin + 1, "ull", 3) == 0) || (std::strncmp(p_begin + 1, "ULL", 3) == 0))
+                           ? node_type::NULL_OBJECT
+                           : node_type::STRING;
+            case 't':
+                // no possible case of being a number otherwise.
+                return (std::strncmp(p_begin + 1, "rue", 3) == 0) ? node_type::BOOLEAN : node_type::STRING;
+            case 'T':
+                // no possible case of being a number otherwise.
+                return ((std::strncmp(p_begin + 1, "rue", 3) == 0) || (std::strncmp(p_begin + 1, "RUE", 3) == 0))
+                           ? node_type::BOOLEAN
+                           : node_type::STRING;
+            case '.': {
+                const char* p_from_second = p_begin + 1;
+                bool is_inf_or_nan_scalar =
+                    (std::strncmp(p_from_second, "inf", 3) == 0) || (std::strncmp(p_from_second, "Inf", 3) == 0) ||
+                    (std::strncmp(p_from_second, "INF", 3) == 0) || (std::strncmp(p_from_second, "nan", 3) == 0) ||
+                    (std::strncmp(p_from_second, "NaN", 3) == 0) || (std::strncmp(p_from_second, "NAN", 3) == 0);
+                if (is_inf_or_nan_scalar) {
+                    return node_type::FLOAT;
+                }
+                // maybe a number.
+                break;
+            }
+            }
+            break;
+        case 5:
+            switch (*p_begin) {
+            case 'f':
+                // no possible case of being a number otherwise.
+                return (std::strncmp(p_begin + 1, "alse", 4) == 0) ? node_type::BOOLEAN : node_type::STRING;
+            case 'F':
+                // no possible case of being a number otherwise.
+                return ((std::strncmp(p_begin + 1, "alse", 4) == 0) || (std::strncmp(p_begin + 1, "ALSE", 4) == 0))
+                           ? node_type::BOOLEAN
+                           : node_type::STRING;
+            case '+':
+            case '-':
+                if (*(p_begin + 1) == '.') {
+                    const char* p_from_third = p_begin + 2;
+                    bool is_min_inf_scalar = (std::strncmp(p_from_third, "inf", 3) == 0) ||
+                                             (std::strncmp(p_from_third, "Inf", 3) == 0) ||
+                                             (std::strncmp(p_from_third, "INF", 3) == 0);
+                    if (is_min_inf_scalar) {
+                        return node_type::FLOAT;
+                    }
+                }
+                // maybe a number.
+                break;
+            }
+            break;
+        }
+
+        return scan_possible_number_token(begin, len);
+    }
+
+private:
+    /// @brief Detects a scalar value type from the contents (possibly an integer or a floating-point value).
+    /// @param itr The iterator to the first element of the scalar.
+    /// @param len The length of the scalar contents.
+    /// @return A detected scalar value type.
+    static node_type scan_possible_number_token(const char* itr, uint32_t len) {
+        FK_YAML_ASSERT(len > 0);
+
+        switch (*itr) {
+        case '-':
+            return (len > 1) ? scan_negative_number(++itr, --len) : node_type::STRING;
+        case '+':
+            return (len > 1) ? scan_decimal_number(++itr, --len, false) : node_type::STRING;
+        case '0':
+            return (len > 1) ? scan_after_zero_at_first(++itr, --len) : node_type::INTEGER;
+        case '1':
+        case '2':
+        case '3':
+        case '4':
+        case '5':
+        case '6':
+        case '7':
+        case '8':
+        case '9':
+            return (len > 1) ? scan_decimal_number(++itr, --len, false) : node_type::INTEGER;
+        default:
+            return node_type::STRING;
+        }
+    }
+
+    /// @brief Detects a scalar value type by scanning the contents right after the negative sign.
+    /// @param itr The iterator to the past-the-negative-sign element of the scalar.
+    /// @param len The length of the scalar contents left unscanned.
+    /// @return A detected scalar value type.
+    static node_type scan_negative_number(const char* itr, uint32_t len) {
+        FK_YAML_ASSERT(len > 0);
+
+        if (is_digit(*itr)) {
+            return (len > 1) ? scan_decimal_number(++itr, --len, false) : node_type::INTEGER;
+        }
+
+        return node_type::STRING;
+    }
+
+    /// @brief Detects a scalar value type by scanning the contents right after the beginning 0.
+    /// @param itr The iterator to the past-the-zero element of the scalar.
+    /// @param len The length of the scalar left unscanned.
+    /// @return A detected scalar value type.
+    static node_type scan_after_zero_at_first(const char* itr, uint32_t len) {
+        FK_YAML_ASSERT(len > 0);
+
+        if (is_digit(*itr)) {
+            // a token consisting of the beginning '0' and some following numbers, e.g., `0123`, is not an integer
+            // according to https://yaml.org/spec/1.2.2/#10213-integer.
+            return node_type::STRING;
+        }
+
+        switch (*itr) {
+        case '.': {
+            if (len == 1) {
+                // 0 is omitted after `0.`.
+                return node_type::FLOAT;
+            }
+            node_type ret = scan_after_decimal_point(++itr, --len, true);
+            return (ret == node_type::STRING) ? node_type::STRING : node_type::FLOAT;
+        }
+        case 'o':
+            return (len > 1) ? scan_octal_number(++itr, --len) : node_type::STRING;
+        case 'x':
+            return (len > 1) ? scan_hexadecimal_number(++itr, --len) : node_type::STRING;
+        default:
+            return node_type::STRING;
+        }
+    }
+
+    /// @brief Detects a scalar value type by scanning the contents part starting with a decimal.
+    /// @param itr The iterator to the beginning decimal element of the scalar.
+    /// @param len The length of the scalar left unscanned.
+    /// @param has_decimal_point Whether a decimal point has already been found in the previous part.
+    /// @return A detected scalar value type.
+    static node_type scan_decimal_number(const char* itr, uint32_t len, bool has_decimal_point) {
+        FK_YAML_ASSERT(len > 0);
+
+        if (is_digit(*itr)) {
+            return (len > 1) ? scan_decimal_number(++itr, --len, has_decimal_point) : node_type::INTEGER;
+        }
+
+        switch (*itr) {
+        case '.': {
+            if (has_decimal_point) {
+                // the token has more than one period, e.g., a semantic version `1.2.3`.
+                return node_type::STRING;
+            }
+            if (len == 1) {
+                // 0 is omitted after the decimal point
+                return node_type::FLOAT;
+            }
+            node_type ret = scan_after_decimal_point(++itr, --len, true);
+            return (ret == node_type::STRING) ? node_type::STRING : node_type::FLOAT;
+        }
+        case 'e':
+        case 'E':
+            return (len > 1) ? scan_after_exponent(++itr, --len, has_decimal_point) : node_type::STRING;
+        default:
+            return node_type::STRING;
+        }
+    }
+
+    /// @brief Detects a scalar value type by scanning the contents right after a decimal point.
+    /// @param itr The iterator to the past-the-decimal-point element of the scalar.
+    /// @param len The length of the scalar left unscanned.
+    /// @param has_decimal_point Whether the decimal point has already been found in the previous part.
+    /// @return A detected scalar value type.
+    static node_type scan_after_decimal_point(const char* itr, uint32_t len, bool has_decimal_point) {
+        FK_YAML_ASSERT(len > 0);
+
+        if (is_digit(*itr)) {
+            return (len > 1) ? scan_decimal_number(++itr, --len, has_decimal_point) : node_type::FLOAT;
+        }
+
+        return node_type::STRING;
+    }
+
+    /// @brief Detects a scalar value type by scanning the contents right after the exponent prefix ("e" or "E").
+    /// @param itr The iterator to the past-the-exponent-prefix element of the scalar.
+    /// @param len The length of the scalar left unscanned.
+    /// @param has_decimal_point Whether the decimal point has already been found in the previous part.
+    /// @return A detected scalar value type.
+    static node_type scan_after_exponent(const char* itr, uint32_t len, bool has_decimal_point) {
+        FK_YAML_ASSERT(len > 0);
+
+        if (is_digit(*itr)) {
+            return (len > 1) ? scan_decimal_number(++itr, --len, has_decimal_point) : node_type::FLOAT;
+        }
+
+        switch (*itr) {
+        case '+':
+        case '-':
+            return (len > 1) ? scan_decimal_number(++itr, --len, has_decimal_point) : node_type::STRING;
+        default:
+            return node_type::STRING;
+        }
+    }
+
+    /// @brief Detects a scalar value type by scanning the contents assuming octal numbers.
+    /// @param itr The iterator to the octal-number element of the scalar.
+    /// @param len The length of the scalar left unscanned.
+    /// @return A detected scalar value type.
+    static node_type scan_octal_number(const char* itr, uint32_t len) {
+        FK_YAML_ASSERT(len > 0);
+
+        switch (*itr) {
+        case '0':
+        case '1':
+        case '2':
+        case '3':
+        case '4':
+        case '5':
+        case '6':
+        case '7':
+            return (len > 1) ? scan_octal_number(++itr, --len) : node_type::INTEGER;
+        default:
+            return node_type::STRING;
+        }
+    }
+
+    /// @brief Detects a scalar value type by scanning the contents assuming hexadecimal numbers.
+    /// @param itr The iterator to the hexadecimal-number element of the scalar.
+    /// @param len The length of the scalar left unscanned.
+    /// @return A detected scalar value type.
+    static node_type scan_hexadecimal_number(const char* itr, uint32_t len) {
+        FK_YAML_ASSERT(len > 0);
+
+        if (is_xdigit(*itr)) {
+            return (len > 1) ? scan_hexadecimal_number(++itr, --len) : node_type::INTEGER;
+        }
+        return node_type::STRING;
+    }
+};
+
+FK_YAML_DETAIL_NAMESPACE_END
+
+#endif /* FK_YAML_DETAIL_INPUT_SCALAR_SCANNER_HPP_ */
+
 // #include <fkYAML/detail/meta/stl_supplement.hpp>
 
 // #include <fkYAML/detail/node_attrs.hpp>
@@ -6230,7 +6219,7 @@ class basic_deserializer {
     /** A type for the target basic_node. */
     using basic_node_type = BasicNodeType;
     /** A type for the lexical analyzer. */
-    using lexer_type = lexical_analyzer<basic_node_type>;
+    using lexer_type = lexical_analyzer;
     /** A type for the document metainfo. */
     using doc_metainfo_type = document_metainfo<basic_node_type>;
     /** A type for the tag resolver. */

--- a/single_include/fkYAML/node.hpp
+++ b/single_include/fkYAML/node.hpp
@@ -1749,6 +1749,7 @@ FK_YAML_DETAIL_NAMESPACE_END
 #ifndef FK_YAML_DETAIL_INPUT_LEXICAL_ANALIZER_HPP_
 #define FK_YAML_DETAIL_INPUT_LEXICAL_ANALIZER_HPP_
 
+#include <algorithm>
 #include <cctype>
 #include <cstdlib>
 
@@ -2939,79 +2940,8 @@ FK_YAML_DETAIL_NAMESPACE_END
 #define FK_YAML_DETAIL_INPUT_POSITION_TRACKER_HPP_
 
 #include <algorithm>
-#include <string>
-#include <utility>
-#include <vector>
 
 // #include <fkYAML/detail/macros/version_macros.hpp>
-
-// #include <fkYAML/detail/meta/input_adapter_traits.hpp>
-///  _______   __ __   __  _____   __  __  __
-/// |   __| |_/  |  \_/  |/  _  \ /  \/  \|  |     fkYAML: A C++ header-only YAML library
-/// |   __|  _  < \_   _/|  ___  |    _   |  |___  version 0.3.11
-/// |__|  |_| \__|  |_|  |_|   |_|___||___|______| https://github.com/fktn-k/fkYAML
-///
-/// SPDX-FileCopyrightText: 2023-2024 Kensuke Fukutani <fktn.dev@gmail.com>
-/// SPDX-License-Identifier: MIT
-///
-/// @file
-
-#ifndef FK_YAML_DETAIL_META_INPUT_ADAPTER_TRAITS_HPP_
-#define FK_YAML_DETAIL_META_INPUT_ADAPTER_TRAITS_HPP_
-
-#include <string>
-#include <type_traits>
-
-// #include <fkYAML/detail/macros/version_macros.hpp>
-
-// #include <fkYAML/detail/meta/detect.hpp>
-
-// #include <fkYAML/detail/meta/stl_supplement.hpp>
-
-
-FK_YAML_DETAIL_NAMESPACE_BEGIN
-
-///////////////////////////////////////////
-//   Input Adapter API detection traits
-///////////////////////////////////////////
-
-/// @brief A type which represents get_character function.
-/// @tparam T A target type.
-template <typename T>
-using fill_buffer_fn_t = decltype(std::declval<T>().fill_buffer());
-
-/// @brief Type traits to check if InputAdapterType has get_character member function.
-/// @tparam InputAdapterType An input adapter type to check if it has get_character function.
-/// @tparam typename N/A
-template <typename InputAdapterType, typename = void>
-struct has_fill_buffer : std::false_type {};
-
-/// @brief A partial specialization of has_fill_buffer if InputAdapterType has get_character member function.
-/// @tparam InputAdapterType A type of a target input adapter.
-template <typename InputAdapterType>
-struct has_fill_buffer<InputAdapterType, enable_if_t<is_detected<fill_buffer_fn_t, InputAdapterType>::value>>
-    : std::true_type {};
-
-////////////////////////////////
-//   is_input_adapter traits
-////////////////////////////////
-
-/// @brief Type traits to check if T is an input adapter type.
-/// @tparam T A target type.
-/// @tparam typename N/A
-template <typename T, typename = void>
-struct is_input_adapter : std::false_type {};
-
-/// @brief A partial specialization of is_input_adapter if T is an input adapter type.
-/// @tparam InputAdapterType
-template <typename InputAdapterType>
-struct is_input_adapter<InputAdapterType, enable_if_t<has_fill_buffer<InputAdapterType>::value>> : std::true_type {};
-
-FK_YAML_DETAIL_NAMESPACE_END
-
-#endif /* FK_YAML_DETAIL_META_INPUT_ADAPTER_TRAITS_HPP_ */
-
-// #include <fkYAML/detail/meta/stl_supplement.hpp>
 
 // #include <fkYAML/detail/str_view.hpp>
 ///  _______   __ __   __  _____   __  __  __
@@ -3987,7 +3917,7 @@ public:
     /// @note This function doesn't support cases where cur_pos has moved backward from the last call.
     /// @param cur_pos The iterator to the current element of the buffer.
     void update_position(const char* p_current) {
-        uint32_t diff = static_cast<uint32_t>(std::distance(m_last, p_current));
+        uint32_t diff = static_cast<uint32_t>(p_current - m_last);
         if (diff == 0) {
             return;
         }
@@ -4003,7 +3933,8 @@ public:
         }
 
         uint32_t count = 0;
-        while (--p_current != m_begin) {
+        const char* p_begin = m_begin;
+        while (--p_current != p_begin) {
             if (*p_current == '\n') {
                 break;
             }
@@ -5706,6 +5637,70 @@ FK_YAML_DETAIL_NAMESPACE_END
 #endif /* FK_YAML_DETAIL_INPUT_TAG_RESOLVER_HPP_ */
 
 // #include <fkYAML/detail/meta/input_adapter_traits.hpp>
+///  _______   __ __   __  _____   __  __  __
+/// |   __| |_/  |  \_/  |/  _  \ /  \/  \|  |     fkYAML: A C++ header-only YAML library
+/// |   __|  _  < \_   _/|  ___  |    _   |  |___  version 0.3.11
+/// |__|  |_| \__|  |_|  |_|   |_|___||___|______| https://github.com/fktn-k/fkYAML
+///
+/// SPDX-FileCopyrightText: 2023-2024 Kensuke Fukutani <fktn.dev@gmail.com>
+/// SPDX-License-Identifier: MIT
+///
+/// @file
+
+#ifndef FK_YAML_DETAIL_META_INPUT_ADAPTER_TRAITS_HPP_
+#define FK_YAML_DETAIL_META_INPUT_ADAPTER_TRAITS_HPP_
+
+#include <string>
+#include <type_traits>
+
+// #include <fkYAML/detail/macros/version_macros.hpp>
+
+// #include <fkYAML/detail/meta/detect.hpp>
+
+// #include <fkYAML/detail/meta/stl_supplement.hpp>
+
+
+FK_YAML_DETAIL_NAMESPACE_BEGIN
+
+///////////////////////////////////////////
+//   Input Adapter API detection traits
+///////////////////////////////////////////
+
+/// @brief A type which represents get_character function.
+/// @tparam T A target type.
+template <typename T>
+using fill_buffer_fn_t = decltype(std::declval<T>().fill_buffer());
+
+/// @brief Type traits to check if InputAdapterType has get_character member function.
+/// @tparam InputAdapterType An input adapter type to check if it has get_character function.
+/// @tparam typename N/A
+template <typename InputAdapterType, typename = void>
+struct has_fill_buffer : std::false_type {};
+
+/// @brief A partial specialization of has_fill_buffer if InputAdapterType has get_character member function.
+/// @tparam InputAdapterType A type of a target input adapter.
+template <typename InputAdapterType>
+struct has_fill_buffer<InputAdapterType, enable_if_t<is_detected<fill_buffer_fn_t, InputAdapterType>::value>>
+    : std::true_type {};
+
+////////////////////////////////
+//   is_input_adapter traits
+////////////////////////////////
+
+/// @brief Type traits to check if T is an input adapter type.
+/// @tparam T A target type.
+/// @tparam typename N/A
+template <typename T, typename = void>
+struct is_input_adapter : std::false_type {};
+
+/// @brief A partial specialization of is_input_adapter if T is an input adapter type.
+/// @tparam InputAdapterType
+template <typename InputAdapterType>
+struct is_input_adapter<InputAdapterType, enable_if_t<has_fill_buffer<InputAdapterType>::value>> : std::true_type {};
+
+FK_YAML_DETAIL_NAMESPACE_END
+
+#endif /* FK_YAML_DETAIL_META_INPUT_ADAPTER_TRAITS_HPP_ */
 
 // #include <fkYAML/detail/meta/node_traits.hpp>
 

--- a/single_include/fkYAML/node.hpp
+++ b/single_include/fkYAML/node.hpp
@@ -3149,7 +3149,7 @@ public:
     /// @brief Get the maximum number of the character sequence size.
     /// @return The maximum number of the character sequence size.
     constexpr size_type max_size() const noexcept {
-        return std::numeric_limits<difference_type>::max();
+        return static_cast<size_type>(std::numeric_limits<difference_type>::max());
     }
 
     /// @brief Checks if the referenced character sequence is empty.
@@ -8161,7 +8161,7 @@ public:
     /// @param encode_type The encoding type for this input adapter.
     /// @param is_contiguous Whether iterators are contiguous or not.
     iterator_input_adapter(IterType begin, IterType end, utf_encode_t encode_type, bool is_contiguous) noexcept
-        : m_current(begin),
+        : m_begin(begin),
           m_end(end),
           m_encode_type(encode_type),
           m_is_contiguous(is_contiguous) {

--- a/single_include/fkYAML/node.hpp
+++ b/single_include/fkYAML/node.hpp
@@ -1792,12 +1792,12 @@ public:
     /// @param begin An iterator to the first element of the character sequence.
     /// @param end An iterator to the past-the-end element of the character sequence.
     /// @return true if all the characters are valid, false otherwise.
-    static bool validate(std::string::const_iterator begin, std::string::const_iterator end) noexcept {
+    static bool validate(const char* begin, const char* end) noexcept {
         if (begin == end) {
             return true;
         }
 
-        std::string::const_iterator current = begin;
+        const char* current = begin;
 
         for (; current != end; ++current) {
             if (*current == '%') {
@@ -1823,7 +1823,7 @@ private:
     /// @param begin An iterator to the first octet.
     /// @param end An iterator to the past-the-end element of the whole character sequence.
     /// @return true if the octets are valid, false otherwise.
-    static bool validate_octets(std::string::const_iterator& begin, std::string::const_iterator& end) {
+    static bool validate_octets(const char*& begin, const char*& end) {
         for (int i = 0; i < 2; i++, ++begin) {
             if (begin == end) {
                 return false;
@@ -2611,7 +2611,7 @@ class yaml_escaper {
     using iterator = ::std::string::const_iterator;
 
 public:
-    static bool unescape(iterator& begin, iterator end, std::string& buff) {
+    static bool unescape(const char*& begin, const char* end, std::string& buff) {
         FK_YAML_ASSERT(*begin == '\\' && std::distance(begin, end) > 0);
         bool ret = true;
 
@@ -2698,7 +2698,7 @@ public:
         return ret;
     }
 
-    static ::std::string escape(iterator begin, iterator end, bool& is_escaped) {
+    static ::std::string escape(const char* begin, const char* end, bool& is_escaped) {
         ::std::string escaped {};
         escaped.reserve(std::distance(begin, end));
         for (; begin != end; ++begin) {
@@ -2897,7 +2897,7 @@ private:
         return false;
     }
 
-    static bool extract_codepoint(iterator& begin, iterator end, int bytes_to_read, char32_t& codepoint) {
+    static bool extract_codepoint(const char*& begin, const char* end, int bytes_to_read, char32_t& codepoint) {
         bool has_enough_room = static_cast<int>(std::distance(begin, end)) >= (bytes_to_read - 1);
         if (!has_enough_room) {
             return false;
@@ -2984,7 +2984,7 @@ public:
     /// @param begin The iterator to the first element of the scalar.
     /// @param end The iterator to the past-the-end element of the scalar.
     /// @return A detected scalar value type.
-    static node_type scan(std::string::const_iterator begin, std::string::const_iterator end) {
+    static node_type scan(const char* begin, const char* end) {
         if (begin == end) {
             return node_type::STRING;
         }
@@ -3069,7 +3069,7 @@ private:
     /// @param itr The iterator to the first element of the scalar.
     /// @param len The length of the scalar contents.
     /// @return A detected scalar value type.
-    static node_type scan_possible_number_token(std::string::const_iterator itr, uint32_t len) {
+    static node_type scan_possible_number_token(const char* itr, uint32_t len) {
         FK_YAML_ASSERT(len > 0);
 
         switch (*itr) {
@@ -3098,7 +3098,7 @@ private:
     /// @param itr The iterator to the past-the-negative-sign element of the scalar.
     /// @param len The length of the scalar contents left unscanned.
     /// @return A detected scalar value type.
-    static node_type scan_negative_number(std::string::const_iterator itr, uint32_t len) {
+    static node_type scan_negative_number(const char* itr, uint32_t len) {
         FK_YAML_ASSERT(len > 0);
 
         if (is_digit(*itr)) {
@@ -3112,7 +3112,7 @@ private:
     /// @param itr The iterator to the past-the-zero element of the scalar.
     /// @param len The length of the scalar left unscanned.
     /// @return A detected scalar value type.
-    static node_type scan_after_zero_at_first(std::string::const_iterator itr, uint32_t len) {
+    static node_type scan_after_zero_at_first(const char* itr, uint32_t len) {
         FK_YAML_ASSERT(len > 0);
 
         if (is_digit(*itr)) {
@@ -3144,7 +3144,7 @@ private:
     /// @param len The length of the scalar left unscanned.
     /// @param has_decimal_point Whether a decimal point has already been found in the previous part.
     /// @return A detected scalar value type.
-    static node_type scan_decimal_number(std::string::const_iterator itr, uint32_t len, bool has_decimal_point) {
+    static node_type scan_decimal_number(const char* itr, uint32_t len, bool has_decimal_point) {
         FK_YAML_ASSERT(len > 0);
 
         if (is_digit(*itr)) {
@@ -3177,7 +3177,7 @@ private:
     /// @param len The length of the scalar left unscanned.
     /// @param has_decimal_point Whether the decimal point has already been found in the previous part.
     /// @return A detected scalar value type.
-    static node_type scan_after_decimal_point(std::string::const_iterator itr, uint32_t len, bool has_decimal_point) {
+    static node_type scan_after_decimal_point(const char* itr, uint32_t len, bool has_decimal_point) {
         FK_YAML_ASSERT(len > 0);
 
         if (is_digit(*itr)) {
@@ -3192,7 +3192,7 @@ private:
     /// @param len The length of the scalar left unscanned.
     /// @param has_decimal_point Whether the decimal point has already been found in the previous part.
     /// @return A detected scalar value type.
-    static node_type scan_after_exponent(std::string::const_iterator itr, uint32_t len, bool has_decimal_point) {
+    static node_type scan_after_exponent(const char* itr, uint32_t len, bool has_decimal_point) {
         FK_YAML_ASSERT(len > 0);
 
         if (is_digit(*itr)) {
@@ -3212,7 +3212,7 @@ private:
     /// @param itr The iterator to the octal-number element of the scalar.
     /// @param len The length of the scalar left unscanned.
     /// @return A detected scalar value type.
-    static node_type scan_octal_number(std::string::const_iterator itr, uint32_t len) {
+    static node_type scan_octal_number(const char* itr, uint32_t len) {
         FK_YAML_ASSERT(len > 0);
 
         switch (*itr) {
@@ -3234,7 +3234,7 @@ private:
     /// @param itr The iterator to the hexadecimal-number element of the scalar.
     /// @param len The length of the scalar left unscanned.
     /// @return A detected scalar value type.
-    static node_type scan_hexadecimal_number(std::string::const_iterator itr, uint32_t len) {
+    static node_type scan_hexadecimal_number(const char* itr, uint32_t len) {
         FK_YAML_ASSERT(len > 0);
 
         if (is_xdigit(*itr)) {
@@ -3302,7 +3302,7 @@ FK_YAML_DETAIL_NAMESPACE_BEGIN
 /// @brief A type which represents get_character function.
 /// @tparam T A target type.
 template <typename T>
-using fill_buffer_fn_t = decltype(std::declval<T>().fill_buffer(std::declval<std::string&>()));
+using fill_buffer_fn_t = decltype(std::declval<T>().fill_buffer());
 
 /// @brief Type traits to check if InputAdapterType has get_character member function.
 /// @tparam InputAdapterType An input adapter type to check if it has get_character function.
@@ -3337,13 +3337,550 @@ FK_YAML_DETAIL_NAMESPACE_END
 
 // #include <fkYAML/detail/meta/stl_supplement.hpp>
 
+// #include <fkYAML/detail/str_view.hpp>
+///  _______   __ __   __  _____   __  __  __
+/// |   __| |_/  |  \_/  |/  _  \ /  \/  \|  |     fkYAML: A C++ header-only YAML library
+/// |   __|  _  < \_   _/|  ___  |    _   |  |___  version 0.3.11
+/// |__|  |_| \__|  |_|  |_|   |_|___||___|______| https://github.com/fktn-k/fkYAML
+///
+/// SPDX-FileCopyrightText: 2023-2024 Kensuke Fukutani <fktn.dev@gmail.com>
+/// SPDX-License-Identifier: MIT
+///
+/// @file
+
+#ifndef FK_YAML_DETAIL_STR_VIEW_HPP_
+#define FK_YAML_DETAIL_STR_VIEW_HPP_
+
+#include <limits>
+#include <string>
+
+// #include <fkYAML/detail/macros/version_macros.hpp>
+
+// #include <fkYAML/detail/meta/stl_supplement.hpp>
+
+// #include <fkYAML/detail/meta/type_traits.hpp>
+
+// #include <fkYAML/exception.hpp>
+
+
+FK_YAML_DETAIL_NAMESPACE_BEGIN
+
+template <typename CharT, typename Traits = std::char_traits<CharT>>
+class basic_str_view {
+    static_assert(!std::is_array<CharT>::value, "CharT must not be an array type.");
+    static_assert(
+        std::is_trivial<CharT>::value && std::is_standard_layout<CharT>::value,
+        "CharT must be a trivial, standard layout type.");
+    static_assert(
+        std::is_same<CharT, typename Traits::char_type>::value, "CharT & Traits::char_type must be the same type.");
+
+public:
+    using traits_type = Traits;
+    using value_type = CharT;
+    using pointer = value_type*;
+    using const_pointer = const value_type*;
+    using reference = value_type&;
+    using const_reference = const value_type&;
+    using const_iterator = const value_type*;
+    using iterator = const_iterator;
+    using const_reverse_iterator = std::reverse_iterator<const_iterator>;
+    using reverse_iterator = const_reverse_iterator;
+    using size_type = std::size_t;
+    using difference_type = std::ptrdiff_t;
+
+    static constexpr size_type npos = static_cast<size_type>(-1);
+
+    basic_str_view() noexcept = default;
+    ~basic_str_view() noexcept = default;
+    basic_str_view(const basic_str_view&) noexcept = default;
+    basic_str_view(basic_str_view&&) noexcept = default;
+
+    basic_str_view(const value_type* p_str) noexcept
+        : m_len(traits_type::length(p_str)),
+          mp_str(p_str) {
+    }
+
+    basic_str_view(std::nullptr_t) = delete;
+
+    basic_str_view(const value_type* p_str, size_type len) noexcept
+        : m_len(len),
+          mp_str(p_str) {
+    }
+
+    template <
+        typename ItrType,
+        enable_if_t<
+            conjunction<
+                is_iterator_of<ItrType, CharT>,
+                std::is_base_of<
+                    std::random_access_iterator_tag, typename std::iterator_traits<ItrType>::iterator_category>>::value,
+            int> = 0>
+    basic_str_view(ItrType first, ItrType last) noexcept
+        : m_len(last - first),
+          mp_str(m_len > 0 ? &*first : nullptr) {
+    }
+
+    basic_str_view(const std::basic_string<CharT>& str) noexcept
+        : m_len(str.length()),
+          mp_str(str.data()) {
+    }
+
+    basic_str_view& operator=(const basic_str_view&) noexcept = default;
+    basic_str_view& operator=(basic_str_view&&) noexcept = default;
+
+    const_iterator begin() const noexcept {
+        return mp_str;
+    }
+
+    const_iterator end() const noexcept {
+        return mp_str + m_len;
+    }
+
+    const_iterator cbegin() const noexcept {
+        return mp_str;
+    }
+
+    const_iterator cend() const noexcept {
+        return mp_str + m_len;
+    }
+
+    const_reverse_iterator rbegin() const noexcept {
+        return const_reverse_iterator(end());
+    }
+
+    const_reverse_iterator rend() const noexcept {
+        return const_reverse_iterator(begin());
+    }
+
+    const_reverse_iterator crbegin() const noexcept {
+        return const_reverse_iterator(end());
+    }
+
+    const_reverse_iterator crend() const noexcept {
+        return const_reverse_iterator(begin());
+    }
+
+    size_type size() const noexcept {
+        return m_len;
+    }
+
+    size_type length() const noexcept {
+        return m_len;
+    }
+
+    constexpr size_type max_size() const noexcept {
+        return std::numeric_limits<difference_type>::max();
+    }
+
+    bool empty() const noexcept {
+        return m_len == 0;
+    }
+
+    const_reference operator[](size_type pos) const noexcept {
+        return *(mp_str + pos);
+    }
+
+    const_reference at(size_type pos) const {
+        if (pos >= m_len) {
+            throw fkyaml::out_of_range(pos);
+        }
+        return *(mp_str + pos);
+    }
+
+    const_reference front() const noexcept {
+        return *mp_str;
+    }
+
+    const_reference back() const {
+        return *(mp_str + m_len - 1);
+    }
+
+    const_pointer data() const noexcept {
+        return mp_str;
+    }
+
+    void remove_prefix(size_type n) noexcept {
+        mp_str += n;
+        m_len -= n;
+    }
+
+    void remove_suffix(size_type n) noexcept {
+        m_len -= n;
+    }
+
+    void swap(basic_str_view& other) noexcept {
+        auto tmp = *this;
+        *this = other;
+        other = tmp;
+    }
+
+    size_type copy(CharT* p_str, size_type n, size_type pos = 0) const {
+        if (pos > m_len) {
+            throw fkyaml::out_of_range(pos);
+        }
+        const size_type rlen = std::min(n, m_len - pos);
+        traits_type::copy(p_str, mp_str + pos, rlen);
+        return rlen;
+    }
+
+    basic_str_view substr(size_type pos = 0, size_type n = npos) const {
+        if (pos > m_len) {
+            throw fkyaml::out_of_range(pos);
+        }
+        const size_type rlen = std::min(n, m_len - pos);
+        return basic_str_view(mp_str + pos, rlen);
+    }
+
+    int compare(basic_str_view sv) const noexcept {
+        const size_type rlen = std::min(m_len, sv.m_len);
+        int ret = traits_type::compare(mp_str, sv.mp_str, rlen);
+
+        if (ret == 0) {
+            using int_limits = std::numeric_limits<int>;
+            difference_type diff = m_len - sv.m_len;
+
+            if (diff > int_limits::max()) {
+                ret = int_limits::max();
+            }
+            else if (diff < int_limits::min()) {
+                ret = int_limits::min();
+            }
+            else {
+                ret = static_cast<int>(diff);
+            }
+        }
+
+        return ret;
+    }
+
+    int compare(size_type pos1, size_type n1, basic_str_view sv) const {
+        return substr(pos1, n1).compare(sv);
+    }
+
+    int compare(size_type pos1, size_type n1, basic_str_view sv, size_type pos2, size_type n2) const {
+        return substr(pos1, n1).compare(sv.substr(pos2, n2));
+    }
+
+    int compare(const CharT* s) const {
+        return compare(basic_str_view(s));
+    }
+
+    int compare(size_type pos1, size_type n1, const CharT* s) const {
+        return substr(pos1, n1).compare(basic_str_view(s));
+    }
+
+    int compare(size_type pos1, size_type n1, const CharT* s, size_type n2) const {
+        return substr(pos1, n1).compare(basic_str_view(s, n2));
+    }
+
+    bool starts_with(basic_str_view sv) const noexcept {
+        return substr(0, sv.size()) == sv;
+    }
+
+    bool starts_with(CharT c) const noexcept {
+        return !empty() && traits_type::eq(front(), c);
+    }
+
+    bool starts_with(const CharT* s) const noexcept {
+        return starts_with(basic_str_view(s));
+    }
+
+    bool ends_with(basic_str_view sv) const noexcept {
+        const size_type size = m_len;
+        const size_type sv_size = sv.size();
+        return size >= sv_size && traits_type::compare(end() - sv_size, sv.data(), sv_size) == 0;
+    }
+
+    bool ends_with(CharT c) const noexcept {
+        return !empty() && traits_type::eq(back(), c);
+    }
+
+    bool ends_with(const CharT* s) const noexcept {
+        return ends_with(basic_str_view(s));
+    }
+
+    bool contains(basic_str_view sv) const noexcept {
+        return find(sv) != npos;
+    }
+
+    bool contains(CharT c) const noexcept {
+        return find(c) != npos;
+    }
+
+    bool contains(const CharT* s) const noexcept {
+        return find(s) != npos;
+    }
+
+    size_type find(basic_str_view sv, size_type pos = 0) const noexcept {
+        return find(sv.mp_str, pos, sv.m_len);
+    }
+
+    size_type find(CharT c, size_type pos = 0) const noexcept {
+        size_type ret = npos;
+
+        if (pos < m_len) {
+            const size_type n = m_len - pos;
+            const CharT* p_found = traits_type::find(mp_str + pos, n, c);
+            if (p_found) {
+                ret = p_found - mp_str;
+            }
+        }
+
+        return ret;
+    }
+
+    size_type find(const CharT* s, size_type pos, size_type n) const noexcept {
+        if (n == 0) {
+            return pos <= m_len ? pos : npos;
+        }
+
+        if (pos >= m_len) {
+            return npos;
+        }
+
+        CharT s0 = s[0];
+        const CharT* p_first = mp_str + pos;
+        const CharT* p_last = mp_str + m_len;
+        size_type len = m_len - pos;
+
+        while (len >= n) {
+            // find the first occurence of s0
+            p_first = traits_type::find(p_first, len - n + 1, s0);
+            if (!p_first) {
+                return npos;
+            }
+
+            // compare the full strings from the first occurence of s0
+            if (traits_type::compare(p_first, s, n) == 0) {
+                return p_first - mp_str;
+            }
+
+            len = p_last - (++p_first);
+        }
+
+        return npos;
+    }
+
+    size_type find(const CharT* s, size_type pos = 0) const noexcept {
+        return find(basic_str_view(s), pos);
+    }
+
+    size_type rfind(basic_str_view sv, size_type pos = npos) const noexcept {
+        return rfind(sv.mp_str, pos, sv.m_len);
+    }
+
+    size_type rfind(CharT c, size_type pos = npos) const noexcept {
+        if (m_len == 0) {
+            return npos;
+        }
+
+        size_type idx = pos;
+        if (pos >= m_len) {
+            idx = m_len - 1;
+        }
+
+        while (idx > 0) {
+            if (traits_type::eq(mp_str[idx], c)) {
+                return idx;
+            }
+            --idx;
+        }
+
+        return npos;
+    }
+
+    size_type rfind(const CharT* s, size_type pos, size_type n) const noexcept {
+        if (n <= m_len) {
+            pos = std::min(m_len - n, pos) + 1;
+
+            do {
+                if (traits_type::compare(mp_str + --pos, s, n) == 0) {
+                    return pos;
+                }
+            } while (pos > 0);
+        }
+
+        return npos;
+    }
+
+    size_type rfind(const CharT* s, size_type pos = npos) const noexcept {
+        return rfind(basic_str_view(s), pos);
+    }
+
+    size_type find_first_of(basic_str_view sv, size_type pos = 0) const noexcept {
+        return find_first_of(sv.mp_str, pos, sv.m_len);
+    }
+
+    size_type find_first_of(CharT c, size_type pos = 0) const noexcept {
+        return find(c, pos);
+    }
+
+    size_type find_first_of(const CharT* s, size_type pos, size_type n) const noexcept {
+        if (n == 0) {
+            return npos;
+        }
+
+        for (size_type idx = pos; idx < m_len; ++idx) {
+            const CharT* p_found = traits_type::find(s, n, mp_str[idx]);
+            if (p_found) {
+                return idx;
+            }
+        }
+
+        return npos;
+    }
+
+    size_type find_first_of(const CharT* s, size_type pos = 0) const noexcept {
+        return find_first_of(basic_str_view(s), pos);
+    }
+
+    size_type find_last_of(basic_str_view sv, size_type pos = npos) const noexcept {
+        return find_last_of(sv.mp_str, pos, sv.m_len);
+    }
+
+    size_type find_last_of(CharT c, size_type pos = npos) const noexcept {
+        return rfind(c, pos);
+    }
+
+    size_type find_last_of(const CharT* s, size_type pos, size_type n) const noexcept {
+        if (n <= m_len) {
+            pos = std::min(m_len - n, pos) + 1;
+
+            do {
+                const CharT* p_found = traits_type::find(s, n, mp_str[--pos]);
+                if (p_found) {
+                    return pos;
+                }
+            } while (pos > 0);
+        }
+
+        return npos;
+    }
+
+    size_type find_last_of(const CharT* s, size_type pos = npos) const noexcept {
+        return find_last_of(basic_str_view(s), pos);
+    }
+
+    size_type find_first_not_of(basic_str_view sv, size_type pos = npos) const noexcept {
+        return find_first_not_of(sv.mp_str, pos, sv.m_len);
+    }
+
+    size_type find_first_not_of(CharT c, size_type pos = npos) const noexcept {
+        for (; pos < m_len; ++pos) {
+            if (!traits_type::eq(mp_str[pos], c)) {
+                return pos;
+            }
+        }
+
+        return npos;
+    }
+
+    size_type find_first_not_of(const CharT* s, size_type pos, size_type n) const noexcept {
+        for (; pos < m_len; ++pos) {
+            const CharT* p_found = traits_type::find(s, n, mp_str[pos]);
+            if (!p_found) {
+                return pos;
+            }
+        }
+
+        return npos;
+    }
+
+    size_type find_first_not_of(const CharT* s, size_type pos = npos) const noexcept {
+        return find_first_not_of(basic_str_view(s), pos);
+    }
+
+    size_type find_last_not_of(basic_str_view sv, size_type pos = npos) const noexcept {
+        return find_last_not_of(sv.mp_str, pos, sv.m_len);
+    }
+
+    size_type find_last_not_of(CharT c, size_type pos = npos) const noexcept {
+        if (m_len > 0) {
+            pos = std::min(m_len, pos);
+
+            do {
+                if (!traits_type::eq(mp_str[--pos], c)) {
+                    return pos;
+                }
+            } while (pos > 0);
+        }
+
+        return npos;
+    }
+
+    size_type find_last_not_of(const CharT* s, size_type pos, size_type n) const noexcept {
+        if (n <= m_len) {
+            pos = std::min(m_len - n, pos) + 1;
+
+            do {
+                const CharT* p_found = traits_type::find(s, n, mp_str[--pos]);
+                if (!p_found) {
+                    return pos;
+                }
+            } while (pos > 0);
+        }
+
+        return npos;
+    }
+
+    size_type find_last_not_of(const CharT* s, size_type pos = npos) const noexcept {
+        return find_last_not_of(basic_str_view(s), pos);
+    }
+
+private:
+    size_type m_len {0};
+    const value_type* mp_str {nullptr};
+};
+
+template <typename CharT, typename Traits>
+bool operator==(basic_str_view<CharT, Traits> lhs, basic_str_view<CharT, Traits> rhs) noexcept {
+    // Comparing the lengths first will omit unnecessary value comparison in compare().
+    return lhs.size() == rhs.size() && lhs.compare(rhs) == 0;
+}
+
+template <typename CharT, typename Traits>
+bool operator!=(basic_str_view<CharT, Traits> lhs, basic_str_view<CharT, Traits> rhs) noexcept {
+    return !(lhs == rhs);
+}
+
+template <typename CharT, typename Traits>
+bool operator<(basic_str_view<CharT, Traits> lhs, basic_str_view<CharT, Traits> rhs) noexcept {
+    return lhs.compare(rhs) < 0;
+}
+
+template <typename CharT, typename Traits>
+bool operator<=(basic_str_view<CharT, Traits> lhs, basic_str_view<CharT, Traits> rhs) noexcept {
+    return lhs.compare(rhs) <= 0;
+}
+
+template <typename CharT, typename Traits>
+bool operator>(basic_str_view<CharT, Traits> lhs, basic_str_view<CharT, Traits> rhs) noexcept {
+    return lhs.compare(rhs) > 0;
+}
+
+template <typename CharT, typename Traits>
+bool operator>=(basic_str_view<CharT, Traits> lhs, basic_str_view<CharT, Traits> rhs) noexcept {
+    return lhs.compare(rhs) >= 0;
+}
+
+template <typename CharT, typename Traits>
+std::basic_ostream<CharT, Traits>& operator<<(std::basic_ostream<CharT, Traits>& os, basic_str_view<CharT, Traits> sv) {
+    return os.write(sv.data(), static_cast<std::streamsize>(sv.size()));
+}
+
+using str_view = basic_str_view<char>;
+
+FK_YAML_DETAIL_NAMESPACE_END
+
+#endif /* FK_YAML_DETAIL_STR_VIEW_HPP_ */
+
 
 FK_YAML_DETAIL_NAMESPACE_BEGIN
 
 /// @brief A position tracker of the target buffer.
 class position_tracker {
 public:
-    void set_target_buffer(const std::string& buffer) {
+    void set_target_buffer(str_view buffer) noexcept {
         m_begin = m_last = buffer.begin();
         m_end = buffer.end();
     }
@@ -3351,16 +3888,16 @@ public:
     /// @brief Update the set of the current position informations.
     /// @note This function doesn't support cases where cur_pos has moved backward from the last call.
     /// @param cur_pos The iterator to the current element of the buffer.
-    void update_position(std::string::const_iterator cur_pos) {
-        uint32_t diff = static_cast<uint32_t>(std::distance(m_last, cur_pos));
+    void update_position(const char* p_current) {
+        uint32_t diff = static_cast<uint32_t>(std::distance(m_last, p_current));
         if (diff == 0) {
             return;
         }
 
         m_cur_pos += diff;
         uint32_t prev_lines_read = m_lines_read;
-        m_lines_read += static_cast<uint32_t>(std::count(m_last, cur_pos, '\n'));
-        m_last = cur_pos;
+        m_lines_read += static_cast<uint32_t>(std::count(m_last, p_current, '\n'));
+        m_last = p_current;
 
         if (prev_lines_read == m_lines_read) {
             m_cur_pos_in_line += diff;
@@ -3368,8 +3905,8 @@ public:
         }
 
         uint32_t count = 0;
-        while (--cur_pos != m_begin) {
-            if (*cur_pos == '\n') {
+        while (--p_current != m_begin) {
+            if (*p_current == '\n') {
                 break;
             }
             count++;
@@ -3395,11 +3932,11 @@ public:
 
 private:
     /// The iterator to the beginning element in the target buffer.
-    std::string::const_iterator m_begin {};
+    const char* m_begin {};
     /// The iterator to the past-the-end element in the target buffer.
-    std::string::const_iterator m_end {};
+    const char* m_end {};
     /// The iterator to the last updated element in the target buffer.
-    std::string::const_iterator m_last {};
+    const char* m_last {};
     /// The current position from the beginning of an input buffer.
     uint32_t m_cur_pos {0};
     /// The current position in the current line.
@@ -3412,11 +3949,11 @@ FK_YAML_DETAIL_NAMESPACE_END
 
 #endif /* FK_YAML_DETAIL_INPUT_POSITION_TRACKER_HPP_ */
 
-// #include <fkYAML/detail/meta/input_adapter_traits.hpp>
-
 // #include <fkYAML/detail/meta/node_traits.hpp>
 
 // #include <fkYAML/detail/meta/stl_supplement.hpp>
+
+// #include <fkYAML/detail/str_view.hpp>
 
 // #include <fkYAML/detail/types/lexical_token_t.hpp>
 ///  _______   __ __   __  _____   __  __  __
@@ -3473,8 +4010,8 @@ FK_YAML_DETAIL_NAMESPACE_BEGIN
 
 struct lexical_token {
     lexical_token_t type {lexical_token_t::END_OF_BUFFER};
-    std::string::const_iterator token_begin_itr {};
-    std::string::const_iterator token_end_itr {};
+    const char* token_begin_itr {};
+    const char* token_end_itr {};
 };
 
 /// @brief A class which lexically analizes YAML formatted inputs.
@@ -3504,11 +4041,10 @@ public:
     /// @brief Construct a new lexical_analyzer object.
     /// @tparam InputAdapterType The type of the input adapter.
     /// @param input_adapter An input adapter object.
-    template <typename InputAdapterType, enable_if_t<is_input_adapter<InputAdapterType>::value, int> = 0>
-    explicit lexical_analyzer(InputAdapterType&& input_adapter) {
-        std::forward<InputAdapterType>(input_adapter).fill_buffer(m_input_buffer);
-        m_cur_itr = m_token_begin_itr = m_input_buffer.cbegin();
-        m_end_itr = m_input_buffer.cend();
+    explicit lexical_analyzer(str_view input_buffer) noexcept
+        : m_input_buffer(input_buffer),
+          m_cur_itr(m_input_buffer.begin()),
+          m_end_itr(m_input_buffer.end()) {
         m_pos_tracker.set_target_buffer(m_input_buffer);
     }
 
@@ -3689,8 +4225,8 @@ public:
             get_block_style_metadata(chomp_type, indent);
             scan_block_style_string_token(block_style_indicator_t::LITERAL, chomp_type, indent);
             token.type = lexical_token_t::BLOCK_SCALAR;
-            token.token_begin_itr = m_value_buffer.cbegin();
-            token.token_end_itr = m_value_buffer.cend();
+            token.token_begin_itr = m_value_buffer.c_str();
+            token.token_end_itr = m_value_buffer.c_str() + m_value_buffer.size();
             return token;
         }
         case '>': {
@@ -3700,8 +4236,8 @@ public:
             get_block_style_metadata(chomp_type, indent);
             scan_block_style_string_token(block_style_indicator_t::FOLDED, chomp_type, indent);
             token.type = lexical_token_t::BLOCK_SCALAR;
-            token.token_begin_itr = m_value_buffer.cbegin();
-            token.token_end_itr = m_value_buffer.cend();
+            token.token_begin_itr = m_value_buffer.c_str();
+            token.token_end_itr = m_value_buffer.c_str() + m_value_buffer.size();
             return token;
         }
         default:
@@ -3723,25 +4259,20 @@ public:
     }
 
     /// @brief Get the YAML version specification.
-    /// @return const string_type& A YAML version specification.
-    const string_type& get_yaml_version() const {
-        FK_YAML_ASSERT(!m_value_buffer.empty() && m_value_buffer.size() == 3);
-        FK_YAML_ASSERT(m_value_buffer == "1.1" || m_value_buffer == "1.2");
-
-        return m_value_buffer;
+    /// @return str_view A YAML version specification.
+    str_view get_yaml_version() const noexcept {
+        return m_yaml_version;
     }
 
     /// @brief Get the YAML tag handle defined in the TAG directive.
-    /// @return const std::string& A tag handle.
-    const std::string& get_tag_handle() const {
-        FK_YAML_ASSERT(!m_tag_handle.empty());
+    /// @return str_view A tag handle.
+    str_view get_tag_handle() const noexcept {
         return m_tag_handle;
     }
 
     /// @brief Get the YAML tag prefix defined in the TAG directive.
-    /// @return const std::string A tag prefix.
-    const std::string& get_tag_prefix() const {
-        FK_YAML_ASSERT(!m_tag_prefix.empty());
+    /// @return str_view A tag prefix.
+    str_view get_tag_prefix() const noexcept {
         return m_tag_prefix;
     }
 
@@ -3789,7 +4320,7 @@ private:
 
         if (m_value_buffer == "YAML") {
             if (!ends_loop) {
-                emit_error("There must be at least one white space between \"%YAML\" and tag info.");
+                emit_error("There must be at least one white space between \"%YAML\" and version.");
             }
             skip_white_spaces();
             return scan_yaml_version_directive();
@@ -3802,8 +4333,6 @@ private:
     /// @brief Scan a YAML tag directive.
     /// @return lexical_token_t The lexical token type for YAML tag directives.
     lexical_token_t scan_tag_directive() {
-        m_tag_handle.clear();
-        m_tag_prefix.clear();
         m_token_begin_itr = m_cur_itr;
 
         //
@@ -3868,7 +4397,7 @@ private:
         }
         }
 
-        m_tag_handle.assign(m_token_begin_itr, m_cur_itr);
+        m_tag_handle = str_view {m_token_begin_itr, m_cur_itr};
 
         skip_white_spaces();
 
@@ -3877,6 +4406,7 @@ private:
         //
 
         m_token_begin_itr = m_cur_itr;
+        const char* p_tag_prefix_begin = m_cur_itr;
         switch (*m_cur_itr) {
         // a tag prefix must not start with flow indicators to avoid ambiguity.
         // See https://yaml.org/spec/1.2.2/#rule-ns-global-tag-prefix for more details.
@@ -3900,12 +4430,12 @@ private:
             }
         } while (!ends_loop && ++m_cur_itr != m_end_itr);
 
-        m_tag_prefix.assign(m_token_begin_itr, m_cur_itr);
-
-        bool is_valid = uri_encoding::validate(m_tag_prefix.begin(), m_tag_prefix.end());
+        bool is_valid = uri_encoding::validate(p_tag_prefix_begin, m_cur_itr);
         if (!is_valid) {
             emit_error("invalid URI character is found in a tag prefix.");
         }
+
+        m_tag_prefix = str_view {p_tag_prefix_begin, m_cur_itr};
 
         return lexical_token_t::TAG_DIRECTIVE;
     }
@@ -3914,7 +4444,6 @@ private:
     /// @note Only 1.1 and 1.2 are supported. If not, throws an exception.
     /// @return lexical_token_t The lexical token type for YAML version directives.
     lexical_token_t scan_yaml_version_directive() {
-        m_value_buffer.clear();
         m_token_begin_itr = m_cur_itr;
 
         bool ends_loop = false;
@@ -3931,9 +4460,9 @@ private:
             }
         }
 
-        m_value_buffer.assign(m_token_begin_itr, m_cur_itr);
+        m_yaml_version = str_view {m_token_begin_itr, m_cur_itr};
 
-        if (m_value_buffer != "1.1" && m_value_buffer != "1.2") {
+        if (m_yaml_version.compare("1.1") != 0 && m_yaml_version.compare("1.2") != 0) {
             emit_error("Only 1.1 and 1.2 can be specified as the YAML version.");
         }
 
@@ -4071,12 +4600,12 @@ private:
             }
 
             // TODO: This should be achieved with no copy...
-            const std::string named_handle(token.token_begin_itr, token.token_end_itr);
+            str_view named_handle(token.token_begin_itr, token.token_end_itr);
             std::size_t last_tag_prefix_pos = named_handle.find_last_of('!');
-            FK_YAML_ASSERT(last_tag_prefix_pos != std::string::npos);
+            FK_YAML_ASSERT(last_tag_prefix_pos != str_view::npos);
 
-            bool is_valid_uri =
-                uri_encoding::validate(named_handle.begin() + last_tag_prefix_pos + 1, named_handle.end());
+            str_view tag_uri = named_handle.substr(last_tag_prefix_pos + 1);
+            bool is_valid_uri = uri_encoding::validate(tag_uri.begin(), tag_uri.end());
             if (!is_valid_uri) {
                 emit_error("Invalid URI character is found in a named tag handle.");
             }
@@ -4108,8 +4637,8 @@ private:
         bool is_value_buff_used = extract_string_token(needs_last_single_quote, needs_last_double_quote);
 
         if (is_value_buff_used) {
-            token.token_begin_itr = m_value_buffer.cbegin();
-            token.token_end_itr = m_value_buffer.cend();
+            token.token_begin_itr = m_value_buffer.c_str();
+            token.token_end_itr = m_value_buffer.c_str() + m_value_buffer.size();
         }
         else {
             token.token_end_itr = m_cur_itr;
@@ -4437,7 +4966,7 @@ private:
         // scan the contents of a string scalar token.
 
         bool is_value_buffer_used = false;
-        for (; m_cur_itr != m_end_itr; m_cur_itr = (m_cur_itr == m_end_itr) ? m_cur_itr : ++m_cur_itr) {
+        for (; m_cur_itr != m_end_itr; ++m_cur_itr) {
             char current = *m_cur_itr;
             uint32_t num_bytes = utf8::get_num_bytes(static_cast<uint8_t>(current));
             if (num_bytes == 1) {
@@ -4446,6 +4975,10 @@ private:
                     bool is_allowed = (this->*pfn_is_allowed)(current, is_value_buffer_used);
                     if (!is_allowed) {
                         return is_value_buffer_used;
+                    }
+
+                    if (m_cur_itr == m_end_itr) {
+                        break;
                     }
 
                     continue;
@@ -4845,21 +5378,23 @@ private:
 
 private:
     /// An input buffer adapter to be analyzed.
-    std::string m_input_buffer {};
+    str_view m_input_buffer {};
     /// The iterator to the current character in the input buffer.
-    std::string::const_iterator m_cur_itr {};
+    const char* m_cur_itr {};
     /// The iterator to the beginning of the current token.
-    std::string::const_iterator m_token_begin_itr {};
+    const char* m_token_begin_itr {};
     /// The iterator to the past-the-end element in the input buffer.
-    std::string::const_iterator m_end_itr {};
+    const char* m_end_itr {};
     /// The current position tracker of the input buffer.
     mutable position_tracker m_pos_tracker {};
     /// A temporal buffer to store a string to be parsed to an actual token value.
     std::string m_value_buffer {};
+    /// The last yaml version.
+    str_view m_yaml_version {};
     /// The last tag handle.
-    std::string m_tag_handle {};
-    /// The last tag prefix
-    std::string m_tag_prefix {};
+    str_view m_tag_handle {};
+    /// The last tag prefix.
+    str_view m_tag_prefix {};
     /// The beginning position of the last lexical token. (zero origin)
     uint32_t m_last_token_begin_pos {0};
     /// The beginning line of the last lexical token. (zero origin)
@@ -5383,8 +5918,10 @@ public:
     /// @return basic_node_type A root YAML node deserialized from the source string.
     template <typename InputAdapterType, enable_if_t<is_input_adapter<InputAdapterType>::value, int> = 0>
     basic_node_type deserialize(InputAdapterType&& input_adapter) {
+        input_adapter.fill_buffer();
+        lexer_type lexer(input_adapter.get_buffer());
+
         lexical_token_t type {lexical_token_t::END_OF_BUFFER};
-        lexer_type lexer(std::forward<InputAdapterType>(input_adapter));
         return deserialize_document(lexer, type);
     }
 
@@ -5394,7 +5931,9 @@ public:
     /// @return std::vector<basic_node_type> Root YAML nodes for deserialized YAML documents.
     template <typename InputAdapterType, enable_if_t<is_input_adapter<InputAdapterType>::value, int> = 0>
     std::vector<basic_node_type> deserialize_docs(InputAdapterType&& input_adapter) {
-        lexer_type lexer(std::forward<InputAdapterType>(input_adapter));
+        input_adapter.fill_buffer();
+        lexer_type lexer(input_adapter.get_buffer());
+
         std::vector<basic_node_type> nodes {};
         lexical_token_t type {lexical_token_t::END_OF_BUFFER};
 
@@ -5515,9 +6054,9 @@ private:
                 lacks_end_of_directives_marker = true;
                 break;
             case lexical_token_t::TAG_DIRECTIVE: {
-                const std::string& tag_handle = lexer.get_tag_handle();
-                switch (tag_handle.size()) {
-                case 1: {
+                str_view tag_handle_view = lexer.get_tag_handle();
+                switch (tag_handle_view.size()) {
+                case 1 /* ! */: {
                     bool is_already_specified = !mp_meta->primary_handle_prefix.empty();
                     if (is_already_specified) {
                         throw parse_error(
@@ -5525,11 +6064,12 @@ private:
                             lexer.get_lines_processed(),
                             lexer.get_last_token_begin_pos());
                     }
-                    mp_meta->primary_handle_prefix = lexer.get_tag_prefix();
+                    str_view tag_prefix = lexer.get_tag_prefix();
+                    mp_meta->primary_handle_prefix.assign(tag_prefix.begin(), tag_prefix.end());
                     lacks_end_of_directives_marker = true;
                     break;
                 }
-                case 2: {
+                case 2 /* !! */: {
                     bool is_already_specified = !mp_meta->secondary_handle_prefix.empty();
                     if (is_already_specified) {
                         throw parse_error(
@@ -5537,13 +6077,17 @@ private:
                             lexer.get_lines_processed(),
                             lexer.get_last_token_begin_pos());
                     }
-                    mp_meta->secondary_handle_prefix = lexer.get_tag_prefix();
+                    str_view tag_prefix = lexer.get_tag_prefix();
+                    mp_meta->secondary_handle_prefix.assign(tag_prefix.begin(), tag_prefix.end());
                     lacks_end_of_directives_marker = true;
                     break;
                 }
-                default: {
+                default /* !<handle>! */: {
+                    std::string tag_handle(tag_handle_view.begin(), tag_handle_view.end());
+                    str_view tag_prefix_view = lexer.get_tag_prefix();
+                    std::string tag_prefix(tag_prefix_view.begin(), tag_prefix_view.end());
                     bool is_already_specified =
-                        !(mp_meta->named_handle_map.emplace(tag_handle, lexer.get_tag_prefix()).second);
+                        !(mp_meta->named_handle_map.emplace(std::move(tag_handle), std::move(tag_prefix)).second);
                     if (is_already_specified) {
                         throw parse_error(
                             "The same named handle cannot be specified more than once.",
@@ -6501,8 +7045,8 @@ private:
 
     /// @brief Update the target YAML version with an input string.
     /// @param version_str A YAML version string.
-    yaml_version_type convert_yaml_version(const string_type& version_str) noexcept {
-        return (version_str == "1.1") ? yaml_version_type::VERSION_1_1 : yaml_version_type::VERSION_1_2;
+    yaml_version_type convert_yaml_version(str_view version_str) noexcept {
+        return (version_str.compare("1.1") == 0) ? yaml_version_type::VERSION_1_1 : yaml_version_type::VERSION_1_2;
     }
 
 private:
@@ -6936,6 +7480,8 @@ FK_YAML_DETAIL_NAMESPACE_END
 
 // #include <fkYAML/detail/meta/stl_supplement.hpp>
 
+// #include <fkYAML/detail/str_view.hpp>
+
 // #include <fkYAML/exception.hpp>
 
 
@@ -6977,29 +7523,32 @@ public:
 
     /// @brief Get a character at the current position and move forward.
     /// @return std::char_traits<char_type>::int_type A character or EOF.
-    void fill_buffer(std::string& buffer) {
-        buffer.clear();
-        buffer.reserve(std::distance(m_current, m_end));
+    void fill_buffer() {
+        m_buffer.clear();
 
         switch (m_encode_type) {
         case utf_encode_t::UTF_8:
-            fill_buffer_utf8(buffer);
+            fill_buffer_utf8();
             break;
         case utf_encode_t::UTF_16BE:
         case utf_encode_t::UTF_16LE:
-            fill_buffer_utf16(buffer);
+            fill_buffer_utf16();
             break;
         case utf_encode_t::UTF_32BE:
         case utf_encode_t::UTF_32LE:
-            fill_buffer_utf32(buffer);
+            fill_buffer_utf32();
             break;
         }
+    }
+
+    str_view get_buffer() const noexcept {
+        return str_view {m_buffer.begin(), m_buffer.end()};
     }
 
 private:
     /// @brief The concrete implementation of fill_buffer() for UTF-8 encoded inputs.
     /// @param buffer A buffer to be filled with the input.
-    void fill_buffer_utf8(std::string& buffer) {
+    void fill_buffer_utf8() {
         FK_YAML_ASSERT(m_encode_type == utf_encode_t::UTF_8);
 
         IterType current = m_current;
@@ -7039,19 +7588,23 @@ private:
             }
         }
 
-        buffer.reserve(std::distance(m_current, m_end));
+        m_buffer.reserve(std::distance(m_current, m_end));
 
         do {
             IterType cr_or_end_itr = std::find(m_current, m_end, '\r');
-            buffer.append(m_current, cr_or_end_itr);
+            m_buffer.append(m_current, cr_or_end_itr);
             m_current = (cr_or_end_itr == m_end) ? cr_or_end_itr : std::next(cr_or_end_itr);
         } while (m_current != m_end);
     }
 
     /// @brief The concrete implementation of get_character() for UTF-16 encoded inputs.
     /// @param buffer A buffer to be filled with the input.
-    void fill_buffer_utf16(std::string& buffer) {
+    void fill_buffer_utf16() {
         FK_YAML_ASSERT(m_encode_type == utf_encode_t::UTF_16BE || m_encode_type == utf_encode_t::UTF_16LE);
+
+        // Assume the input characters are all ASCII characters.
+        // That's the most probably the case.
+        m_buffer.reserve(std::distance(m_current, m_end) / 2);
 
         int shift_bits[2] {0, 0};
         if (m_encode_type == utf_encode_t::UTF_16BE) {
@@ -7084,14 +7637,18 @@ private:
             }
             encoded_buf_size -= consumed_size;
 
-            buffer.append(reinterpret_cast<const char*>(utf8_buffer.data()), utf8_buf_size);
+            m_buffer.append(reinterpret_cast<const char*>(utf8_buffer.data()), utf8_buf_size);
         }
     }
 
     /// @brief The concrete implementation of get_character() for UTF-32 encoded inputs.
     /// @return A UTF-8 encoded byte at the current position, or EOF.
-    void fill_buffer_utf32(std::string& buffer) {
+    void fill_buffer_utf32() {
         FK_YAML_ASSERT(m_encode_type == utf_encode_t::UTF_32BE || m_encode_type == utf_encode_t::UTF_32LE);
+
+        // Assume the input characters are all ASCII characters.
+        // That's the most probably the case.
+        m_buffer.reserve(std::distance(m_current, m_end) / 4);
 
         int shift_bits[4] {0, 0, 0, 0};
         if (m_encode_type == utf_encode_t::UTF_32BE) {
@@ -7117,7 +7674,7 @@ private:
 
             if (utf32 != char32_t(0x0000000Du)) {
                 utf8::from_utf32(utf32, utf8_buffer, utf8_buf_size);
-                buffer.append(reinterpret_cast<const char*>(utf8_buffer.data()), utf8_buf_size);
+                m_buffer.append(reinterpret_cast<const char*>(utf8_buffer.data()), utf8_buf_size);
             }
         }
     }
@@ -7129,6 +7686,8 @@ private:
     IterType m_end {};
     /// The encoding type for this input adapter.
     utf_encode_t m_encode_type {utf_encode_t::UTF_8};
+    /// The normalized owned buffer.
+    std::string m_buffer {};
 };
 
 #ifdef FK_YAML_HAS_CHAR8_T
@@ -7165,7 +7724,7 @@ public:
 
     /// @brief Get a character at the current position and move forward.
     /// @return std::char_traits<char_type>::int_type A character or EOF.
-    void fill_buffer(std::string& buffer) {
+    void fill_buffer() {
         IterType current = m_current;
         while (current != m_end) {
             uint8_t first = static_cast<uint8_t>(*current++);
@@ -7203,13 +7762,17 @@ public:
             }
         }
 
-        buffer.reserve(std::distance(m_current, m_end));
+        m_buffer.reserve(std::distance(m_current, m_end));
         while (m_current != m_end) {
             char c = char(*m_current++);
             if (c != '\r') {
-                buffer.push_back(c);
+                m_buffer.push_back(c);
             }
         }
+    }
+
+    str_view get_buffer() const noexcept {
+        return str_view {m_buffer.begin(), m_buffer.end()};
     }
 
 private:
@@ -7219,6 +7782,8 @@ private:
     IterType m_end {};
     /// The encoding type for this input adapter.
     utf_encode_t m_encode_type {utf_encode_t::UTF_8};
+    /// The normalized owned buffer.
+    std::string m_buffer {};
 };
 
 #endif // defined(FK_YAML_HAS_CHAR8_T)
@@ -7253,7 +7818,7 @@ public:
 
     /// @brief Get a character at the current position and move forward.
     /// @return std::char_traits<char_type>::int_type A character or EOF.
-    void fill_buffer(std::string& buffer) {
+    void fill_buffer() {
         int shift_bits = (m_encode_type == utf_encode_t::UTF_16BE) ? 0 : 8;
 
         std::array<char16_t, 2> encoded_buffer {{0, 0}};
@@ -7261,7 +7826,9 @@ public:
         std::array<uint8_t, 4> utf8_buffer {{0, 0, 0, 0}};
         uint32_t utf8_buf_size {0};
 
-        buffer.reserve(std::distance(m_current, m_end) * 2);
+        // Assume the input characters are all ASCII characters.
+        // That's the most probably the case.
+        m_buffer.reserve(std::distance(m_current, m_end));
 
         while (m_current != m_end || encoded_buf_size != 0) {
             while (m_current != m_end && encoded_buf_size < 2) {
@@ -7284,8 +7851,12 @@ public:
             }
             encoded_buf_size -= consumed_size;
 
-            buffer.append(reinterpret_cast<const char*>(utf8_buffer.data()), utf8_buf_size);
+            m_buffer.append(reinterpret_cast<const char*>(utf8_buffer.data()), utf8_buf_size);
         }
+    }
+
+    str_view get_buffer() const noexcept {
+        return str_view {m_buffer.begin(), m_buffer.end()};
     }
 
 private:
@@ -7295,6 +7866,8 @@ private:
     IterType m_end {};
     /// The encoding type for this input adapter.
     utf_encode_t m_encode_type {utf_encode_t::UTF_16BE};
+    /// The normalized owned buffer.
+    std::string m_buffer {};
 };
 
 /// @brief An input adapter for iterators of type char32_t.
@@ -7327,7 +7900,7 @@ public:
 
     /// @brief Get a character at the current position and move forward.
     /// @return std::char_traits<char_type>::int_type A character or EOF.
-    void fill_buffer(std::string& buffer) {
+    void fill_buffer() {
         int shift_bits[4] {0, 0, 0, 0};
         if (m_encode_type == utf_encode_t::UTF_32LE) {
             shift_bits[0] = 24;
@@ -7339,7 +7912,9 @@ public:
         std::array<uint8_t, 4> utf8_buffer {{0, 0, 0, 0}};
         uint32_t utf8_buf_size {0};
 
-        buffer.reserve(std::distance(m_current, m_end) * 4);
+        // Assume the input characters are all ASCII characters.
+        // That's the most probably the case.
+        m_buffer.reserve(std::distance(m_current, m_end));
 
         while (m_current != m_end) {
             char32_t tmp = *m_current++;
@@ -7351,9 +7926,13 @@ public:
 
             if (utf32 != char32_t(0x0000000Du)) {
                 utf8::from_utf32(utf32, utf8_buffer, utf8_buf_size);
-                buffer.append(reinterpret_cast<const char*>(utf8_buffer.data()), utf8_buf_size);
+                m_buffer.append(reinterpret_cast<const char*>(utf8_buffer.data()), utf8_buf_size);
             }
         }
+    }
+
+    str_view get_buffer() const noexcept {
+        return str_view {m_buffer.begin(), m_buffer.end()};
     }
 
 private:
@@ -7363,6 +7942,8 @@ private:
     IterType m_end {};
     /// The encoding type for this input adapter.
     utf_encode_t m_encode_type {utf_encode_t::UTF_32BE};
+    /// The normalized owned buffer.
+    std::string m_buffer {};
 };
 
 /// @brief An input adapter for C-style file handles.
@@ -7391,26 +7972,30 @@ public:
 
     /// @brief Get a character at the current position and move forward.
     /// @return std::char_traits<char_type>::int_type A character or EOF.
-    void fill_buffer(std::string& buffer) {
+    void fill_buffer() {
         switch (m_encode_type) {
         case utf_encode_t::UTF_8:
-            fill_buffer_utf8(buffer);
+            fill_buffer_utf8();
             break;
         case utf_encode_t::UTF_16BE:
         case utf_encode_t::UTF_16LE:
-            fill_buffer_utf16(buffer);
+            fill_buffer_utf16();
             break;
         case utf_encode_t::UTF_32BE:
         case utf_encode_t::UTF_32LE:
-            fill_buffer_utf32(buffer);
+            fill_buffer_utf32();
             break;
         }
+    }
+
+    str_view get_buffer() const noexcept {
+        return str_view {m_buffer.begin(), m_buffer.end()};
     }
 
 private:
     /// @brief The concrete implementation of get_character() for UTF-8 encoded inputs.
     /// @return A UTF-8 encoded byte at the current position, or EOF.
-    void fill_buffer_utf8(std::string& buffer) {
+    void fill_buffer_utf8() {
         FK_YAML_ASSERT(m_encode_type == utf_encode_t::UTF_8);
 
         char tmp_buf[256] {};
@@ -7429,13 +8014,13 @@ private:
                     ++p_cr_or_end;
                 }
 
-                buffer.append(p_current, p_cr_or_end);
+                m_buffer.append(p_current, p_cr_or_end);
                 p_current = (p_cr_or_end == p_end) ? p_end : p_cr_or_end + 1;
             } while (p_current != p_end);
         }
 
-        auto current = buffer.begin();
-        auto end = buffer.end();
+        auto current = m_buffer.begin();
+        auto end = m_buffer.end();
         while (current != end) {
             uint8_t first = static_cast<uint8_t>(*current++);
             uint32_t num_bytes = utf8::get_num_bytes(first);
@@ -7475,7 +8060,7 @@ private:
 
     /// @brief The concrete implementation of get_character() for UTF-16 encoded inputs.
     /// @return A UTF-8 encoded byte at the current position, or EOF.
-    void fill_buffer_utf16(std::string& buffer) {
+    void fill_buffer_utf16() {
         FK_YAML_ASSERT(m_encode_type == utf_encode_t::UTF_16BE || m_encode_type == utf_encode_t::UTF_16LE);
 
         int shift_bits[2] {0, 0};
@@ -7510,13 +8095,13 @@ private:
             }
             encoded_buf_size -= consumed_size;
 
-            buffer.append(reinterpret_cast<const char*>(utf8_buffer.data()), utf8_buf_size);
+            m_buffer.append(reinterpret_cast<const char*>(utf8_buffer.data()), utf8_buf_size);
         }
     }
 
     /// @brief The concrete implementation of get_character() for UTF-32 encoded inputs.
     /// @return A UTF-8 encoded byte at the current position, or EOF.
-    void fill_buffer_utf32(std::string& buffer) {
+    void fill_buffer_utf32() {
         FK_YAML_ASSERT(m_encode_type == utf_encode_t::UTF_32BE || m_encode_type == utf_encode_t::UTF_32LE);
 
         int shift_bits[4] {0, 0, 0, 0};
@@ -7549,7 +8134,7 @@ private:
 
             if (utf32 != char32_t(0x0000000Du)) {
                 utf8::from_utf32(utf32, utf8_buffer, utf8_buf_size);
-                buffer.append(reinterpret_cast<const char*>(utf8_buffer.data()), utf8_buf_size);
+                m_buffer.append(reinterpret_cast<const char*>(utf8_buffer.data()), utf8_buf_size);
             }
         }
     }
@@ -7559,6 +8144,8 @@ private:
     std::FILE* m_file {nullptr};
     /// The encoding type for this input adapter.
     utf_encode_t m_encode_type {utf_encode_t::UTF_8};
+    /// The normalized owned buffer.
+    std::string m_buffer {};
 };
 
 /// @brief An input adapter for streams
@@ -7583,26 +8170,30 @@ public:
 
     /// @brief Get a character at the current position and move forward.
     /// @return std::char_traits<char_type>::int_type A character or EOF.
-    void fill_buffer(std::string& buffer) {
+    void fill_buffer() {
         switch (m_encode_type) {
         case utf_encode_t::UTF_8:
-            fill_buffer_utf8(buffer);
+            fill_buffer_utf8();
             break;
         case utf_encode_t::UTF_16BE:
         case utf_encode_t::UTF_16LE:
-            fill_buffer_utf16(buffer);
+            fill_buffer_utf16();
             break;
         case utf_encode_t::UTF_32BE:
         case utf_encode_t::UTF_32LE:
-            fill_buffer_utf32(buffer);
+            fill_buffer_utf32();
             break;
         }
+    }
+
+    str_view get_buffer() const noexcept {
+        return str_view {m_buffer.begin(), m_buffer.end()};
     }
 
 private:
     /// @brief The concrete implementation of get_character() for UTF-8 encoded inputs.
     /// @return A UTF-8 encoded byte at the current position, or EOF.
-    void fill_buffer_utf8(std::string& buffer) {
+    void fill_buffer_utf8() {
         FK_YAML_ASSERT(m_encode_type == utf_encode_t::UTF_8);
 
         char tmp_buf[256] {};
@@ -7622,13 +8213,13 @@ private:
                     ++p_cr_or_end;
                 }
 
-                buffer.append(p_current, p_cr_or_end);
+                m_buffer.append(p_current, p_cr_or_end);
                 p_current = (p_cr_or_end == p_end) ? p_end : p_cr_or_end + 1;
             } while (p_current != p_end);
         } while (!m_istream->eof());
 
-        auto current = buffer.begin();
-        auto end = buffer.end();
+        auto current = m_buffer.begin();
+        auto end = m_buffer.end();
         while (current != end) {
             uint8_t first = static_cast<uint8_t>(*current++);
             uint32_t num_bytes = utf8::get_num_bytes(first);
@@ -7668,7 +8259,7 @@ private:
 
     /// @brief The concrete implementation of get_character() for UTF-16 encoded inputs.
     /// @return A UTF-8 encoded byte at the current position, or EOF.
-    void fill_buffer_utf16(std::string& buffer) {
+    void fill_buffer_utf16() {
         FK_YAML_ASSERT(m_encode_type == utf_encode_t::UTF_16BE || m_encode_type == utf_encode_t::UTF_16LE);
 
         int shift_bits[2] {0, 0};
@@ -7710,13 +8301,13 @@ private:
             }
             encoded_buf_size -= consumed_size;
 
-            buffer.append(reinterpret_cast<const char*>(utf8_buffer.data()), utf8_buf_size);
+            m_buffer.append(reinterpret_cast<const char*>(utf8_buffer.data()), utf8_buf_size);
         } while (!m_istream->eof());
     }
 
     /// @brief The concrete implementation of get_character() for UTF-32 encoded inputs.
     /// @return A UTF-8 encoded byte at the current position, or EOF.
-    void fill_buffer_utf32(std::string& buffer) {
+    void fill_buffer_utf32() {
         FK_YAML_ASSERT(m_encode_type == utf_encode_t::UTF_32BE || m_encode_type == utf_encode_t::UTF_32LE);
 
         int shift_bits[4] {0, 0, 0, 0};
@@ -7750,7 +8341,7 @@ private:
 
             if (utf32 != char32_t(0x0000000Du)) {
                 utf8::from_utf32(utf32, utf8_buffer, utf8_buf_size);
-                buffer.append(reinterpret_cast<const char*>(utf8_buffer.data()), utf8_buf_size);
+                m_buffer.append(reinterpret_cast<const char*>(utf8_buffer.data()), utf8_buf_size);
             }
         } while (!m_istream->eof());
     }
@@ -7760,6 +8351,8 @@ private:
     std::istream* m_istream {nullptr};
     /// The encoding type for this input adapter.
     utf_encode_t m_encode_type {utf_encode_t::UTF_8};
+    /// The normalized owned buffer.
+    std::string m_buffer {};
 };
 
 /////////////////////////////////
@@ -8703,7 +9296,8 @@ private:
             // The next line is intentionally excluded from the LCOV coverage target since the next line is somehow
             // misrecognized as it has a binary branch. Possibly begin() or end() has some conditional branch(es)
             // internally. Confirmed with LCOV 1.14 on Ubuntu22.04.
-            node_type type_if_plain = scalar_scanner::scan(str_val.begin(), str_val.end()); // LCOV_EXCL_LINE
+            node_type type_if_plain =
+                scalar_scanner::scan(str_val.c_str(), str_val.c_str() + str_val.size()); // LCOV_EXCL_LINE
 
             if (type_if_plain != node_type::STRING) {
                 // Surround a string value with double quotes to keep semantic equality.
@@ -8800,7 +9394,7 @@ private:
 
         using string_type = typename BasicNodeType::string_type;
         const string_type& s = node.template get_value_ref<const string_type&>();
-        return yaml_escaper::escape(s.begin(), s.end(), is_escaped);
+        return yaml_escaper::escape(s.c_str(), s.c_str() + s.size(), is_escaped);
     } // LCOV_EXCL_LINE
 
 private:

--- a/single_include/fkYAML/node.hpp
+++ b/single_include/fkYAML/node.hpp
@@ -4019,8 +4019,6 @@ struct lexical_token {
 template <typename BasicNodeType, enable_if_t<is_basic_node<BasicNodeType>::value, int> = 0>
 class lexical_analyzer {
 private:
-    using char_traits_type = typename std::char_traits<char>;
-
     enum class block_style_indicator_t {
         LITERAL, //!< keeps newlines inside the block as they are indicated by a pipe `|`.
         FOLDED,  //!< replaces newlines inside the block with spaces indicated by a right angle bracket `>`.
@@ -4033,11 +4031,6 @@ private:
     };
 
 public:
-    using boolean_type = typename BasicNodeType::boolean_type;
-    using integer_type = typename BasicNodeType::integer_type;
-    using float_number_type = typename BasicNodeType::float_number_type;
-    using string_type = typename BasicNodeType::string_type;
-
     /// @brief Construct a new lexical_analyzer object.
     /// @tparam InputAdapterType The type of the input adapter.
     /// @param input_adapter An input adapter object.

--- a/single_include/fkYAML/node.hpp
+++ b/single_include/fkYAML/node.hpp
@@ -3365,6 +3365,15 @@ FK_YAML_DETAIL_NAMESPACE_END
 
 FK_YAML_DETAIL_NAMESPACE_BEGIN
 
+/// @brief Non owning view into constant character sequence.
+/// @note
+/// This class is a minimal implementation of std::basic_string_view which has been available since C++17
+/// but pretty useful and efficient for referencing/investigating character sequences.
+/// @warning
+/// This class intentionally omits a lot of value checks to improve efficiency. Necessary checks should be
+/// made before calling this class' APIs for safety.
+/// @tparam CharT Character type
+/// @tparam Traits Character traits type which defaults to std::char_traits<CharT>.
 template <typename CharT, typename Traits = std::char_traits<CharT>>
 class basic_str_view {
     static_assert(!std::is_array<CharT>::value, "CharT must not be an array type.");
@@ -3375,38 +3384,72 @@ class basic_str_view {
         std::is_same<CharT, typename Traits::char_type>::value, "CharT & Traits::char_type must be the same type.");
 
 public:
+    /// Character traits type.
     using traits_type = Traits;
+    /// Character type.
     using value_type = CharT;
+    /// Pointer type to a character.
     using pointer = value_type*;
+    /// Constant pointer type to a character.
     using const_pointer = const value_type*;
+    /// Reference type to a character.
     using reference = value_type&;
+    /// Constant reference type to a character.
     using const_reference = const value_type&;
+    /// Constant iterator type to a character.
     using const_iterator = const value_type*;
+    /// Iterator type to a character.
+    /// (Always constant since this class isn't meant to provide any mutating features.)
     using iterator = const_iterator;
+    /// Constant reverse iterator type to a character.
     using const_reverse_iterator = std::reverse_iterator<const_iterator>;
+    /// Reverse iterator type to a character.
+    /// (Always constant since this class isn't meant to provide any mutating features.)
     using reverse_iterator = const_reverse_iterator;
+    /// Size type for character sequence sizes.
     using size_type = std::size_t;
+    /// Difference type for distances between characters.
     using difference_type = std::ptrdiff_t;
 
+    /// Invalid position value.
     static constexpr size_type npos = static_cast<size_type>(-1);
 
+    /// Constructs a basic_str_view object.
     basic_str_view() noexcept = default;
+
+    /// Destroys a basic_str_view object.
     ~basic_str_view() noexcept = default;
+
+    /// @brief Copy constructs a basic_str_view object.
+    /// @param _ A basic_str_view object to copy from.
     basic_str_view(const basic_str_view&) noexcept = default;
+
+    /// @brief Move constructs a basic_str_view object.
+    /// @param _ A basic_str_view object to move from.
     basic_str_view(basic_str_view&&) noexcept = default;
 
+    /// @brief Constructs a basic_str_view object from a pointer to a character sequence.
+    /// @param p_str A pointer to a character sequence. (Must be null-terminated, or an undefined behavior.)
     basic_str_view(const value_type* p_str) noexcept
         : m_len(traits_type::length(p_str)),
           mp_str(p_str) {
     }
 
+    /// @brief Construction from a null pointer is forbidden.
     basic_str_view(std::nullptr_t) = delete;
 
+    /// @brief Constructs a basic_str_view object from a poineter to a character sequence and its size.
+    /// @param p_str A pointer to a character sequence. (May or may not be null-terminated.)
+    /// @param len The length of a character sequence.
     basic_str_view(const value_type* p_str, size_type len) noexcept
         : m_len(len),
           mp_str(p_str) {
     }
 
+    /// @brief Constructs a basic_str_view object from compatible begin/end iterators
+    /// @tparam ItrType Iterator type to a character.
+    /// @param first The iterator to the first element of a character sequence.
+    /// @param last The iterator to the past-the-end of a character sequence.
     template <
         typename ItrType,
         enable_if_t<
@@ -3420,66 +3463,106 @@ public:
           mp_str(m_len > 0 ? &*first : nullptr) {
     }
 
+    /// @brief Constructs a basic_str_view object from a compatible std::basic_string object.
+    /// @param str A compatible character sequence container.
     basic_str_view(const std::basic_string<CharT>& str) noexcept
         : m_len(str.length()),
           mp_str(str.data()) {
     }
 
+    /// @brief Copy assignment operator for this basic_str_view class.
+    /// @param _ A basic_str_view object to copy from.
+    /// @return Reference to this basic_str_view object.
     basic_str_view& operator=(const basic_str_view&) noexcept = default;
+
+    /// @brief Move assignment operator for this basic_str_view class.
+    /// @param _ A basic_str_view object to move from.
+    /// @return Reference to this basic_str_view object.
     basic_str_view& operator=(basic_str_view&&) noexcept = default;
 
+    /// @brief Get the iterator to the first element. (Always constant)
+    /// @return The iterator to the first element.
     const_iterator begin() const noexcept {
         return mp_str;
     }
 
+    /// @brief Get the iterator to the past-the-end element. (Always constant)
+    /// @return The iterator to the past-the-end element.
     const_iterator end() const noexcept {
         return mp_str + m_len;
     }
 
+    /// @brief Get the iterator to the first element. (Always constant)
+    /// @return The iterator to the first element.
     const_iterator cbegin() const noexcept {
         return mp_str;
     }
 
+    /// @brief Get the iterator to the past-the-end element. (Always constant)
+    /// @return The iterator to the past-the-end element.
     const_iterator cend() const noexcept {
         return mp_str + m_len;
     }
 
+    /// @brief Get the iterator to the first element in the reverse order. (Always constant)
+    /// @return The iterator to the first element in the reverse order.
     const_reverse_iterator rbegin() const noexcept {
         return const_reverse_iterator(end());
     }
 
+    /// @brief Get the iterator to the past-the-end element in the reverse order. (Always constant)
+    /// @return The iterator to the past-the-end element in the reverse order.
     const_reverse_iterator rend() const noexcept {
         return const_reverse_iterator(begin());
     }
 
+    /// @brief Get the iterator to the first element in the reverse order. (Always constant)
+    /// @return The iterator to the first element in the reverse order.
     const_reverse_iterator crbegin() const noexcept {
         return const_reverse_iterator(end());
     }
 
+    /// @brief Get the iterator to the past-the-end element in the reverse order. (Always constant)
+    /// @return The iterator to the past-the-end element in the reverse order.
     const_reverse_iterator crend() const noexcept {
         return const_reverse_iterator(begin());
     }
 
+    /// @brief Get the size of the referenced character sequence.
+    /// @return The size of the referenced character sequence.
     size_type size() const noexcept {
         return m_len;
     }
 
+    /// @brief Get the size of the referenced character sequence.
+    /// @return The size of the referenced character sequence.
     size_type length() const noexcept {
         return m_len;
     }
 
+    /// @brief Get the maximum number of the character sequence size.
+    /// @return The maximum number of the character sequence size.
     constexpr size_type max_size() const noexcept {
         return std::numeric_limits<difference_type>::max();
     }
 
+    /// @brief Checks if the referenced character sequence is empty.
+    /// @return true if empty, false otherwise.
     bool empty() const noexcept {
         return m_len == 0;
     }
 
+    /// @brief Get the element at the given position.
+    /// @param pos The position of the target element.
+    /// @return The element at the given position.
     const_reference operator[](size_type pos) const noexcept {
         return *(mp_str + pos);
     }
 
+    /// @brief Get the element at the given position with bounds checks.
+    /// @warning Throws an fkyaml::out_of_range exception if the position exceeds the character sequence size.
+    /// @param pos The position of the target element.
+    /// @return The element at the given position.
     const_reference at(size_type pos) const {
         if (pos >= m_len) {
             throw fkyaml::out_of_range(pos);
@@ -3487,33 +3570,50 @@ public:
         return *(mp_str + pos);
     }
 
+    /// @brief Get the first element.
+    /// @return The first element.
     const_reference front() const noexcept {
         return *mp_str;
     }
 
+    /// @brief Get the last element.
+    /// @return The last element.
     const_reference back() const {
         return *(mp_str + m_len - 1);
     }
 
+    /// @brief Get the pointer to the raw data of referenced character sequence.
+    /// @return The pointer to the raw data of referenced character sequence.
     const_pointer data() const noexcept {
         return mp_str;
     }
 
+    /// @brief Moves the beginning position by `n` elements.
+    /// @param n The number of elements by which to move the beginning position.
     void remove_prefix(size_type n) noexcept {
         mp_str += n;
         m_len -= n;
     }
 
+    /// @brief Shrinks the referenced character sequence from the last by `n` elements.
+    /// @param n The number of elements by which to shrink the sequence from the last.
     void remove_suffix(size_type n) noexcept {
         m_len -= n;
     }
 
+    /// @brief Swaps data with the given basic_str_view object.
+    /// @param other A basic_str_view object to swap data with.
     void swap(basic_str_view& other) noexcept {
         auto tmp = *this;
         *this = other;
         other = tmp;
     }
 
+    /// @brief Copys the referenced character sequence values from `pos` by `n` size.
+    /// @param p_str The pointer to a character sequence buffer for output.
+    /// @param n The number of elements to write into `p_str`.
+    /// @param pos The offset of the beginning position to copy values.
+    /// @return The number of elements to be written into `p_str`.
     size_type copy(CharT* p_str, size_type n, size_type pos = 0) const {
         if (pos > m_len) {
             throw fkyaml::out_of_range(pos);
@@ -3523,6 +3623,11 @@ public:
         return rlen;
     }
 
+    /// @brief Constructs a sub basic_str_view object from `pos` by `n` size.
+    /// @warning Throws an fkyaml::out_of_range exception if the given `pos` is bigger than the lenth.
+    /// @param pos The offset of the beginning position.
+    /// @param n The number of elements to the end of a new sub basic_str_view object.
+    /// @return A newly created sub basic_str_view object.
     basic_str_view substr(size_type pos = 0, size_type n = npos) const {
         if (pos > m_len) {
             throw fkyaml::out_of_range(pos);
@@ -3531,6 +3636,9 @@ public:
         return basic_str_view(mp_str + pos, rlen);
     }
 
+    /// @brief Compares the referenced character sequence values with the given basic_str_view object.
+    /// @param sv The basic_str_view object to compare with.
+    /// @return The lexicographical comparison result. The values are same as std::strncmp().
     int compare(basic_str_view sv) const noexcept {
         const size_type rlen = std::min(m_len, sv.m_len);
         int ret = traits_type::compare(mp_str, sv.mp_str, rlen);
@@ -3553,68 +3661,131 @@ public:
         return ret;
     }
 
+    /// @brief Compares the referenced character sequence values from `pos1` by `n1` characters with `sv`.
+    /// @param pos1 The offset of the beginning element.
+    /// @param n1 The length of character sequence used for comparison.
+    /// @param sv A basic_str_view object to compare with.
+    /// @return The lexicographical comparison result. The values are same as std::strncmp().
     int compare(size_type pos1, size_type n1, basic_str_view sv) const {
         return substr(pos1, n1).compare(sv);
     }
 
+    /// @brief Compares the referenced character sequence value from `pos1` by `n1` characters with `sv` from `pos2` by
+    /// `n2` characters.
+    /// @param pos1 The offset of the beginning element in this character sequence.
+    /// @param n1 The length of this character sequence used for comparison.
+    /// @param sv A basic_str_view object to compare with.
+    /// @param pos2 The offset of the beginning element in `sv`.
+    /// @param n2 The length of `sv` used for comparison.
+    /// @return The lexicographical comparison result. The values are same as std::strncmp().
     int compare(size_type pos1, size_type n1, basic_str_view sv, size_type pos2, size_type n2) const {
         return substr(pos1, n1).compare(sv.substr(pos2, n2));
     }
 
+    /// @brief Compares the referenced character sequence with `s` character sequence.
+    /// @param s The pointer to a character sequence to compare with.
+    /// @return The lexicolographical comparison result. The values are same as std::strncmp().
     int compare(const CharT* s) const {
         return compare(basic_str_view(s));
     }
 
+    /// @brief Compares the referenced character sequence from `pos1` by `n1` characters with `s` character sequence.
+    /// @param pos1 The offset of the beginning element in this character sequence.
+    /// @param n1 The length of this character sequence used fo comparison.
+    /// @param s The pointer to a character sequence to compare with.
+    /// @return The lexicographical comparison result. The values are same as std::strncmp().
     int compare(size_type pos1, size_type n1, const CharT* s) const {
         return substr(pos1, n1).compare(basic_str_view(s));
     }
 
+    /// @brief Compares the referenced character sequence from `pos1` by `n1` characters with `s` character sequence by
+    /// `n2` characters.
+    /// @param pos1 The offset of the beginning element in this character sequence.
+    /// @param n1 The length of this character sequence used fo comparison.
+    /// @param s The pointer to a character sequence to compare with.
+    /// @param n2 The length of `s` used fo comparison.
+    /// @return
     int compare(size_type pos1, size_type n1, const CharT* s, size_type n2) const {
         return substr(pos1, n1).compare(basic_str_view(s, n2));
     }
 
+    /// @brief Checks if this character sequence starts with `sv` characters.
+    /// @param sv The character sequence to compare with.
+    /// @return true if the character sequence starts with `sv` characters, false otherwise.
     bool starts_with(basic_str_view sv) const noexcept {
         return substr(0, sv.size()) == sv;
     }
 
+    /// @brief Checks if this character sequence starts with `c` character.
+    /// @param c The character to compare with.
+    /// @return true if the character sequence starts with `c` character, false otherwise.
     bool starts_with(CharT c) const noexcept {
         return !empty() && traits_type::eq(front(), c);
     }
 
+    /// @brief Checks if this character sequence starts with `s` characters.
+    /// @param s The character sequence to compare with.
+    /// @return true if the character sequence starts with `s` characters, false otherwise.
     bool starts_with(const CharT* s) const noexcept {
         return starts_with(basic_str_view(s));
     }
 
+    /// @brief Checks if this character sequence ends with `sv` characters.
+    /// @param sv The character sequence to compare with.
+    /// @return true if the character sequence ends with `sv` characters, false otherwise.
     bool ends_with(basic_str_view sv) const noexcept {
         const size_type size = m_len;
         const size_type sv_size = sv.size();
         return size >= sv_size && traits_type::compare(end() - sv_size, sv.data(), sv_size) == 0;
     }
 
+    /// @brief Checks if this character sequence ends with `c` character.
+    /// @param c The character to compare with.
+    /// @return true if the character sequence ends with `c` character, false otherwise.
     bool ends_with(CharT c) const noexcept {
         return !empty() && traits_type::eq(back(), c);
     }
 
+    /// @brief Checks if this character sequence ends with `s` characters.
+    /// @param s The character sequence to compare with.
+    /// @return true if the character sequence ends with `s` characters, false otherwise.
     bool ends_with(const CharT* s) const noexcept {
         return ends_with(basic_str_view(s));
     }
 
+    /// @brief Checks if this character sequence contains `sv` characters.
+    /// @param sv The character sequence to compare with.
+    /// @return true if the character sequence contains `sv` characters, false otherwise.
     bool contains(basic_str_view sv) const noexcept {
         return find(sv) != npos;
     }
 
+    /// @brief Checks if this character sequence contains `c` character.
+    /// @param c The character to compare with.
+    /// @return true if the character sequence contains `c` character, false otherwise.
     bool contains(CharT c) const noexcept {
         return find(c) != npos;
     }
 
+    /// @brief Checks if this character sequence contains `s` characters.
+    /// @param s The character sequence to compare with.
+    /// @return true if the character sequence contains `s` characters, false otherwise.
     bool contains(const CharT* s) const noexcept {
         return find(s) != npos;
     }
 
+    /// @brief Finds the beginning position of `sv` characters in this referenced character sequence.
+    /// @param sv The character sequence to compare with.
+    /// @param pos The offset of the search beginning position in this referenced character sequence.
+    /// @return The beginning position of `sv` characters, `npos` otherwise.
     size_type find(basic_str_view sv, size_type pos = 0) const noexcept {
         return find(sv.mp_str, pos, sv.m_len);
     }
 
+    /// @brief Finds the beginning position of `c` character in this referenced character sequence.
+    /// @param sv The character to compare with.
+    /// @param pos The offset of the search beginning position in this referenced character sequence.
+    /// @return The beginning position of `c` character, `npos` otherwise.
     size_type find(CharT c, size_type pos = 0) const noexcept {
         size_type ret = npos;
 
@@ -3629,6 +3800,12 @@ public:
         return ret;
     }
 
+    /// @brief Finds the beginning position of `s` character sequence by `n` characters in this referenced character
+    /// sequence.
+    /// @param s The character sequence to compare with.
+    /// @param pos The offset of the search beginning position in this referenced character sequence.
+    /// @param n The length of `s` character sequence used for comparison.
+    /// @return The beginning position of `s` characters, `npos` otherwise.
     size_type find(const CharT* s, size_type pos, size_type n) const noexcept {
         if (n == 0) {
             return pos <= m_len ? pos : npos;
@@ -3661,14 +3838,26 @@ public:
         return npos;
     }
 
+    /// @brief Finds the beginning position of `s` character sequence in this referenced character sequence.
+    /// @param s The character sequence to compare with.
+    /// @param pos The offset of the search beginning position in this referenced character sequence.
+    /// @return The beginning position of `s` characters, `npos` otherwise.
     size_type find(const CharT* s, size_type pos = 0) const noexcept {
         return find(basic_str_view(s), pos);
     }
 
+    /// @brief Retrospectively finds the beginning position of `sv` characters in this referenced character sequence.
+    /// @param sv The character sequence to compare with.
+    /// @param pos The offset of the search beginning position in this referenced character sequence.
+    /// @return The beginning position of `sv` characters, `npos` otherwise.
     size_type rfind(basic_str_view sv, size_type pos = npos) const noexcept {
         return rfind(sv.mp_str, pos, sv.m_len);
     }
 
+    /// @brief Retrospectively finds the beginning position of `c` character in this referenced character sequence.
+    /// @param sv The character to compare with.
+    /// @param pos The offset of the search beginning position in this referenced character sequence.
+    /// @return The beginning position of `c` character, `npos` otherwise.
     size_type rfind(CharT c, size_type pos = npos) const noexcept {
         if (m_len == 0) {
             return npos;
@@ -3689,6 +3878,12 @@ public:
         return npos;
     }
 
+    /// @brief Retrospectively finds the beginning position of `s` character sequence by `n` characters in this
+    /// referenced character sequence.
+    /// @param s The character sequence to compare with.
+    /// @param pos The offset of the search beginning position in this referenced character sequence.
+    /// @param n The length of `s` character sequence used for comparison.
+    /// @return The beginning position of `s` characters, `npos` otherwise.
     size_type rfind(const CharT* s, size_type pos, size_type n) const noexcept {
         if (n <= m_len) {
             pos = std::min(m_len - n, pos) + 1;
@@ -3703,18 +3898,37 @@ public:
         return npos;
     }
 
+    /// @brief Retrospectively finds the beginning position of `s` character sequence in this referenced character
+    /// sequence.
+    /// @param s The character sequence to compare with.
+    /// @param pos The offset of the search beginning position in this referenced character sequence.
+    /// @return The beginning position of `s` characters, `npos` otherwise.
     size_type rfind(const CharT* s, size_type pos = npos) const noexcept {
         return rfind(basic_str_view(s), pos);
     }
 
+    /// @brief Finds the first occurence of `sv` character sequence in this referenced character sequence.
+    /// @param sv The character sequence to compare with.
+    /// @param pos The offset of the search beginning position in this referenced character sequence.
+    /// @return The beginning position of `sv` characters, `npos` otherwise.
     size_type find_first_of(basic_str_view sv, size_type pos = 0) const noexcept {
         return find_first_of(sv.mp_str, pos, sv.m_len);
     }
 
+    /// @brief Finds the first occurence of `c` character in this referenced character sequence.
+    /// @param c The character to compare with.
+    /// @param pos The offset of the search beginning position in this referenced character sequence.
+    /// @return The beginning position of `c` character, `npos` otherwise.
     size_type find_first_of(CharT c, size_type pos = 0) const noexcept {
         return find(c, pos);
     }
 
+    /// @brief Finds the first occurence of `s` character sequence by `n` characters in this referenced character
+    /// sequence.
+    /// @param s The character sequence to compare with.
+    /// @param pos The offset of the search beginning position in this referenced character sequence.
+    /// @param n The length of `s` character sequence used for comparison.
+    /// @return The beginning position of `s` characters, `npos` otherwise.
     size_type find_first_of(const CharT* s, size_type pos, size_type n) const noexcept {
         if (n == 0) {
             return npos;
@@ -3730,18 +3944,36 @@ public:
         return npos;
     }
 
+    /// @brief Finds the first occurence of `s` character sequence in this referenced character sequence.
+    /// @param s The character sequence to compare with.
+    /// @param pos The offset of the search beginning position in this referenced character sequence.
+    /// @return The beginning position of `s` characters, `npos` otherwise.
     size_type find_first_of(const CharT* s, size_type pos = 0) const noexcept {
         return find_first_of(basic_str_view(s), pos);
     }
 
+    /// @brief Finds the last occurence of `sv` character sequence in this referenced character sequence.
+    /// @param sv The character sequence to compare with.
+    /// @param pos The offset of the search beginning position in this referenced character sequence.
+    /// @return The beginning position of `sv` characters, `npos` otherwise.
     size_type find_last_of(basic_str_view sv, size_type pos = npos) const noexcept {
         return find_last_of(sv.mp_str, pos, sv.m_len);
     }
 
+    /// @brief Finds the last occurence of `c` character in this referenced character sequence.
+    /// @param c The character to compare with.
+    /// @param pos The offset of the search beginning position in this referenced character sequence.
+    /// @return The beginning position of `c` character, `npos` otherwise.
     size_type find_last_of(CharT c, size_type pos = npos) const noexcept {
         return rfind(c, pos);
     }
 
+    /// @brief Finds the last occurence of `s` character sequence by `n` characters in this referenced character
+    /// sequence.
+    /// @param s The character sequence to compare with.
+    /// @param pos The offset of the search beginning position in this referenced character sequence.
+    /// @param n The length of `s` character sequence used for comparison.
+    /// @return The beginning position of `s` characters, `npos` otherwise.
     size_type find_last_of(const CharT* s, size_type pos, size_type n) const noexcept {
         if (n <= m_len) {
             pos = std::min(m_len - n, pos) + 1;
@@ -3757,14 +3989,26 @@ public:
         return npos;
     }
 
+    /// @brief Finds the last occurence of `s` character sequence in this referenced character sequence.
+    /// @param s The character sequence to compare with.
+    /// @param pos The offset of the search beginning position in this referenced character sequence.
+    /// @return The beginning position of `s` characters, `npos` otherwise.
     size_type find_last_of(const CharT* s, size_type pos = npos) const noexcept {
         return find_last_of(basic_str_view(s), pos);
     }
 
+    /// @brief Finds the first absence of `sv` character sequence in this referenced character sequence.
+    /// @param sv The character sequence to compare with.
+    /// @param pos The offset of the search beginning position in this referenced character sequence.
+    /// @return The beginning position of non `sv` characters, `npos` otherwise.
     size_type find_first_not_of(basic_str_view sv, size_type pos = npos) const noexcept {
         return find_first_not_of(sv.mp_str, pos, sv.m_len);
     }
 
+    /// @brief Finds the first absence of `c` character in this referenced character sequence.
+    /// @param c The character to compare with.
+    /// @param pos The offset of the search beginning position in this referenced character sequence.
+    /// @return The beginning position of non `c` character, `npos` otherwise.
     size_type find_first_not_of(CharT c, size_type pos = npos) const noexcept {
         for (; pos < m_len; ++pos) {
             if (!traits_type::eq(mp_str[pos], c)) {
@@ -3775,6 +4019,12 @@ public:
         return npos;
     }
 
+    /// @brief Finds the first absence of `s` character sequence by `n` characters in this referenced character
+    /// sequence.
+    /// @param s The character sequence to compare with.
+    /// @param pos The offset of the search beginning position in this referenced character sequence.
+    /// @param n The length of `s` character sequence used for comparison.
+    /// @return The beginning position of non `s` characters, `npos` otherwise.
     size_type find_first_not_of(const CharT* s, size_type pos, size_type n) const noexcept {
         for (; pos < m_len; ++pos) {
             const CharT* p_found = traits_type::find(s, n, mp_str[pos]);
@@ -3786,14 +4036,26 @@ public:
         return npos;
     }
 
+    /// @brief Finds the first absence of `s` character sequence in this referenced character sequence.
+    /// @param s The character sequence to compare with.
+    /// @param pos The offset of the search beginning position in this referenced character sequence.
+    /// @return The beginning position of non `s` characters, `npos` otherwise.
     size_type find_first_not_of(const CharT* s, size_type pos = npos) const noexcept {
         return find_first_not_of(basic_str_view(s), pos);
     }
 
+    /// @brief Finds the last absence of `sv` character sequence in this referenced character sequence.
+    /// @param sv The character sequence to compare with.
+    /// @param pos The offset of the search beginning position in this referenced character sequence.
+    /// @return The beginning position of non `sv` characters, `npos` otherwise.
     size_type find_last_not_of(basic_str_view sv, size_type pos = npos) const noexcept {
         return find_last_not_of(sv.mp_str, pos, sv.m_len);
     }
 
+    /// @brief Finds the last absence of `c` character in this referenced character sequence.
+    /// @param c The character to compare with.
+    /// @param pos The offset of the search beginning position in this referenced character sequence.
+    /// @return The beginning position of non `c` character, `npos` otherwise.
     size_type find_last_not_of(CharT c, size_type pos = npos) const noexcept {
         if (m_len > 0) {
             pos = std::min(m_len, pos);
@@ -3808,6 +4070,12 @@ public:
         return npos;
     }
 
+    /// @brief Finds the last absence of `s` character sequence by `n` characters in this referenced character
+    /// sequence.
+    /// @param s The character sequence to compare with.
+    /// @param pos The offset of the search beginning position in this referenced character sequence.
+    /// @param n The length of `s` character sequence used for comparison.
+    /// @return The beginning position of non `s` characters, `npos` otherwise.
     size_type find_last_not_of(const CharT* s, size_type pos, size_type n) const noexcept {
         if (n <= m_len) {
             pos = std::min(m_len - n, pos) + 1;
@@ -3823,6 +4091,10 @@ public:
         return npos;
     }
 
+    /// @brief Finds the last absence of `s` character sequence in this referenced character sequence.
+    /// @param s The character sequence to compare with.
+    /// @param pos The offset of the search beginning position in this referenced character sequence.
+    /// @return The beginning position of non `s` characters, `npos` otherwise.
     size_type find_last_not_of(const CharT* s, size_type pos = npos) const noexcept {
         return find_last_not_of(basic_str_view(s), pos);
     }
@@ -3832,82 +4104,193 @@ private:
     const value_type* mp_str {nullptr};
 };
 
+/// @brief An equal-to operator of the basic_str_view class.
+/// @tparam CharT Character type
+/// @tparam Traits Character traits type.
+/// @param lhs A basic_str_view object for comparison.
+/// @param rhs A basic_str_view object to compare with.
+/// @return true if the two objects are the same, false otherwise.
 template <typename CharT, typename Traits>
 bool operator==(basic_str_view<CharT, Traits> lhs, basic_str_view<CharT, Traits> rhs) noexcept {
     // Comparing the lengths first will omit unnecessary value comparison in compare().
     return lhs.size() == rhs.size() && lhs.compare(rhs) == 0;
 }
 
+/// @brief An equal-to operator of the basic_str_view class.
+/// @tparam CharT Character type
+/// @tparam Traits Character traits type.
+/// @param lhs A basic_str_view object for comparison.
+/// @param rhs A basic_string object to compare with.
+/// @return true if the two objects are the same, false otherwise.
 template <typename CharT, typename Traits>
 bool operator==(basic_str_view<CharT, Traits> lhs, const std::basic_string<CharT, Traits>& rhs) noexcept {
     return lhs == basic_str_view<CharT, Traits>(rhs);
 }
 
+/// @brief An equal-to operator of the basic_str_view class.
+/// @tparam CharT Character type
+/// @tparam Traits Character traits type.
+/// @param lhs A basic_string object for comparison.
+/// @param rhs A basic_str_view object to compare with.
+/// @return true if the two objects are the same, false otherwise.
 template <typename CharT, typename Traits>
 bool operator==(const std::basic_string<CharT, Traits>& lhs, basic_str_view<CharT, Traits> rhs) noexcept {
     return basic_str_view<CharT, Traits>(lhs) == rhs;
 }
 
+/// @brief An equal-to operator of the basic_str_view class.
+/// @tparam CharT Character type
+/// @tparam Traits Character traits type.
+/// @tparam N The length of the character array.
+/// @param lhs A basic_str_view object for comparison.
+/// @param rhs A character array to compare with.
+/// @return true if the two objects are the same, false otherwise.
 template <typename CharT, typename Traits, std::size_t N>
 bool operator==(basic_str_view<CharT, Traits> lhs, const CharT (&rhs)[N]) noexcept {
     // assume `rhs` is null terminated
     return lhs == basic_str_view<CharT, Traits>(rhs, N - 1);
 }
 
+/// @brief An equal-to operator of the basic_str_view class.
+/// @tparam CharT Character type
+/// @tparam Traits Character traits type.
+/// @tparam N The length of the character array.
+/// @param rhs A character array for comparison.
+/// @param lhs A basic_str_view object to compare with.
+/// @return true if the two objects are the same, false otherwise.
 template <typename CharT, typename Traits, std::size_t N>
 bool operator==(const CharT (&lhs)[N], basic_str_view<CharT, Traits> rhs) noexcept {
     // assume `lhs` is null terminated
     return basic_str_view<CharT, Traits>(lhs, N - 1) == rhs;
 }
 
+/// @brief An not-equal-to operator of the basic_str_view class.
+/// @tparam CharT Character type
+/// @tparam Traits Character traits type.
+/// @param lhs A basic_str_view object for comparison.
+/// @param rhs A basic_str_view object to compare with.
+/// @return true if the two objects are different, false otherwise.
 template <typename CharT, typename Traits>
 bool operator!=(basic_str_view<CharT, Traits> lhs, basic_str_view<CharT, Traits> rhs) noexcept {
     return !(lhs == rhs);
 }
 
+/// @brief An not-equal-to operator of the basic_str_view class.
+/// @tparam CharT Character type
+/// @tparam Traits Character traits type.
+/// @param lhs A basic_str_view object for comparison.
+/// @param rhs A basic_string object to compare with.
+/// @return true if the two objects are different, false otherwise.
 template <typename CharT, typename Traits>
 bool operator!=(basic_str_view<CharT, Traits> lhs, const std::basic_string<CharT, Traits>& rhs) noexcept {
     return !(lhs == basic_str_view<CharT, Traits>(rhs));
 }
 
+/// @brief An not-equal-to operator of the basic_str_view class.
+/// @tparam CharT Character type
+/// @tparam Traits Character traits type.
+/// @param lhs A basic_string object for comparison.
+/// @param rhs A basic_str_view object to compare with.
+/// @return true if the two objects are different, false otherwise.
+template <typename CharT, typename Traits>
+bool operator!=(const std::basic_string<CharT, Traits>& lhs, basic_str_view<CharT, Traits> rhs) noexcept {
+    return !(basic_str_view<CharT, Traits>(lhs) == rhs);
+}
+
+/// @brief An not-equal-to operator of the basic_str_view class.
+/// @tparam CharT Character type
+/// @tparam Traits Character traits type.
+/// @tparam N The length of the character array.
+/// @param lhs A basic_str_view object for comparison.
+/// @param rhs A character array to compare with.
+/// @return true if the two objects are different, false otherwise.
 template <typename CharT, typename Traits, std::size_t N>
 bool operator!=(basic_str_view<CharT, Traits> lhs, const CharT (&rhs)[N]) noexcept {
     // assume `rhs` is null terminated.
     return !(lhs == basic_str_view<CharT, Traits>(rhs, N - 1));
 }
 
+/// @brief An not-equal-to operator of the basic_str_view class.
+/// @tparam CharT Character type
+/// @tparam Traits Character traits type.
+/// @tparam N The length of the character array.
+/// @param rhs A character array for comparison.
+/// @param lhs A basic_str_view object to compare with.
+/// @return true if the two objects are different, false otherwise.
 template <typename CharT, typename Traits, std::size_t N>
 bool operator!=(const CharT (&lhs)[N], basic_str_view<CharT, Traits> rhs) noexcept {
     // assume `lhs` is null terminate
     return !(basic_str_view<CharT, Traits>(lhs, N - 1) == rhs);
 }
 
+/// @brief An less-than operator of the basic_str_view class.
+/// @tparam CharT Character type
+/// @tparam Traits Character traits type.
+/// @param lhs A basic_str_view object for comparison.
+/// @param rhs A basic_str_view object to compare with.
+/// @return true if `lhs` is less than `rhs`, false otherwise.
 template <typename CharT, typename Traits>
 bool operator<(basic_str_view<CharT, Traits> lhs, basic_str_view<CharT, Traits> rhs) noexcept {
     return lhs.compare(rhs) < 0;
 }
 
+/// @brief An less-than-or-equal-to operator of the basic_str_view class.
+/// @tparam CharT Character type
+/// @tparam Traits Character traits type.
+/// @param lhs A basic_str_view object for comparison.
+/// @param rhs A basic_str_view object to compare with.
+/// @return true if `lhs` is less than or equal to `rhs`, false otherwise.
 template <typename CharT, typename Traits>
 bool operator<=(basic_str_view<CharT, Traits> lhs, basic_str_view<CharT, Traits> rhs) noexcept {
     return lhs.compare(rhs) <= 0;
 }
 
+/// @brief An greater-than operator of the basic_str_view class.
+/// @tparam CharT Character type
+/// @tparam Traits Character traits type.
+/// @param lhs A basic_str_view object for comparison.
+/// @param rhs A basic_str_view object to compare with.
+/// @return true if `lhs` is greater than `rhs`, false otherwise.
 template <typename CharT, typename Traits>
 bool operator>(basic_str_view<CharT, Traits> lhs, basic_str_view<CharT, Traits> rhs) noexcept {
     return lhs.compare(rhs) > 0;
 }
 
+/// @brief An greater-than-or-equal-to operator of the basic_str_view class.
+/// @tparam CharT Character type
+/// @tparam Traits Character traits type.
+/// @param lhs A basic_str_view object for comparison.
+/// @param rhs A basic_str_view object to compare with.
+/// @return true if `lhs` is greater than or equal to `rhs`, false otherwise.
 template <typename CharT, typename Traits>
 bool operator>=(basic_str_view<CharT, Traits> lhs, basic_str_view<CharT, Traits> rhs) noexcept {
     return lhs.compare(rhs) >= 0;
 }
 
+/// @brief Insertion operator of the basic_str_view class.
+/// @tparam CharT Character type.
+/// @tparam Traits Character traits type.
+/// @param os An output stream object.
+/// @param sv A basic_str_view object.
+/// @return Reference to the output stream object `os`.
 template <typename CharT, typename Traits>
 std::basic_ostream<CharT, Traits>& operator<<(std::basic_ostream<CharT, Traits>& os, basic_str_view<CharT, Traits> sv) {
     return os.write(sv.data(), static_cast<std::streamsize>(sv.size()));
 }
 
+/// @brief view into `char` sequence.
 using str_view = basic_str_view<char>;
+
+#ifdef FK_YAML_HAS_CHAR8_T
+/// @brief view into `char8_t` sequence.
+using u8str_view = basic_str_view<char8_t>;
+#endif
+
+/// @brief view into `char16_t` sequence.
+using u16str_view = basic_str_view<char16_t>;
+
+/// @brief view into `char32_t` sequence.
+using u16str_view = basic_str_view<char32_t>;
 
 FK_YAML_DETAIL_NAMESPACE_END
 

--- a/single_include/fkYAML/node.hpp
+++ b/single_include/fkYAML/node.hpp
@@ -3171,7 +3171,7 @@ public:
     /// @return The element at the given position.
     const_reference at(size_type pos) const {
         if (pos >= m_len) {
-            throw fkyaml::out_of_range(pos);
+            throw fkyaml::out_of_range(static_cast<int>(pos));
         }
         return *(mp_str + pos);
     }
@@ -3216,13 +3216,14 @@ public:
     }
 
     /// @brief Copys the referenced character sequence values from `pos` by `n` size.
+    /// @warning Throws an fkyaml::out_of_range exception if the given `pos` is bigger than the lenth.
     /// @param p_str The pointer to a character sequence buffer for output.
     /// @param n The number of elements to write into `p_str`.
     /// @param pos The offset of the beginning position to copy values.
     /// @return The number of elements to be written into `p_str`.
     size_type copy(CharT* p_str, size_type n, size_type pos = 0) const {
         if (pos > m_len) {
-            throw fkyaml::out_of_range(pos);
+            throw fkyaml::out_of_range(static_cast<int>(pos));
         }
         const size_type rlen = std::min(n, m_len - pos);
         traits_type::copy(p_str, mp_str + pos, rlen);
@@ -3236,7 +3237,7 @@ public:
     /// @return A newly created sub basic_str_view object.
     basic_str_view substr(size_type pos = 0, size_type n = npos) const {
         if (pos > m_len) {
-            throw fkyaml::out_of_range(pos);
+            throw fkyaml::out_of_range(static_cast<int>(pos));
         }
         const size_type rlen = std::min(n, m_len - pos);
         return basic_str_view(mp_str + pos, rlen);

--- a/test/unit_test/CMakeLists.txt
+++ b/test/unit_test/CMakeLists.txt
@@ -126,6 +126,10 @@ target_compile_options(
       -Wno-c++98-compat -Wno-c++98-compat-pedantic
       -Wno-deprecated-declarations # for testing deprecated functions
     >
+    $<$<CXX_COMPILER_ID:AppleClang>:
+      -Wall -Wextra -Werror -pedantic
+      -Wno-deprecated-declarations # for testing deprecated functions
+    >
     # IntelLLVM
     $<$<CXX_COMPILER_ID:IntelLLVM>:
       # IntelLLVM warns the usage of nans and infinities due to its over-estimation.

--- a/test/unit_test/CMakeLists.txt
+++ b/test/unit_test/CMakeLists.txt
@@ -228,6 +228,7 @@ add_executable(
   test_scalar_conv.cpp
   test_scalar_scanner_class.cpp
   test_serializer_class.cpp
+  test_str_view_class.cpp
   test_string_formatter.cpp
   test_tag_resolver_class.cpp
   test_uri_encoding_class.cpp

--- a/test/unit_test/test_input_adapter.cpp
+++ b/test/unit_test/test_input_adapter.cpp
@@ -172,8 +172,8 @@ TEST_CASE("InputAdapter_FillBuffer_UTF8N") {
         auto input_adapter = fkyaml::detail::input_adapter(input);
         REQUIRE(std::is_same<decltype(input_adapter), fkyaml::detail::iterator_input_adapter<char*>>::value);
 
-        std::string buffer {};
-        input_adapter.fill_buffer(buffer);
+        input_adapter.fill_buffer();
+        fkyaml::detail::str_view buffer = input_adapter.get_buffer();
 
         REQUIRE(buffer.size() == 12);
         REQUIRE(buffer[0] == 't');
@@ -196,8 +196,8 @@ TEST_CASE("InputAdapter_FillBuffer_UTF8N") {
         using itr_type = typename std::string::iterator;
         REQUIRE(std::is_same<decltype(input_adapter), fkyaml::detail::iterator_input_adapter<itr_type>>::value);
 
-        std::string buffer {};
-        input_adapter.fill_buffer(buffer);
+        input_adapter.fill_buffer();
+        fkyaml::detail::str_view buffer = input_adapter.get_buffer();
 
         REQUIRE(buffer.size() == 12);
         REQUIRE(buffer[0] == 't');
@@ -222,8 +222,8 @@ TEST_CASE("InputAdapter_FillBuffer_UTF8N") {
         auto input_adapter = fkyaml::detail::input_adapter(p_file);
         REQUIRE(std::is_same<decltype(input_adapter), fkyaml::detail::file_input_adapter>::value);
 
-        std::string buffer {};
-        input_adapter.fill_buffer(buffer);
+        input_adapter.fill_buffer();
+        fkyaml::detail::str_view buffer = input_adapter.get_buffer();
 
         REQUIRE(buffer.size() == 8);
         REQUIRE(buffer[0] == 'a');
@@ -243,8 +243,8 @@ TEST_CASE("InputAdapter_FillBuffer_UTF8N") {
         auto input_adapter = fkyaml::detail::input_adapter(ifs);
         REQUIRE(std::is_same<decltype(input_adapter), fkyaml::detail::stream_input_adapter>::value);
 
-        std::string buffer {};
-        input_adapter.fill_buffer(buffer);
+        input_adapter.fill_buffer();
+        fkyaml::detail::str_view buffer = input_adapter.get_buffer();
 
         REQUIRE(buffer.size() == 8);
         REQUIRE(buffer[0] == 'a');
@@ -265,8 +265,8 @@ TEST_CASE("InputAdapter_FillBuffer_UTF8BOM") {
         auto input_adapter = fkyaml::detail::input_adapter(input);
         REQUIRE(std::is_same<decltype(input_adapter), fkyaml::detail::iterator_input_adapter<char*>>::value);
 
-        std::string buffer {};
-        input_adapter.fill_buffer(buffer);
+        input_adapter.fill_buffer();
+        fkyaml::detail::str_view buffer = input_adapter.get_buffer();
 
         REQUIRE(buffer.size() == 12);
         REQUIRE(buffer[0] == 't');
@@ -291,8 +291,8 @@ TEST_CASE("InputAdapter_FillBuffer_UTF8BOM") {
         using itr_type = typename std::string::iterator;
         REQUIRE(std::is_same<decltype(input_adapter), fkyaml::detail::iterator_input_adapter<itr_type>>::value);
 
-        std::string buffer {};
-        input_adapter.fill_buffer(buffer);
+        input_adapter.fill_buffer();
+        fkyaml::detail::str_view buffer = input_adapter.get_buffer();
 
         REQUIRE(buffer.size() == 12);
         REQUIRE(buffer[0] == 't');
@@ -317,8 +317,8 @@ TEST_CASE("InputAdapter_FillBuffer_UTF8BOM") {
         auto input_adapter = fkyaml::detail::input_adapter(p_file);
         REQUIRE(std::is_same<decltype(input_adapter), fkyaml::detail::file_input_adapter>::value);
 
-        std::string buffer {};
-        input_adapter.fill_buffer(buffer);
+        input_adapter.fill_buffer();
+        fkyaml::detail::str_view buffer = input_adapter.get_buffer();
 
         REQUIRE(buffer.size() == 8);
         REQUIRE(buffer[0] == 'a');
@@ -338,8 +338,8 @@ TEST_CASE("InputAdapter_FillBuffer_UTF8BOM") {
         auto input_adapter = fkyaml::detail::input_adapter(ifs);
         REQUIRE(std::is_same<decltype(input_adapter), fkyaml::detail::stream_input_adapter>::value);
 
-        std::string buffer {};
-        input_adapter.fill_buffer(buffer);
+        input_adapter.fill_buffer();
+        fkyaml::detail::str_view buffer = input_adapter.get_buffer();
 
         REQUIRE(buffer.size() == 8);
         REQUIRE(buffer[0] == 'a');
@@ -359,8 +359,8 @@ TEST_CASE("InputAdapter_FillBuffer_UTF16BEN") {
         auto input_adapter = fkyaml::detail::input_adapter(input);
         REQUIRE(std::is_same<decltype(input_adapter), fkyaml::detail::iterator_input_adapter<char*>>::value);
 
-        std::string buffer {};
-        input_adapter.fill_buffer(buffer);
+        input_adapter.fill_buffer();
+        fkyaml::detail::str_view buffer = input_adapter.get_buffer();
 
         REQUIRE(buffer.size() == 9);
         REQUIRE(buffer[0] == 'a');
@@ -380,8 +380,8 @@ TEST_CASE("InputAdapter_FillBuffer_UTF16BEN") {
         using itr_type = typename std::string::iterator;
         REQUIRE(std::is_same<decltype(input_adapter), fkyaml::detail::iterator_input_adapter<itr_type>>::value);
 
-        std::string buffer {};
-        input_adapter.fill_buffer(buffer);
+        input_adapter.fill_buffer();
+        fkyaml::detail::str_view buffer = input_adapter.get_buffer();
 
         REQUIRE(buffer.size() == 10);
         REQUIRE(buffer[0] == 'a');
@@ -401,8 +401,8 @@ TEST_CASE("InputAdapter_FillBuffer_UTF16BEN") {
         auto input_adapter = fkyaml::detail::input_adapter(input);
         REQUIRE(std::is_same<decltype(input_adapter), fkyaml::detail::iterator_input_adapter<char16_t*>>::value);
 
-        std::string buffer {};
-        input_adapter.fill_buffer(buffer);
+        input_adapter.fill_buffer();
+        fkyaml::detail::str_view buffer = input_adapter.get_buffer();
 
         REQUIRE(buffer.size() == 9);
         REQUIRE(buffer[0] == 'a');
@@ -423,8 +423,8 @@ TEST_CASE("InputAdapter_FillBuffer_UTF16BEN") {
         using itr_type = typename std::u16string::iterator;
         REQUIRE(std::is_same<decltype(input_adapter), fkyaml::detail::iterator_input_adapter<itr_type>>::value);
 
-        std::string buffer {};
-        input_adapter.fill_buffer(buffer);
+        input_adapter.fill_buffer();
+        fkyaml::detail::str_view buffer = input_adapter.get_buffer();
 
         REQUIRE(buffer.size() == 10);
         REQUIRE(buffer[0] == 'a');
@@ -447,8 +447,8 @@ TEST_CASE("InputAdapter_FillBuffer_UTF16BEN") {
         auto input_adapter = fkyaml::detail::input_adapter(p_file);
         REQUIRE(std::is_same<decltype(input_adapter), fkyaml::detail::file_input_adapter>::value);
 
-        std::string buffer {};
-        input_adapter.fill_buffer(buffer);
+        input_adapter.fill_buffer();
+        fkyaml::detail::str_view buffer = input_adapter.get_buffer();
 
         REQUIRE(buffer.size() == 9);
         REQUIRE(buffer[0] == 'a');
@@ -469,8 +469,8 @@ TEST_CASE("InputAdapter_FillBuffer_UTF16BEN") {
         auto input_adapter = fkyaml::detail::input_adapter(ifs);
         REQUIRE(std::is_same<decltype(input_adapter), fkyaml::detail::stream_input_adapter>::value);
 
-        std::string buffer {};
-        input_adapter.fill_buffer(buffer);
+        input_adapter.fill_buffer();
+        fkyaml::detail::str_view buffer = input_adapter.get_buffer();
 
         REQUIRE(buffer.size() == 9);
         REQUIRE(buffer[0] == 'a');
@@ -492,8 +492,8 @@ TEST_CASE("InputAdapter_FillBuffer_UTF16BEBOM") {
         auto input_adapter = fkyaml::detail::input_adapter(input);
         REQUIRE(std::is_same<decltype(input_adapter), fkyaml::detail::iterator_input_adapter<char*>>::value);
 
-        std::string buffer {};
-        input_adapter.fill_buffer(buffer);
+        input_adapter.fill_buffer();
+        fkyaml::detail::str_view buffer = input_adapter.get_buffer();
 
         REQUIRE(buffer.size() == 9);
         REQUIRE(buffer[0] == 'a');
@@ -514,8 +514,8 @@ TEST_CASE("InputAdapter_FillBuffer_UTF16BEBOM") {
         using itr_type = typename std::string::iterator;
         REQUIRE(std::is_same<decltype(input_adapter), fkyaml::detail::iterator_input_adapter<itr_type>>::value);
 
-        std::string buffer {};
-        input_adapter.fill_buffer(buffer);
+        input_adapter.fill_buffer();
+        fkyaml::detail::str_view buffer = input_adapter.get_buffer();
 
         REQUIRE(buffer.size() == 9);
         REQUIRE(buffer[0] == 'a');
@@ -534,8 +534,8 @@ TEST_CASE("InputAdapter_FillBuffer_UTF16BEBOM") {
         auto input_adapter = fkyaml::detail::input_adapter(input);
         REQUIRE(std::is_same<decltype(input_adapter), fkyaml::detail::iterator_input_adapter<char16_t*>>::value);
 
-        std::string buffer {};
-        input_adapter.fill_buffer(buffer);
+        input_adapter.fill_buffer();
+        fkyaml::detail::str_view buffer = input_adapter.get_buffer();
 
         REQUIRE(buffer.size() == 9);
         REQUIRE(buffer[0] == 'a');
@@ -556,8 +556,8 @@ TEST_CASE("InputAdapter_FillBuffer_UTF16BEBOM") {
         using itr_type = typename std::u16string::iterator;
         REQUIRE(std::is_same<decltype(input_adapter), fkyaml::detail::iterator_input_adapter<itr_type>>::value);
 
-        std::string buffer {};
-        input_adapter.fill_buffer(buffer);
+        input_adapter.fill_buffer();
+        fkyaml::detail::str_view buffer = input_adapter.get_buffer();
 
         REQUIRE(buffer.size() == 9);
         REQUIRE(buffer[0] == 'a');
@@ -579,8 +579,8 @@ TEST_CASE("InputAdapter_FillBuffer_UTF16BEBOM") {
         auto input_adapter = fkyaml::detail::input_adapter(p_file);
         REQUIRE(std::is_same<decltype(input_adapter), fkyaml::detail::file_input_adapter>::value);
 
-        std::string buffer {};
-        input_adapter.fill_buffer(buffer);
+        input_adapter.fill_buffer();
+        fkyaml::detail::str_view buffer = input_adapter.get_buffer();
 
         REQUIRE(buffer.size() == 9);
         REQUIRE(buffer[0] == 'a');
@@ -601,8 +601,8 @@ TEST_CASE("InputAdapter_FillBuffer_UTF16BEBOM") {
         auto input_adapter = fkyaml::detail::input_adapter(ifs);
         REQUIRE(std::is_same<decltype(input_adapter), fkyaml::detail::stream_input_adapter>::value);
 
-        std::string buffer {};
-        input_adapter.fill_buffer(buffer);
+        input_adapter.fill_buffer();
+        fkyaml::detail::str_view buffer = input_adapter.get_buffer();
 
         REQUIRE(buffer[0] == 'a');
         REQUIRE(buffer[1] == char(0xE3u));
@@ -622,8 +622,8 @@ TEST_CASE("InputAdapter_FillBuffer_UTF16LEN") {
         auto input_adapter = fkyaml::detail::input_adapter(input);
         REQUIRE(std::is_same<decltype(input_adapter), fkyaml::detail::iterator_input_adapter<char*>>::value);
 
-        std::string buffer {};
-        input_adapter.fill_buffer(buffer);
+        input_adapter.fill_buffer();
+        fkyaml::detail::str_view buffer = input_adapter.get_buffer();
 
         REQUIRE(buffer.size() == 9);
         REQUIRE(buffer[0] == 'a');
@@ -643,8 +643,8 @@ TEST_CASE("InputAdapter_FillBuffer_UTF16LEN") {
         using itr_type = typename std::string::iterator;
         REQUIRE(std::is_same<decltype(input_adapter), fkyaml::detail::iterator_input_adapter<itr_type>>::value);
 
-        std::string buffer {};
-        input_adapter.fill_buffer(buffer);
+        input_adapter.fill_buffer();
+        fkyaml::detail::str_view buffer = input_adapter.get_buffer();
 
         REQUIRE(buffer.size() == 9);
         REQUIRE(buffer[0] == 'a');
@@ -663,8 +663,8 @@ TEST_CASE("InputAdapter_FillBuffer_UTF16LEN") {
         auto input_adapter = fkyaml::detail::input_adapter(input);
         REQUIRE(std::is_same<decltype(input_adapter), fkyaml::detail::iterator_input_adapter<char16_t*>>::value);
 
-        std::string buffer {};
-        input_adapter.fill_buffer(buffer);
+        input_adapter.fill_buffer();
+        fkyaml::detail::str_view buffer = input_adapter.get_buffer();
 
         REQUIRE(buffer.size() == 9);
         REQUIRE(buffer[0] == 'a');
@@ -685,8 +685,8 @@ TEST_CASE("InputAdapter_FillBuffer_UTF16LEN") {
         using itr_type = typename std::u16string::iterator;
         REQUIRE(std::is_same<decltype(input_adapter), fkyaml::detail::iterator_input_adapter<itr_type>>::value);
 
-        std::string buffer {};
-        input_adapter.fill_buffer(buffer);
+        input_adapter.fill_buffer();
+        fkyaml::detail::str_view buffer = input_adapter.get_buffer();
 
         REQUIRE(buffer.size() == 9);
         REQUIRE(buffer[0] == 'a');
@@ -708,8 +708,8 @@ TEST_CASE("InputAdapter_FillBuffer_UTF16LEN") {
         auto input_adapter = fkyaml::detail::input_adapter(p_file);
         REQUIRE(std::is_same<decltype(input_adapter), fkyaml::detail::file_input_adapter>::value);
 
-        std::string buffer {};
-        input_adapter.fill_buffer(buffer);
+        input_adapter.fill_buffer();
+        fkyaml::detail::str_view buffer = input_adapter.get_buffer();
 
         REQUIRE(buffer.size() == 9);
         REQUIRE(buffer[0] == 'a');
@@ -730,8 +730,8 @@ TEST_CASE("InputAdapter_FillBuffer_UTF16LEN") {
         auto input_adapter = fkyaml::detail::input_adapter(ifs);
         REQUIRE(std::is_same<decltype(input_adapter), fkyaml::detail::stream_input_adapter>::value);
 
-        std::string buffer {};
-        input_adapter.fill_buffer(buffer);
+        input_adapter.fill_buffer();
+        fkyaml::detail::str_view buffer = input_adapter.get_buffer();
 
         REQUIRE(buffer.size() == 9);
         REQUIRE(buffer[0] == 'a');
@@ -753,8 +753,8 @@ TEST_CASE("InputAdapter_FillBuffer_UTF16LEBOM") {
         auto input_adapter = fkyaml::detail::input_adapter(input);
         REQUIRE(std::is_same<decltype(input_adapter), fkyaml::detail::iterator_input_adapter<char*>>::value);
 
-        std::string buffer {};
-        input_adapter.fill_buffer(buffer);
+        input_adapter.fill_buffer();
+        fkyaml::detail::str_view buffer = input_adapter.get_buffer();
 
         REQUIRE(buffer.size() == 9);
         REQUIRE(buffer[0] == 'a');
@@ -775,8 +775,8 @@ TEST_CASE("InputAdapter_FillBuffer_UTF16LEBOM") {
         using itr_type = typename std::string::iterator;
         REQUIRE(std::is_same<decltype(input_adapter), fkyaml::detail::iterator_input_adapter<itr_type>>::value);
 
-        std::string buffer {};
-        input_adapter.fill_buffer(buffer);
+        input_adapter.fill_buffer();
+        fkyaml::detail::str_view buffer = input_adapter.get_buffer();
 
         REQUIRE(buffer.size() == 9);
         REQUIRE(buffer[0] == 'a');
@@ -795,8 +795,8 @@ TEST_CASE("InputAdapter_FillBuffer_UTF16LEBOM") {
         auto input_adapter = fkyaml::detail::input_adapter(input);
         REQUIRE(std::is_same<decltype(input_adapter), fkyaml::detail::iterator_input_adapter<char16_t*>>::value);
 
-        std::string buffer {};
-        input_adapter.fill_buffer(buffer);
+        input_adapter.fill_buffer();
+        fkyaml::detail::str_view buffer = input_adapter.get_buffer();
 
         REQUIRE(buffer.size() == 9);
         REQUIRE(buffer[0] == 'a');
@@ -817,8 +817,8 @@ TEST_CASE("InputAdapter_FillBuffer_UTF16LEBOM") {
         using itr_type = typename std::u16string::iterator;
         REQUIRE(std::is_same<decltype(input_adapter), fkyaml::detail::iterator_input_adapter<itr_type>>::value);
 
-        std::string buffer {};
-        input_adapter.fill_buffer(buffer);
+        input_adapter.fill_buffer();
+        fkyaml::detail::str_view buffer = input_adapter.get_buffer();
 
         REQUIRE(buffer.size() == 9);
         REQUIRE(buffer[0] == 'a');
@@ -840,8 +840,8 @@ TEST_CASE("InputAdapter_FillBuffer_UTF16LEBOM") {
         auto input_adapter = fkyaml::detail::input_adapter(p_file);
         REQUIRE(std::is_same<decltype(input_adapter), fkyaml::detail::file_input_adapter>::value);
 
-        std::string buffer {};
-        input_adapter.fill_buffer(buffer);
+        input_adapter.fill_buffer();
+        fkyaml::detail::str_view buffer = input_adapter.get_buffer();
 
         REQUIRE(buffer.size() == 9);
         REQUIRE(buffer[0] == 'a');
@@ -862,8 +862,8 @@ TEST_CASE("InputAdapter_FillBuffer_UTF16LEBOM") {
         auto input_adapter = fkyaml::detail::input_adapter(ifs);
         REQUIRE(std::is_same<decltype(input_adapter), fkyaml::detail::stream_input_adapter>::value);
 
-        std::string buffer {};
-        input_adapter.fill_buffer(buffer);
+        input_adapter.fill_buffer();
+        fkyaml::detail::str_view buffer = input_adapter.get_buffer();
 
         REQUIRE(buffer.size() == 9);
         REQUIRE(buffer[0] == 'a');
@@ -884,8 +884,8 @@ TEST_CASE("InputAdapter_FillBuffer_UTF32BEN") {
         auto input_adapter = fkyaml::detail::input_adapter(input);
         REQUIRE(std::is_same<decltype(input_adapter), fkyaml::detail::iterator_input_adapter<char*>>::value);
 
-        std::string buffer {};
-        input_adapter.fill_buffer(buffer);
+        input_adapter.fill_buffer();
+        fkyaml::detail::str_view buffer = input_adapter.get_buffer();
 
         REQUIRE(buffer.size() == 8);
         REQUIRE(buffer[0] == 'a');
@@ -904,8 +904,8 @@ TEST_CASE("InputAdapter_FillBuffer_UTF32BEN") {
         using itr_type = typename std::string::iterator;
         REQUIRE(std::is_same<decltype(input_adapter), fkyaml::detail::iterator_input_adapter<itr_type>>::value);
 
-        std::string buffer {};
-        input_adapter.fill_buffer(buffer);
+        input_adapter.fill_buffer();
+        fkyaml::detail::str_view buffer = input_adapter.get_buffer();
 
         REQUIRE(buffer.size() == 8);
         REQUIRE(buffer[0] == 'a');
@@ -923,8 +923,8 @@ TEST_CASE("InputAdapter_FillBuffer_UTF32BEN") {
         auto input_adapter = fkyaml::detail::input_adapter(input);
         REQUIRE(std::is_same<decltype(input_adapter), fkyaml::detail::iterator_input_adapter<char32_t*>>::value);
 
-        std::string buffer {};
-        input_adapter.fill_buffer(buffer);
+        input_adapter.fill_buffer();
+        fkyaml::detail::str_view buffer = input_adapter.get_buffer();
 
         REQUIRE(buffer.size() == 8);
         REQUIRE(buffer[0] == 'a');
@@ -944,8 +944,8 @@ TEST_CASE("InputAdapter_FillBuffer_UTF32BEN") {
         using itr_type = typename std::u32string::iterator;
         REQUIRE(std::is_same<decltype(input_adapter), fkyaml::detail::iterator_input_adapter<itr_type>>::value);
 
-        std::string buffer {};
-        input_adapter.fill_buffer(buffer);
+        input_adapter.fill_buffer();
+        fkyaml::detail::str_view buffer = input_adapter.get_buffer();
 
         REQUIRE(buffer.size() == 8);
         REQUIRE(buffer[0] == 'a');
@@ -966,8 +966,8 @@ TEST_CASE("InputAdapter_FillBuffer_UTF32BEN") {
         auto input_adapter = fkyaml::detail::input_adapter(p_file);
         REQUIRE(std::is_same<decltype(input_adapter), fkyaml::detail::file_input_adapter>::value);
 
-        std::string buffer {};
-        input_adapter.fill_buffer(buffer);
+        input_adapter.fill_buffer();
+        fkyaml::detail::str_view buffer = input_adapter.get_buffer();
 
         REQUIRE(buffer.size() == 8);
         REQUIRE(buffer[0] == 'a');
@@ -987,8 +987,8 @@ TEST_CASE("InputAdapter_FillBuffer_UTF32BEN") {
         auto input_adapter = fkyaml::detail::input_adapter(ifs);
         REQUIRE(std::is_same<decltype(input_adapter), fkyaml::detail::stream_input_adapter>::value);
 
-        std::string buffer {};
-        input_adapter.fill_buffer(buffer);
+        input_adapter.fill_buffer();
+        fkyaml::detail::str_view buffer = input_adapter.get_buffer();
 
         REQUIRE(buffer.size() == 8);
         REQUIRE(buffer[0] == 'a');
@@ -1008,8 +1008,8 @@ TEST_CASE("InputAdapter_FillBuffer_UTF32BEBOM") {
         auto input_adapter = fkyaml::detail::input_adapter(input);
         REQUIRE(std::is_same<decltype(input_adapter), fkyaml::detail::iterator_input_adapter<char*>>::value);
 
-        std::string buffer {};
-        input_adapter.fill_buffer(buffer);
+        input_adapter.fill_buffer();
+        fkyaml::detail::str_view buffer = input_adapter.get_buffer();
 
         REQUIRE(buffer.size() == 8);
         REQUIRE(buffer[0] == 'a');
@@ -1028,8 +1028,8 @@ TEST_CASE("InputAdapter_FillBuffer_UTF32BEBOM") {
         using itr_type = typename std::string::iterator;
         REQUIRE(std::is_same<decltype(input_adapter), fkyaml::detail::iterator_input_adapter<itr_type>>::value);
 
-        std::string buffer {};
-        input_adapter.fill_buffer(buffer);
+        input_adapter.fill_buffer();
+        fkyaml::detail::str_view buffer = input_adapter.get_buffer();
 
         REQUIRE(buffer.size() == 8);
         REQUIRE(buffer[0] == 'a');
@@ -1047,8 +1047,8 @@ TEST_CASE("InputAdapter_FillBuffer_UTF32BEBOM") {
         auto input_adapter = fkyaml::detail::input_adapter(input);
         REQUIRE(std::is_same<decltype(input_adapter), fkyaml::detail::iterator_input_adapter<char32_t*>>::value);
 
-        std::string buffer {};
-        input_adapter.fill_buffer(buffer);
+        input_adapter.fill_buffer();
+        fkyaml::detail::str_view buffer = input_adapter.get_buffer();
 
         REQUIRE(buffer.size() == 8);
         REQUIRE(buffer[0] == 'a');
@@ -1068,8 +1068,8 @@ TEST_CASE("InputAdapter_FillBuffer_UTF32BEBOM") {
         using itr_type = typename std::u32string::iterator;
         REQUIRE(std::is_same<decltype(input_adapter), fkyaml::detail::iterator_input_adapter<itr_type>>::value);
 
-        std::string buffer {};
-        input_adapter.fill_buffer(buffer);
+        input_adapter.fill_buffer();
+        fkyaml::detail::str_view buffer = input_adapter.get_buffer();
 
         REQUIRE(buffer.size() == 8);
         REQUIRE(buffer[0] == 'a');
@@ -1090,8 +1090,8 @@ TEST_CASE("InputAdapter_FillBuffer_UTF32BEBOM") {
         auto input_adapter = fkyaml::detail::input_adapter(p_file);
         REQUIRE(std::is_same<decltype(input_adapter), fkyaml::detail::file_input_adapter>::value);
 
-        std::string buffer {};
-        input_adapter.fill_buffer(buffer);
+        input_adapter.fill_buffer();
+        fkyaml::detail::str_view buffer = input_adapter.get_buffer();
 
         REQUIRE(buffer.size() == 8);
         REQUIRE(buffer[0] == 'a');
@@ -1111,8 +1111,8 @@ TEST_CASE("InputAdapter_FillBuffer_UTF32BEBOM") {
         auto input_adapter = fkyaml::detail::input_adapter(ifs);
         REQUIRE(std::is_same<decltype(input_adapter), fkyaml::detail::stream_input_adapter>::value);
 
-        std::string buffer {};
-        input_adapter.fill_buffer(buffer);
+        input_adapter.fill_buffer();
+        fkyaml::detail::str_view buffer = input_adapter.get_buffer();
 
         REQUIRE(buffer.size() == 8);
         REQUIRE(buffer[0] == 'a');
@@ -1132,8 +1132,8 @@ TEST_CASE("InputAdapter_FillBuffer_UTF32LEN") {
         auto input_adapter = fkyaml::detail::input_adapter(input);
         REQUIRE(std::is_same<decltype(input_adapter), fkyaml::detail::iterator_input_adapter<char*>>::value);
 
-        std::string buffer {};
-        input_adapter.fill_buffer(buffer);
+        input_adapter.fill_buffer();
+        fkyaml::detail::str_view buffer = input_adapter.get_buffer();
 
         REQUIRE(buffer.size() == 8);
         REQUIRE(buffer[0] == 'a');
@@ -1152,8 +1152,8 @@ TEST_CASE("InputAdapter_FillBuffer_UTF32LEN") {
         using itr_type = typename std::string::iterator;
         REQUIRE(std::is_same<decltype(input_adapter), fkyaml::detail::iterator_input_adapter<itr_type>>::value);
 
-        std::string buffer {};
-        input_adapter.fill_buffer(buffer);
+        input_adapter.fill_buffer();
+        fkyaml::detail::str_view buffer = input_adapter.get_buffer();
 
         REQUIRE(buffer.size() == 8);
         REQUIRE(buffer[0] == 'a');
@@ -1171,8 +1171,8 @@ TEST_CASE("InputAdapter_FillBuffer_UTF32LEN") {
         auto input_adapter = fkyaml::detail::input_adapter(input);
         REQUIRE(std::is_same<decltype(input_adapter), fkyaml::detail::iterator_input_adapter<char32_t*>>::value);
 
-        std::string buffer {};
-        input_adapter.fill_buffer(buffer);
+        input_adapter.fill_buffer();
+        fkyaml::detail::str_view buffer = input_adapter.get_buffer();
 
         REQUIRE(buffer.size() == 8);
         REQUIRE(buffer[0] == 'a');
@@ -1192,8 +1192,8 @@ TEST_CASE("InputAdapter_FillBuffer_UTF32LEN") {
         using itr_type = typename std::u32string::iterator;
         REQUIRE(std::is_same<decltype(input_adapter), fkyaml::detail::iterator_input_adapter<itr_type>>::value);
 
-        std::string buffer {};
-        input_adapter.fill_buffer(buffer);
+        input_adapter.fill_buffer();
+        fkyaml::detail::str_view buffer = input_adapter.get_buffer();
 
         REQUIRE(buffer.size() == 8);
         REQUIRE(buffer[0] == 'a');
@@ -1214,8 +1214,8 @@ TEST_CASE("InputAdapter_FillBuffer_UTF32LEN") {
         auto input_adapter = fkyaml::detail::input_adapter(p_file);
         REQUIRE(std::is_same<decltype(input_adapter), fkyaml::detail::file_input_adapter>::value);
 
-        std::string buffer {};
-        input_adapter.fill_buffer(buffer);
+        input_adapter.fill_buffer();
+        fkyaml::detail::str_view buffer = input_adapter.get_buffer();
 
         REQUIRE(buffer.size() == 8);
         REQUIRE(buffer[0] == 'a');
@@ -1235,8 +1235,8 @@ TEST_CASE("InputAdapter_FillBuffer_UTF32LEN") {
         auto input_adapter = fkyaml::detail::input_adapter(ifs);
         REQUIRE(std::is_same<decltype(input_adapter), fkyaml::detail::stream_input_adapter>::value);
 
-        std::string buffer {};
-        input_adapter.fill_buffer(buffer);
+        input_adapter.fill_buffer();
+        fkyaml::detail::str_view buffer = input_adapter.get_buffer();
 
         REQUIRE(buffer.size() == 8);
         REQUIRE(buffer[0] == 'a');
@@ -1256,8 +1256,8 @@ TEST_CASE("InputAdapter_FillBuffer_UTF32LEBOM") {
         auto input_adapter = fkyaml::detail::input_adapter(input);
         REQUIRE(std::is_same<decltype(input_adapter), fkyaml::detail::iterator_input_adapter<char*>>::value);
 
-        std::string buffer {};
-        input_adapter.fill_buffer(buffer);
+        input_adapter.fill_buffer();
+        fkyaml::detail::str_view buffer = input_adapter.get_buffer();
 
         REQUIRE(buffer.size() == 8);
         REQUIRE(buffer[0] == 'a');
@@ -1276,8 +1276,8 @@ TEST_CASE("InputAdapter_FillBuffer_UTF32LEBOM") {
         using itr_type = typename std::string::iterator;
         REQUIRE(std::is_same<decltype(input_adapter), fkyaml::detail::iterator_input_adapter<itr_type>>::value);
 
-        std::string buffer {};
-        input_adapter.fill_buffer(buffer);
+        input_adapter.fill_buffer();
+        fkyaml::detail::str_view buffer = input_adapter.get_buffer();
 
         REQUIRE(buffer.size() == 8);
         REQUIRE(buffer[0] == 'a');
@@ -1295,8 +1295,8 @@ TEST_CASE("InputAdapter_FillBuffer_UTF32LEBOM") {
         auto input_adapter = fkyaml::detail::input_adapter(input);
         REQUIRE(std::is_same<decltype(input_adapter), fkyaml::detail::iterator_input_adapter<char32_t*>>::value);
 
-        std::string buffer {};
-        input_adapter.fill_buffer(buffer);
+        input_adapter.fill_buffer();
+        fkyaml::detail::str_view buffer = input_adapter.get_buffer();
 
         REQUIRE(buffer.size() == 8);
         REQUIRE(buffer[0] == 'a');
@@ -1316,8 +1316,8 @@ TEST_CASE("InputAdapter_FillBuffer_UTF32LEBOM") {
         using itr_type = typename std::u32string::iterator;
         REQUIRE(std::is_same<decltype(input_adapter), fkyaml::detail::iterator_input_adapter<itr_type>>::value);
 
-        std::string buffer {};
-        input_adapter.fill_buffer(buffer);
+        input_adapter.fill_buffer();
+        fkyaml::detail::str_view buffer = input_adapter.get_buffer();
 
         REQUIRE(buffer.size() == 8);
         REQUIRE(buffer[0] == 'a');
@@ -1338,8 +1338,8 @@ TEST_CASE("InputAdapter_FillBuffer_UTF32LEBOM") {
         auto input_adapter = fkyaml::detail::input_adapter(p_file);
         REQUIRE(std::is_same<decltype(input_adapter), fkyaml::detail::file_input_adapter>::value);
 
-        std::string buffer {};
-        input_adapter.fill_buffer(buffer);
+        input_adapter.fill_buffer();
+        fkyaml::detail::str_view buffer = input_adapter.get_buffer();
 
         REQUIRE(buffer.size() == 8);
         REQUIRE(buffer[0] == 'a');
@@ -1359,8 +1359,8 @@ TEST_CASE("InputAdapter_FillBuffer_UTF32LEBOM") {
         auto input_adapter = fkyaml::detail::input_adapter(ifs);
         REQUIRE(std::is_same<decltype(input_adapter), fkyaml::detail::stream_input_adapter>::value);
 
-        std::string buffer {};
-        input_adapter.fill_buffer(buffer);
+        input_adapter.fill_buffer();
+        fkyaml::detail::str_view buffer = input_adapter.get_buffer();
 
         REQUIRE(buffer.size() == 8);
         REQUIRE(buffer[0] == 'a');
@@ -1387,8 +1387,8 @@ TEST_CASE("InputAdapter_FillBuffer_UTF8CharsValidation") {
         auto input_adapter = fkyaml::detail::input_adapter(p_file);
         REQUIRE(std::is_same<decltype(input_adapter), fkyaml::detail::file_input_adapter>::value);
 
-        std::string buffer {};
-        input_adapter.fill_buffer(buffer);
+        input_adapter.fill_buffer();
+        fkyaml::detail::str_view buffer = input_adapter.get_buffer();
 
         REQUIRE(buffer.size() == 3);
         REQUIRE(buffer[0] == char(0x5Au));
@@ -1406,8 +1406,7 @@ TEST_CASE("InputAdapter_FillBuffer_UTF8CharsValidation") {
         auto input_adapter = fkyaml::detail::input_adapter(p_file);
         REQUIRE(std::is_same<decltype(input_adapter), fkyaml::detail::file_input_adapter>::value);
 
-        std::string buffer {};
-        REQUIRE_THROWS_AS(input_adapter.fill_buffer(buffer), fkyaml::invalid_encoding);
+        REQUIRE_THROWS_AS(input_adapter.fill_buffer(), fkyaml::invalid_encoding);
 
         std::fclose(p_file);
     }
@@ -1417,8 +1416,8 @@ TEST_CASE("InputAdapter_FillBuffer_UTF8CharsValidation") {
         auto input_adapter = fkyaml::detail::input_adapter(ifs);
         REQUIRE(std::is_same<decltype(input_adapter), fkyaml::detail::stream_input_adapter>::value);
 
-        std::string buffer {};
-        input_adapter.fill_buffer(buffer);
+        input_adapter.fill_buffer();
+        fkyaml::detail::str_view buffer = input_adapter.get_buffer();
 
         REQUIRE(buffer.size() == 3);
         REQUIRE(buffer[0] == char(0x5Au));
@@ -1431,8 +1430,7 @@ TEST_CASE("InputAdapter_FillBuffer_UTF8CharsValidation") {
         auto input_adapter = fkyaml::detail::input_adapter(ifs);
         REQUIRE(std::is_same<decltype(input_adapter), fkyaml::detail::stream_input_adapter>::value);
 
-        std::string buffer {};
-        REQUIRE_THROWS_AS(input_adapter.fill_buffer(buffer), fkyaml::invalid_encoding);
+        REQUIRE_THROWS_AS(input_adapter.fill_buffer(), fkyaml::invalid_encoding);
     }
 
     /////////////////////////////////
@@ -1447,8 +1445,8 @@ TEST_CASE("InputAdapter_FillBuffer_UTF8CharsValidation") {
         auto input_adapter = fkyaml::detail::input_adapter(p_file);
         REQUIRE(std::is_same<decltype(input_adapter), fkyaml::detail::file_input_adapter>::value);
 
-        std::string buffer {};
-        input_adapter.fill_buffer(buffer);
+        input_adapter.fill_buffer();
+        fkyaml::detail::str_view buffer = input_adapter.get_buffer();
 
         REQUIRE(buffer.size() == 4);
         REQUIRE(buffer[0] == char(0xC2u));
@@ -1467,8 +1465,7 @@ TEST_CASE("InputAdapter_FillBuffer_UTF8CharsValidation") {
         auto input_adapter = fkyaml::detail::input_adapter(p_file);
         REQUIRE(std::is_same<decltype(input_adapter), fkyaml::detail::file_input_adapter>::value);
 
-        std::string buffer {};
-        REQUIRE_THROWS_AS(input_adapter.fill_buffer(buffer), fkyaml::invalid_encoding);
+        REQUIRE_THROWS_AS(input_adapter.fill_buffer(), fkyaml::invalid_encoding);
 
         std::fclose(p_file);
     }
@@ -1478,8 +1475,8 @@ TEST_CASE("InputAdapter_FillBuffer_UTF8CharsValidation") {
         auto input_adapter = fkyaml::detail::input_adapter(ifs);
         REQUIRE(std::is_same<decltype(input_adapter), fkyaml::detail::stream_input_adapter>::value);
 
-        std::string buffer {};
-        input_adapter.fill_buffer(buffer);
+        input_adapter.fill_buffer();
+        fkyaml::detail::str_view buffer = input_adapter.get_buffer();
 
         REQUIRE(buffer.size() == 4);
         REQUIRE(buffer[0] == char(0xC2u));
@@ -1493,8 +1490,7 @@ TEST_CASE("InputAdapter_FillBuffer_UTF8CharsValidation") {
         auto input_adapter = fkyaml::detail::input_adapter(ifs);
         REQUIRE(std::is_same<decltype(input_adapter), fkyaml::detail::stream_input_adapter>::value);
 
-        std::string buffer {};
-        REQUIRE_THROWS_AS(input_adapter.fill_buffer(buffer), fkyaml::invalid_encoding);
+        REQUIRE_THROWS_AS(input_adapter.fill_buffer(), fkyaml::invalid_encoding);
     }
 
     /////////////////////////////////
@@ -1509,8 +1505,8 @@ TEST_CASE("InputAdapter_FillBuffer_UTF8CharsValidation") {
         auto input_adapter = fkyaml::detail::input_adapter(p_file);
         REQUIRE(std::is_same<decltype(input_adapter), fkyaml::detail::file_input_adapter>::value);
 
-        std::string buffer {};
-        input_adapter.fill_buffer(buffer);
+        input_adapter.fill_buffer();
+        fkyaml::detail::str_view buffer = input_adapter.get_buffer();
 
         REQUIRE(buffer.size() == 6);
         REQUIRE(buffer[0] == char(0xE0u));
@@ -1531,8 +1527,7 @@ TEST_CASE("InputAdapter_FillBuffer_UTF8CharsValidation") {
         auto input_adapter = fkyaml::detail::input_adapter(p_file);
         REQUIRE(std::is_same<decltype(input_adapter), fkyaml::detail::file_input_adapter>::value);
 
-        std::string buffer {};
-        REQUIRE_THROWS_AS(input_adapter.fill_buffer(buffer), fkyaml::invalid_encoding);
+        REQUIRE_THROWS_AS(input_adapter.fill_buffer(), fkyaml::invalid_encoding);
 
         std::fclose(p_file);
     }
@@ -1542,8 +1537,8 @@ TEST_CASE("InputAdapter_FillBuffer_UTF8CharsValidation") {
         auto input_adapter = fkyaml::detail::input_adapter(ifs);
         REQUIRE(std::is_same<decltype(input_adapter), fkyaml::detail::stream_input_adapter>::value);
 
-        std::string buffer {};
-        input_adapter.fill_buffer(buffer);
+        input_adapter.fill_buffer();
+        fkyaml::detail::str_view buffer = input_adapter.get_buffer();
 
         REQUIRE(buffer.size() == 6);
         REQUIRE(buffer[0] == char(0xE0u));
@@ -1559,8 +1554,7 @@ TEST_CASE("InputAdapter_FillBuffer_UTF8CharsValidation") {
         auto input_adapter = fkyaml::detail::input_adapter(ifs);
         REQUIRE(std::is_same<decltype(input_adapter), fkyaml::detail::stream_input_adapter>::value);
 
-        std::string buffer {};
-        REQUIRE_THROWS_AS(input_adapter.fill_buffer(buffer), fkyaml::invalid_encoding);
+        REQUIRE_THROWS_AS(input_adapter.fill_buffer(), fkyaml::invalid_encoding);
     }
 
     /////////////////////////////////
@@ -1575,8 +1569,8 @@ TEST_CASE("InputAdapter_FillBuffer_UTF8CharsValidation") {
         auto input_adapter = fkyaml::detail::input_adapter(p_file);
         REQUIRE(std::is_same<decltype(input_adapter), fkyaml::detail::file_input_adapter>::value);
 
-        std::string buffer {};
-        input_adapter.fill_buffer(buffer);
+        input_adapter.fill_buffer();
+        fkyaml::detail::str_view buffer = input_adapter.get_buffer();
 
         REQUIRE(buffer.size() == 8);
         REQUIRE(buffer[0] == char(0xF0u));
@@ -1599,8 +1593,7 @@ TEST_CASE("InputAdapter_FillBuffer_UTF8CharsValidation") {
         auto input_adapter = fkyaml::detail::input_adapter(p_file);
         REQUIRE(std::is_same<decltype(input_adapter), fkyaml::detail::file_input_adapter>::value);
 
-        std::string buffer {};
-        REQUIRE_THROWS_AS(input_adapter.fill_buffer(buffer), fkyaml::invalid_encoding);
+        REQUIRE_THROWS_AS(input_adapter.fill_buffer(), fkyaml::invalid_encoding);
 
         std::fclose(p_file);
     }
@@ -1610,8 +1603,8 @@ TEST_CASE("InputAdapter_FillBuffer_UTF8CharsValidation") {
         auto input_adapter = fkyaml::detail::input_adapter(ifs);
         REQUIRE(std::is_same<decltype(input_adapter), fkyaml::detail::stream_input_adapter>::value);
 
-        std::string buffer {};
-        input_adapter.fill_buffer(buffer);
+        input_adapter.fill_buffer();
+        fkyaml::detail::str_view buffer = input_adapter.get_buffer();
 
         REQUIRE(buffer.size() == 8);
         REQUIRE(buffer[0] == char(0xF0u));
@@ -1629,8 +1622,7 @@ TEST_CASE("InputAdapter_FillBuffer_UTF8CharsValidation") {
         auto input_adapter = fkyaml::detail::input_adapter(ifs);
         REQUIRE(std::is_same<decltype(input_adapter), fkyaml::detail::stream_input_adapter>::value);
 
-        std::string buffer {};
-        REQUIRE_THROWS_AS(input_adapter.fill_buffer(buffer), fkyaml::invalid_encoding);
+        REQUIRE_THROWS_AS(input_adapter.fill_buffer(), fkyaml::invalid_encoding);
     }
 }
 
@@ -1640,8 +1632,8 @@ TEST_CASE("InputAdapter_FillBuffer_UTF8NewlineCodeNormalization") {
         auto input_adapter = fkyaml::detail::input_adapter(input);
         REQUIRE(std::is_same<decltype(input_adapter), fkyaml::detail::iterator_input_adapter<char*>>::value);
 
-        std::string buffer {};
-        input_adapter.fill_buffer(buffer);
+        input_adapter.fill_buffer();
+        fkyaml::detail::str_view buffer = input_adapter.get_buffer();
 
         REQUIRE(buffer.size() == 10);
         REQUIRE(buffer[0] == 't');
@@ -1662,8 +1654,8 @@ TEST_CASE("InputAdapter_FillBuffer_UTF8NewlineCodeNormalization") {
         auto input_adapter = fkyaml::detail::input_adapter(input);
         REQUIRE(std::is_same<decltype(input_adapter), fkyaml::detail::iterator_input_adapter<char8_t*>>::value);
 
-        std::string buffer {};
-        input_adapter.fill_buffer(buffer);
+        input_adapter.fill_buffer();
+        fkyaml::detail::str_view buffer = input_adapter.get_buffer();
 
         REQUIRE(buffer.size() == 10);
         REQUIRE(buffer[0] == 't');
@@ -1687,8 +1679,8 @@ TEST_CASE("InputAdapter_FillBuffer_UTF8NewlineCodeNormalization") {
         auto input_adapter = fkyaml::detail::input_adapter(p_file);
         REQUIRE(std::is_same<decltype(input_adapter), fkyaml::detail::file_input_adapter>::value);
 
-        std::string buffer {};
-        input_adapter.fill_buffer(buffer);
+        input_adapter.fill_buffer();
+        fkyaml::detail::str_view buffer = input_adapter.get_buffer();
 
         REQUIRE(buffer.size() == 10);
         REQUIRE(buffer[0] == 't');
@@ -1710,8 +1702,8 @@ TEST_CASE("InputAdapter_FillBuffer_UTF8NewlineCodeNormalization") {
         auto input_adapter = fkyaml::detail::input_adapter(ifs);
         REQUIRE(std::is_same<decltype(input_adapter), fkyaml::detail::stream_input_adapter>::value);
 
-        std::string buffer {};
-        input_adapter.fill_buffer(buffer);
+        input_adapter.fill_buffer();
+        fkyaml::detail::str_view buffer = input_adapter.get_buffer();
 
         REQUIRE(buffer.size() == 10);
         REQUIRE(buffer[0] == 't');
@@ -1735,8 +1727,8 @@ TEST_CASE("InputAdapter_FillBuffer_UTF16BENewlineCodeNormalization") {
         auto input_adapter = fkyaml::detail::input_adapter(input);
         REQUIRE(std::is_same<decltype(input_adapter), fkyaml::detail::iterator_input_adapter<char*>>::value);
 
-        std::string buffer {};
-        input_adapter.fill_buffer(buffer);
+        input_adapter.fill_buffer();
+        fkyaml::detail::str_view buffer = input_adapter.get_buffer();
 
         REQUIRE(buffer.size() == 10);
         REQUIRE(buffer[0] == 't');
@@ -1769,8 +1761,8 @@ TEST_CASE("InputAdapter_FillBuffer_UTF16BENewlineCodeNormalization") {
         auto input_adapter = fkyaml::detail::input_adapter(input);
         REQUIRE(std::is_same<decltype(input_adapter), fkyaml::detail::iterator_input_adapter<char16_t*>>::value);
 
-        std::string buffer {};
-        input_adapter.fill_buffer(buffer);
+        input_adapter.fill_buffer();
+        fkyaml::detail::str_view buffer = input_adapter.get_buffer();
 
         REQUIRE(buffer.size() == 10);
         REQUIRE(buffer[0] == 't');
@@ -1793,8 +1785,8 @@ TEST_CASE("InputAdapter_FillBuffer_UTF16BENewlineCodeNormalization") {
         auto input_adapter = fkyaml::detail::input_adapter(p_file);
         REQUIRE(std::is_same<decltype(input_adapter), fkyaml::detail::file_input_adapter>::value);
 
-        std::string buffer {};
-        input_adapter.fill_buffer(buffer);
+        input_adapter.fill_buffer();
+        fkyaml::detail::str_view buffer = input_adapter.get_buffer();
 
         REQUIRE(buffer.size() == 10);
         REQUIRE(buffer[0] == 't');
@@ -1816,8 +1808,8 @@ TEST_CASE("InputAdapter_FillBuffer_UTF16BENewlineCodeNormalization") {
         auto input_adapter = fkyaml::detail::input_adapter(ifs);
         REQUIRE(std::is_same<decltype(input_adapter), fkyaml::detail::stream_input_adapter>::value);
 
-        std::string buffer {};
-        input_adapter.fill_buffer(buffer);
+        input_adapter.fill_buffer();
+        fkyaml::detail::str_view buffer = input_adapter.get_buffer();
 
         REQUIRE(buffer.size() == 10);
         REQUIRE(buffer[0] == 't');
@@ -1842,8 +1834,8 @@ TEST_CASE("InputAdapter_FillBuffer_UTF32BENewlineCodeNormalization") {
         auto input_adapter = fkyaml::detail::input_adapter(input);
         REQUIRE(std::is_same<decltype(input_adapter), fkyaml::detail::iterator_input_adapter<char*>>::value);
 
-        std::string buffer {};
-        input_adapter.fill_buffer(buffer);
+        input_adapter.fill_buffer();
+        fkyaml::detail::str_view buffer = input_adapter.get_buffer();
 
         REQUIRE(buffer.size() == 10);
         REQUIRE(buffer[0] == 't');
@@ -1876,8 +1868,8 @@ TEST_CASE("InputAdapter_FillBuffer_UTF32BENewlineCodeNormalization") {
         auto input_adapter = fkyaml::detail::input_adapter(input);
         REQUIRE(std::is_same<decltype(input_adapter), fkyaml::detail::iterator_input_adapter<char32_t*>>::value);
 
-        std::string buffer {};
-        input_adapter.fill_buffer(buffer);
+        input_adapter.fill_buffer();
+        fkyaml::detail::str_view buffer = input_adapter.get_buffer();
 
         REQUIRE(buffer.size() == 10);
         REQUIRE(buffer[0] == 't');
@@ -1900,8 +1892,8 @@ TEST_CASE("InputAdapter_FillBuffer_UTF32BENewlineCodeNormalization") {
         auto input_adapter = fkyaml::detail::input_adapter(p_file);
         REQUIRE(std::is_same<decltype(input_adapter), fkyaml::detail::file_input_adapter>::value);
 
-        std::string buffer {};
-        input_adapter.fill_buffer(buffer);
+        input_adapter.fill_buffer();
+        fkyaml::detail::str_view buffer = input_adapter.get_buffer();
 
         REQUIRE(buffer.size() == 10);
         REQUIRE(buffer[0] == 't');
@@ -1923,8 +1915,8 @@ TEST_CASE("InputAdapter_FillBuffer_UTF32BENewlineCodeNormalization") {
         auto input_adapter = fkyaml::detail::input_adapter(ifs);
         REQUIRE(std::is_same<decltype(input_adapter), fkyaml::detail::stream_input_adapter>::value);
 
-        std::string buffer {};
-        input_adapter.fill_buffer(buffer);
+        input_adapter.fill_buffer();
+        fkyaml::detail::str_view buffer = input_adapter.get_buffer();
 
         REQUIRE(buffer.size() == 10);
         REQUIRE(buffer[0] == 't');

--- a/test/unit_test/test_input_adapter.cpp
+++ b/test/unit_test/test_input_adapter.cpp
@@ -1323,6 +1323,27 @@ TEST_CASE("InputAdapter_FillBuffer_UTF8CharsValidation") {
     //   UTF-8 1-Byte Characters   //
     /////////////////////////////////
 
+    SECTION("iterator_input_adapter with valid 1-byte UTF-8 encodings") {
+        char input[] = {0x5A, 0x30, 0x61, 0};
+        auto input_adapter = fkyaml::detail::input_adapter(input);
+        REQUIRE(std::is_same<decltype(input_adapter), fkyaml::detail::iterator_input_adapter<char*>>::value);
+
+        fkyaml::detail::str_view buffer = input_adapter.get_buffer_view();
+
+        REQUIRE(buffer.size() == 3);
+        REQUIRE(buffer[0] == char(0x5Au));
+        REQUIRE(buffer[1] == char(0x30u));
+        REQUIRE(buffer[2] == char(0x61u));
+    }
+
+    SECTION("iterator_input_adapter with invalid 1-byte UTF-8 encodings") {
+        char input[] = {char(0x81u), char(0x82u), char(0x83u), 0};
+        auto input_adapter = fkyaml::detail::input_adapter(input);
+        REQUIRE(std::is_same<decltype(input_adapter), fkyaml::detail::iterator_input_adapter<char*>>::value);
+
+        REQUIRE_THROWS_AS(input_adapter.get_buffer_view(), fkyaml::invalid_encoding);
+    }
+
     SECTION("file_input_adapter with valid 1-byte UTF-8 encodings") {
         DISABLE_C4996
         FILE* p_file = std::fopen(FK_YAML_TEST_DATA_DIR "/input_adapter_test_data_utf8n_valid_1byte_char.txt", "r");
@@ -1378,6 +1399,28 @@ TEST_CASE("InputAdapter_FillBuffer_UTF8CharsValidation") {
     /////////////////////////////////
     //   UTF-8 2-Byte Characters   //
     /////////////////////////////////
+
+    SECTION("iterator_input_adapter with valid 2-byte UTF-8 encodings") {
+        char input[] = {char(0xC2u), char(0x80u), char(0xDFu), char(0xBFu), 0};
+        auto input_adapter = fkyaml::detail::input_adapter(input);
+        REQUIRE(std::is_same<decltype(input_adapter), fkyaml::detail::iterator_input_adapter<char*>>::value);
+
+        fkyaml::detail::str_view buffer = input_adapter.get_buffer_view();
+
+        REQUIRE(buffer.size() == 4);
+        REQUIRE(buffer[0] == char(0xC2u));
+        REQUIRE(buffer[1] == char(0x80u));
+        REQUIRE(buffer[2] == char(0xDFu));
+        REQUIRE(buffer[3] == char(0xBFu));
+    }
+
+    SECTION("iterator_input_adapter with invalid 2-byte UTF-8 encodings") {
+        char input[] = {char(0xC1u), char(0x80u), char(0xC2u), 0x7F, 0};
+        auto input_adapter = fkyaml::detail::input_adapter(input);
+        REQUIRE(std::is_same<decltype(input_adapter), fkyaml::detail::iterator_input_adapter<char*>>::value);
+
+        REQUIRE_THROWS_AS(input_adapter.get_buffer_view(), fkyaml::invalid_encoding);
+    }
 
     SECTION("file_input_adapter with valid 2-byte UTF-8 encodings") {
         DISABLE_C4996
@@ -1436,6 +1479,30 @@ TEST_CASE("InputAdapter_FillBuffer_UTF8CharsValidation") {
     /////////////////////////////////
     //   UTF-8 3-Byte Characters   //
     /////////////////////////////////
+
+    SECTION("iterator_input_adapter with valid 3-byte UTF-8 encodings") {
+        char input[] = {char(0xE0u), char(0x80u), char(0x80u), char(0xECu), char(0xBFu), char(0xBFu), 0};
+        auto input_adapter = fkyaml::detail::input_adapter(input);
+        REQUIRE(std::is_same<decltype(input_adapter), fkyaml::detail::iterator_input_adapter<char*>>::value);
+
+        fkyaml::detail::str_view buffer = input_adapter.get_buffer_view();
+
+        REQUIRE(buffer.size() == 6);
+        REQUIRE(buffer[0] == char(0xE0u));
+        REQUIRE(buffer[1] == char(0x80u));
+        REQUIRE(buffer[2] == char(0x80u));
+        REQUIRE(buffer[3] == char(0xECu));
+        REQUIRE(buffer[4] == char(0xBFu));
+        REQUIRE(buffer[5] == char(0xBFu));
+    }
+
+    SECTION("iterator_input_adapter with invalid 3-byte UTF-8 encodings") {
+        char input[] = {char(0xE0u), 0x6A, char(0x80u), char(0xEDu), char(0xA0u), char(0xC0u), 0};
+        auto input_adapter = fkyaml::detail::input_adapter(input);
+        REQUIRE(std::is_same<decltype(input_adapter), fkyaml::detail::iterator_input_adapter<char*>>::value);
+
+        REQUIRE_THROWS_AS(input_adapter.get_buffer_view(), fkyaml::invalid_encoding);
+    }
 
     SECTION("file_input_adapter with valid 3-byte UTF-8 encodings") {
         DISABLE_C4996
@@ -1498,6 +1565,33 @@ TEST_CASE("InputAdapter_FillBuffer_UTF8CharsValidation") {
     /////////////////////////////////
     //   UTF-8 4-Byte Characters   //
     /////////////////////////////////
+
+    SECTION("iterator_input_adapter with valid 4-byte UTF-8 encodings") {
+        char input[] = {
+            char(0xF0u), char(0x90u), char(0x80u), char(0x80u), char(0xF2u), char(0xBFu), char(0x80u), char(0x80u), 0};
+        auto input_adapter = fkyaml::detail::input_adapter(input);
+        REQUIRE(std::is_same<decltype(input_adapter), fkyaml::detail::iterator_input_adapter<char*>>::value);
+
+        fkyaml::detail::str_view buffer = input_adapter.get_buffer_view();
+
+        REQUIRE(buffer.size() == 8);
+        REQUIRE(buffer[0] == char(0xF0u));
+        REQUIRE(buffer[1] == char(0x90u));
+        REQUIRE(buffer[2] == char(0x80u));
+        REQUIRE(buffer[3] == char(0x80u));
+        REQUIRE(buffer[4] == char(0xF2u));
+        REQUIRE(buffer[5] == char(0xBFu));
+        REQUIRE(buffer[6] == char(0x80u));
+        REQUIRE(buffer[7] == char(0x80u));
+    }
+
+    SECTION("iterator_input_adapter with invalid 4-byte UTF-8 encodings") {
+        char input[] = {char(0xF0u), char(0x80u), 0x70, 0x70, char(0xF4u), char(0xC0u), char(0xC0u), 0};
+        auto input_adapter = fkyaml::detail::input_adapter(input);
+        REQUIRE(std::is_same<decltype(input_adapter), fkyaml::detail::iterator_input_adapter<char*>>::value);
+
+        REQUIRE_THROWS_AS(input_adapter.get_buffer_view(), fkyaml::invalid_encoding);
+    }
 
     SECTION("file_input_adapter with valid 4-byte UTF-8 encodings") {
         DISABLE_C4996

--- a/test/unit_test/test_input_adapter.cpp
+++ b/test/unit_test/test_input_adapter.cpp
@@ -172,8 +172,7 @@ TEST_CASE("InputAdapter_FillBuffer_UTF8N") {
         auto input_adapter = fkyaml::detail::input_adapter(input);
         REQUIRE(std::is_same<decltype(input_adapter), fkyaml::detail::iterator_input_adapter<char*>>::value);
 
-        input_adapter.fill_buffer();
-        fkyaml::detail::str_view buffer = input_adapter.get_buffer();
+        fkyaml::detail::str_view buffer = input_adapter.get_buffer_view();
 
         REQUIRE(buffer.size() == 12);
         REQUIRE(buffer[0] == 't');
@@ -196,8 +195,7 @@ TEST_CASE("InputAdapter_FillBuffer_UTF8N") {
         using itr_type = typename std::string::iterator;
         REQUIRE(std::is_same<decltype(input_adapter), fkyaml::detail::iterator_input_adapter<itr_type>>::value);
 
-        input_adapter.fill_buffer();
-        fkyaml::detail::str_view buffer = input_adapter.get_buffer();
+        fkyaml::detail::str_view buffer = input_adapter.get_buffer_view();
 
         REQUIRE(buffer.size() == 12);
         REQUIRE(buffer[0] == 't');
@@ -222,8 +220,7 @@ TEST_CASE("InputAdapter_FillBuffer_UTF8N") {
         auto input_adapter = fkyaml::detail::input_adapter(p_file);
         REQUIRE(std::is_same<decltype(input_adapter), fkyaml::detail::file_input_adapter>::value);
 
-        input_adapter.fill_buffer();
-        fkyaml::detail::str_view buffer = input_adapter.get_buffer();
+        fkyaml::detail::str_view buffer = input_adapter.get_buffer_view();
 
         REQUIRE(buffer.size() == 8);
         REQUIRE(buffer[0] == 'a');
@@ -243,8 +240,7 @@ TEST_CASE("InputAdapter_FillBuffer_UTF8N") {
         auto input_adapter = fkyaml::detail::input_adapter(ifs);
         REQUIRE(std::is_same<decltype(input_adapter), fkyaml::detail::stream_input_adapter>::value);
 
-        input_adapter.fill_buffer();
-        fkyaml::detail::str_view buffer = input_adapter.get_buffer();
+        fkyaml::detail::str_view buffer = input_adapter.get_buffer_view();
 
         REQUIRE(buffer.size() == 8);
         REQUIRE(buffer[0] == 'a');
@@ -265,8 +261,7 @@ TEST_CASE("InputAdapter_FillBuffer_UTF8BOM") {
         auto input_adapter = fkyaml::detail::input_adapter(input);
         REQUIRE(std::is_same<decltype(input_adapter), fkyaml::detail::iterator_input_adapter<char*>>::value);
 
-        input_adapter.fill_buffer();
-        fkyaml::detail::str_view buffer = input_adapter.get_buffer();
+        fkyaml::detail::str_view buffer = input_adapter.get_buffer_view();
 
         REQUIRE(buffer.size() == 12);
         REQUIRE(buffer[0] == 't');
@@ -291,8 +286,7 @@ TEST_CASE("InputAdapter_FillBuffer_UTF8BOM") {
         using itr_type = typename std::string::iterator;
         REQUIRE(std::is_same<decltype(input_adapter), fkyaml::detail::iterator_input_adapter<itr_type>>::value);
 
-        input_adapter.fill_buffer();
-        fkyaml::detail::str_view buffer = input_adapter.get_buffer();
+        fkyaml::detail::str_view buffer = input_adapter.get_buffer_view();
 
         REQUIRE(buffer.size() == 12);
         REQUIRE(buffer[0] == 't');
@@ -317,8 +311,7 @@ TEST_CASE("InputAdapter_FillBuffer_UTF8BOM") {
         auto input_adapter = fkyaml::detail::input_adapter(p_file);
         REQUIRE(std::is_same<decltype(input_adapter), fkyaml::detail::file_input_adapter>::value);
 
-        input_adapter.fill_buffer();
-        fkyaml::detail::str_view buffer = input_adapter.get_buffer();
+        fkyaml::detail::str_view buffer = input_adapter.get_buffer_view();
 
         REQUIRE(buffer.size() == 8);
         REQUIRE(buffer[0] == 'a');
@@ -338,8 +331,7 @@ TEST_CASE("InputAdapter_FillBuffer_UTF8BOM") {
         auto input_adapter = fkyaml::detail::input_adapter(ifs);
         REQUIRE(std::is_same<decltype(input_adapter), fkyaml::detail::stream_input_adapter>::value);
 
-        input_adapter.fill_buffer();
-        fkyaml::detail::str_view buffer = input_adapter.get_buffer();
+        fkyaml::detail::str_view buffer = input_adapter.get_buffer_view();
 
         REQUIRE(buffer.size() == 8);
         REQUIRE(buffer[0] == 'a');
@@ -359,8 +351,7 @@ TEST_CASE("InputAdapter_FillBuffer_UTF16BEN") {
         auto input_adapter = fkyaml::detail::input_adapter(input);
         REQUIRE(std::is_same<decltype(input_adapter), fkyaml::detail::iterator_input_adapter<char*>>::value);
 
-        input_adapter.fill_buffer();
-        fkyaml::detail::str_view buffer = input_adapter.get_buffer();
+        fkyaml::detail::str_view buffer = input_adapter.get_buffer_view();
 
         REQUIRE(buffer.size() == 9);
         REQUIRE(buffer[0] == 'a');
@@ -380,8 +371,7 @@ TEST_CASE("InputAdapter_FillBuffer_UTF16BEN") {
         using itr_type = typename std::string::iterator;
         REQUIRE(std::is_same<decltype(input_adapter), fkyaml::detail::iterator_input_adapter<itr_type>>::value);
 
-        input_adapter.fill_buffer();
-        fkyaml::detail::str_view buffer = input_adapter.get_buffer();
+        fkyaml::detail::str_view buffer = input_adapter.get_buffer_view();
 
         REQUIRE(buffer.size() == 10);
         REQUIRE(buffer[0] == 'a');
@@ -401,8 +391,7 @@ TEST_CASE("InputAdapter_FillBuffer_UTF16BEN") {
         auto input_adapter = fkyaml::detail::input_adapter(input);
         REQUIRE(std::is_same<decltype(input_adapter), fkyaml::detail::iterator_input_adapter<char16_t*>>::value);
 
-        input_adapter.fill_buffer();
-        fkyaml::detail::str_view buffer = input_adapter.get_buffer();
+        fkyaml::detail::str_view buffer = input_adapter.get_buffer_view();
 
         REQUIRE(buffer.size() == 9);
         REQUIRE(buffer[0] == 'a');
@@ -423,8 +412,7 @@ TEST_CASE("InputAdapter_FillBuffer_UTF16BEN") {
         using itr_type = typename std::u16string::iterator;
         REQUIRE(std::is_same<decltype(input_adapter), fkyaml::detail::iterator_input_adapter<itr_type>>::value);
 
-        input_adapter.fill_buffer();
-        fkyaml::detail::str_view buffer = input_adapter.get_buffer();
+        fkyaml::detail::str_view buffer = input_adapter.get_buffer_view();
 
         REQUIRE(buffer.size() == 10);
         REQUIRE(buffer[0] == 'a');
@@ -447,8 +435,7 @@ TEST_CASE("InputAdapter_FillBuffer_UTF16BEN") {
         auto input_adapter = fkyaml::detail::input_adapter(p_file);
         REQUIRE(std::is_same<decltype(input_adapter), fkyaml::detail::file_input_adapter>::value);
 
-        input_adapter.fill_buffer();
-        fkyaml::detail::str_view buffer = input_adapter.get_buffer();
+        fkyaml::detail::str_view buffer = input_adapter.get_buffer_view();
 
         REQUIRE(buffer.size() == 9);
         REQUIRE(buffer[0] == 'a');
@@ -469,8 +456,7 @@ TEST_CASE("InputAdapter_FillBuffer_UTF16BEN") {
         auto input_adapter = fkyaml::detail::input_adapter(ifs);
         REQUIRE(std::is_same<decltype(input_adapter), fkyaml::detail::stream_input_adapter>::value);
 
-        input_adapter.fill_buffer();
-        fkyaml::detail::str_view buffer = input_adapter.get_buffer();
+        fkyaml::detail::str_view buffer = input_adapter.get_buffer_view();
 
         REQUIRE(buffer.size() == 9);
         REQUIRE(buffer[0] == 'a');
@@ -492,8 +478,7 @@ TEST_CASE("InputAdapter_FillBuffer_UTF16BEBOM") {
         auto input_adapter = fkyaml::detail::input_adapter(input);
         REQUIRE(std::is_same<decltype(input_adapter), fkyaml::detail::iterator_input_adapter<char*>>::value);
 
-        input_adapter.fill_buffer();
-        fkyaml::detail::str_view buffer = input_adapter.get_buffer();
+        fkyaml::detail::str_view buffer = input_adapter.get_buffer_view();
 
         REQUIRE(buffer.size() == 9);
         REQUIRE(buffer[0] == 'a');
@@ -514,8 +499,7 @@ TEST_CASE("InputAdapter_FillBuffer_UTF16BEBOM") {
         using itr_type = typename std::string::iterator;
         REQUIRE(std::is_same<decltype(input_adapter), fkyaml::detail::iterator_input_adapter<itr_type>>::value);
 
-        input_adapter.fill_buffer();
-        fkyaml::detail::str_view buffer = input_adapter.get_buffer();
+        fkyaml::detail::str_view buffer = input_adapter.get_buffer_view();
 
         REQUIRE(buffer.size() == 9);
         REQUIRE(buffer[0] == 'a');
@@ -534,8 +518,7 @@ TEST_CASE("InputAdapter_FillBuffer_UTF16BEBOM") {
         auto input_adapter = fkyaml::detail::input_adapter(input);
         REQUIRE(std::is_same<decltype(input_adapter), fkyaml::detail::iterator_input_adapter<char16_t*>>::value);
 
-        input_adapter.fill_buffer();
-        fkyaml::detail::str_view buffer = input_adapter.get_buffer();
+        fkyaml::detail::str_view buffer = input_adapter.get_buffer_view();
 
         REQUIRE(buffer.size() == 9);
         REQUIRE(buffer[0] == 'a');
@@ -556,8 +539,7 @@ TEST_CASE("InputAdapter_FillBuffer_UTF16BEBOM") {
         using itr_type = typename std::u16string::iterator;
         REQUIRE(std::is_same<decltype(input_adapter), fkyaml::detail::iterator_input_adapter<itr_type>>::value);
 
-        input_adapter.fill_buffer();
-        fkyaml::detail::str_view buffer = input_adapter.get_buffer();
+        fkyaml::detail::str_view buffer = input_adapter.get_buffer_view();
 
         REQUIRE(buffer.size() == 9);
         REQUIRE(buffer[0] == 'a');
@@ -579,8 +561,7 @@ TEST_CASE("InputAdapter_FillBuffer_UTF16BEBOM") {
         auto input_adapter = fkyaml::detail::input_adapter(p_file);
         REQUIRE(std::is_same<decltype(input_adapter), fkyaml::detail::file_input_adapter>::value);
 
-        input_adapter.fill_buffer();
-        fkyaml::detail::str_view buffer = input_adapter.get_buffer();
+        fkyaml::detail::str_view buffer = input_adapter.get_buffer_view();
 
         REQUIRE(buffer.size() == 9);
         REQUIRE(buffer[0] == 'a');
@@ -601,8 +582,7 @@ TEST_CASE("InputAdapter_FillBuffer_UTF16BEBOM") {
         auto input_adapter = fkyaml::detail::input_adapter(ifs);
         REQUIRE(std::is_same<decltype(input_adapter), fkyaml::detail::stream_input_adapter>::value);
 
-        input_adapter.fill_buffer();
-        fkyaml::detail::str_view buffer = input_adapter.get_buffer();
+        fkyaml::detail::str_view buffer = input_adapter.get_buffer_view();
 
         REQUIRE(buffer[0] == 'a');
         REQUIRE(buffer[1] == char(0xE3u));
@@ -622,8 +602,7 @@ TEST_CASE("InputAdapter_FillBuffer_UTF16LEN") {
         auto input_adapter = fkyaml::detail::input_adapter(input);
         REQUIRE(std::is_same<decltype(input_adapter), fkyaml::detail::iterator_input_adapter<char*>>::value);
 
-        input_adapter.fill_buffer();
-        fkyaml::detail::str_view buffer = input_adapter.get_buffer();
+        fkyaml::detail::str_view buffer = input_adapter.get_buffer_view();
 
         REQUIRE(buffer.size() == 9);
         REQUIRE(buffer[0] == 'a');
@@ -643,8 +622,7 @@ TEST_CASE("InputAdapter_FillBuffer_UTF16LEN") {
         using itr_type = typename std::string::iterator;
         REQUIRE(std::is_same<decltype(input_adapter), fkyaml::detail::iterator_input_adapter<itr_type>>::value);
 
-        input_adapter.fill_buffer();
-        fkyaml::detail::str_view buffer = input_adapter.get_buffer();
+        fkyaml::detail::str_view buffer = input_adapter.get_buffer_view();
 
         REQUIRE(buffer.size() == 9);
         REQUIRE(buffer[0] == 'a');
@@ -663,8 +641,7 @@ TEST_CASE("InputAdapter_FillBuffer_UTF16LEN") {
         auto input_adapter = fkyaml::detail::input_adapter(input);
         REQUIRE(std::is_same<decltype(input_adapter), fkyaml::detail::iterator_input_adapter<char16_t*>>::value);
 
-        input_adapter.fill_buffer();
-        fkyaml::detail::str_view buffer = input_adapter.get_buffer();
+        fkyaml::detail::str_view buffer = input_adapter.get_buffer_view();
 
         REQUIRE(buffer.size() == 9);
         REQUIRE(buffer[0] == 'a');
@@ -685,8 +662,7 @@ TEST_CASE("InputAdapter_FillBuffer_UTF16LEN") {
         using itr_type = typename std::u16string::iterator;
         REQUIRE(std::is_same<decltype(input_adapter), fkyaml::detail::iterator_input_adapter<itr_type>>::value);
 
-        input_adapter.fill_buffer();
-        fkyaml::detail::str_view buffer = input_adapter.get_buffer();
+        fkyaml::detail::str_view buffer = input_adapter.get_buffer_view();
 
         REQUIRE(buffer.size() == 9);
         REQUIRE(buffer[0] == 'a');
@@ -708,8 +684,7 @@ TEST_CASE("InputAdapter_FillBuffer_UTF16LEN") {
         auto input_adapter = fkyaml::detail::input_adapter(p_file);
         REQUIRE(std::is_same<decltype(input_adapter), fkyaml::detail::file_input_adapter>::value);
 
-        input_adapter.fill_buffer();
-        fkyaml::detail::str_view buffer = input_adapter.get_buffer();
+        fkyaml::detail::str_view buffer = input_adapter.get_buffer_view();
 
         REQUIRE(buffer.size() == 9);
         REQUIRE(buffer[0] == 'a');
@@ -730,8 +705,7 @@ TEST_CASE("InputAdapter_FillBuffer_UTF16LEN") {
         auto input_adapter = fkyaml::detail::input_adapter(ifs);
         REQUIRE(std::is_same<decltype(input_adapter), fkyaml::detail::stream_input_adapter>::value);
 
-        input_adapter.fill_buffer();
-        fkyaml::detail::str_view buffer = input_adapter.get_buffer();
+        fkyaml::detail::str_view buffer = input_adapter.get_buffer_view();
 
         REQUIRE(buffer.size() == 9);
         REQUIRE(buffer[0] == 'a');
@@ -753,8 +727,7 @@ TEST_CASE("InputAdapter_FillBuffer_UTF16LEBOM") {
         auto input_adapter = fkyaml::detail::input_adapter(input);
         REQUIRE(std::is_same<decltype(input_adapter), fkyaml::detail::iterator_input_adapter<char*>>::value);
 
-        input_adapter.fill_buffer();
-        fkyaml::detail::str_view buffer = input_adapter.get_buffer();
+        fkyaml::detail::str_view buffer = input_adapter.get_buffer_view();
 
         REQUIRE(buffer.size() == 9);
         REQUIRE(buffer[0] == 'a');
@@ -775,8 +748,7 @@ TEST_CASE("InputAdapter_FillBuffer_UTF16LEBOM") {
         using itr_type = typename std::string::iterator;
         REQUIRE(std::is_same<decltype(input_adapter), fkyaml::detail::iterator_input_adapter<itr_type>>::value);
 
-        input_adapter.fill_buffer();
-        fkyaml::detail::str_view buffer = input_adapter.get_buffer();
+        fkyaml::detail::str_view buffer = input_adapter.get_buffer_view();
 
         REQUIRE(buffer.size() == 9);
         REQUIRE(buffer[0] == 'a');
@@ -795,8 +767,7 @@ TEST_CASE("InputAdapter_FillBuffer_UTF16LEBOM") {
         auto input_adapter = fkyaml::detail::input_adapter(input);
         REQUIRE(std::is_same<decltype(input_adapter), fkyaml::detail::iterator_input_adapter<char16_t*>>::value);
 
-        input_adapter.fill_buffer();
-        fkyaml::detail::str_view buffer = input_adapter.get_buffer();
+        fkyaml::detail::str_view buffer = input_adapter.get_buffer_view();
 
         REQUIRE(buffer.size() == 9);
         REQUIRE(buffer[0] == 'a');
@@ -817,8 +788,7 @@ TEST_CASE("InputAdapter_FillBuffer_UTF16LEBOM") {
         using itr_type = typename std::u16string::iterator;
         REQUIRE(std::is_same<decltype(input_adapter), fkyaml::detail::iterator_input_adapter<itr_type>>::value);
 
-        input_adapter.fill_buffer();
-        fkyaml::detail::str_view buffer = input_adapter.get_buffer();
+        fkyaml::detail::str_view buffer = input_adapter.get_buffer_view();
 
         REQUIRE(buffer.size() == 9);
         REQUIRE(buffer[0] == 'a');
@@ -840,8 +810,7 @@ TEST_CASE("InputAdapter_FillBuffer_UTF16LEBOM") {
         auto input_adapter = fkyaml::detail::input_adapter(p_file);
         REQUIRE(std::is_same<decltype(input_adapter), fkyaml::detail::file_input_adapter>::value);
 
-        input_adapter.fill_buffer();
-        fkyaml::detail::str_view buffer = input_adapter.get_buffer();
+        fkyaml::detail::str_view buffer = input_adapter.get_buffer_view();
 
         REQUIRE(buffer.size() == 9);
         REQUIRE(buffer[0] == 'a');
@@ -862,8 +831,7 @@ TEST_CASE("InputAdapter_FillBuffer_UTF16LEBOM") {
         auto input_adapter = fkyaml::detail::input_adapter(ifs);
         REQUIRE(std::is_same<decltype(input_adapter), fkyaml::detail::stream_input_adapter>::value);
 
-        input_adapter.fill_buffer();
-        fkyaml::detail::str_view buffer = input_adapter.get_buffer();
+        fkyaml::detail::str_view buffer = input_adapter.get_buffer_view();
 
         REQUIRE(buffer.size() == 9);
         REQUIRE(buffer[0] == 'a');
@@ -884,8 +852,7 @@ TEST_CASE("InputAdapter_FillBuffer_UTF32BEN") {
         auto input_adapter = fkyaml::detail::input_adapter(input);
         REQUIRE(std::is_same<decltype(input_adapter), fkyaml::detail::iterator_input_adapter<char*>>::value);
 
-        input_adapter.fill_buffer();
-        fkyaml::detail::str_view buffer = input_adapter.get_buffer();
+        fkyaml::detail::str_view buffer = input_adapter.get_buffer_view();
 
         REQUIRE(buffer.size() == 8);
         REQUIRE(buffer[0] == 'a');
@@ -904,8 +871,7 @@ TEST_CASE("InputAdapter_FillBuffer_UTF32BEN") {
         using itr_type = typename std::string::iterator;
         REQUIRE(std::is_same<decltype(input_adapter), fkyaml::detail::iterator_input_adapter<itr_type>>::value);
 
-        input_adapter.fill_buffer();
-        fkyaml::detail::str_view buffer = input_adapter.get_buffer();
+        fkyaml::detail::str_view buffer = input_adapter.get_buffer_view();
 
         REQUIRE(buffer.size() == 8);
         REQUIRE(buffer[0] == 'a');
@@ -923,8 +889,7 @@ TEST_CASE("InputAdapter_FillBuffer_UTF32BEN") {
         auto input_adapter = fkyaml::detail::input_adapter(input);
         REQUIRE(std::is_same<decltype(input_adapter), fkyaml::detail::iterator_input_adapter<char32_t*>>::value);
 
-        input_adapter.fill_buffer();
-        fkyaml::detail::str_view buffer = input_adapter.get_buffer();
+        fkyaml::detail::str_view buffer = input_adapter.get_buffer_view();
 
         REQUIRE(buffer.size() == 8);
         REQUIRE(buffer[0] == 'a');
@@ -944,8 +909,7 @@ TEST_CASE("InputAdapter_FillBuffer_UTF32BEN") {
         using itr_type = typename std::u32string::iterator;
         REQUIRE(std::is_same<decltype(input_adapter), fkyaml::detail::iterator_input_adapter<itr_type>>::value);
 
-        input_adapter.fill_buffer();
-        fkyaml::detail::str_view buffer = input_adapter.get_buffer();
+        fkyaml::detail::str_view buffer = input_adapter.get_buffer_view();
 
         REQUIRE(buffer.size() == 8);
         REQUIRE(buffer[0] == 'a');
@@ -966,8 +930,7 @@ TEST_CASE("InputAdapter_FillBuffer_UTF32BEN") {
         auto input_adapter = fkyaml::detail::input_adapter(p_file);
         REQUIRE(std::is_same<decltype(input_adapter), fkyaml::detail::file_input_adapter>::value);
 
-        input_adapter.fill_buffer();
-        fkyaml::detail::str_view buffer = input_adapter.get_buffer();
+        fkyaml::detail::str_view buffer = input_adapter.get_buffer_view();
 
         REQUIRE(buffer.size() == 8);
         REQUIRE(buffer[0] == 'a');
@@ -987,8 +950,7 @@ TEST_CASE("InputAdapter_FillBuffer_UTF32BEN") {
         auto input_adapter = fkyaml::detail::input_adapter(ifs);
         REQUIRE(std::is_same<decltype(input_adapter), fkyaml::detail::stream_input_adapter>::value);
 
-        input_adapter.fill_buffer();
-        fkyaml::detail::str_view buffer = input_adapter.get_buffer();
+        fkyaml::detail::str_view buffer = input_adapter.get_buffer_view();
 
         REQUIRE(buffer.size() == 8);
         REQUIRE(buffer[0] == 'a');
@@ -1008,8 +970,7 @@ TEST_CASE("InputAdapter_FillBuffer_UTF32BEBOM") {
         auto input_adapter = fkyaml::detail::input_adapter(input);
         REQUIRE(std::is_same<decltype(input_adapter), fkyaml::detail::iterator_input_adapter<char*>>::value);
 
-        input_adapter.fill_buffer();
-        fkyaml::detail::str_view buffer = input_adapter.get_buffer();
+        fkyaml::detail::str_view buffer = input_adapter.get_buffer_view();
 
         REQUIRE(buffer.size() == 8);
         REQUIRE(buffer[0] == 'a');
@@ -1028,8 +989,7 @@ TEST_CASE("InputAdapter_FillBuffer_UTF32BEBOM") {
         using itr_type = typename std::string::iterator;
         REQUIRE(std::is_same<decltype(input_adapter), fkyaml::detail::iterator_input_adapter<itr_type>>::value);
 
-        input_adapter.fill_buffer();
-        fkyaml::detail::str_view buffer = input_adapter.get_buffer();
+        fkyaml::detail::str_view buffer = input_adapter.get_buffer_view();
 
         REQUIRE(buffer.size() == 8);
         REQUIRE(buffer[0] == 'a');
@@ -1047,8 +1007,7 @@ TEST_CASE("InputAdapter_FillBuffer_UTF32BEBOM") {
         auto input_adapter = fkyaml::detail::input_adapter(input);
         REQUIRE(std::is_same<decltype(input_adapter), fkyaml::detail::iterator_input_adapter<char32_t*>>::value);
 
-        input_adapter.fill_buffer();
-        fkyaml::detail::str_view buffer = input_adapter.get_buffer();
+        fkyaml::detail::str_view buffer = input_adapter.get_buffer_view();
 
         REQUIRE(buffer.size() == 8);
         REQUIRE(buffer[0] == 'a');
@@ -1068,8 +1027,7 @@ TEST_CASE("InputAdapter_FillBuffer_UTF32BEBOM") {
         using itr_type = typename std::u32string::iterator;
         REQUIRE(std::is_same<decltype(input_adapter), fkyaml::detail::iterator_input_adapter<itr_type>>::value);
 
-        input_adapter.fill_buffer();
-        fkyaml::detail::str_view buffer = input_adapter.get_buffer();
+        fkyaml::detail::str_view buffer = input_adapter.get_buffer_view();
 
         REQUIRE(buffer.size() == 8);
         REQUIRE(buffer[0] == 'a');
@@ -1090,8 +1048,7 @@ TEST_CASE("InputAdapter_FillBuffer_UTF32BEBOM") {
         auto input_adapter = fkyaml::detail::input_adapter(p_file);
         REQUIRE(std::is_same<decltype(input_adapter), fkyaml::detail::file_input_adapter>::value);
 
-        input_adapter.fill_buffer();
-        fkyaml::detail::str_view buffer = input_adapter.get_buffer();
+        fkyaml::detail::str_view buffer = input_adapter.get_buffer_view();
 
         REQUIRE(buffer.size() == 8);
         REQUIRE(buffer[0] == 'a');
@@ -1111,8 +1068,7 @@ TEST_CASE("InputAdapter_FillBuffer_UTF32BEBOM") {
         auto input_adapter = fkyaml::detail::input_adapter(ifs);
         REQUIRE(std::is_same<decltype(input_adapter), fkyaml::detail::stream_input_adapter>::value);
 
-        input_adapter.fill_buffer();
-        fkyaml::detail::str_view buffer = input_adapter.get_buffer();
+        fkyaml::detail::str_view buffer = input_adapter.get_buffer_view();
 
         REQUIRE(buffer.size() == 8);
         REQUIRE(buffer[0] == 'a');
@@ -1132,8 +1088,7 @@ TEST_CASE("InputAdapter_FillBuffer_UTF32LEN") {
         auto input_adapter = fkyaml::detail::input_adapter(input);
         REQUIRE(std::is_same<decltype(input_adapter), fkyaml::detail::iterator_input_adapter<char*>>::value);
 
-        input_adapter.fill_buffer();
-        fkyaml::detail::str_view buffer = input_adapter.get_buffer();
+        fkyaml::detail::str_view buffer = input_adapter.get_buffer_view();
 
         REQUIRE(buffer.size() == 8);
         REQUIRE(buffer[0] == 'a');
@@ -1152,8 +1107,7 @@ TEST_CASE("InputAdapter_FillBuffer_UTF32LEN") {
         using itr_type = typename std::string::iterator;
         REQUIRE(std::is_same<decltype(input_adapter), fkyaml::detail::iterator_input_adapter<itr_type>>::value);
 
-        input_adapter.fill_buffer();
-        fkyaml::detail::str_view buffer = input_adapter.get_buffer();
+        fkyaml::detail::str_view buffer = input_adapter.get_buffer_view();
 
         REQUIRE(buffer.size() == 8);
         REQUIRE(buffer[0] == 'a');
@@ -1171,8 +1125,7 @@ TEST_CASE("InputAdapter_FillBuffer_UTF32LEN") {
         auto input_adapter = fkyaml::detail::input_adapter(input);
         REQUIRE(std::is_same<decltype(input_adapter), fkyaml::detail::iterator_input_adapter<char32_t*>>::value);
 
-        input_adapter.fill_buffer();
-        fkyaml::detail::str_view buffer = input_adapter.get_buffer();
+        fkyaml::detail::str_view buffer = input_adapter.get_buffer_view();
 
         REQUIRE(buffer.size() == 8);
         REQUIRE(buffer[0] == 'a');
@@ -1192,8 +1145,7 @@ TEST_CASE("InputAdapter_FillBuffer_UTF32LEN") {
         using itr_type = typename std::u32string::iterator;
         REQUIRE(std::is_same<decltype(input_adapter), fkyaml::detail::iterator_input_adapter<itr_type>>::value);
 
-        input_adapter.fill_buffer();
-        fkyaml::detail::str_view buffer = input_adapter.get_buffer();
+        fkyaml::detail::str_view buffer = input_adapter.get_buffer_view();
 
         REQUIRE(buffer.size() == 8);
         REQUIRE(buffer[0] == 'a');
@@ -1214,8 +1166,7 @@ TEST_CASE("InputAdapter_FillBuffer_UTF32LEN") {
         auto input_adapter = fkyaml::detail::input_adapter(p_file);
         REQUIRE(std::is_same<decltype(input_adapter), fkyaml::detail::file_input_adapter>::value);
 
-        input_adapter.fill_buffer();
-        fkyaml::detail::str_view buffer = input_adapter.get_buffer();
+        fkyaml::detail::str_view buffer = input_adapter.get_buffer_view();
 
         REQUIRE(buffer.size() == 8);
         REQUIRE(buffer[0] == 'a');
@@ -1235,8 +1186,7 @@ TEST_CASE("InputAdapter_FillBuffer_UTF32LEN") {
         auto input_adapter = fkyaml::detail::input_adapter(ifs);
         REQUIRE(std::is_same<decltype(input_adapter), fkyaml::detail::stream_input_adapter>::value);
 
-        input_adapter.fill_buffer();
-        fkyaml::detail::str_view buffer = input_adapter.get_buffer();
+        fkyaml::detail::str_view buffer = input_adapter.get_buffer_view();
 
         REQUIRE(buffer.size() == 8);
         REQUIRE(buffer[0] == 'a');
@@ -1256,8 +1206,7 @@ TEST_CASE("InputAdapter_FillBuffer_UTF32LEBOM") {
         auto input_adapter = fkyaml::detail::input_adapter(input);
         REQUIRE(std::is_same<decltype(input_adapter), fkyaml::detail::iterator_input_adapter<char*>>::value);
 
-        input_adapter.fill_buffer();
-        fkyaml::detail::str_view buffer = input_adapter.get_buffer();
+        fkyaml::detail::str_view buffer = input_adapter.get_buffer_view();
 
         REQUIRE(buffer.size() == 8);
         REQUIRE(buffer[0] == 'a');
@@ -1276,8 +1225,7 @@ TEST_CASE("InputAdapter_FillBuffer_UTF32LEBOM") {
         using itr_type = typename std::string::iterator;
         REQUIRE(std::is_same<decltype(input_adapter), fkyaml::detail::iterator_input_adapter<itr_type>>::value);
 
-        input_adapter.fill_buffer();
-        fkyaml::detail::str_view buffer = input_adapter.get_buffer();
+        fkyaml::detail::str_view buffer = input_adapter.get_buffer_view();
 
         REQUIRE(buffer.size() == 8);
         REQUIRE(buffer[0] == 'a');
@@ -1295,8 +1243,7 @@ TEST_CASE("InputAdapter_FillBuffer_UTF32LEBOM") {
         auto input_adapter = fkyaml::detail::input_adapter(input);
         REQUIRE(std::is_same<decltype(input_adapter), fkyaml::detail::iterator_input_adapter<char32_t*>>::value);
 
-        input_adapter.fill_buffer();
-        fkyaml::detail::str_view buffer = input_adapter.get_buffer();
+        fkyaml::detail::str_view buffer = input_adapter.get_buffer_view();
 
         REQUIRE(buffer.size() == 8);
         REQUIRE(buffer[0] == 'a');
@@ -1316,8 +1263,7 @@ TEST_CASE("InputAdapter_FillBuffer_UTF32LEBOM") {
         using itr_type = typename std::u32string::iterator;
         REQUIRE(std::is_same<decltype(input_adapter), fkyaml::detail::iterator_input_adapter<itr_type>>::value);
 
-        input_adapter.fill_buffer();
-        fkyaml::detail::str_view buffer = input_adapter.get_buffer();
+        fkyaml::detail::str_view buffer = input_adapter.get_buffer_view();
 
         REQUIRE(buffer.size() == 8);
         REQUIRE(buffer[0] == 'a');
@@ -1338,8 +1284,7 @@ TEST_CASE("InputAdapter_FillBuffer_UTF32LEBOM") {
         auto input_adapter = fkyaml::detail::input_adapter(p_file);
         REQUIRE(std::is_same<decltype(input_adapter), fkyaml::detail::file_input_adapter>::value);
 
-        input_adapter.fill_buffer();
-        fkyaml::detail::str_view buffer = input_adapter.get_buffer();
+        fkyaml::detail::str_view buffer = input_adapter.get_buffer_view();
 
         REQUIRE(buffer.size() == 8);
         REQUIRE(buffer[0] == 'a');
@@ -1359,8 +1304,7 @@ TEST_CASE("InputAdapter_FillBuffer_UTF32LEBOM") {
         auto input_adapter = fkyaml::detail::input_adapter(ifs);
         REQUIRE(std::is_same<decltype(input_adapter), fkyaml::detail::stream_input_adapter>::value);
 
-        input_adapter.fill_buffer();
-        fkyaml::detail::str_view buffer = input_adapter.get_buffer();
+        fkyaml::detail::str_view buffer = input_adapter.get_buffer_view();
 
         REQUIRE(buffer.size() == 8);
         REQUIRE(buffer[0] == 'a');
@@ -1387,8 +1331,7 @@ TEST_CASE("InputAdapter_FillBuffer_UTF8CharsValidation") {
         auto input_adapter = fkyaml::detail::input_adapter(p_file);
         REQUIRE(std::is_same<decltype(input_adapter), fkyaml::detail::file_input_adapter>::value);
 
-        input_adapter.fill_buffer();
-        fkyaml::detail::str_view buffer = input_adapter.get_buffer();
+        fkyaml::detail::str_view buffer = input_adapter.get_buffer_view();
 
         REQUIRE(buffer.size() == 3);
         REQUIRE(buffer[0] == char(0x5Au));
@@ -1406,7 +1349,7 @@ TEST_CASE("InputAdapter_FillBuffer_UTF8CharsValidation") {
         auto input_adapter = fkyaml::detail::input_adapter(p_file);
         REQUIRE(std::is_same<decltype(input_adapter), fkyaml::detail::file_input_adapter>::value);
 
-        REQUIRE_THROWS_AS(input_adapter.fill_buffer(), fkyaml::invalid_encoding);
+        REQUIRE_THROWS_AS(input_adapter.get_buffer_view(), fkyaml::invalid_encoding);
 
         std::fclose(p_file);
     }
@@ -1416,8 +1359,7 @@ TEST_CASE("InputAdapter_FillBuffer_UTF8CharsValidation") {
         auto input_adapter = fkyaml::detail::input_adapter(ifs);
         REQUIRE(std::is_same<decltype(input_adapter), fkyaml::detail::stream_input_adapter>::value);
 
-        input_adapter.fill_buffer();
-        fkyaml::detail::str_view buffer = input_adapter.get_buffer();
+        fkyaml::detail::str_view buffer = input_adapter.get_buffer_view();
 
         REQUIRE(buffer.size() == 3);
         REQUIRE(buffer[0] == char(0x5Au));
@@ -1430,7 +1372,7 @@ TEST_CASE("InputAdapter_FillBuffer_UTF8CharsValidation") {
         auto input_adapter = fkyaml::detail::input_adapter(ifs);
         REQUIRE(std::is_same<decltype(input_adapter), fkyaml::detail::stream_input_adapter>::value);
 
-        REQUIRE_THROWS_AS(input_adapter.fill_buffer(), fkyaml::invalid_encoding);
+        REQUIRE_THROWS_AS(input_adapter.get_buffer_view(), fkyaml::invalid_encoding);
     }
 
     /////////////////////////////////
@@ -1445,8 +1387,7 @@ TEST_CASE("InputAdapter_FillBuffer_UTF8CharsValidation") {
         auto input_adapter = fkyaml::detail::input_adapter(p_file);
         REQUIRE(std::is_same<decltype(input_adapter), fkyaml::detail::file_input_adapter>::value);
 
-        input_adapter.fill_buffer();
-        fkyaml::detail::str_view buffer = input_adapter.get_buffer();
+        fkyaml::detail::str_view buffer = input_adapter.get_buffer_view();
 
         REQUIRE(buffer.size() == 4);
         REQUIRE(buffer[0] == char(0xC2u));
@@ -1465,7 +1406,7 @@ TEST_CASE("InputAdapter_FillBuffer_UTF8CharsValidation") {
         auto input_adapter = fkyaml::detail::input_adapter(p_file);
         REQUIRE(std::is_same<decltype(input_adapter), fkyaml::detail::file_input_adapter>::value);
 
-        REQUIRE_THROWS_AS(input_adapter.fill_buffer(), fkyaml::invalid_encoding);
+        REQUIRE_THROWS_AS(input_adapter.get_buffer_view(), fkyaml::invalid_encoding);
 
         std::fclose(p_file);
     }
@@ -1475,8 +1416,7 @@ TEST_CASE("InputAdapter_FillBuffer_UTF8CharsValidation") {
         auto input_adapter = fkyaml::detail::input_adapter(ifs);
         REQUIRE(std::is_same<decltype(input_adapter), fkyaml::detail::stream_input_adapter>::value);
 
-        input_adapter.fill_buffer();
-        fkyaml::detail::str_view buffer = input_adapter.get_buffer();
+        fkyaml::detail::str_view buffer = input_adapter.get_buffer_view();
 
         REQUIRE(buffer.size() == 4);
         REQUIRE(buffer[0] == char(0xC2u));
@@ -1490,7 +1430,7 @@ TEST_CASE("InputAdapter_FillBuffer_UTF8CharsValidation") {
         auto input_adapter = fkyaml::detail::input_adapter(ifs);
         REQUIRE(std::is_same<decltype(input_adapter), fkyaml::detail::stream_input_adapter>::value);
 
-        REQUIRE_THROWS_AS(input_adapter.fill_buffer(), fkyaml::invalid_encoding);
+        REQUIRE_THROWS_AS(input_adapter.get_buffer_view(), fkyaml::invalid_encoding);
     }
 
     /////////////////////////////////
@@ -1505,8 +1445,7 @@ TEST_CASE("InputAdapter_FillBuffer_UTF8CharsValidation") {
         auto input_adapter = fkyaml::detail::input_adapter(p_file);
         REQUIRE(std::is_same<decltype(input_adapter), fkyaml::detail::file_input_adapter>::value);
 
-        input_adapter.fill_buffer();
-        fkyaml::detail::str_view buffer = input_adapter.get_buffer();
+        fkyaml::detail::str_view buffer = input_adapter.get_buffer_view();
 
         REQUIRE(buffer.size() == 6);
         REQUIRE(buffer[0] == char(0xE0u));
@@ -1527,7 +1466,7 @@ TEST_CASE("InputAdapter_FillBuffer_UTF8CharsValidation") {
         auto input_adapter = fkyaml::detail::input_adapter(p_file);
         REQUIRE(std::is_same<decltype(input_adapter), fkyaml::detail::file_input_adapter>::value);
 
-        REQUIRE_THROWS_AS(input_adapter.fill_buffer(), fkyaml::invalid_encoding);
+        REQUIRE_THROWS_AS(input_adapter.get_buffer_view(), fkyaml::invalid_encoding);
 
         std::fclose(p_file);
     }
@@ -1537,8 +1476,7 @@ TEST_CASE("InputAdapter_FillBuffer_UTF8CharsValidation") {
         auto input_adapter = fkyaml::detail::input_adapter(ifs);
         REQUIRE(std::is_same<decltype(input_adapter), fkyaml::detail::stream_input_adapter>::value);
 
-        input_adapter.fill_buffer();
-        fkyaml::detail::str_view buffer = input_adapter.get_buffer();
+        fkyaml::detail::str_view buffer = input_adapter.get_buffer_view();
 
         REQUIRE(buffer.size() == 6);
         REQUIRE(buffer[0] == char(0xE0u));
@@ -1554,7 +1492,7 @@ TEST_CASE("InputAdapter_FillBuffer_UTF8CharsValidation") {
         auto input_adapter = fkyaml::detail::input_adapter(ifs);
         REQUIRE(std::is_same<decltype(input_adapter), fkyaml::detail::stream_input_adapter>::value);
 
-        REQUIRE_THROWS_AS(input_adapter.fill_buffer(), fkyaml::invalid_encoding);
+        REQUIRE_THROWS_AS(input_adapter.get_buffer_view(), fkyaml::invalid_encoding);
     }
 
     /////////////////////////////////
@@ -1569,8 +1507,7 @@ TEST_CASE("InputAdapter_FillBuffer_UTF8CharsValidation") {
         auto input_adapter = fkyaml::detail::input_adapter(p_file);
         REQUIRE(std::is_same<decltype(input_adapter), fkyaml::detail::file_input_adapter>::value);
 
-        input_adapter.fill_buffer();
-        fkyaml::detail::str_view buffer = input_adapter.get_buffer();
+        fkyaml::detail::str_view buffer = input_adapter.get_buffer_view();
 
         REQUIRE(buffer.size() == 8);
         REQUIRE(buffer[0] == char(0xF0u));
@@ -1593,7 +1530,7 @@ TEST_CASE("InputAdapter_FillBuffer_UTF8CharsValidation") {
         auto input_adapter = fkyaml::detail::input_adapter(p_file);
         REQUIRE(std::is_same<decltype(input_adapter), fkyaml::detail::file_input_adapter>::value);
 
-        REQUIRE_THROWS_AS(input_adapter.fill_buffer(), fkyaml::invalid_encoding);
+        REQUIRE_THROWS_AS(input_adapter.get_buffer_view(), fkyaml::invalid_encoding);
 
         std::fclose(p_file);
     }
@@ -1603,8 +1540,7 @@ TEST_CASE("InputAdapter_FillBuffer_UTF8CharsValidation") {
         auto input_adapter = fkyaml::detail::input_adapter(ifs);
         REQUIRE(std::is_same<decltype(input_adapter), fkyaml::detail::stream_input_adapter>::value);
 
-        input_adapter.fill_buffer();
-        fkyaml::detail::str_view buffer = input_adapter.get_buffer();
+        fkyaml::detail::str_view buffer = input_adapter.get_buffer_view();
 
         REQUIRE(buffer.size() == 8);
         REQUIRE(buffer[0] == char(0xF0u));
@@ -1622,7 +1558,7 @@ TEST_CASE("InputAdapter_FillBuffer_UTF8CharsValidation") {
         auto input_adapter = fkyaml::detail::input_adapter(ifs);
         REQUIRE(std::is_same<decltype(input_adapter), fkyaml::detail::stream_input_adapter>::value);
 
-        REQUIRE_THROWS_AS(input_adapter.fill_buffer(), fkyaml::invalid_encoding);
+        REQUIRE_THROWS_AS(input_adapter.get_buffer_view(), fkyaml::invalid_encoding);
     }
 }
 
@@ -1632,8 +1568,7 @@ TEST_CASE("InputAdapter_FillBuffer_UTF8NewlineCodeNormalization") {
         auto input_adapter = fkyaml::detail::input_adapter(input);
         REQUIRE(std::is_same<decltype(input_adapter), fkyaml::detail::iterator_input_adapter<char*>>::value);
 
-        input_adapter.fill_buffer();
-        fkyaml::detail::str_view buffer = input_adapter.get_buffer();
+        fkyaml::detail::str_view buffer = input_adapter.get_buffer_view();
 
         REQUIRE(buffer.size() == 10);
         REQUIRE(buffer[0] == 't');
@@ -1654,8 +1589,7 @@ TEST_CASE("InputAdapter_FillBuffer_UTF8NewlineCodeNormalization") {
         auto input_adapter = fkyaml::detail::input_adapter(input);
         REQUIRE(std::is_same<decltype(input_adapter), fkyaml::detail::iterator_input_adapter<char8_t*>>::value);
 
-        input_adapter.fill_buffer();
-        fkyaml::detail::str_view buffer = input_adapter.get_buffer();
+        fkyaml::detail::str_view buffer = input_adapter.get_buffer_view();
 
         REQUIRE(buffer.size() == 10);
         REQUIRE(buffer[0] == 't');
@@ -1679,8 +1613,7 @@ TEST_CASE("InputAdapter_FillBuffer_UTF8NewlineCodeNormalization") {
         auto input_adapter = fkyaml::detail::input_adapter(p_file);
         REQUIRE(std::is_same<decltype(input_adapter), fkyaml::detail::file_input_adapter>::value);
 
-        input_adapter.fill_buffer();
-        fkyaml::detail::str_view buffer = input_adapter.get_buffer();
+        fkyaml::detail::str_view buffer = input_adapter.get_buffer_view();
 
         REQUIRE(buffer.size() == 10);
         REQUIRE(buffer[0] == 't');
@@ -1702,8 +1635,7 @@ TEST_CASE("InputAdapter_FillBuffer_UTF8NewlineCodeNormalization") {
         auto input_adapter = fkyaml::detail::input_adapter(ifs);
         REQUIRE(std::is_same<decltype(input_adapter), fkyaml::detail::stream_input_adapter>::value);
 
-        input_adapter.fill_buffer();
-        fkyaml::detail::str_view buffer = input_adapter.get_buffer();
+        fkyaml::detail::str_view buffer = input_adapter.get_buffer_view();
 
         REQUIRE(buffer.size() == 10);
         REQUIRE(buffer[0] == 't');
@@ -1727,8 +1659,7 @@ TEST_CASE("InputAdapter_FillBuffer_UTF16BENewlineCodeNormalization") {
         auto input_adapter = fkyaml::detail::input_adapter(input);
         REQUIRE(std::is_same<decltype(input_adapter), fkyaml::detail::iterator_input_adapter<char*>>::value);
 
-        input_adapter.fill_buffer();
-        fkyaml::detail::str_view buffer = input_adapter.get_buffer();
+        fkyaml::detail::str_view buffer = input_adapter.get_buffer_view();
 
         REQUIRE(buffer.size() == 10);
         REQUIRE(buffer[0] == 't');
@@ -1761,8 +1692,7 @@ TEST_CASE("InputAdapter_FillBuffer_UTF16BENewlineCodeNormalization") {
         auto input_adapter = fkyaml::detail::input_adapter(input);
         REQUIRE(std::is_same<decltype(input_adapter), fkyaml::detail::iterator_input_adapter<char16_t*>>::value);
 
-        input_adapter.fill_buffer();
-        fkyaml::detail::str_view buffer = input_adapter.get_buffer();
+        fkyaml::detail::str_view buffer = input_adapter.get_buffer_view();
 
         REQUIRE(buffer.size() == 10);
         REQUIRE(buffer[0] == 't');
@@ -1785,8 +1715,7 @@ TEST_CASE("InputAdapter_FillBuffer_UTF16BENewlineCodeNormalization") {
         auto input_adapter = fkyaml::detail::input_adapter(p_file);
         REQUIRE(std::is_same<decltype(input_adapter), fkyaml::detail::file_input_adapter>::value);
 
-        input_adapter.fill_buffer();
-        fkyaml::detail::str_view buffer = input_adapter.get_buffer();
+        fkyaml::detail::str_view buffer = input_adapter.get_buffer_view();
 
         REQUIRE(buffer.size() == 10);
         REQUIRE(buffer[0] == 't');
@@ -1808,8 +1737,7 @@ TEST_CASE("InputAdapter_FillBuffer_UTF16BENewlineCodeNormalization") {
         auto input_adapter = fkyaml::detail::input_adapter(ifs);
         REQUIRE(std::is_same<decltype(input_adapter), fkyaml::detail::stream_input_adapter>::value);
 
-        input_adapter.fill_buffer();
-        fkyaml::detail::str_view buffer = input_adapter.get_buffer();
+        fkyaml::detail::str_view buffer = input_adapter.get_buffer_view();
 
         REQUIRE(buffer.size() == 10);
         REQUIRE(buffer[0] == 't');
@@ -1834,8 +1762,7 @@ TEST_CASE("InputAdapter_FillBuffer_UTF32BENewlineCodeNormalization") {
         auto input_adapter = fkyaml::detail::input_adapter(input);
         REQUIRE(std::is_same<decltype(input_adapter), fkyaml::detail::iterator_input_adapter<char*>>::value);
 
-        input_adapter.fill_buffer();
-        fkyaml::detail::str_view buffer = input_adapter.get_buffer();
+        fkyaml::detail::str_view buffer = input_adapter.get_buffer_view();
 
         REQUIRE(buffer.size() == 10);
         REQUIRE(buffer[0] == 't');
@@ -1868,8 +1795,7 @@ TEST_CASE("InputAdapter_FillBuffer_UTF32BENewlineCodeNormalization") {
         auto input_adapter = fkyaml::detail::input_adapter(input);
         REQUIRE(std::is_same<decltype(input_adapter), fkyaml::detail::iterator_input_adapter<char32_t*>>::value);
 
-        input_adapter.fill_buffer();
-        fkyaml::detail::str_view buffer = input_adapter.get_buffer();
+        fkyaml::detail::str_view buffer = input_adapter.get_buffer_view();
 
         REQUIRE(buffer.size() == 10);
         REQUIRE(buffer[0] == 't');
@@ -1892,8 +1818,7 @@ TEST_CASE("InputAdapter_FillBuffer_UTF32BENewlineCodeNormalization") {
         auto input_adapter = fkyaml::detail::input_adapter(p_file);
         REQUIRE(std::is_same<decltype(input_adapter), fkyaml::detail::file_input_adapter>::value);
 
-        input_adapter.fill_buffer();
-        fkyaml::detail::str_view buffer = input_adapter.get_buffer();
+        fkyaml::detail::str_view buffer = input_adapter.get_buffer_view();
 
         REQUIRE(buffer.size() == 10);
         REQUIRE(buffer[0] == 't');
@@ -1915,8 +1840,7 @@ TEST_CASE("InputAdapter_FillBuffer_UTF32BENewlineCodeNormalization") {
         auto input_adapter = fkyaml::detail::input_adapter(ifs);
         REQUIRE(std::is_same<decltype(input_adapter), fkyaml::detail::stream_input_adapter>::value);
 
-        input_adapter.fill_buffer();
-        fkyaml::detail::str_view buffer = input_adapter.get_buffer();
+        fkyaml::detail::str_view buffer = input_adapter.get_buffer_view();
 
         REQUIRE(buffer.size() == 10);
         REQUIRE(buffer[0] == 't');

--- a/test/unit_test/test_lexical_analyzer_class.cpp
+++ b/test/unit_test/test_lexical_analyzer_class.cpp
@@ -10,8 +10,6 @@
 
 #include <fkYAML/node.hpp>
 
-using lexer_t = fkyaml::detail::lexical_analyzer<fkyaml::node>;
-
 TEST_CASE("LexicalAnalyzer_YamlVersionDirective") {
     fkyaml::detail::lexical_token token;
 
@@ -27,7 +25,7 @@ TEST_CASE("LexicalAnalyzer_YamlVersionDirective") {
             value_pair_t("%YAML 1.2\n", "1.2"),
             value_pair_t("%YAML 1.2", "1.2"));
 
-        lexer_t lexer(value_pair.first);
+        fkyaml::detail::lexical_analyzer lexer(value_pair.first);
 
         REQUIRE_NOTHROW(token = lexer.get_next_token());
         REQUIRE(token.type == fkyaml::detail::lexical_token_t::YAML_VER_DIRECTIVE);
@@ -43,7 +41,7 @@ TEST_CASE("LexicalAnalyzer_YamlVersionDirective") {
             fkyaml::detail::str_view("%YANL 1.2    \n"),
             fkyaml::detail::str_view("%YAML1.2"));
 
-        lexer_t lexer(buffer);
+        fkyaml::detail::lexical_analyzer lexer(buffer);
         REQUIRE_NOTHROW(token = lexer.get_next_token());
         REQUIRE(token.type == fkyaml::detail::lexical_token_t::INVALID_DIRECTIVE);
 
@@ -62,7 +60,7 @@ TEST_CASE("LexicalAnalyzer_YamlVersionDirective") {
             fkyaml::detail::str_view("%YAML 1.A"),
             fkyaml::detail::str_view("%YAML AbC"));
 
-        lexer_t lexer(buffer);
+        fkyaml::detail::lexical_analyzer lexer(buffer);
         REQUIRE_THROWS_AS(lexer.get_next_token(), fkyaml::parse_error);
     }
 }
@@ -72,7 +70,7 @@ TEST_CASE("LexicalAnalyzer_TagDirective") {
 
     SECTION("primary tag handle") {
         auto input = GENERATE(fkyaml::detail::str_view("%TAG ! foo"), fkyaml::detail::str_view("%TAG\t!\tfoo"));
-        lexer_t lexer(input);
+        fkyaml::detail::lexical_analyzer lexer(input);
 
         REQUIRE_NOTHROW(token = lexer.get_next_token());
         REQUIRE(token.type == fkyaml::detail::lexical_token_t::TAG_DIRECTIVE);
@@ -84,7 +82,7 @@ TEST_CASE("LexicalAnalyzer_TagDirective") {
 
     SECTION("secondary tag handle") {
         auto input = GENERATE(fkyaml::detail::str_view("%TAG !! foo"), fkyaml::detail::str_view("%TAG\t!!\tfoo"));
-        lexer_t lexer(input);
+        fkyaml::detail::lexical_analyzer lexer(input);
 
         REQUIRE_NOTHROW(token = lexer.get_next_token());
         REQUIRE(token.type == fkyaml::detail::lexical_token_t::TAG_DIRECTIVE);
@@ -97,7 +95,7 @@ TEST_CASE("LexicalAnalyzer_TagDirective") {
     SECTION("named tag handle") {
         auto input = GENERATE(
             fkyaml::detail::str_view("%TAG !va1id-ta9! foo"), fkyaml::detail::str_view("%TAG\t!va1id-ta9!\tfoo"));
-        lexer_t lexer(input);
+        fkyaml::detail::lexical_analyzer lexer(input);
 
         REQUIRE_NOTHROW(token = lexer.get_next_token());
         REQUIRE(token.type == fkyaml::detail::lexical_token_t::TAG_DIRECTIVE);
@@ -111,7 +109,7 @@ TEST_CASE("LexicalAnalyzer_TagDirective") {
         auto buffer = GENERATE(
             fkyaml::detail::str_view("%TUB"), fkyaml::detail::str_view("%TAC"), fkyaml::detail::str_view("%TAGE"));
 
-        lexer_t lexer(buffer);
+        fkyaml::detail::lexical_analyzer lexer(buffer);
         REQUIRE_NOTHROW(token = lexer.get_next_token());
         REQUIRE(token.type == fkyaml::detail::lexical_token_t::INVALID_DIRECTIVE);
         REQUIRE_NOTHROW(token = lexer.get_next_token());
@@ -132,7 +130,7 @@ TEST_CASE("LexicalAnalyzer_TagDirective") {
             fkyaml::detail::str_view("%TAG !invalid!tag bar"),
             fkyaml::detail::str_view("%TAG !invalid"));
 
-        lexer_t lexer(input);
+        fkyaml::detail::lexical_analyzer lexer(input);
         REQUIRE_THROWS_AS(lexer.get_next_token(), fkyaml::parse_error);
     }
 
@@ -145,7 +143,7 @@ TEST_CASE("LexicalAnalyzer_TagDirective") {
             fkyaml::detail::str_view("%TAG !valid! ,invalid"),
             fkyaml::detail::str_view("%TAG !valid! %prefix"));
 
-        lexer_t lexer(input);
+        fkyaml::detail::lexical_analyzer lexer(input);
         REQUIRE_THROWS_AS(lexer.get_next_token(), fkyaml::parse_error);
     }
 }
@@ -153,7 +151,7 @@ TEST_CASE("LexicalAnalyzer_TagDirective") {
 TEST_CASE("LexicalAnalyzer_InvalidDirective") {
     auto buffer = GENERATE(fkyaml::detail::str_view("%TAG"), fkyaml::detail::str_view("%YAML"));
 
-    lexer_t lexer(buffer);
+    fkyaml::detail::lexical_analyzer lexer(buffer);
     REQUIRE_THROWS_AS(lexer.get_next_token(), fkyaml::parse_error);
 }
 
@@ -165,7 +163,7 @@ TEST_CASE("LexicalAnalyzer_ReservedDirective") {
         fkyaml::detail::str_view("%%ERROR"));
 
     fkyaml::detail::lexical_token token;
-    lexer_t lexer(buffer);
+    fkyaml::detail::lexical_analyzer lexer(buffer);
     REQUIRE_NOTHROW(token = lexer.get_next_token());
     REQUIRE(token.type == fkyaml::detail::lexical_token_t::INVALID_DIRECTIVE);
 
@@ -174,12 +172,12 @@ TEST_CASE("LexicalAnalyzer_ReservedDirective") {
 }
 
 TEST_CASE("LexicalAnalyzer_EmptyDirective") {
-    lexer_t lexer("%");
+    fkyaml::detail::lexical_analyzer lexer("%");
     REQUIRE(lexer.get_next_token().type == fkyaml::detail::lexical_token_t::INVALID_DIRECTIVE);
 }
 
 TEST_CASE("LexicalAnalyzer_EndOfDirectives") {
-    lexer_t lexer("%YAML 1.2\n---\nfoo: bar");
+    fkyaml::detail::lexical_analyzer lexer("%YAML 1.2\n---\nfoo: bar");
     fkyaml::detail::lexical_token token;
 
     REQUIRE_NOTHROW(token = lexer.get_next_token());
@@ -200,7 +198,7 @@ TEST_CASE("LexicalAnalyzer_EndOfDirectives") {
 }
 
 TEST_CASE("LexicalAnalyzer_EndOfDocuments") {
-    lexer_t lexer("%YAML 1.2\n---\n...");
+    fkyaml::detail::lexical_analyzer lexer("%YAML 1.2\n---\n...");
     fkyaml::detail::lexical_token token;
 
     REQUIRE_NOTHROW(token = lexer.get_next_token());
@@ -218,49 +216,49 @@ TEST_CASE("LexicalAnalyzer_Colon") {
     fkyaml::detail::lexical_token token;
 
     SECTION("colon with half-width space") {
-        lexer_t lexer(": ");
+        fkyaml::detail::lexical_analyzer lexer(": ");
         REQUIRE_NOTHROW(token = lexer.get_next_token());
         REQUIRE(token.type == fkyaml::detail::lexical_token_t::KEY_SEPARATOR);
     }
 
     SECTION("colon with LF newline code") {
-        lexer_t lexer(":\n");
+        fkyaml::detail::lexical_analyzer lexer(":\n");
         REQUIRE_NOTHROW(token = lexer.get_next_token());
         REQUIRE(token.type == fkyaml::detail::lexical_token_t::KEY_SEPARATOR);
     }
 
     SECTION("colon with the end of the buffer") {
-        lexer_t lexer(":");
+        fkyaml::detail::lexical_analyzer lexer(":");
         REQUIRE_NOTHROW(token = lexer.get_next_token());
         REQUIRE(token.type == fkyaml::detail::lexical_token_t::KEY_SEPARATOR);
     }
 
     SECTION("colon with a comment and a LF newline code") {
-        lexer_t lexer(": # comment\n");
+        fkyaml::detail::lexical_analyzer lexer(": # comment\n");
         REQUIRE_NOTHROW(token = lexer.get_next_token());
         REQUIRE(token.type == fkyaml::detail::lexical_token_t::KEY_SEPARATOR);
     }
 
     SECTION("colon with a comment and no newline code") {
-        lexer_t lexer(": # comment");
+        fkyaml::detail::lexical_analyzer lexer(": # comment");
         REQUIRE_NOTHROW(token = lexer.get_next_token());
         REQUIRE(token.type == fkyaml::detail::lexical_token_t::KEY_SEPARATOR);
     }
 
     SECTION("colon with many spaces and a LF newline code") {
-        lexer_t lexer(":                         \n");
+        fkyaml::detail::lexical_analyzer lexer(":                         \n");
         REQUIRE_NOTHROW(token = lexer.get_next_token());
         REQUIRE(token.type == fkyaml::detail::lexical_token_t::KEY_SEPARATOR);
     }
 
     SECTION("colon with many spaces and no newline code") {
-        lexer_t lexer(":                         ");
+        fkyaml::detail::lexical_analyzer lexer(":                         ");
         REQUIRE_NOTHROW(token = lexer.get_next_token());
         REQUIRE(token.type == fkyaml::detail::lexical_token_t::KEY_SEPARATOR);
     }
 
     SECTION("colon with an always-safe character") {
-        lexer_t lexer(":test");
+        fkyaml::detail::lexical_analyzer lexer(":test");
         REQUIRE_NOTHROW(token = lexer.get_next_token());
         REQUIRE(token.type == fkyaml::detail::lexical_token_t::PLAIN_SCALAR);
         REQUIRE(token.str == ":test");
@@ -273,7 +271,7 @@ TEST_CASE("LexicalAnalyzer_Colon") {
             fkyaml::detail::str_view(":}"),
             fkyaml::detail::str_view(":["),
             fkyaml::detail::str_view(":]"));
-        lexer_t lexer(input);
+        fkyaml::detail::lexical_analyzer lexer(input);
         REQUIRE_NOTHROW(token = lexer.get_next_token());
         REQUIRE(token.type == fkyaml::detail::lexical_token_t::PLAIN_SCALAR);
         REQUIRE(token.str == input);
@@ -286,7 +284,7 @@ TEST_CASE("LexicalAnalyzer_Colon") {
             fkyaml::detail::str_view("{:}"),
             fkyaml::detail::str_view("{:["),
             fkyaml::detail::str_view("{:]"));
-        lexer_t lexer(input);
+        fkyaml::detail::lexical_analyzer lexer(input);
         REQUIRE_NOTHROW(token = lexer.get_next_token());
         REQUIRE(token.type == fkyaml::detail::lexical_token_t::MAPPING_FLOW_BEGIN);
         REQUIRE_NOTHROW(token = lexer.get_next_token());
@@ -299,7 +297,7 @@ TEST_CASE("LexicalAnalzer_BlockSequenceEntryPrefix") {
         fkyaml::detail::str_view("- foo"), fkyaml::detail::str_view("-\tfoo"), fkyaml::detail::str_view("-\n  foo"));
 
     fkyaml::detail::lexical_token token;
-    lexer_t lexer(input);
+    fkyaml::detail::lexical_analyzer lexer(input);
     REQUIRE_NOTHROW(token = lexer.get_next_token());
     REQUIRE(token.type == fkyaml::detail::lexical_token_t::SEQUENCE_BLOCK_PREFIX);
     REQUIRE_NOTHROW(token = lexer.get_next_token());
@@ -354,7 +352,7 @@ TEST_CASE("LexicalAnalyzer_PlainScalar") {
         value_pair_t(".NaNValue", ".NaNValue"),
         value_pair_t(".NAN_VALUE", ".NAN_VALUE"));
 
-    lexer_t lexer(value_pair.first);
+    fkyaml::detail::lexical_analyzer lexer(value_pair.first);
     fkyaml::detail::lexical_token token;
 
     REQUIRE_NOTHROW(token = lexer.get_next_token());
@@ -383,7 +381,7 @@ TEST_CASE("LexicalAnalyzer_SingleQuotedScalar") {
         value_pair_t("\'\nfoo\n\n \t\nbar\'", " foo\n\nbar"),
         value_pair_t("\'foo\nbar\n\'", "foo bar "));
 
-    lexer_t lexer(value_pair.first);
+    fkyaml::detail::lexical_analyzer lexer(value_pair.first);
     fkyaml::detail::lexical_token token;
 
     REQUIRE_NOTHROW(token = lexer.get_next_token());
@@ -413,7 +411,7 @@ TEST_CASE("LexicalAnalyzer_DoubleQuotedScalar") {
         value_pair_t("\"foo \t\\\nbar\"", "foo \tbar"),
         value_pair_t("\"\\\n  foo \t\\\n\tbar\t  \t\\\n\"", "foo \tbar\t  \t"));
 
-    lexer_t lexer(value_pair.first);
+    fkyaml::detail::lexical_analyzer lexer(value_pair.first);
     fkyaml::detail::lexical_token token;
 
     REQUIRE_NOTHROW(token = lexer.get_next_token());
@@ -470,7 +468,7 @@ TEST_CASE("LexicalAnalyzer_MultiByteCharString") {
             char_traits_t::to_char_type(0xBF)});
 
     fkyaml::detail::str_view input(mb_char);
-    lexer_t lexer(input);
+    fkyaml::detail::lexical_analyzer lexer(input);
     fkyaml::detail::lexical_token token;
 
     REQUIRE_NOTHROW(token = lexer.get_next_token());
@@ -534,7 +532,7 @@ TEST_CASE("LexicalAnalyzer_EscapedUnicodeCharacter") {
              char_traits_t::to_char_type(0xBF),
              char_traits_t::to_char_type(0xBF)}));
 
-    lexer_t lexer(value_pair.first);
+    fkyaml::detail::lexical_analyzer lexer(value_pair.first);
     fkyaml::detail::lexical_token token;
 
     REQUIRE_NOTHROW(token = lexer.get_next_token());
@@ -554,12 +552,12 @@ TEST_CASE("LexicalAnalyzer_InvalidString") {
             fkyaml::detail::str_view("\"\\x{\""),
             fkyaml::detail::str_view("\"\\Q\""));
 
-        lexer_t lexer(buffer);
+        fkyaml::detail::lexical_analyzer lexer(buffer);
         REQUIRE_THROWS_AS(lexer.get_next_token(), fkyaml::parse_error);
     }
 
     SECTION("invalid encoding") {
-        lexer_t lexer("\"\\U00110000\"");
+        fkyaml::detail::lexical_analyzer lexer("\"\\U00110000\"");
         REQUIRE_THROWS_AS(lexer.get_next_token(), fkyaml::invalid_encoding);
     }
 }
@@ -597,7 +595,7 @@ TEST_CASE("LexicalAnalyzer_UnescapedControlCharacter") {
     std::string buffer("test");
     buffer.push_back(unescaped_char);
 
-    lexer_t lexer(buffer);
+    fkyaml::detail::lexical_analyzer lexer(buffer);
     REQUIRE_THROWS_AS(lexer.get_next_token(), fkyaml::parse_error);
 }
 
@@ -607,7 +605,7 @@ TEST_CASE("LexicalAnalyzer_LiteralStringScalar") {
     SECTION("empty literal string scalar with strip chomping") {
         const char input[] = "|-\n"
                              "  \n";
-        lexer_t lexer(input);
+        fkyaml::detail::lexical_analyzer lexer(input);
 
         REQUIRE_NOTHROW(token = lexer.get_next_token());
         REQUIRE(token.type == fkyaml::detail::lexical_token_t::BLOCK_SCALAR);
@@ -617,7 +615,7 @@ TEST_CASE("LexicalAnalyzer_LiteralStringScalar") {
     SECTION("empty literal string scalar with clip chomping") {
         const char input[] = "|\n"
                              "  \n";
-        lexer_t lexer(input);
+        fkyaml::detail::lexical_analyzer lexer(input);
 
         REQUIRE_NOTHROW(token = lexer.get_next_token());
         REQUIRE(token.type == fkyaml::detail::lexical_token_t::BLOCK_SCALAR);
@@ -627,7 +625,7 @@ TEST_CASE("LexicalAnalyzer_LiteralStringScalar") {
     SECTION("empty literal string scalar with keep chomping") {
         const char input[] = "|+\n"
                              "  \n";
-        lexer_t lexer(input);
+        fkyaml::detail::lexical_analyzer lexer(input);
 
         REQUIRE_NOTHROW(token = lexer.get_next_token());
         REQUIRE(token.type == fkyaml::detail::lexical_token_t::BLOCK_SCALAR);
@@ -638,7 +636,7 @@ TEST_CASE("LexicalAnalyzer_LiteralStringScalar") {
         const char input[] = "|0\n"
                              "foo";
 
-        lexer_t lexer(input);
+        fkyaml::detail::lexical_analyzer lexer(input);
         REQUIRE_THROWS_AS(lexer.get_next_token(), fkyaml::parse_error);
     }
 
@@ -646,7 +644,7 @@ TEST_CASE("LexicalAnalyzer_LiteralStringScalar") {
         const char input[] = "|2\n"
                              " foo";
 
-        lexer_t lexer(input);
+        fkyaml::detail::lexical_analyzer lexer(input);
         REQUIRE_THROWS_AS(lexer.get_next_token(), fkyaml::parse_error);
     }
 
@@ -654,7 +652,7 @@ TEST_CASE("LexicalAnalyzer_LiteralStringScalar") {
         const char input[] = "|2\n"
                              "    foo\n"
                              "  bar\n";
-        lexer_t lexer(input);
+        fkyaml::detail::lexical_analyzer lexer(input);
 
         REQUIRE_NOTHROW(token = lexer.get_next_token());
         REQUIRE(token.type == fkyaml::detail::lexical_token_t::BLOCK_SCALAR);
@@ -665,7 +663,7 @@ TEST_CASE("LexicalAnalyzer_LiteralStringScalar") {
         const char input[] = "|\n"
                              "  foo\n"
                              "  bar\n";
-        lexer_t lexer(input);
+        fkyaml::detail::lexical_analyzer lexer(input);
 
         REQUIRE_NOTHROW(token = lexer.get_next_token());
         REQUIRE(token.type == fkyaml::detail::lexical_token_t::BLOCK_SCALAR);
@@ -680,7 +678,7 @@ TEST_CASE("LexicalAnalyzer_LiteralStringScalar") {
                              "\n"
                              "  baz\n"
                              "\n";
-        lexer_t lexer(input);
+        fkyaml::detail::lexical_analyzer lexer(input);
 
         REQUIRE_NOTHROW(token = lexer.get_next_token());
         REQUIRE(token.type == fkyaml::detail::lexical_token_t::BLOCK_SCALAR);
@@ -694,7 +692,7 @@ TEST_CASE("LexicalAnalyzer_LiteralStringScalar") {
                              "\n"
                              "  baz\n"
                              "\n";
-        lexer_t lexer(input);
+        fkyaml::detail::lexical_analyzer lexer(input);
 
         REQUIRE_NOTHROW(token = lexer.get_next_token());
         REQUIRE(token.type == fkyaml::detail::lexical_token_t::BLOCK_SCALAR);
@@ -709,7 +707,7 @@ TEST_CASE("LexicalAnalyzer_LiteralStringScalar") {
                              "\n"
                              "  baz\n"
                              "\n";
-        lexer_t lexer(input);
+        fkyaml::detail::lexical_analyzer lexer(input);
 
         REQUIRE_NOTHROW(token = lexer.get_next_token());
         REQUIRE(token.type == fkyaml::detail::lexical_token_t::BLOCK_SCALAR);
@@ -723,7 +721,7 @@ TEST_CASE("LexicalAnalyzer_LiteralStringScalar") {
                              "\n"
                              "  baz\n"
                              "\n";
-        lexer_t lexer(input);
+        fkyaml::detail::lexical_analyzer lexer(input);
 
         REQUIRE_NOTHROW(token = lexer.get_next_token());
         REQUIRE(token.type == fkyaml::detail::lexical_token_t::BLOCK_SCALAR);
@@ -736,7 +734,7 @@ TEST_CASE("LexicalAnalyzer_LiteralStringScalar") {
                              "    bar\n"
                              "\n"
                              "  baz";
-        lexer_t lexer(input);
+        fkyaml::detail::lexical_analyzer lexer(input);
 
         REQUIRE_NOTHROW(token = lexer.get_next_token());
         REQUIRE(token.type == fkyaml::detail::lexical_token_t::BLOCK_SCALAR);
@@ -751,7 +749,7 @@ TEST_CASE("LexicalAnalyzer_LiteralStringScalar") {
                              "\n"
                              "  baz\n"
                              "\n";
-        lexer_t lexer(input);
+        fkyaml::detail::lexical_analyzer lexer(input);
 
         REQUIRE_NOTHROW(token = lexer.get_next_token());
         REQUIRE(token.type == fkyaml::detail::lexical_token_t::BLOCK_SCALAR);
@@ -765,7 +763,7 @@ TEST_CASE("LexicalAnalyzer_LiteralStringScalar") {
                              "\n"
                              "  baz\n"
                              "\n";
-        lexer_t lexer(input);
+        fkyaml::detail::lexical_analyzer lexer(input);
 
         REQUIRE_NOTHROW(token = lexer.get_next_token());
         REQUIRE(token.type == fkyaml::detail::lexical_token_t::BLOCK_SCALAR);
@@ -777,7 +775,7 @@ TEST_CASE("LexicalAnalyzer_LiteralStringScalar") {
             fkyaml::detail::str_view("|2  \n  foo\n"),
             fkyaml::detail::str_view("|2\t\t\n  foo\n"),
             fkyaml::detail::str_view("|2 # comment\n  foo\n"));
-        lexer_t lexer(input);
+        fkyaml::detail::lexical_analyzer lexer(input);
 
         REQUIRE_NOTHROW(token = lexer.get_next_token());
         REQUIRE(token.type == fkyaml::detail::lexical_token_t::BLOCK_SCALAR);
@@ -794,7 +792,7 @@ TEST_CASE("LexicalAnalyzer_LiteralStringScalar") {
             fkyaml::detail::str_view("|+11\n           foo"),
             fkyaml::detail::str_view("|invalid\n  foo"));
 
-        lexer_t lexer(input);
+        fkyaml::detail::lexical_analyzer lexer(input);
         REQUIRE_THROWS_AS(token = lexer.get_next_token(), fkyaml::parse_error);
     }
 }
@@ -805,7 +803,7 @@ TEST_CASE("LexicalAnalyzer_FoldedString") {
     SECTION("empty folded string scalar with strip chomping") {
         const char input[] = ">-\n"
                              "  \n";
-        lexer_t lexer(input);
+        fkyaml::detail::lexical_analyzer lexer(input);
 
         REQUIRE_NOTHROW(token = lexer.get_next_token());
         REQUIRE(token.type == fkyaml::detail::lexical_token_t::BLOCK_SCALAR);
@@ -815,7 +813,7 @@ TEST_CASE("LexicalAnalyzer_FoldedString") {
     SECTION("empty folded string scalar with clip chomping") {
         const char input[] = ">\n"
                              "  \n";
-        lexer_t lexer(input);
+        fkyaml::detail::lexical_analyzer lexer(input);
 
         REQUIRE_NOTHROW(token = lexer.get_next_token());
         REQUIRE(token.type == fkyaml::detail::lexical_token_t::BLOCK_SCALAR);
@@ -825,7 +823,7 @@ TEST_CASE("LexicalAnalyzer_FoldedString") {
     SECTION("empty folded string scalar with keep chomping") {
         const char input[] = ">+\n"
                              "  \n";
-        lexer_t lexer(input);
+        fkyaml::detail::lexical_analyzer lexer(input);
 
         REQUIRE_NOTHROW(token = lexer.get_next_token());
         REQUIRE(token.type == fkyaml::detail::lexical_token_t::BLOCK_SCALAR);
@@ -836,7 +834,7 @@ TEST_CASE("LexicalAnalyzer_FoldedString") {
         const char input[] = "|0\n"
                              "foo";
 
-        lexer_t lexer(input);
+        fkyaml::detail::lexical_analyzer lexer(input);
         REQUIRE_THROWS_AS(lexer.get_next_token(), fkyaml::parse_error);
     }
 
@@ -844,7 +842,7 @@ TEST_CASE("LexicalAnalyzer_FoldedString") {
         const char input[] = ">2\n"
                              " foo";
 
-        lexer_t lexer(input);
+        fkyaml::detail::lexical_analyzer lexer(input);
         REQUIRE_THROWS_AS(lexer.get_next_token(), fkyaml::parse_error);
     }
 
@@ -852,7 +850,7 @@ TEST_CASE("LexicalAnalyzer_FoldedString") {
         const char input[] = ">2\n"
                              "    foo\n"
                              "  bar\n";
-        lexer_t lexer(input);
+        fkyaml::detail::lexical_analyzer lexer(input);
 
         REQUIRE_NOTHROW(token = lexer.get_next_token());
         REQUIRE(token.type == fkyaml::detail::lexical_token_t::BLOCK_SCALAR);
@@ -863,7 +861,7 @@ TEST_CASE("LexicalAnalyzer_FoldedString") {
         const char input[] = ">2\n"
                              "  foo\n"
                              "    bar\n";
-        lexer_t lexer(input);
+        fkyaml::detail::lexical_analyzer lexer(input);
 
         REQUIRE_NOTHROW(token = lexer.get_next_token());
         REQUIRE(token.type == fkyaml::detail::lexical_token_t::BLOCK_SCALAR);
@@ -877,7 +875,7 @@ TEST_CASE("LexicalAnalyzer_FoldedString") {
                              "\n"
                              "  bar\n"
                              " \n";
-        lexer_t lexer(input);
+        fkyaml::detail::lexical_analyzer lexer(input);
 
         REQUIRE_NOTHROW(token = lexer.get_next_token());
         REQUIRE(token.type == fkyaml::detail::lexical_token_t::BLOCK_SCALAR);
@@ -890,7 +888,7 @@ TEST_CASE("LexicalAnalyzer_FoldedString") {
                              "  bar\n"
                              " \n"
                              "\n";
-        lexer_t lexer(input);
+        fkyaml::detail::lexical_analyzer lexer(input);
 
         REQUIRE_NOTHROW(token = lexer.get_next_token());
         REQUIRE(token.type == fkyaml::detail::lexical_token_t::BLOCK_SCALAR);
@@ -903,7 +901,7 @@ TEST_CASE("LexicalAnalyzer_FoldedString") {
                              "  bar\n"
                              "  \n"
                              "\n";
-        lexer_t lexer(input);
+        fkyaml::detail::lexical_analyzer lexer(input);
 
         REQUIRE_NOTHROW(token = lexer.get_next_token());
         REQUIRE(token.type == fkyaml::detail::lexical_token_t::BLOCK_SCALAR);
@@ -916,7 +914,7 @@ TEST_CASE("LexicalAnalyzer_FoldedString") {
                              "  bar\n"
                              " \n"
                              "\n";
-        lexer_t lexer(input);
+        fkyaml::detail::lexical_analyzer lexer(input);
 
         REQUIRE_NOTHROW(token = lexer.get_next_token());
         REQUIRE(token.type == fkyaml::detail::lexical_token_t::BLOCK_SCALAR);
@@ -928,7 +926,7 @@ TEST_CASE("LexicalAnalyzer_FoldedString") {
             fkyaml::detail::str_view(">2  \n  foo\n"),
             fkyaml::detail::str_view(">2\t\t\n  foo\n"),
             fkyaml::detail::str_view(">2 # comment\n  foo\n"));
-        lexer_t lexer(input);
+        fkyaml::detail::lexical_analyzer lexer(input);
 
         REQUIRE_NOTHROW(token = lexer.get_next_token());
         REQUIRE(token.type == fkyaml::detail::lexical_token_t::BLOCK_SCALAR);
@@ -945,7 +943,7 @@ TEST_CASE("LexicalAnalyzer_FoldedString") {
             fkyaml::detail::str_view(">+11\n           foo"),
             fkyaml::detail::str_view(">invalid\n  foo"));
 
-        lexer_t lexer(input);
+        fkyaml::detail::lexical_analyzer lexer(input);
         REQUIRE_THROWS_AS(token = lexer.get_next_token(), fkyaml::parse_error);
     }
 }
@@ -968,7 +966,7 @@ TEST_CASE("LexicalAnalyzer_Anchor") {
             test_data_t {"&anchor: ", "anchor:"},
             test_data_t {"&anchor:", "anchor:"});
 
-        lexer_t lexer(test_data.first);
+        fkyaml::detail::lexical_analyzer lexer(test_data.first);
 
         REQUIRE_NOTHROW(token = lexer.get_next_token());
         REQUIRE(token.type == fkyaml::detail::lexical_token_t::ANCHOR_PREFIX);
@@ -987,7 +985,7 @@ TEST_CASE("LexicalAnalyzer_Anchor") {
             fkyaml::detail::str_view("&]"),
             fkyaml::detail::str_view("&,"));
 
-        lexer_t lexer(input);
+        fkyaml::detail::lexical_analyzer lexer(input);
         REQUIRE_THROWS_AS(lexer.get_next_token(), fkyaml::parse_error);
     }
 }
@@ -1010,7 +1008,7 @@ TEST_CASE("LexicalAnalyzer_Alias") {
             test_data_t {"*anchor: ", "anchor:"},
             test_data_t {"*anchor:", "anchor:"});
 
-        lexer_t lexer(test_data.first);
+        fkyaml::detail::lexical_analyzer lexer(test_data.first);
 
         REQUIRE_NOTHROW(token = lexer.get_next_token());
         REQUIRE(token.type == fkyaml::detail::lexical_token_t::ALIAS_PREFIX);
@@ -1029,7 +1027,7 @@ TEST_CASE("LexicalAnalyzer_Alias") {
             fkyaml::detail::str_view("*]"),
             fkyaml::detail::str_view("*,"));
 
-        lexer_t lexer(input);
+        fkyaml::detail::lexical_analyzer lexer(input);
         REQUIRE_THROWS_AS(lexer.get_next_token(), fkyaml::parse_error);
     }
 }
@@ -1051,7 +1049,7 @@ TEST_CASE("LexicalAnalyzer_Tag") {
             fkyaml::detail::str_view("!<!foo%2A%7C> tag"),
             fkyaml::detail::str_view("!foo!bar tag"));
 
-        lexer_t lexer(input);
+        fkyaml::detail::lexical_analyzer lexer(input);
         REQUIRE_NOTHROW(token = lexer.get_next_token());
         REQUIRE(token.type == fkyaml::detail::lexical_token_t::TAG_PREFIX);
         REQUIRE(token.str == input.substr(0, input.size() - 4));
@@ -1068,7 +1066,7 @@ TEST_CASE("LexicalAnalyzer_Tag") {
             fkyaml::detail::str_view("!foo!bar"),
             fkyaml::detail::str_view("!foo"));
 
-        lexer_t lexer(input);
+        fkyaml::detail::lexical_analyzer lexer(input);
         REQUIRE_NOTHROW(token = lexer.get_next_token());
         REQUIRE(token.type == fkyaml::detail::lexical_token_t::TAG_PREFIX);
         REQUIRE(token.str == input);
@@ -1085,19 +1083,19 @@ TEST_CASE("LexicalAnalyzer_Tag") {
             fkyaml::detail::str_view("!foo! tag"),
             fkyaml::detail::str_view("!foo!%f:oo tag"));
 
-        lexer_t lexer(input);
+        fkyaml::detail::lexical_analyzer lexer(input);
         REQUIRE_THROWS_AS(token = lexer.get_next_token(), fkyaml::parse_error);
     }
 }
 
 TEST_CASE("LexicalAnalyzer_ReservedIndicator") {
     auto buffer = GENERATE(fkyaml::detail::str_view("@invalid"), fkyaml::detail::str_view("`invalid"));
-    lexer_t lexer(buffer);
+    fkyaml::detail::lexical_analyzer lexer(buffer);
     REQUIRE_THROWS_AS(lexer.get_next_token(), fkyaml::parse_error);
 }
 
 TEST_CASE("LexicalAnalyzer_KeyBooleanValuePair") {
-    lexer_t lexer("test: true");
+    fkyaml::detail::lexical_analyzer lexer("test: true");
     fkyaml::detail::lexical_token token;
 
     REQUIRE_NOTHROW(token = lexer.get_next_token());
@@ -1116,7 +1114,7 @@ TEST_CASE("LexicalAnalyzer_KeyBooleanValuePair") {
 }
 
 TEST_CASE("LexicalAnalyzer_KeyIntegerValuePair") {
-    lexer_t lexer("test: -5784");
+    fkyaml::detail::lexical_analyzer lexer("test: -5784");
     fkyaml::detail::lexical_token token;
 
     REQUIRE_NOTHROW(token = lexer.get_next_token());
@@ -1135,7 +1133,7 @@ TEST_CASE("LexicalAnalyzer_KeyIntegerValuePair") {
 }
 
 TEST_CASE("LexicalAnalyzer_KeyFloatNumberValuePair") {
-    lexer_t lexer("test: -5.58e-3");
+    fkyaml::detail::lexical_analyzer lexer("test: -5.58e-3");
     fkyaml::detail::lexical_token token;
 
     REQUIRE_NOTHROW(token = lexer.get_next_token());
@@ -1154,7 +1152,7 @@ TEST_CASE("LexicalAnalyzer_KeyFloatNumberValuePair") {
 }
 
 TEST_CASE("LexicalAnalyzer_KeyStringValuePair") {
-    lexer_t lexer("test: \"some value\"");
+    fkyaml::detail::lexical_analyzer lexer("test: \"some value\"");
     fkyaml::detail::lexical_token token;
 
     REQUIRE_NOTHROW(token = lexer.get_next_token());
@@ -1176,7 +1174,7 @@ TEST_CASE("LexicalAnalyzer_FlowSequence") {
     fkyaml::detail::lexical_token token;
 
     SECTION("simple flow sequence") {
-        lexer_t lexer("test: [ foo, bar ]");
+        fkyaml::detail::lexical_analyzer lexer("test: [ foo, bar ]");
 
         REQUIRE_NOTHROW(token = lexer.get_next_token());
         REQUIRE(token.type == fkyaml::detail::lexical_token_t::PLAIN_SCALAR);
@@ -1207,7 +1205,7 @@ TEST_CASE("LexicalAnalyzer_FlowSequence") {
     }
 
     SECTION("flow sequence with flow mapping child nodes") {
-        lexer_t lexer("test: [ { foo: one, bar: false }, { foo: two, bar: true } ]");
+        fkyaml::detail::lexical_analyzer lexer("test: [ { foo: one, bar: false }, { foo: two, bar: true } ]");
 
         REQUIRE_NOTHROW(token = lexer.get_next_token());
         REQUIRE(token.type == fkyaml::detail::lexical_token_t::PLAIN_SCALAR);
@@ -1296,7 +1294,7 @@ TEST_CASE("LexicalAnalyzer_FlowMapping") {
     fkyaml::detail::lexical_token token;
 
     SECTION("simple flow mapping") {
-        lexer_t lexer("test: { bool : true, foo :b: bar, pi: 3.14 }");
+        fkyaml::detail::lexical_analyzer lexer("test: { bool : true, foo :b: bar, pi: 3.14 }");
 
         REQUIRE_NOTHROW(token = lexer.get_next_token());
         REQUIRE(token.type == fkyaml::detail::lexical_token_t::PLAIN_SCALAR);
@@ -1355,7 +1353,7 @@ TEST_CASE("LexicalAnalyzer_FlowMapping") {
     }
 
     SECTION("flow maping with a child mapping node") {
-        lexer_t lexer("test: {foo: bar baz}");
+        fkyaml::detail::lexical_analyzer lexer("test: {foo: bar baz}");
 
         REQUIRE_NOTHROW(token = lexer.get_next_token());
         REQUIRE(token.type == fkyaml::detail::lexical_token_t::PLAIN_SCALAR);
@@ -1390,7 +1388,7 @@ TEST_CASE("LexicalAnalyzer_BlockSequence") {
     fkyaml::detail::lexical_token token;
 
     SECTION("simple block sequence") {
-        lexer_t lexer("test:\n  - foo\n  - bar");
+        fkyaml::detail::lexical_analyzer lexer("test:\n  - foo\n  - bar");
 
         REQUIRE_NOTHROW(token = lexer.get_next_token());
         REQUIRE(token.type == fkyaml::detail::lexical_token_t::PLAIN_SCALAR);
@@ -1418,7 +1416,7 @@ TEST_CASE("LexicalAnalyzer_BlockSequence") {
     }
 
     SECTION("block sequence with block mapping child nodes") {
-        lexer_t lexer("test:\n  - foo: one\n    bar: false\n  - foo: two\n    bar: true");
+        fkyaml::detail::lexical_analyzer lexer("test:\n  - foo: one\n    bar: false\n  - foo: two\n    bar: true");
 
         REQUIRE_NOTHROW(token = lexer.get_next_token());
         REQUIRE(token.type == fkyaml::detail::lexical_token_t::PLAIN_SCALAR);
@@ -1486,7 +1484,7 @@ TEST_CASE("LexicalAnalyzer_BlockMapping") {
     fkyaml::detail::lexical_token token;
 
     SECTION("simple block mapping") {
-        lexer_t lexer("test:\n  bool: true\n  foo: \'bar\'\n  pi: 3.14");
+        fkyaml::detail::lexical_analyzer lexer("test:\n  bool: true\n  foo: \'bar\'\n  pi: 3.14");
 
         REQUIRE_NOTHROW(token = lexer.get_next_token());
         REQUIRE(token.type == fkyaml::detail::lexical_token_t::PLAIN_SCALAR);
@@ -1533,7 +1531,7 @@ TEST_CASE("LexicalAnalyzer_BlockMapping") {
     }
 
     SECTION("block mapping with a literal string scalar value") {
-        lexer_t lexer("test: |\n  a literal scalar.\nfoo: \'bar\'\npi: 3.14");
+        fkyaml::detail::lexical_analyzer lexer("test: |\n  a literal scalar.\nfoo: \'bar\'\npi: 3.14");
 
         REQUIRE_NOTHROW(token = lexer.get_next_token());
         REQUIRE(token.type == fkyaml::detail::lexical_token_t::PLAIN_SCALAR);
@@ -1573,7 +1571,7 @@ TEST_CASE("LexicalAnalyzer_BlockMapping") {
     }
 
     SECTION("block mapping with a folded string scalar value") {
-        lexer_t lexer("test: >\n  a literal scalar.\nfoo: \'bar\'\npi: 3.14");
+        fkyaml::detail::lexical_analyzer lexer("test: >\n  a literal scalar.\nfoo: \'bar\'\npi: 3.14");
 
         REQUIRE_NOTHROW(token = lexer.get_next_token());
         REQUIRE(token.type == fkyaml::detail::lexical_token_t::PLAIN_SCALAR);

--- a/test/unit_test/test_lexical_analyzer_class.cpp
+++ b/test/unit_test/test_lexical_analyzer_class.cpp
@@ -16,18 +16,18 @@ TEST_CASE("LexicalAnalyzer_YamlVersionDirective") {
     fkyaml::detail::lexical_token token;
 
     SECTION("valid YAML directive") {
-        using value_pair_t = std::pair<std::string, std::string>;
+        using value_pair_t = std::pair<fkyaml::detail::str_view, std::string>;
         auto value_pair = GENERATE(
-            value_pair_t(std::string("%YAML 1.1 "), std::string("1.1")),
-            value_pair_t(std::string("%YAML\t1.1\t"), std::string("1.1")),
-            value_pair_t(std::string("%YAML 1.1\n"), std::string("1.1")),
-            value_pair_t(std::string("%YAML 1.1"), std::string("1.1")),
-            value_pair_t(std::string("%YAML 1.2 "), std::string("1.2")),
-            value_pair_t(std::string("%YAML\t1.2\t"), std::string("1.2")),
-            value_pair_t(std::string("%YAML 1.2\n"), std::string("1.2")),
-            value_pair_t(std::string("%YAML 1.2"), std::string("1.2")));
+            value_pair_t("%YAML 1.1 ", std::string("1.1")),
+            value_pair_t("%YAML\t1.1\t", std::string("1.1")),
+            value_pair_t("%YAML 1.1\n", std::string("1.1")),
+            value_pair_t("%YAML 1.1", std::string("1.1")),
+            value_pair_t("%YAML 1.2 ", std::string("1.2")),
+            value_pair_t("%YAML\t1.2\t", std::string("1.2")),
+            value_pair_t("%YAML 1.2\n", std::string("1.2")),
+            value_pair_t("%YAML 1.2", std::string("1.2")));
 
-        lexer_t lexer(fkyaml::detail::input_adapter(value_pair.first));
+        lexer_t lexer(value_pair.first);
 
         REQUIRE_NOTHROW(token = lexer.get_next_token());
         REQUIRE(token.type == fkyaml::detail::lexical_token_t::YAML_VER_DIRECTIVE);
@@ -38,9 +38,12 @@ TEST_CASE("LexicalAnalyzer_YamlVersionDirective") {
     }
 
     SECTION("wrong YAML directive") {
-        auto buffer = GENERATE(std::string("%YUML 1.2"), std::string("%YANL 1.2    \n"), std::string("%YAML1.2"));
+        auto buffer = GENERATE(
+            fkyaml::detail::str_view("%YUML 1.2"),
+            fkyaml::detail::str_view("%YANL 1.2    \n"),
+            fkyaml::detail::str_view("%YAML1.2"));
 
-        lexer_t lexer(fkyaml::detail::input_adapter(buffer));
+        lexer_t lexer(buffer);
         REQUIRE_NOTHROW(token = lexer.get_next_token());
         REQUIRE(token.type == fkyaml::detail::lexical_token_t::INVALID_DIRECTIVE);
 
@@ -50,16 +53,16 @@ TEST_CASE("LexicalAnalyzer_YamlVersionDirective") {
 
     SECTION("invalid YAML directive value") {
         auto buffer = GENERATE(
-            std::string("%YAML 1.3\n"),
-            std::string("%YAML 2.0\n"),
-            std::string("%YAML 12"),
-            std::string("%YAML 123"),
-            std::string("%YAML 1.23"),
-            std::string("%YAML 1.11"),
-            std::string("%YAML 1.A"),
-            std::string("%YAML AbC"));
+            fkyaml::detail::str_view("%YAML 1.3\n"),
+            fkyaml::detail::str_view("%YAML 2.0\n"),
+            fkyaml::detail::str_view("%YAML 12"),
+            fkyaml::detail::str_view("%YAML 123"),
+            fkyaml::detail::str_view("%YAML 1.23"),
+            fkyaml::detail::str_view("%YAML 1.11"),
+            fkyaml::detail::str_view("%YAML 1.A"),
+            fkyaml::detail::str_view("%YAML AbC"));
 
-        lexer_t lexer(fkyaml::detail::input_adapter(buffer));
+        lexer_t lexer(buffer);
         REQUIRE_THROWS_AS(lexer.get_next_token(), fkyaml::parse_error);
     }
 }
@@ -68,8 +71,8 @@ TEST_CASE("LexicalAnalyzer_TagDirective") {
     fkyaml::detail::lexical_token token;
 
     SECTION("primary tag handle") {
-        auto input = GENERATE(std::string("%TAG ! foo"), std::string("%TAG\t!\tfoo"));
-        lexer_t lexer(fkyaml::detail::input_adapter(input));
+        auto input = GENERATE(fkyaml::detail::str_view("%TAG ! foo"), fkyaml::detail::str_view("%TAG\t!\tfoo"));
+        lexer_t lexer(input);
 
         REQUIRE_NOTHROW(token = lexer.get_next_token());
         REQUIRE(token.type == fkyaml::detail::lexical_token_t::TAG_DIRECTIVE);
@@ -80,8 +83,8 @@ TEST_CASE("LexicalAnalyzer_TagDirective") {
     }
 
     SECTION("secondary tag handle") {
-        auto input = GENERATE(std::string("%TAG !! foo"), std::string("%TAG\t!!\tfoo"));
-        lexer_t lexer(fkyaml::detail::input_adapter(input));
+        auto input = GENERATE(fkyaml::detail::str_view("%TAG !! foo"), fkyaml::detail::str_view("%TAG\t!!\tfoo"));
+        lexer_t lexer(input);
 
         REQUIRE_NOTHROW(token = lexer.get_next_token());
         REQUIRE(token.type == fkyaml::detail::lexical_token_t::TAG_DIRECTIVE);
@@ -92,8 +95,9 @@ TEST_CASE("LexicalAnalyzer_TagDirective") {
     }
 
     SECTION("named tag handle") {
-        auto input = GENERATE(std::string("%TAG !va1id-ta9! foo"), std::string("%TAG\t!va1id-ta9!\tfoo"));
-        lexer_t lexer(fkyaml::detail::input_adapter(input));
+        auto input = GENERATE(
+            fkyaml::detail::str_view("%TAG !va1id-ta9! foo"), fkyaml::detail::str_view("%TAG\t!va1id-ta9!\tfoo"));
+        lexer_t lexer(input);
 
         REQUIRE_NOTHROW(token = lexer.get_next_token());
         REQUIRE(token.type == fkyaml::detail::lexical_token_t::TAG_DIRECTIVE);
@@ -104,9 +108,10 @@ TEST_CASE("LexicalAnalyzer_TagDirective") {
     }
 
     SECTION("invalid TAG directive") {
-        auto buffer = GENERATE(std::string("%TUB"), std::string("%TAC"), std::string("%TAGE"));
+        auto buffer = GENERATE(
+            fkyaml::detail::str_view("%TUB"), fkyaml::detail::str_view("%TAC"), fkyaml::detail::str_view("%TAGE"));
 
-        lexer_t lexer(fkyaml::detail::input_adapter(buffer));
+        lexer_t lexer(buffer);
         REQUIRE_NOTHROW(token = lexer.get_next_token());
         REQUIRE(token.type == fkyaml::detail::lexical_token_t::INVALID_DIRECTIVE);
         REQUIRE_NOTHROW(token = lexer.get_next_token());
@@ -115,49 +120,52 @@ TEST_CASE("LexicalAnalyzer_TagDirective") {
 
     SECTION("invalid tag handle") {
         auto input = GENERATE(
-            std::string("%TAG foo bar"),
-            std::string("%TAG !!abc bar"),
-            std::string("%TAG !"),
-            std::string("%TAG !!"),
-            std::string("%TAG !valid!"),
-            std::string("%TAG !invalid"),
-            std::string("%TAG !invalid bar"),
-            std::string("%TAG !invalid\tbar"),
-            std::string("%TAG !inv@lid! bar"),
-            std::string("%TAG !invalid!tag bar"),
-            std::string("%TAG !invalid"));
+            fkyaml::detail::str_view("%TAG foo bar"),
+            fkyaml::detail::str_view("%TAG !!abc bar"),
+            fkyaml::detail::str_view("%TAG !"),
+            fkyaml::detail::str_view("%TAG !!"),
+            fkyaml::detail::str_view("%TAG !valid!"),
+            fkyaml::detail::str_view("%TAG !invalid"),
+            fkyaml::detail::str_view("%TAG !invalid bar"),
+            fkyaml::detail::str_view("%TAG !invalid\tbar"),
+            fkyaml::detail::str_view("%TAG !inv@lid! bar"),
+            fkyaml::detail::str_view("%TAG !invalid!tag bar"),
+            fkyaml::detail::str_view("%TAG !invalid"));
 
-        lexer_t lexer(fkyaml::detail::input_adapter(input));
+        lexer_t lexer(input);
         REQUIRE_THROWS_AS(lexer.get_next_token(), fkyaml::parse_error);
     }
 
     SECTION("invalid tag prefix") {
         auto input = GENERATE(
-            std::string("%TAG ! [invalid"),
-            std::string("%TAG !! ]invalid"),
-            std::string("%TAG !valid! {invalid"),
-            std::string("%TAG !valid! }invalid"),
-            std::string("%TAG !valid! ,invalid"),
-            std::string("%TAG !valid! %prefix"));
+            fkyaml::detail::str_view("%TAG ! [invalid"),
+            fkyaml::detail::str_view("%TAG !! ]invalid"),
+            fkyaml::detail::str_view("%TAG !valid! {invalid"),
+            fkyaml::detail::str_view("%TAG !valid! }invalid"),
+            fkyaml::detail::str_view("%TAG !valid! ,invalid"),
+            fkyaml::detail::str_view("%TAG !valid! %prefix"));
 
-        lexer_t lexer(fkyaml::detail::input_adapter(input));
+        lexer_t lexer(input);
         REQUIRE_THROWS_AS(lexer.get_next_token(), fkyaml::parse_error);
     }
 }
 
 TEST_CASE("LexicalAnalyzer_InvalidDirective") {
-    auto buffer = GENERATE(std::string("%TAG"), std::string("%YAML"));
+    auto buffer = GENERATE(fkyaml::detail::str_view("%TAG"), fkyaml::detail::str_view("%YAML"));
 
-    lexer_t lexer(fkyaml::detail::input_adapter(buffer));
+    lexer_t lexer(buffer);
     REQUIRE_THROWS_AS(lexer.get_next_token(), fkyaml::parse_error);
 }
 
 TEST_CASE("LexicalAnalyzer_ReservedDirective") {
-    auto buffer =
-        GENERATE(std::string("%TEST\n"), std::string("%1984\n "), std::string("%TEST4LIB\n"), std::string("%%ERROR"));
+    auto buffer = GENERATE(
+        fkyaml::detail::str_view("%TEST\n"),
+        fkyaml::detail::str_view("%1984\n "),
+        fkyaml::detail::str_view("%TEST4LIB\n"),
+        fkyaml::detail::str_view("%%ERROR"));
 
     fkyaml::detail::lexical_token token;
-    lexer_t lexer(fkyaml::detail::input_adapter(buffer));
+    lexer_t lexer(buffer);
     REQUIRE_NOTHROW(token = lexer.get_next_token());
     REQUIRE(token.type == fkyaml::detail::lexical_token_t::INVALID_DIRECTIVE);
 
@@ -166,12 +174,12 @@ TEST_CASE("LexicalAnalyzer_ReservedDirective") {
 }
 
 TEST_CASE("LexicalAnalyzer_EmptyDirective") {
-    lexer_t lexer(fkyaml::detail::input_adapter("%"));
+    lexer_t lexer("%");
     REQUIRE(lexer.get_next_token().type == fkyaml::detail::lexical_token_t::INVALID_DIRECTIVE);
 }
 
 TEST_CASE("LexicalAnalyzer_EndOfDirectives") {
-    lexer_t lexer(fkyaml::detail::input_adapter("%YAML 1.2\n---\nfoo: bar"));
+    lexer_t lexer("%YAML 1.2\n---\nfoo: bar");
     fkyaml::detail::lexical_token token;
 
     REQUIRE_NOTHROW(token = lexer.get_next_token());
@@ -192,7 +200,7 @@ TEST_CASE("LexicalAnalyzer_EndOfDirectives") {
 }
 
 TEST_CASE("LexicalAnalyzer_EndOfDocuments") {
-    lexer_t lexer(fkyaml::detail::input_adapter("%YAML 1.2\n---\n..."));
+    lexer_t lexer("%YAML 1.2\n---\n...");
     fkyaml::detail::lexical_token token;
 
     REQUIRE_NOTHROW(token = lexer.get_next_token());
@@ -210,67 +218,76 @@ TEST_CASE("LexicalAnalyzer_Colon") {
     fkyaml::detail::lexical_token token;
 
     SECTION("colon with half-width space") {
-        lexer_t lexer(fkyaml::detail::input_adapter(": "));
+        lexer_t lexer(": ");
         REQUIRE_NOTHROW(token = lexer.get_next_token());
         REQUIRE(token.type == fkyaml::detail::lexical_token_t::KEY_SEPARATOR);
     }
 
     SECTION("colon with LF newline code") {
-        lexer_t lexer(fkyaml::detail::input_adapter(":\n"));
+        lexer_t lexer(":\n");
         REQUIRE_NOTHROW(token = lexer.get_next_token());
         REQUIRE(token.type == fkyaml::detail::lexical_token_t::KEY_SEPARATOR);
     }
 
     SECTION("colon with the end of the buffer") {
-        lexer_t lexer(fkyaml::detail::input_adapter(":"));
+        lexer_t lexer(":");
         REQUIRE_NOTHROW(token = lexer.get_next_token());
         REQUIRE(token.type == fkyaml::detail::lexical_token_t::KEY_SEPARATOR);
     }
 
     SECTION("colon with a comment and a LF newline code") {
-        lexer_t lexer(fkyaml::detail::input_adapter(": # comment\n"));
+        lexer_t lexer(": # comment\n");
         REQUIRE_NOTHROW(token = lexer.get_next_token());
         REQUIRE(token.type == fkyaml::detail::lexical_token_t::KEY_SEPARATOR);
     }
 
     SECTION("colon with a comment and no newline code") {
-        lexer_t lexer(fkyaml::detail::input_adapter(": # comment"));
+        lexer_t lexer(": # comment");
         REQUIRE_NOTHROW(token = lexer.get_next_token());
         REQUIRE(token.type == fkyaml::detail::lexical_token_t::KEY_SEPARATOR);
     }
 
     SECTION("colon with many spaces and a LF newline code") {
-        lexer_t lexer(fkyaml::detail::input_adapter(":                         \n"));
+        lexer_t lexer(":                         \n");
         REQUIRE_NOTHROW(token = lexer.get_next_token());
         REQUIRE(token.type == fkyaml::detail::lexical_token_t::KEY_SEPARATOR);
     }
 
     SECTION("colon with many spaces and no newline code") {
-        lexer_t lexer(fkyaml::detail::input_adapter(":                         "));
+        lexer_t lexer(":                         ");
         REQUIRE_NOTHROW(token = lexer.get_next_token());
         REQUIRE(token.type == fkyaml::detail::lexical_token_t::KEY_SEPARATOR);
     }
 
     SECTION("colon with an always-safe character") {
-        lexer_t lexer(fkyaml::detail::input_adapter(":test"));
+        lexer_t lexer(":test");
         REQUIRE_NOTHROW(token = lexer.get_next_token());
         REQUIRE(token.type == fkyaml::detail::lexical_token_t::PLAIN_SCALAR);
         REQUIRE(std::string(token.token_begin_itr, token.token_end_itr) == ":test");
     }
 
     SECTION("colon with a flow indicator in a non-flow context") {
-        auto input =
-            GENERATE(std::string(":,"), std::string(":{"), std::string(":}"), std::string(":["), std::string(":]"));
-        lexer_t lexer(fkyaml::detail::input_adapter(input));
+        auto input = GENERATE(
+            fkyaml::detail::str_view(":,"),
+            fkyaml::detail::str_view(":{"),
+            fkyaml::detail::str_view(":}"),
+            fkyaml::detail::str_view(":["),
+            fkyaml::detail::str_view(":]"));
+        lexer_t lexer(input);
         REQUIRE_NOTHROW(token = lexer.get_next_token());
         REQUIRE(token.type == fkyaml::detail::lexical_token_t::PLAIN_SCALAR);
-        REQUIRE(std::string(token.token_begin_itr, token.token_end_itr) == input);
+        fkyaml::detail::str_view token_str(token.token_begin_itr, token.token_end_itr);
+        REQUIRE(token_str == input);
     }
 
     SECTION("colon with a flow indicator in a flow context") {
         auto input = GENERATE(
-            std::string("{:,"), std::string("{:{"), std::string("{:}"), std::string("{:["), std::string("{:]"));
-        lexer_t lexer(fkyaml::detail::input_adapter(input));
+            fkyaml::detail::str_view("{:,"),
+            fkyaml::detail::str_view("{:{"),
+            fkyaml::detail::str_view("{:}"),
+            fkyaml::detail::str_view("{:["),
+            fkyaml::detail::str_view("{:]"));
+        lexer_t lexer(input);
         REQUIRE_NOTHROW(token = lexer.get_next_token());
         REQUIRE(token.type == fkyaml::detail::lexical_token_t::MAPPING_FLOW_BEGIN);
         REQUIRE_NOTHROW(token = lexer.get_next_token());
@@ -279,129 +296,136 @@ TEST_CASE("LexicalAnalyzer_Colon") {
 }
 
 TEST_CASE("LexicalAnalzer_BlockSequenceEntryPrefix") {
-    auto input = GENERATE(std::string("- foo"), std::string("-\tfoo"), std::string("-\n  foo"));
+    auto input = GENERATE(
+        fkyaml::detail::str_view("- foo"), fkyaml::detail::str_view("-\tfoo"), fkyaml::detail::str_view("-\n  foo"));
 
     fkyaml::detail::lexical_token token;
-    lexer_t lexer(fkyaml::detail::input_adapter(input));
+    lexer_t lexer(input);
     REQUIRE_NOTHROW(token = lexer.get_next_token());
     REQUIRE(token.type == fkyaml::detail::lexical_token_t::SEQUENCE_BLOCK_PREFIX);
     REQUIRE_NOTHROW(token = lexer.get_next_token());
     REQUIRE(token.type == fkyaml::detail::lexical_token_t::PLAIN_SCALAR);
-    REQUIRE(std::string(token.token_begin_itr, token.token_end_itr) == "foo");
+    fkyaml::detail::str_view token_str(token.token_begin_itr, token.token_end_itr);
+    REQUIRE(token_str == fkyaml::detail::str_view("foo"));
 }
 
 TEST_CASE("LexicalAnalyzer_PlainScalar") {
-    using value_pair_t = std::pair<std::string, fkyaml::node::string_type>;
+    using value_pair_t = std::pair<fkyaml::detail::str_view, fkyaml::detail::str_view>;
     auto value_pair = GENERATE(
-        value_pair_t(std::string("test"), fkyaml::node::string_type("test")),
-        value_pair_t(std::string("nop"), fkyaml::node::string_type("nop")),
-        value_pair_t(std::string("none"), fkyaml::node::string_type("none")),
-        value_pair_t(std::string("?test"), fkyaml::node::string_type("?test")),
-        value_pair_t(std::string(".NET"), fkyaml::node::string_type(".NET")),
-        value_pair_t(std::string(".on"), fkyaml::node::string_type(".on")),
-        value_pair_t(std::string(".n"), fkyaml::node::string_type(".n")),
-        value_pair_t(std::string("-t"), fkyaml::node::string_type("-t")),
-        value_pair_t(std::string("-foo"), fkyaml::node::string_type("-foo")),
-        value_pair_t(std::string("-.test"), fkyaml::node::string_type("-.test")),
-        value_pair_t(std::string("?"), fkyaml::node::string_type("?")),
-        value_pair_t(std::string("--foo"), fkyaml::node::string_type("--foo")),
-        value_pair_t(std::string("+123"), fkyaml::node::string_type("+123")),
-        value_pair_t(std::string("1.2.3"), fkyaml::node::string_type("1.2.3")),
-        value_pair_t(std::string("foo,bar"), fkyaml::node::string_type("foo,bar")),
-        value_pair_t(std::string("foo[bar"), fkyaml::node::string_type("foo[bar")),
-        value_pair_t(std::string("foo]bar"), fkyaml::node::string_type("foo]bar")),
-        value_pair_t(std::string("foo{bar"), fkyaml::node::string_type("foo{bar")),
-        value_pair_t(std::string("foo}bar"), fkyaml::node::string_type("foo}bar")),
-        value_pair_t(std::string("foo:bar"), fkyaml::node::string_type("foo:bar")),
-        value_pair_t(std::string("foo bar"), fkyaml::node::string_type("foo bar")),
-        value_pair_t(std::string("foo\"bar"), fkyaml::node::string_type("foo\"bar")),
-        value_pair_t(std::string("foo\'s bar"), fkyaml::node::string_type("foo\'s bar")),
-        value_pair_t(std::string("foo\\bar"), fkyaml::node::string_type("foo\\bar")),
-        value_pair_t(std::string("nullValue"), fkyaml::node::string_type("nullValue")),
-        value_pair_t(std::string("NullValue"), fkyaml::node::string_type("NullValue")),
-        value_pair_t(std::string("NULL_VALUE"), fkyaml::node::string_type("NULL_VALUE")),
-        value_pair_t(std::string("~Value"), fkyaml::node::string_type("~Value")),
-        value_pair_t(std::string("trueValue"), fkyaml::node::string_type("trueValue")),
-        value_pair_t(std::string("TrueValue"), fkyaml::node::string_type("TrueValue")),
-        value_pair_t(std::string("TRUE_VALUE"), fkyaml::node::string_type("TRUE_VALUE")),
-        value_pair_t(std::string("falseValue"), fkyaml::node::string_type("falseValue")),
-        value_pair_t(std::string("FalseValue"), fkyaml::node::string_type("FalseValue")),
-        value_pair_t(std::string("FALSE_VALUE"), fkyaml::node::string_type("FALSE_VALUE")),
-        value_pair_t(std::string(".infValue"), fkyaml::node::string_type(".infValue")),
-        value_pair_t(std::string(".InfValue"), fkyaml::node::string_type(".InfValue")),
-        value_pair_t(std::string(".INF_VALUE"), fkyaml::node::string_type(".INF_VALUE")),
-        value_pair_t(std::string("-.infValue"), fkyaml::node::string_type("-.infValue")),
-        value_pair_t(std::string("-.InfValue"), fkyaml::node::string_type("-.InfValue")),
-        value_pair_t(std::string("-.INF_VALUE"), fkyaml::node::string_type("-.INF_VALUE")),
-        value_pair_t(std::string(".nanValue"), fkyaml::node::string_type(".nanValue")),
-        value_pair_t(std::string(".NaNValue"), fkyaml::node::string_type(".NaNValue")),
-        value_pair_t(std::string(".NAN_VALUE"), fkyaml::node::string_type(".NAN_VALUE")));
+        value_pair_t(fkyaml::detail::str_view("test"), fkyaml::detail::str_view("test")),
+        value_pair_t(fkyaml::detail::str_view("nop"), fkyaml::detail::str_view("nop")),
+        value_pair_t(fkyaml::detail::str_view("none"), fkyaml::detail::str_view("none")),
+        value_pair_t(fkyaml::detail::str_view("?test"), fkyaml::detail::str_view("?test")),
+        value_pair_t(fkyaml::detail::str_view(".NET"), fkyaml::detail::str_view(".NET")),
+        value_pair_t(fkyaml::detail::str_view(".on"), fkyaml::detail::str_view(".on")),
+        value_pair_t(fkyaml::detail::str_view(".n"), fkyaml::detail::str_view(".n")),
+        value_pair_t(fkyaml::detail::str_view("-t"), fkyaml::detail::str_view("-t")),
+        value_pair_t(fkyaml::detail::str_view("-foo"), fkyaml::detail::str_view("-foo")),
+        value_pair_t(fkyaml::detail::str_view("-.test"), fkyaml::detail::str_view("-.test")),
+        value_pair_t(fkyaml::detail::str_view("?"), fkyaml::detail::str_view("?")),
+        value_pair_t(fkyaml::detail::str_view("--foo"), fkyaml::detail::str_view("--foo")),
+        value_pair_t(fkyaml::detail::str_view("+123"), fkyaml::detail::str_view("+123")),
+        value_pair_t(fkyaml::detail::str_view("1.2.3"), fkyaml::detail::str_view("1.2.3")),
+        value_pair_t(fkyaml::detail::str_view("foo,bar"), fkyaml::detail::str_view("foo,bar")),
+        value_pair_t(fkyaml::detail::str_view("foo[bar"), fkyaml::detail::str_view("foo[bar")),
+        value_pair_t(fkyaml::detail::str_view("foo]bar"), fkyaml::detail::str_view("foo]bar")),
+        value_pair_t(fkyaml::detail::str_view("foo{bar"), fkyaml::detail::str_view("foo{bar")),
+        value_pair_t(fkyaml::detail::str_view("foo}bar"), fkyaml::detail::str_view("foo}bar")),
+        value_pair_t(fkyaml::detail::str_view("foo:bar"), fkyaml::detail::str_view("foo:bar")),
+        value_pair_t(fkyaml::detail::str_view("foo bar"), fkyaml::detail::str_view("foo bar")),
+        value_pair_t(fkyaml::detail::str_view("foo\"bar"), fkyaml::detail::str_view("foo\"bar")),
+        value_pair_t(fkyaml::detail::str_view("foo\'s bar"), fkyaml::detail::str_view("foo\'s bar")),
+        value_pair_t(fkyaml::detail::str_view("foo\\bar"), fkyaml::detail::str_view("foo\\bar")),
+        value_pair_t(fkyaml::detail::str_view("nullValue"), fkyaml::detail::str_view("nullValue")),
+        value_pair_t(fkyaml::detail::str_view("NullValue"), fkyaml::detail::str_view("NullValue")),
+        value_pair_t(fkyaml::detail::str_view("NULL_VALUE"), fkyaml::detail::str_view("NULL_VALUE")),
+        value_pair_t(fkyaml::detail::str_view("~Value"), fkyaml::detail::str_view("~Value")),
+        value_pair_t(fkyaml::detail::str_view("trueValue"), fkyaml::detail::str_view("trueValue")),
+        value_pair_t(fkyaml::detail::str_view("TrueValue"), fkyaml::detail::str_view("TrueValue")),
+        value_pair_t(fkyaml::detail::str_view("TRUE_VALUE"), fkyaml::detail::str_view("TRUE_VALUE")),
+        value_pair_t(fkyaml::detail::str_view("falseValue"), fkyaml::detail::str_view("falseValue")),
+        value_pair_t(fkyaml::detail::str_view("FalseValue"), fkyaml::detail::str_view("FalseValue")),
+        value_pair_t(fkyaml::detail::str_view("FALSE_VALUE"), fkyaml::detail::str_view("FALSE_VALUE")),
+        value_pair_t(fkyaml::detail::str_view(".infValue"), fkyaml::detail::str_view(".infValue")),
+        value_pair_t(fkyaml::detail::str_view(".InfValue"), fkyaml::detail::str_view(".InfValue")),
+        value_pair_t(fkyaml::detail::str_view(".INF_VALUE"), fkyaml::detail::str_view(".INF_VALUE")),
+        value_pair_t(fkyaml::detail::str_view("-.infValue"), fkyaml::detail::str_view("-.infValue")),
+        value_pair_t(fkyaml::detail::str_view("-.InfValue"), fkyaml::detail::str_view("-.InfValue")),
+        value_pair_t(fkyaml::detail::str_view("-.INF_VALUE"), fkyaml::detail::str_view("-.INF_VALUE")),
+        value_pair_t(fkyaml::detail::str_view(".nanValue"), fkyaml::detail::str_view(".nanValue")),
+        value_pair_t(fkyaml::detail::str_view(".NaNValue"), fkyaml::detail::str_view(".NaNValue")),
+        value_pair_t(fkyaml::detail::str_view(".NAN_VALUE"), fkyaml::detail::str_view(".NAN_VALUE")));
 
-    lexer_t lexer(fkyaml::detail::input_adapter(value_pair.first));
+    lexer_t lexer(value_pair.first);
     fkyaml::detail::lexical_token token;
 
     REQUIRE_NOTHROW(token = lexer.get_next_token());
     REQUIRE(token.type == fkyaml::detail::lexical_token_t::PLAIN_SCALAR);
-    REQUIRE(std::string(token.token_begin_itr, token.token_end_itr) == value_pair.second);
+    fkyaml::detail::str_view token_str(token.token_begin_itr, token.token_end_itr);
+    REQUIRE(token_str == value_pair.second);
 }
 
 TEST_CASE("LexicalAnalyzer_SingleQuotedScalar") {
-    using value_pair_t = std::pair<std::string, fkyaml::node::string_type>;
+    using value_pair_t = std::pair<fkyaml::detail::str_view, fkyaml::detail::str_view>;
     auto value_pair = GENERATE(
-        value_pair_t(std::string("\'\'"), fkyaml::node::string_type("")),
-        value_pair_t(std::string("\'foo\"bar\'"), fkyaml::node::string_type("foo\"bar")),
-        value_pair_t(std::string("\'foo bar\'"), fkyaml::node::string_type("foo bar")),
-        value_pair_t(std::string("\'foo\'\'bar\'"), fkyaml::node::string_type("foo\'bar")),
-        value_pair_t(std::string("\'foo\'\'bar\' "), fkyaml::node::string_type("foo\'bar")),
-        value_pair_t(std::string("\'foo,bar\'"), fkyaml::node::string_type("foo,bar")),
-        value_pair_t(std::string("\'foo]bar\'"), fkyaml::node::string_type("foo]bar")),
-        value_pair_t(std::string("\'foo}bar\'"), fkyaml::node::string_type("foo}bar")),
-        value_pair_t(std::string("\'foo\"bar\'"), fkyaml::node::string_type("foo\"bar")),
-        value_pair_t(std::string("\'foo:bar\'"), fkyaml::node::string_type("foo:bar")),
-        value_pair_t(std::string("\'foo\\bar\'"), fkyaml::node::string_type("foo\\bar")),
+        value_pair_t(fkyaml::detail::str_view("\'\'"), fkyaml::detail::str_view("")),
+        value_pair_t(fkyaml::detail::str_view("\'foo\"bar\'"), fkyaml::detail::str_view("foo\"bar")),
+        value_pair_t(fkyaml::detail::str_view("\'foo bar\'"), fkyaml::detail::str_view("foo bar")),
+        value_pair_t(fkyaml::detail::str_view("\'foo\'\'bar\'"), fkyaml::detail::str_view("foo\'bar")),
+        value_pair_t(fkyaml::detail::str_view("\'foo\'\'bar\' "), fkyaml::detail::str_view("foo\'bar")),
+        value_pair_t(fkyaml::detail::str_view("\'foo,bar\'"), fkyaml::detail::str_view("foo,bar")),
+        value_pair_t(fkyaml::detail::str_view("\'foo]bar\'"), fkyaml::detail::str_view("foo]bar")),
+        value_pair_t(fkyaml::detail::str_view("\'foo}bar\'"), fkyaml::detail::str_view("foo}bar")),
+        value_pair_t(fkyaml::detail::str_view("\'foo\"bar\'"), fkyaml::detail::str_view("foo\"bar")),
+        value_pair_t(fkyaml::detail::str_view("\'foo:bar\'"), fkyaml::detail::str_view("foo:bar")),
+        value_pair_t(fkyaml::detail::str_view("\'foo\\bar\'"), fkyaml::detail::str_view("foo\\bar")),
 
-        value_pair_t(std::string("\'foo\nbar\'"), fkyaml::node::string_type("foo bar")),
-        value_pair_t(std::string("\'foo \t\n \tbar\'"), fkyaml::node::string_type("foo bar")),
-        value_pair_t(std::string("\'foo\n\n \t\nbar\'"), fkyaml::node::string_type("foo\n\nbar")),
-        value_pair_t(std::string("\'\nfoo\n\n \t\nbar\'"), fkyaml::node::string_type(" foo\n\nbar")),
-        value_pair_t(std::string("\'foo\nbar\n\'"), fkyaml::node::string_type("foo bar ")));
+        value_pair_t(fkyaml::detail::str_view("\'foo\nbar\'"), fkyaml::detail::str_view("foo bar")),
+        value_pair_t(fkyaml::detail::str_view("\'foo \t\n \tbar\'"), fkyaml::detail::str_view("foo bar")),
+        value_pair_t(fkyaml::detail::str_view("\'foo\n\n \t\nbar\'"), fkyaml::detail::str_view("foo\n\nbar")),
+        value_pair_t(fkyaml::detail::str_view("\'\nfoo\n\n \t\nbar\'"), fkyaml::detail::str_view(" foo\n\nbar")),
+        value_pair_t(fkyaml::detail::str_view("\'foo\nbar\n\'"), fkyaml::detail::str_view("foo bar ")));
 
-    lexer_t lexer(fkyaml::detail::input_adapter(value_pair.first));
+    lexer_t lexer(value_pair.first);
     fkyaml::detail::lexical_token token;
 
     REQUIRE_NOTHROW(token = lexer.get_next_token());
     REQUIRE(token.type == fkyaml::detail::lexical_token_t::SINGLE_QUOTED_SCALAR);
-    REQUIRE(std::string(token.token_begin_itr, token.token_end_itr) == value_pair.second);
+    fkyaml::detail::str_view token_str(token.token_begin_itr, token.token_end_itr);
+    REQUIRE(token_str == value_pair.second);
 }
 
 TEST_CASE("LexicalAnalyzer_DoubleQuotedScalar") {
-    using value_pair_t = std::pair<std::string, fkyaml::node::string_type>;
+    using value_pair_t = std::pair<fkyaml::detail::str_view, fkyaml::detail::str_view>;
     auto value_pair = GENERATE(
-        value_pair_t(std::string("\"\""), fkyaml::node::string_type("")),
-        value_pair_t(std::string("\"foo bar\""), fkyaml::node::string_type("foo bar")),
-        value_pair_t(std::string("\"foo\tbar\""), fkyaml::node::string_type("foo\tbar")),
-        value_pair_t(std::string("\"foo's bar\""), fkyaml::node::string_type("foo's bar")),
-        value_pair_t(std::string("\"foo:bar\""), fkyaml::node::string_type("foo:bar")),
-        value_pair_t(std::string("\"foo,bar\""), fkyaml::node::string_type("foo,bar")),
-        value_pair_t(std::string("\"foo]bar\""), fkyaml::node::string_type("foo]bar")),
-        value_pair_t(std::string("\"foo}bar\""), fkyaml::node::string_type("foo}bar")),
-        value_pair_t(std::string("\"\\x30\\x2B\\x6d\""), fkyaml::node::string_type("0+m")),
+        value_pair_t(fkyaml::detail::str_view("\"\""), fkyaml::detail::str_view("")),
+        value_pair_t(fkyaml::detail::str_view("\"foo bar\""), fkyaml::detail::str_view("foo bar")),
+        value_pair_t(fkyaml::detail::str_view("\"foo\tbar\""), fkyaml::detail::str_view("foo\tbar")),
+        value_pair_t(fkyaml::detail::str_view("\"foo's bar\""), fkyaml::detail::str_view("foo's bar")),
+        value_pair_t(fkyaml::detail::str_view("\"foo:bar\""), fkyaml::detail::str_view("foo:bar")),
+        value_pair_t(fkyaml::detail::str_view("\"foo,bar\""), fkyaml::detail::str_view("foo,bar")),
+        value_pair_t(fkyaml::detail::str_view("\"foo]bar\""), fkyaml::detail::str_view("foo]bar")),
+        value_pair_t(fkyaml::detail::str_view("\"foo}bar\""), fkyaml::detail::str_view("foo}bar")),
+        value_pair_t(fkyaml::detail::str_view("\"\\x30\\x2B\\x6d\""), fkyaml::detail::str_view("0+m")),
 
-        value_pair_t(std::string("\"foo\nbar\""), fkyaml::node::string_type("foo bar")),
-        value_pair_t(std::string("\"foo \t\n \tbar\""), fkyaml::node::string_type("foo bar")),
-        value_pair_t(std::string("\"foo\n\n \t\nbar\""), fkyaml::node::string_type("foo\n\nbar")),
-        value_pair_t(std::string("\"\nfoo\n\n \t\nbar\""), fkyaml::node::string_type(" foo\n\nbar")),
-        value_pair_t(std::string("\"foo\nbar\n\""), fkyaml::node::string_type("foo bar ")),
-        value_pair_t(std::string("\"foo\\\nbar\""), fkyaml::node::string_type("foobar")),
-        value_pair_t(std::string("\"foo \t\\\nbar\""), fkyaml::node::string_type("foo \tbar")),
-        value_pair_t(std::string("\"\\\n  foo \t\\\n\tbar\t  \t\\\n\""), fkyaml::node::string_type("foo \tbar\t  \t")));
+        value_pair_t(fkyaml::detail::str_view("\"foo\nbar\""), fkyaml::detail::str_view("foo bar")),
+        value_pair_t(fkyaml::detail::str_view("\"foo \t\n \tbar\""), fkyaml::detail::str_view("foo bar")),
+        value_pair_t(fkyaml::detail::str_view("\"foo\n\n \t\nbar\""), fkyaml::detail::str_view("foo\n\nbar")),
+        value_pair_t(fkyaml::detail::str_view("\"\nfoo\n\n \t\nbar\""), fkyaml::detail::str_view(" foo\n\nbar")),
+        value_pair_t(fkyaml::detail::str_view("\"foo\nbar\n\""), fkyaml::detail::str_view("foo bar ")),
+        value_pair_t(fkyaml::detail::str_view("\"foo\\\nbar\""), fkyaml::detail::str_view("foobar")),
+        value_pair_t(fkyaml::detail::str_view("\"foo \t\\\nbar\""), fkyaml::detail::str_view("foo \tbar")),
+        value_pair_t(
+            fkyaml::detail::str_view("\"\\\n  foo \t\\\n\tbar\t  \t\\\n\""),
+            fkyaml::detail::str_view("foo \tbar\t  \t")));
 
-    lexer_t lexer(fkyaml::detail::input_adapter(value_pair.first));
+    lexer_t lexer(value_pair.first);
     fkyaml::detail::lexical_token token;
 
     REQUIRE_NOTHROW(token = lexer.get_next_token());
     REQUIRE(token.type == fkyaml::detail::lexical_token_t::DOUBLE_QUOTED_SCALAR);
-    REQUIRE(std::string(token.token_begin_itr, token.token_end_itr) == value_pair.second);
+    fkyaml::detail::str_view token_str(token.token_begin_itr, token.token_end_itr);
+    REQUIRE(token_str == value_pair.second);
 }
 
 TEST_CASE("LexicalAnalyzer_MultiByteCharString") {
@@ -452,264 +476,269 @@ TEST_CASE("LexicalAnalyzer_MultiByteCharString") {
             char_traits_t::to_char_type(0xBF),
             char_traits_t::to_char_type(0xBF)});
 
-    lexer_t lexer(fkyaml::detail::input_adapter(mb_char));
+    fkyaml::detail::str_view input(mb_char);
+    lexer_t lexer(input);
     fkyaml::detail::lexical_token token;
 
     REQUIRE_NOTHROW(token = lexer.get_next_token());
     REQUIRE(token.type == fkyaml::detail::lexical_token_t::PLAIN_SCALAR);
-    REQUIRE(std::string(token.token_begin_itr, token.token_end_itr) == mb_char);
+    fkyaml::detail::str_view token_str(token.token_begin_itr, token.token_end_itr);
+    REQUIRE(token_str == input);
 }
 
 TEST_CASE("LexicalAnalyzer_EscapedUnicodeCharacter") {
-    using value_pair_t = std::pair<std::string, std::string>;
+    using value_pair_t = std::pair<fkyaml::detail::str_view, std::string>;
     using char_traits_t = std::char_traits<char>;
     auto value_pair = GENERATE(
-        value_pair_t(std::string("\"\\x00\""), std::string {char_traits_t::to_char_type(0x00)}),
-        value_pair_t(std::string("\"\\x40\""), std::string {char_traits_t::to_char_type(0x40)}),
-        value_pair_t(std::string("\"\\x7F\""), std::string {char_traits_t::to_char_type(0x7F)}),
-        value_pair_t(std::string("\"\\u0000\""), std::string {char_traits_t::to_char_type(0x00)}),
-        value_pair_t(std::string("\"\\u0040\""), std::string {char_traits_t::to_char_type(0x40)}),
-        value_pair_t(std::string("\"\\u007F\""), std::string {char_traits_t::to_char_type(0x7F)}),
+        value_pair_t(fkyaml::detail::str_view("\"\\x00\""), std::string {char_traits_t::to_char_type(0x00)}),
+        value_pair_t(fkyaml::detail::str_view("\"\\x40\""), std::string {char_traits_t::to_char_type(0x40)}),
+        value_pair_t(fkyaml::detail::str_view("\"\\x7F\""), std::string {char_traits_t::to_char_type(0x7F)}),
+        value_pair_t(fkyaml::detail::str_view("\"\\u0000\""), std::string {char_traits_t::to_char_type(0x00)}),
+        value_pair_t(fkyaml::detail::str_view("\"\\u0040\""), std::string {char_traits_t::to_char_type(0x40)}),
+        value_pair_t(fkyaml::detail::str_view("\"\\u007F\""), std::string {char_traits_t::to_char_type(0x7F)}),
         value_pair_t(
-            std::string("\"\\u0080\""),
+            fkyaml::detail::str_view("\"\\u0080\""),
             std::string {char_traits_t::to_char_type(0xC2), char_traits_t::to_char_type(0x80)}),
         value_pair_t(
-            std::string("\"\\u0400\""),
+            fkyaml::detail::str_view("\"\\u0400\""),
             std::string {char_traits_t::to_char_type(0xD0), char_traits_t::to_char_type(0x80)}),
         value_pair_t(
-            std::string("\"\\u07FF\""),
+            fkyaml::detail::str_view("\"\\u07FF\""),
             std::string {char_traits_t::to_char_type(0xDF), char_traits_t::to_char_type(0xBF)}),
         value_pair_t(
-            std::string("\"\\u0800\""),
+            fkyaml::detail::str_view("\"\\u0800\""),
             std::string {
                 char_traits_t::to_char_type(0xE0),
                 char_traits_t::to_char_type(0xA0),
                 char_traits_t::to_char_type(0x80)}),
         value_pair_t(
-            std::string("\"\\u8000\""),
+            fkyaml::detail::str_view("\"\\u8000\""),
             std::string {
                 char_traits_t::to_char_type(0xE8),
                 char_traits_t::to_char_type(0x80),
                 char_traits_t::to_char_type(0x80)}),
         value_pair_t(
-            std::string("\"\\uFFFF\""),
+            fkyaml::detail::str_view("\"\\uFFFF\""),
             std::string {
                 char_traits_t::to_char_type(0xEF),
                 char_traits_t::to_char_type(0xBF),
                 char_traits_t::to_char_type(0xBF)}),
-        value_pair_t(std::string("\"\\U00000000\""), std::string {char_traits_t::to_char_type(0x00)}),
-        value_pair_t(std::string("\"\\U00000040\""), std::string {char_traits_t::to_char_type(0x40)}),
-        value_pair_t(std::string("\"\\U0000007F\""), std::string {char_traits_t::to_char_type(0x7F)}),
+        value_pair_t(fkyaml::detail::str_view("\"\\U00000000\""), std::string {char_traits_t::to_char_type(0x00)}),
+        value_pair_t(fkyaml::detail::str_view("\"\\U00000040\""), std::string {char_traits_t::to_char_type(0x40)}),
+        value_pair_t(fkyaml::detail::str_view("\"\\U0000007F\""), std::string {char_traits_t::to_char_type(0x7F)}),
         value_pair_t(
-            std::string("\"\\U00000080\""),
+            fkyaml::detail::str_view("\"\\U00000080\""),
             std::string {char_traits_t::to_char_type(0xC2), char_traits_t::to_char_type(0x80)}),
         value_pair_t(
-            std::string("\"\\U00000400\""),
+            fkyaml::detail::str_view("\"\\U00000400\""),
             std::string {char_traits_t::to_char_type(0xD0), char_traits_t::to_char_type(0x80)}),
         value_pair_t(
-            std::string("\"\\U000007FF\""),
+            fkyaml::detail::str_view("\"\\U000007FF\""),
             std::string {char_traits_t::to_char_type(0xDF), char_traits_t::to_char_type(0xBF)}),
         value_pair_t(
-            std::string("\"\\U00000800\""),
+            fkyaml::detail::str_view("\"\\U00000800\""),
             std::string {
                 char_traits_t::to_char_type(0xE0),
                 char_traits_t::to_char_type(0xA0),
                 char_traits_t::to_char_type(0x80)}),
         value_pair_t(
-            std::string("\"\\U00008000\""),
+            fkyaml::detail::str_view("\"\\U00008000\""),
             std::string {
                 char_traits_t::to_char_type(0xE8),
                 char_traits_t::to_char_type(0x80),
                 char_traits_t::to_char_type(0x80)}),
         value_pair_t(
-            std::string("\"\\U0000FFFF\""),
+            fkyaml::detail::str_view("\"\\U0000FFFF\""),
             std::string {
                 char_traits_t::to_char_type(0xEF),
                 char_traits_t::to_char_type(0xBF),
                 char_traits_t::to_char_type(0xBF)}),
         value_pair_t(
-            std::string("\"\\U00010000\""),
+            fkyaml::detail::str_view("\"\\U00010000\""),
             std::string {
                 char_traits_t::to_char_type(0xF0),
                 char_traits_t::to_char_type(0x90),
                 char_traits_t::to_char_type(0x80),
                 char_traits_t::to_char_type(0x80)}),
         value_pair_t(
-            std::string("\"\\U00080000\""),
+            fkyaml::detail::str_view("\"\\U00080000\""),
             std::string {
                 char_traits_t::to_char_type(0xF2),
                 char_traits_t::to_char_type(0x80),
                 char_traits_t::to_char_type(0x80),
                 char_traits_t::to_char_type(0x80)}),
         value_pair_t(
-            std::string("\"\\U0010FFFF\""),
+            fkyaml::detail::str_view("\"\\U0010FFFF\""),
             std::string {
                 char_traits_t::to_char_type(0xF4),
                 char_traits_t::to_char_type(0x8F),
                 char_traits_t::to_char_type(0xBF),
                 char_traits_t::to_char_type(0xBF)}));
 
-    lexer_t lexer(fkyaml::detail::input_adapter(value_pair.first));
+    fkyaml::detail::str_view input = value_pair.first;
+    lexer_t lexer(input);
     fkyaml::detail::lexical_token token;
 
     REQUIRE_NOTHROW(token = lexer.get_next_token());
     REQUIRE(token.type == fkyaml::detail::lexical_token_t::DOUBLE_QUOTED_SCALAR);
-    REQUIRE(std::string(token.token_begin_itr, token.token_end_itr) == value_pair.second);
+    fkyaml::detail::str_view token_str(token.token_begin_itr, token.token_end_itr);
+    fkyaml::detail::str_view escaped_str(value_pair.second);
+    REQUIRE(token_str == escaped_str);
 }
 
 TEST_CASE("LexicalAnalyzer_InvalidString") {
     SECTION("parse error") {
         auto buffer = GENERATE(
-            std::string("\"test"),
-            std::string("\'test"),
-            std::string("\"\\xw\""),
-            std::string("\"\\x+\""),
-            std::string("\"\\x=\""),
-            std::string("\"\\x^\""),
-            std::string("\"\\x{\""),
-            std::string("\"\\Q\""));
+            fkyaml::detail::str_view("\"test"),
+            fkyaml::detail::str_view("\'test"),
+            fkyaml::detail::str_view("\"\\xw\""),
+            fkyaml::detail::str_view("\"\\x+\""),
+            fkyaml::detail::str_view("\"\\x=\""),
+            fkyaml::detail::str_view("\"\\x^\""),
+            fkyaml::detail::str_view("\"\\x{\""),
+            fkyaml::detail::str_view("\"\\Q\""));
 
-        lexer_t lexer(fkyaml::detail::input_adapter(buffer));
+        lexer_t lexer(buffer);
         REQUIRE_THROWS_AS(lexer.get_next_token(), fkyaml::parse_error);
     }
 
     SECTION("invalid encoding") {
-        std::string buffer = "\"\\U00110000\"";
-        lexer_t lexer(fkyaml::detail::input_adapter(buffer));
+        lexer_t lexer("\"\\U00110000\"");
         REQUIRE_THROWS_AS(lexer.get_next_token(), fkyaml::invalid_encoding);
     }
 }
 
-TEST_CASE("LexicalAnalyzer_InvalidMultiByteCharString") {
-    using char_traits_t = std::char_traits<char>;
-    auto mb_char = GENERATE(
-        std::string {char_traits_t::to_char_type(0x80), char_traits_t::to_char_type(0x80)},
-        std::string {char_traits_t::to_char_type(0xC1), char_traits_t::to_char_type(0x80)},
-        std::string {char_traits_t::to_char_type(0xC2), char_traits_t::to_char_type(0x7F)},
-        std::string {char_traits_t::to_char_type(0xC2), char_traits_t::to_char_type(0xC0)},
-        std::string {
-            char_traits_t::to_char_type(0xE0), char_traits_t::to_char_type(0x7F), char_traits_t::to_char_type(0x80)},
-        std::string {
-            char_traits_t::to_char_type(0xE0), char_traits_t::to_char_type(0xC0), char_traits_t::to_char_type(0x80)},
-        std::string {
-            char_traits_t::to_char_type(0xE0), char_traits_t::to_char_type(0x80), char_traits_t::to_char_type(0x7F)},
-        std::string {
-            char_traits_t::to_char_type(0xE0), char_traits_t::to_char_type(0x80), char_traits_t::to_char_type(0xC0)},
-        std::string {
-            char_traits_t::to_char_type(0xED), char_traits_t::to_char_type(0x7F), char_traits_t::to_char_type(0x80)},
-        std::string {
-            char_traits_t::to_char_type(0xED), char_traits_t::to_char_type(0xA0), char_traits_t::to_char_type(0x80)},
-        std::string {
-            char_traits_t::to_char_type(0xED), char_traits_t::to_char_type(0x80), char_traits_t::to_char_type(0x7F)},
-        std::string {
-            char_traits_t::to_char_type(0xED), char_traits_t::to_char_type(0x80), char_traits_t::to_char_type(0xC0)},
-        std::string {
-            char_traits_t::to_char_type(0xEE), char_traits_t::to_char_type(0x7F), char_traits_t::to_char_type(0x80)},
-        std::string {
-            char_traits_t::to_char_type(0xEE), char_traits_t::to_char_type(0xC0), char_traits_t::to_char_type(0x80)},
-        std::string {
-            char_traits_t::to_char_type(0xEF), char_traits_t::to_char_type(0x80), char_traits_t::to_char_type(0x7F)},
-        std::string {
-            char_traits_t::to_char_type(0xEF), char_traits_t::to_char_type(0x80), char_traits_t::to_char_type(0xC0)},
-        std::string {
-            char_traits_t::to_char_type(0xF0),
-            char_traits_t::to_char_type(0x8F),
-            char_traits_t::to_char_type(0x80),
-            char_traits_t::to_char_type(0x80)},
-        std::string {
-            char_traits_t::to_char_type(0xF0),
-            char_traits_t::to_char_type(0xC0),
-            char_traits_t::to_char_type(0x80),
-            char_traits_t::to_char_type(0x80)},
-        std::string {
-            char_traits_t::to_char_type(0xF0),
-            char_traits_t::to_char_type(0x90),
-            char_traits_t::to_char_type(0x7F),
-            char_traits_t::to_char_type(0x80)},
-        std::string {
-            char_traits_t::to_char_type(0xF0),
-            char_traits_t::to_char_type(0x90),
-            char_traits_t::to_char_type(0xC0),
-            char_traits_t::to_char_type(0x80)},
-        std::string {
-            char_traits_t::to_char_type(0xF0),
-            char_traits_t::to_char_type(0x90),
-            char_traits_t::to_char_type(0x80),
-            char_traits_t::to_char_type(0x7F)},
-        std::string {
-            char_traits_t::to_char_type(0xF0),
-            char_traits_t::to_char_type(0x90),
-            char_traits_t::to_char_type(0x80),
-            char_traits_t::to_char_type(0xC0)},
-        std::string {
-            char_traits_t::to_char_type(0xF1),
-            char_traits_t::to_char_type(0x7F),
-            char_traits_t::to_char_type(0x80),
-            char_traits_t::to_char_type(0x80)},
-        std::string {
-            char_traits_t::to_char_type(0xF1),
-            char_traits_t::to_char_type(0xC0),
-            char_traits_t::to_char_type(0x80),
-            char_traits_t::to_char_type(0x80)},
-        std::string {
-            char_traits_t::to_char_type(0xF1),
-            char_traits_t::to_char_type(0x80),
-            char_traits_t::to_char_type(0x7F),
-            char_traits_t::to_char_type(0x80)},
-        std::string {
-            char_traits_t::to_char_type(0xF1),
-            char_traits_t::to_char_type(0x80),
-            char_traits_t::to_char_type(0xC0),
-            char_traits_t::to_char_type(0x80)},
-        std::string {
-            char_traits_t::to_char_type(0xF1),
-            char_traits_t::to_char_type(0x80),
-            char_traits_t::to_char_type(0x80),
-            char_traits_t::to_char_type(0x7F)},
-        std::string {
-            char_traits_t::to_char_type(0xF1),
-            char_traits_t::to_char_type(0x80),
-            char_traits_t::to_char_type(0x80),
-            char_traits_t::to_char_type(0xC0)},
-        std::string {
-            char_traits_t::to_char_type(0xF4),
-            char_traits_t::to_char_type(0x7F),
-            char_traits_t::to_char_type(0x80),
-            char_traits_t::to_char_type(0x80)},
-        std::string {
-            char_traits_t::to_char_type(0xF4),
-            char_traits_t::to_char_type(0x90),
-            char_traits_t::to_char_type(0x80),
-            char_traits_t::to_char_type(0x80)},
-        std::string {
-            char_traits_t::to_char_type(0xF4),
-            char_traits_t::to_char_type(0x80),
-            char_traits_t::to_char_type(0x7F),
-            char_traits_t::to_char_type(0x80)},
-        std::string {
-            char_traits_t::to_char_type(0xF4),
-            char_traits_t::to_char_type(0x80),
-            char_traits_t::to_char_type(0xC0),
-            char_traits_t::to_char_type(0x80)},
-        std::string {
-            char_traits_t::to_char_type(0xF4),
-            char_traits_t::to_char_type(0x80),
-            char_traits_t::to_char_type(0x80),
-            char_traits_t::to_char_type(0x7F)},
-        std::string {
-            char_traits_t::to_char_type(0xF4),
-            char_traits_t::to_char_type(0x80),
-            char_traits_t::to_char_type(0x80),
-            char_traits_t::to_char_type(0xC0)},
-        std::string {
-            char_traits_t::to_char_type(0xF5),
-            char_traits_t::to_char_type(0x80),
-            char_traits_t::to_char_type(0x80),
-            char_traits_t::to_char_type(0x80)});
+// FIXME: to be deleted
+// TEST_CASE("LexicalAnalyzer_InvalidMultiByteCharString") {
+//     using char_traits_t = std::char_traits<char>;
+//     auto mb_char = GENERATE(
+//         std::string {char_traits_t::to_char_type(0x80), char_traits_t::to_char_type(0x80)},
+//         std::string {char_traits_t::to_char_type(0xC1), char_traits_t::to_char_type(0x80)},
+//         std::string {char_traits_t::to_char_type(0xC2), char_traits_t::to_char_type(0x7F)},
+//         std::string {char_traits_t::to_char_type(0xC2), char_traits_t::to_char_type(0xC0)},
+//         std::string {
+//             char_traits_t::to_char_type(0xE0), char_traits_t::to_char_type(0x7F), char_traits_t::to_char_type(0x80)},
+//         std::string {
+//             char_traits_t::to_char_type(0xE0), char_traits_t::to_char_type(0xC0), char_traits_t::to_char_type(0x80)},
+//         std::string {
+//             char_traits_t::to_char_type(0xE0), char_traits_t::to_char_type(0x80), char_traits_t::to_char_type(0x7F)},
+//         std::string {
+//             char_traits_t::to_char_type(0xE0), char_traits_t::to_char_type(0x80), char_traits_t::to_char_type(0xC0)},
+//         std::string {
+//             char_traits_t::to_char_type(0xED), char_traits_t::to_char_type(0x7F), char_traits_t::to_char_type(0x80)},
+//         std::string {
+//             char_traits_t::to_char_type(0xED), char_traits_t::to_char_type(0xA0), char_traits_t::to_char_type(0x80)},
+//         std::string {
+//             char_traits_t::to_char_type(0xED), char_traits_t::to_char_type(0x80), char_traits_t::to_char_type(0x7F)},
+//         std::string {
+//             char_traits_t::to_char_type(0xED), char_traits_t::to_char_type(0x80), char_traits_t::to_char_type(0xC0)},
+//         std::string {
+//             char_traits_t::to_char_type(0xEE), char_traits_t::to_char_type(0x7F), char_traits_t::to_char_type(0x80)},
+//         std::string {
+//             char_traits_t::to_char_type(0xEE), char_traits_t::to_char_type(0xC0), char_traits_t::to_char_type(0x80)},
+//         std::string {
+//             char_traits_t::to_char_type(0xEF), char_traits_t::to_char_type(0x80), char_traits_t::to_char_type(0x7F)},
+//         std::string {
+//             char_traits_t::to_char_type(0xEF), char_traits_t::to_char_type(0x80), char_traits_t::to_char_type(0xC0)},
+//         std::string {
+//             char_traits_t::to_char_type(0xF0),
+//             char_traits_t::to_char_type(0x8F),
+//             char_traits_t::to_char_type(0x80),
+//             char_traits_t::to_char_type(0x80)},
+//         std::string {
+//             char_traits_t::to_char_type(0xF0),
+//             char_traits_t::to_char_type(0xC0),
+//             char_traits_t::to_char_type(0x80),
+//             char_traits_t::to_char_type(0x80)},
+//         std::string {
+//             char_traits_t::to_char_type(0xF0),
+//             char_traits_t::to_char_type(0x90),
+//             char_traits_t::to_char_type(0x7F),
+//             char_traits_t::to_char_type(0x80)},
+//         std::string {
+//             char_traits_t::to_char_type(0xF0),
+//             char_traits_t::to_char_type(0x90),
+//             char_traits_t::to_char_type(0xC0),
+//             char_traits_t::to_char_type(0x80)},
+//         std::string {
+//             char_traits_t::to_char_type(0xF0),
+//             char_traits_t::to_char_type(0x90),
+//             char_traits_t::to_char_type(0x80),
+//             char_traits_t::to_char_type(0x7F)},
+//         std::string {
+//             char_traits_t::to_char_type(0xF0),
+//             char_traits_t::to_char_type(0x90),
+//             char_traits_t::to_char_type(0x80),
+//             char_traits_t::to_char_type(0xC0)},
+//         std::string {
+//             char_traits_t::to_char_type(0xF1),
+//             char_traits_t::to_char_type(0x7F),
+//             char_traits_t::to_char_type(0x80),
+//             char_traits_t::to_char_type(0x80)},
+//         std::string {
+//             char_traits_t::to_char_type(0xF1),
+//             char_traits_t::to_char_type(0xC0),
+//             char_traits_t::to_char_type(0x80),
+//             char_traits_t::to_char_type(0x80)},
+//         std::string {
+//             char_traits_t::to_char_type(0xF1),
+//             char_traits_t::to_char_type(0x80),
+//             char_traits_t::to_char_type(0x7F),
+//             char_traits_t::to_char_type(0x80)},
+//         std::string {
+//             char_traits_t::to_char_type(0xF1),
+//             char_traits_t::to_char_type(0x80),
+//             char_traits_t::to_char_type(0xC0),
+//             char_traits_t::to_char_type(0x80)},
+//         std::string {
+//             char_traits_t::to_char_type(0xF1),
+//             char_traits_t::to_char_type(0x80),
+//             char_traits_t::to_char_type(0x80),
+//             char_traits_t::to_char_type(0x7F)},
+//         std::string {
+//             char_traits_t::to_char_type(0xF1),
+//             char_traits_t::to_char_type(0x80),
+//             char_traits_t::to_char_type(0x80),
+//             char_traits_t::to_char_type(0xC0)},
+//         std::string {
+//             char_traits_t::to_char_type(0xF4),
+//             char_traits_t::to_char_type(0x7F),
+//             char_traits_t::to_char_type(0x80),
+//             char_traits_t::to_char_type(0x80)},
+//         std::string {
+//             char_traits_t::to_char_type(0xF4),
+//             char_traits_t::to_char_type(0x90),
+//             char_traits_t::to_char_type(0x80),
+//             char_traits_t::to_char_type(0x80)},
+//         std::string {
+//             char_traits_t::to_char_type(0xF4),
+//             char_traits_t::to_char_type(0x80),
+//             char_traits_t::to_char_type(0x7F),
+//             char_traits_t::to_char_type(0x80)},
+//         std::string {
+//             char_traits_t::to_char_type(0xF4),
+//             char_traits_t::to_char_type(0x80),
+//             char_traits_t::to_char_type(0xC0),
+//             char_traits_t::to_char_type(0x80)},
+//         std::string {
+//             char_traits_t::to_char_type(0xF4),
+//             char_traits_t::to_char_type(0x80),
+//             char_traits_t::to_char_type(0x80),
+//             char_traits_t::to_char_type(0x7F)},
+//         std::string {
+//             char_traits_t::to_char_type(0xF4),
+//             char_traits_t::to_char_type(0x80),
+//             char_traits_t::to_char_type(0x80),
+//             char_traits_t::to_char_type(0xC0)},
+//         std::string {
+//             char_traits_t::to_char_type(0xF5),
+//             char_traits_t::to_char_type(0x80),
+//             char_traits_t::to_char_type(0x80),
+//             char_traits_t::to_char_type(0x80)});
 
-    auto input_adapter = fkyaml::detail::input_adapter(mb_char);
-    REQUIRE_THROWS_AS(lexer_t(std::move(input_adapter)), fkyaml::invalid_encoding);
-}
+//     fkyaml::detail::str_view input = mb_char;
+//     REQUIRE_THROWS_AS(lexer_t(input), fkyaml::invalid_encoding);
+// }
 
 TEST_CASE("LexicalAnalyzer_UnescapedControlCharacter") {
     auto unescaped_char = GENERATE(
@@ -744,7 +773,7 @@ TEST_CASE("LexicalAnalyzer_UnescapedControlCharacter") {
     std::string buffer("test");
     buffer.push_back(unescaped_char);
 
-    lexer_t lexer(fkyaml::detail::input_adapter(buffer));
+    lexer_t lexer(buffer);
     REQUIRE_THROWS_AS(lexer.get_next_token(), fkyaml::parse_error);
 }
 
@@ -754,7 +783,7 @@ TEST_CASE("LexicalAnalyzer_LiteralStringScalar") {
     SECTION("empty literal string scalar with strip chomping") {
         const char input[] = "|-\n"
                              "  \n";
-        lexer_t lexer(fkyaml::detail::input_adapter(input));
+        lexer_t lexer(input);
 
         REQUIRE_NOTHROW(token = lexer.get_next_token());
         REQUIRE(token.type == fkyaml::detail::lexical_token_t::BLOCK_SCALAR);
@@ -764,7 +793,7 @@ TEST_CASE("LexicalAnalyzer_LiteralStringScalar") {
     SECTION("empty literal string scalar with clip chomping") {
         const char input[] = "|\n"
                              "  \n";
-        lexer_t lexer(fkyaml::detail::input_adapter(input));
+        lexer_t lexer(input);
 
         REQUIRE_NOTHROW(token = lexer.get_next_token());
         REQUIRE(token.type == fkyaml::detail::lexical_token_t::BLOCK_SCALAR);
@@ -774,7 +803,7 @@ TEST_CASE("LexicalAnalyzer_LiteralStringScalar") {
     SECTION("empty literal string scalar with keep chomping") {
         const char input[] = "|+\n"
                              "  \n";
-        lexer_t lexer(fkyaml::detail::input_adapter(input));
+        lexer_t lexer(input);
 
         REQUIRE_NOTHROW(token = lexer.get_next_token());
         REQUIRE(token.type == fkyaml::detail::lexical_token_t::BLOCK_SCALAR);
@@ -785,7 +814,7 @@ TEST_CASE("LexicalAnalyzer_LiteralStringScalar") {
         const char input[] = "|0\n"
                              "foo";
 
-        lexer_t lexer(fkyaml::detail::input_adapter(input));
+        lexer_t lexer(input);
         REQUIRE_THROWS_AS(lexer.get_next_token(), fkyaml::parse_error);
     }
 
@@ -793,7 +822,7 @@ TEST_CASE("LexicalAnalyzer_LiteralStringScalar") {
         const char input[] = "|2\n"
                              " foo";
 
-        lexer_t lexer(fkyaml::detail::input_adapter(input));
+        lexer_t lexer(input);
         REQUIRE_THROWS_AS(lexer.get_next_token(), fkyaml::parse_error);
     }
 
@@ -801,7 +830,7 @@ TEST_CASE("LexicalAnalyzer_LiteralStringScalar") {
         const char input[] = "|2\n"
                              "    foo\n"
                              "  bar\n";
-        lexer_t lexer(fkyaml::detail::input_adapter(input));
+        lexer_t lexer(input);
 
         REQUIRE_NOTHROW(token = lexer.get_next_token());
         REQUIRE(token.type == fkyaml::detail::lexical_token_t::BLOCK_SCALAR);
@@ -812,7 +841,7 @@ TEST_CASE("LexicalAnalyzer_LiteralStringScalar") {
         const char input[] = "|\n"
                              "  foo\n"
                              "  bar\n";
-        lexer_t lexer(fkyaml::detail::input_adapter(input));
+        lexer_t lexer(input);
 
         REQUIRE_NOTHROW(token = lexer.get_next_token());
         REQUIRE(token.type == fkyaml::detail::lexical_token_t::BLOCK_SCALAR);
@@ -827,7 +856,7 @@ TEST_CASE("LexicalAnalyzer_LiteralStringScalar") {
                              "\n"
                              "  baz\n"
                              "\n";
-        lexer_t lexer(fkyaml::detail::input_adapter(input));
+        lexer_t lexer(input);
 
         REQUIRE_NOTHROW(token = lexer.get_next_token());
         REQUIRE(token.type == fkyaml::detail::lexical_token_t::BLOCK_SCALAR);
@@ -841,7 +870,7 @@ TEST_CASE("LexicalAnalyzer_LiteralStringScalar") {
                              "\n"
                              "  baz\n"
                              "\n";
-        lexer_t lexer(fkyaml::detail::input_adapter(input));
+        lexer_t lexer(input);
 
         REQUIRE_NOTHROW(token = lexer.get_next_token());
         REQUIRE(token.type == fkyaml::detail::lexical_token_t::BLOCK_SCALAR);
@@ -856,7 +885,7 @@ TEST_CASE("LexicalAnalyzer_LiteralStringScalar") {
                              "\n"
                              "  baz\n"
                              "\n";
-        lexer_t lexer(fkyaml::detail::input_adapter(input));
+        lexer_t lexer(input);
 
         REQUIRE_NOTHROW(token = lexer.get_next_token());
         REQUIRE(token.type == fkyaml::detail::lexical_token_t::BLOCK_SCALAR);
@@ -870,7 +899,7 @@ TEST_CASE("LexicalAnalyzer_LiteralStringScalar") {
                              "\n"
                              "  baz\n"
                              "\n";
-        lexer_t lexer(fkyaml::detail::input_adapter(input));
+        lexer_t lexer(input);
 
         REQUIRE_NOTHROW(token = lexer.get_next_token());
         REQUIRE(token.type == fkyaml::detail::lexical_token_t::BLOCK_SCALAR);
@@ -883,7 +912,7 @@ TEST_CASE("LexicalAnalyzer_LiteralStringScalar") {
                              "    bar\n"
                              "\n"
                              "  baz";
-        lexer_t lexer(fkyaml::detail::input_adapter(input));
+        lexer_t lexer(input);
 
         REQUIRE_NOTHROW(token = lexer.get_next_token());
         REQUIRE(token.type == fkyaml::detail::lexical_token_t::BLOCK_SCALAR);
@@ -898,7 +927,7 @@ TEST_CASE("LexicalAnalyzer_LiteralStringScalar") {
                              "\n"
                              "  baz\n"
                              "\n";
-        lexer_t lexer(fkyaml::detail::input_adapter(input));
+        lexer_t lexer(input);
 
         REQUIRE_NOTHROW(token = lexer.get_next_token());
         REQUIRE(token.type == fkyaml::detail::lexical_token_t::BLOCK_SCALAR);
@@ -912,7 +941,7 @@ TEST_CASE("LexicalAnalyzer_LiteralStringScalar") {
                              "\n"
                              "  baz\n"
                              "\n";
-        lexer_t lexer(fkyaml::detail::input_adapter(input));
+        lexer_t lexer(input);
 
         REQUIRE_NOTHROW(token = lexer.get_next_token());
         REQUIRE(token.type == fkyaml::detail::lexical_token_t::BLOCK_SCALAR);
@@ -921,8 +950,10 @@ TEST_CASE("LexicalAnalyzer_LiteralStringScalar") {
 
     SECTION("literal string scalar with trailing spaces/tabs after the block scalar header.") {
         auto input = GENERATE(
-            std::string("|2  \n  foo\n"), std::string("|2\t\t\n  foo\n"), std::string("|2 # comment\n  foo\n"));
-        lexer_t lexer(fkyaml::detail::input_adapter(input));
+            fkyaml::detail::str_view("|2  \n  foo\n"),
+            fkyaml::detail::str_view("|2\t\t\n  foo\n"),
+            fkyaml::detail::str_view("|2 # comment\n  foo\n"));
+        lexer_t lexer(input);
 
         REQUIRE_NOTHROW(token = lexer.get_next_token());
         REQUIRE(token.type == fkyaml::detail::lexical_token_t::BLOCK_SCALAR);
@@ -931,15 +962,15 @@ TEST_CASE("LexicalAnalyzer_LiteralStringScalar") {
 
     SECTION("literal string scalar with invalid block scalar headers") {
         auto input = GENERATE(
-            std::string("|++2\n  foo"),
-            std::string("|--2\n  foo"),
-            std::string("|+-2\n  foo"),
-            std::string("|-+2\n  foo"),
-            std::string("|+0\n  foo"),
-            std::string("|+11\n           foo"),
-            std::string("|invalid\n  foo"));
+            fkyaml::detail::str_view("|++2\n  foo"),
+            fkyaml::detail::str_view("|--2\n  foo"),
+            fkyaml::detail::str_view("|+-2\n  foo"),
+            fkyaml::detail::str_view("|-+2\n  foo"),
+            fkyaml::detail::str_view("|+0\n  foo"),
+            fkyaml::detail::str_view("|+11\n           foo"),
+            fkyaml::detail::str_view("|invalid\n  foo"));
 
-        lexer_t lexer(fkyaml::detail::input_adapter(input));
+        lexer_t lexer(input);
         REQUIRE_THROWS_AS(token = lexer.get_next_token(), fkyaml::parse_error);
     }
 }
@@ -950,7 +981,7 @@ TEST_CASE("LexicalAnalyzer_FoldedString") {
     SECTION("empty folded string scalar with strip chomping") {
         const char input[] = ">-\n"
                              "  \n";
-        lexer_t lexer(fkyaml::detail::input_adapter(input));
+        lexer_t lexer(input);
 
         REQUIRE_NOTHROW(token = lexer.get_next_token());
         REQUIRE(token.type == fkyaml::detail::lexical_token_t::BLOCK_SCALAR);
@@ -960,7 +991,7 @@ TEST_CASE("LexicalAnalyzer_FoldedString") {
     SECTION("empty folded string scalar with clip chomping") {
         const char input[] = ">\n"
                              "  \n";
-        lexer_t lexer(fkyaml::detail::input_adapter(input));
+        lexer_t lexer(input);
 
         REQUIRE_NOTHROW(token = lexer.get_next_token());
         REQUIRE(token.type == fkyaml::detail::lexical_token_t::BLOCK_SCALAR);
@@ -970,7 +1001,7 @@ TEST_CASE("LexicalAnalyzer_FoldedString") {
     SECTION("empty folded string scalar with keep chomping") {
         const char input[] = ">+\n"
                              "  \n";
-        lexer_t lexer(fkyaml::detail::input_adapter(input));
+        lexer_t lexer(input);
 
         REQUIRE_NOTHROW(token = lexer.get_next_token());
         REQUIRE(token.type == fkyaml::detail::lexical_token_t::BLOCK_SCALAR);
@@ -981,7 +1012,7 @@ TEST_CASE("LexicalAnalyzer_FoldedString") {
         const char input[] = "|0\n"
                              "foo";
 
-        lexer_t lexer(fkyaml::detail::input_adapter(input));
+        lexer_t lexer(input);
         REQUIRE_THROWS_AS(lexer.get_next_token(), fkyaml::parse_error);
     }
 
@@ -989,7 +1020,7 @@ TEST_CASE("LexicalAnalyzer_FoldedString") {
         const char input[] = ">2\n"
                              " foo";
 
-        lexer_t lexer(fkyaml::detail::input_adapter(input));
+        lexer_t lexer(input);
         REQUIRE_THROWS_AS(lexer.get_next_token(), fkyaml::parse_error);
     }
 
@@ -997,7 +1028,7 @@ TEST_CASE("LexicalAnalyzer_FoldedString") {
         const char input[] = ">2\n"
                              "    foo\n"
                              "  bar\n";
-        lexer_t lexer(fkyaml::detail::input_adapter(input));
+        lexer_t lexer(input);
 
         REQUIRE_NOTHROW(token = lexer.get_next_token());
         REQUIRE(token.type == fkyaml::detail::lexical_token_t::BLOCK_SCALAR);
@@ -1008,7 +1039,7 @@ TEST_CASE("LexicalAnalyzer_FoldedString") {
         const char input[] = ">2\n"
                              "  foo\n"
                              "    bar\n";
-        lexer_t lexer(fkyaml::detail::input_adapter(input));
+        lexer_t lexer(input);
 
         REQUIRE_NOTHROW(token = lexer.get_next_token());
         REQUIRE(token.type == fkyaml::detail::lexical_token_t::BLOCK_SCALAR);
@@ -1022,7 +1053,7 @@ TEST_CASE("LexicalAnalyzer_FoldedString") {
                              "\n"
                              "  bar\n"
                              " \n";
-        lexer_t lexer(fkyaml::detail::input_adapter(input));
+        lexer_t lexer(input);
 
         REQUIRE_NOTHROW(token = lexer.get_next_token());
         REQUIRE(token.type == fkyaml::detail::lexical_token_t::BLOCK_SCALAR);
@@ -1035,7 +1066,7 @@ TEST_CASE("LexicalAnalyzer_FoldedString") {
                              "  bar\n"
                              " \n"
                              "\n";
-        lexer_t lexer(fkyaml::detail::input_adapter(input));
+        lexer_t lexer(input);
 
         REQUIRE_NOTHROW(token = lexer.get_next_token());
         REQUIRE(token.type == fkyaml::detail::lexical_token_t::BLOCK_SCALAR);
@@ -1048,7 +1079,7 @@ TEST_CASE("LexicalAnalyzer_FoldedString") {
                              "  bar\n"
                              "  \n"
                              "\n";
-        lexer_t lexer(fkyaml::detail::input_adapter(input));
+        lexer_t lexer(input);
 
         REQUIRE_NOTHROW(token = lexer.get_next_token());
         REQUIRE(token.type == fkyaml::detail::lexical_token_t::BLOCK_SCALAR);
@@ -1061,7 +1092,7 @@ TEST_CASE("LexicalAnalyzer_FoldedString") {
                              "  bar\n"
                              " \n"
                              "\n";
-        lexer_t lexer(fkyaml::detail::input_adapter(input));
+        lexer_t lexer(input);
 
         REQUIRE_NOTHROW(token = lexer.get_next_token());
         REQUIRE(token.type == fkyaml::detail::lexical_token_t::BLOCK_SCALAR);
@@ -1070,8 +1101,10 @@ TEST_CASE("LexicalAnalyzer_FoldedString") {
 
     SECTION("folded string scalar with trailing spaces/tabs/comments after the block scalar header.") {
         auto input = GENERATE(
-            std::string(">2  \n  foo\n"), std::string(">2\t\t\n  foo\n"), std::string(">2 # comment\n  foo\n"));
-        lexer_t lexer(fkyaml::detail::input_adapter(input));
+            fkyaml::detail::str_view(">2  \n  foo\n"),
+            fkyaml::detail::str_view(">2\t\t\n  foo\n"),
+            fkyaml::detail::str_view(">2 # comment\n  foo\n"));
+        lexer_t lexer(input);
 
         REQUIRE_NOTHROW(token = lexer.get_next_token());
         REQUIRE(token.type == fkyaml::detail::lexical_token_t::BLOCK_SCALAR);
@@ -1080,15 +1113,15 @@ TEST_CASE("LexicalAnalyzer_FoldedString") {
 
     SECTION("folded string scalar with invalid block scalar headers") {
         auto input = GENERATE(
-            std::string(">++2\n  foo"),
-            std::string(">--2\n  foo"),
-            std::string(">+-2\n  foo"),
-            std::string(">-+2\n  foo"),
-            std::string(">+0\n  foo"),
-            std::string(">+11\n           foo"),
-            std::string(">invalid\n  foo"));
+            fkyaml::detail::str_view(">++2\n  foo"),
+            fkyaml::detail::str_view(">--2\n  foo"),
+            fkyaml::detail::str_view(">+-2\n  foo"),
+            fkyaml::detail::str_view(">-+2\n  foo"),
+            fkyaml::detail::str_view(">+0\n  foo"),
+            fkyaml::detail::str_view(">+11\n           foo"),
+            fkyaml::detail::str_view(">invalid\n  foo"));
 
-        lexer_t lexer(fkyaml::detail::input_adapter(input));
+        lexer_t lexer(input);
         REQUIRE_THROWS_AS(token = lexer.get_next_token(), fkyaml::parse_error);
     }
 }
@@ -1097,7 +1130,7 @@ TEST_CASE("LexicalAnalyzer_Anchor") {
     fkyaml::detail::lexical_token token;
 
     SECTION("valid anchor name") {
-        using test_data_t = std::pair<std::string, std::string>;
+        using test_data_t = std::pair<fkyaml::detail::str_view, fkyaml::detail::str_view>;
         auto test_data = GENERATE(
             test_data_t {"&anchor", "anchor"},
             test_data_t {"&anchor name", "anchor"},
@@ -1111,26 +1144,27 @@ TEST_CASE("LexicalAnalyzer_Anchor") {
             test_data_t {"&anchor: ", "anchor:"},
             test_data_t {"&anchor:", "anchor:"});
 
-        lexer_t lexer(fkyaml::detail::input_adapter(test_data.first));
+        lexer_t lexer(test_data.first);
 
         REQUIRE_NOTHROW(token = lexer.get_next_token());
         REQUIRE(token.type == fkyaml::detail::lexical_token_t::ANCHOR_PREFIX);
-        REQUIRE_NOTHROW(std::string(token.token_begin_itr, token.token_end_itr) == test_data.second);
+        fkyaml::detail::str_view token_str(token.token_begin_itr, token.token_end_itr);
+        REQUIRE(token_str == test_data.second);
     }
 
     SECTION("invalid anchor name") {
         auto input = GENERATE(
-            std::string("&"),
-            std::string("& "),
-            std::string("&\t"),
-            std::string("&\n"),
-            std::string("&{"),
-            std::string("&}"),
-            std::string("&["),
-            std::string("&]"),
-            std::string("&,"));
+            fkyaml::detail::str_view("&"),
+            fkyaml::detail::str_view("& "),
+            fkyaml::detail::str_view("&\t"),
+            fkyaml::detail::str_view("&\n"),
+            fkyaml::detail::str_view("&{"),
+            fkyaml::detail::str_view("&}"),
+            fkyaml::detail::str_view("&["),
+            fkyaml::detail::str_view("&]"),
+            fkyaml::detail::str_view("&,"));
 
-        lexer_t lexer(fkyaml::detail::input_adapter(input));
+        lexer_t lexer(input);
         REQUIRE_THROWS_AS(lexer.get_next_token(), fkyaml::parse_error);
     }
 }
@@ -1139,7 +1173,7 @@ TEST_CASE("LexicalAnalyzer_Alias") {
     fkyaml::detail::lexical_token token;
 
     SECTION("valid anchor name") {
-        using test_data_t = std::pair<std::string, std::string>;
+        using test_data_t = std::pair<fkyaml::detail::str_view, fkyaml::detail::str_view>;
         auto test_data = GENERATE(
             test_data_t {"*anchor", "anchor"},
             test_data_t {"*anchor name", "anchor"},
@@ -1153,26 +1187,27 @@ TEST_CASE("LexicalAnalyzer_Alias") {
             test_data_t {"*anchor: ", "anchor:"},
             test_data_t {"*anchor:", "anchor:"});
 
-        lexer_t lexer(fkyaml::detail::input_adapter(test_data.first));
+        lexer_t lexer(test_data.first);
 
         REQUIRE_NOTHROW(token = lexer.get_next_token());
         REQUIRE(token.type == fkyaml::detail::lexical_token_t::ALIAS_PREFIX);
-        REQUIRE_NOTHROW(std::string(token.token_begin_itr, token.token_end_itr) == test_data.second);
+        fkyaml::detail::str_view token_str(token.token_begin_itr, token.token_end_itr);
+        REQUIRE_NOTHROW(token_str == test_data.second);
     }
 
     SECTION("invalid anchor name") {
         auto input = GENERATE(
-            std::string("*"),
-            std::string("* "),
-            std::string("*\t"),
-            std::string("*\n"),
-            std::string("*{"),
-            std::string("*}"),
-            std::string("*["),
-            std::string("*]"),
-            std::string("*,"));
+            fkyaml::detail::str_view("*"),
+            fkyaml::detail::str_view("* "),
+            fkyaml::detail::str_view("*\t"),
+            fkyaml::detail::str_view("*\n"),
+            fkyaml::detail::str_view("*{"),
+            fkyaml::detail::str_view("*}"),
+            fkyaml::detail::str_view("*["),
+            fkyaml::detail::str_view("*]"),
+            fkyaml::detail::str_view("*,"));
 
-        lexer_t lexer(fkyaml::detail::input_adapter(input));
+        lexer_t lexer(input);
         REQUIRE_THROWS_AS(lexer.get_next_token(), fkyaml::parse_error);
     }
 }
@@ -1182,61 +1217,67 @@ TEST_CASE("LexicalAnalyzer_Tag") {
 
     SECTION("valid tag names") {
         auto input = GENERATE(
-            std::string("! tag"),
-            std::string("!\ntag"),
-            std::string("!local tag"),
-            std::string("!local%2A%7C tag"),
-            std::string("!!foo tag"),
-            std::string("!!foo%2A%7C tag"),
-            std::string("!<tag:foo.bar> tag"),
-            std::string("!<tag:foo.%2A%7C.bar> tag"),
-            std::string("!<!foo> tag"),
-            std::string("!<!foo%2A%7C> tag"),
-            std::string("!foo!bar tag"));
+            fkyaml::detail::str_view("! tag"),
+            fkyaml::detail::str_view("!\ntag"),
+            fkyaml::detail::str_view("!local tag"),
+            fkyaml::detail::str_view("!local%2A%7C tag"),
+            fkyaml::detail::str_view("!!foo tag"),
+            fkyaml::detail::str_view("!!foo%2A%7C tag"),
+            fkyaml::detail::str_view("!<tag:foo.bar> tag"),
+            fkyaml::detail::str_view("!<tag:foo.%2A%7C.bar> tag"),
+            fkyaml::detail::str_view("!<!foo> tag"),
+            fkyaml::detail::str_view("!<!foo%2A%7C> tag"),
+            fkyaml::detail::str_view("!foo!bar tag"));
 
-        lexer_t lexer(fkyaml::detail::input_adapter(input));
+        lexer_t lexer(input);
         REQUIRE_NOTHROW(token = lexer.get_next_token());
         REQUIRE(token.type == fkyaml::detail::lexical_token_t::TAG_PREFIX);
-        REQUIRE(std::string(token.token_begin_itr, token.token_end_itr) == input.substr(0, input.size() - 4));
+        REQUIRE(
+            fkyaml::detail::str_view(token.token_begin_itr, token.token_end_itr) == input.substr(0, input.size() - 4));
 
         REQUIRE_NOTHROW(token = lexer.get_next_token());
         REQUIRE(token.type == fkyaml::detail::lexical_token_t::PLAIN_SCALAR);
-        REQUIRE(std::string(token.token_begin_itr, token.token_end_itr) == "tag");
+        REQUIRE(
+            fkyaml::detail::str_view(token.token_begin_itr, token.token_end_itr) == fkyaml::detail::str_view("tag"));
     }
 
     SECTION("valid tag name (not followed by a value)") {
-        auto input = GENERATE(std::string("!"), std::string("!!foo"), std::string("!foo!bar"), std::string("!foo"));
+        auto input = GENERATE(
+            fkyaml::detail::str_view("!"),
+            fkyaml::detail::str_view("!!foo"),
+            fkyaml::detail::str_view("!foo!bar"),
+            fkyaml::detail::str_view("!foo"));
 
-        lexer_t lexer(fkyaml::detail::input_adapter(input));
+        lexer_t lexer(input);
         REQUIRE_NOTHROW(token = lexer.get_next_token());
         REQUIRE(token.type == fkyaml::detail::lexical_token_t::TAG_PREFIX);
-        REQUIRE(std::string(token.token_begin_itr, token.token_end_itr) == input);
+        REQUIRE(fkyaml::detail::str_view(token.token_begin_itr, token.token_end_itr) == input);
     }
 
     SECTION("invalid tag names") {
         auto input = GENERATE(
-            std::string("!!f!oo tag"),
-            std::string("!<!f!oo> tag"),
-            std::string("!<!foo tag"),
-            std::string("!<> tag"),
-            std::string("!<%f:oo> tag"),
-            std::string("!<!%f:oo> tag"),
-            std::string("!foo! tag"),
-            std::string("!foo!%f:oo tag"));
+            fkyaml::detail::str_view("!!f!oo tag"),
+            fkyaml::detail::str_view("!<!f!oo> tag"),
+            fkyaml::detail::str_view("!<!foo tag"),
+            fkyaml::detail::str_view("!<> tag"),
+            fkyaml::detail::str_view("!<%f:oo> tag"),
+            fkyaml::detail::str_view("!<!%f:oo> tag"),
+            fkyaml::detail::str_view("!foo! tag"),
+            fkyaml::detail::str_view("!foo!%f:oo tag"));
 
-        lexer_t lexer(fkyaml::detail::input_adapter(input));
+        lexer_t lexer(input);
         REQUIRE_THROWS_AS(token = lexer.get_next_token(), fkyaml::parse_error);
     }
 }
 
 TEST_CASE("LexicalAnalyzer_ReservedIndicator") {
-    auto buffer = GENERATE(std::string("@invalid"), std::string("`invalid"));
-    lexer_t lexer(fkyaml::detail::input_adapter(buffer));
+    auto buffer = GENERATE(fkyaml::detail::str_view("@invalid"), fkyaml::detail::str_view("`invalid"));
+    lexer_t lexer(buffer);
     REQUIRE_THROWS_AS(lexer.get_next_token(), fkyaml::parse_error);
 }
 
 TEST_CASE("LexicalAnalyzer_KeyBooleanValuePair") {
-    lexer_t lexer(fkyaml::detail::input_adapter("test: true"));
+    lexer_t lexer("test: true");
     fkyaml::detail::lexical_token token;
 
     REQUIRE_NOTHROW(token = lexer.get_next_token());
@@ -1255,7 +1296,7 @@ TEST_CASE("LexicalAnalyzer_KeyBooleanValuePair") {
 }
 
 TEST_CASE("LexicalAnalyzer_KeyIntegerValuePair") {
-    lexer_t lexer(fkyaml::detail::input_adapter("test: -5784"));
+    lexer_t lexer("test: -5784");
     fkyaml::detail::lexical_token token;
 
     REQUIRE_NOTHROW(token = lexer.get_next_token());
@@ -1274,7 +1315,7 @@ TEST_CASE("LexicalAnalyzer_KeyIntegerValuePair") {
 }
 
 TEST_CASE("LexicalAnalyzer_KeyFloatNumberValuePair") {
-    lexer_t lexer(fkyaml::detail::input_adapter("test: -5.58e-3"));
+    lexer_t lexer("test: -5.58e-3");
     fkyaml::detail::lexical_token token;
 
     REQUIRE_NOTHROW(token = lexer.get_next_token());
@@ -1293,7 +1334,7 @@ TEST_CASE("LexicalAnalyzer_KeyFloatNumberValuePair") {
 }
 
 TEST_CASE("LexicalAnalyzer_KeyStringValuePair") {
-    lexer_t lexer(fkyaml::detail::input_adapter("test: \"some value\""));
+    lexer_t lexer("test: \"some value\"");
     fkyaml::detail::lexical_token token;
 
     REQUIRE_NOTHROW(token = lexer.get_next_token());
@@ -1315,7 +1356,7 @@ TEST_CASE("LexicalAnalyzer_FlowSequence") {
     fkyaml::detail::lexical_token token;
 
     SECTION("simple flow sequence") {
-        lexer_t lexer(fkyaml::detail::input_adapter("test: [ foo, bar ]"));
+        lexer_t lexer("test: [ foo, bar ]");
 
         REQUIRE_NOTHROW(token = lexer.get_next_token());
         REQUIRE(token.type == fkyaml::detail::lexical_token_t::PLAIN_SCALAR);
@@ -1346,7 +1387,7 @@ TEST_CASE("LexicalAnalyzer_FlowSequence") {
     }
 
     SECTION("flow sequence with flow mapping child nodes") {
-        lexer_t lexer(fkyaml::detail::input_adapter("test: [ { foo: one, bar: false }, { foo: two, bar: true } ]"));
+        lexer_t lexer("test: [ { foo: one, bar: false }, { foo: two, bar: true } ]");
 
         REQUIRE_NOTHROW(token = lexer.get_next_token());
         REQUIRE(token.type == fkyaml::detail::lexical_token_t::PLAIN_SCALAR);
@@ -1435,7 +1476,7 @@ TEST_CASE("LexicalAnalyzer_FlowMapping") {
     fkyaml::detail::lexical_token token;
 
     SECTION("simple flow mapping") {
-        lexer_t lexer(fkyaml::detail::input_adapter("test: { bool : true, foo :b: bar, pi: 3.14 }"));
+        lexer_t lexer("test: { bool : true, foo :b: bar, pi: 3.14 }");
 
         REQUIRE_NOTHROW(token = lexer.get_next_token());
         REQUIRE(token.type == fkyaml::detail::lexical_token_t::PLAIN_SCALAR);
@@ -1495,7 +1536,7 @@ TEST_CASE("LexicalAnalyzer_FlowMapping") {
     }
 
     SECTION("flow maping with a child mapping node") {
-        lexer_t lexer(fkyaml::detail::input_adapter("test: {foo: bar baz}"));
+        lexer_t lexer("test: {foo: bar baz}");
 
         REQUIRE_NOTHROW(token = lexer.get_next_token());
         REQUIRE(token.type == fkyaml::detail::lexical_token_t::PLAIN_SCALAR);
@@ -1530,8 +1571,7 @@ TEST_CASE("LexicalAnalyzer_BlockSequence") {
     fkyaml::detail::lexical_token token;
 
     SECTION("simple block sequence") {
-        std::string buffer = "test:\n  - foo\n  - bar";
-        lexer_t lexer(fkyaml::detail::input_adapter(buffer));
+        lexer_t lexer("test:\n  - foo\n  - bar");
 
         REQUIRE_NOTHROW(token = lexer.get_next_token());
         REQUIRE(token.type == fkyaml::detail::lexical_token_t::PLAIN_SCALAR);
@@ -1559,8 +1599,7 @@ TEST_CASE("LexicalAnalyzer_BlockSequence") {
     }
 
     SECTION("block sequence with block mapping child nodes") {
-        std::string buffer = "test:\n  - foo: one\n    bar: false\n  - foo: two\n    bar: true";
-        lexer_t lexer(fkyaml::detail::input_adapter(buffer));
+        lexer_t lexer("test:\n  - foo: one\n    bar: false\n  - foo: two\n    bar: true");
 
         REQUIRE_NOTHROW(token = lexer.get_next_token());
         REQUIRE(token.type == fkyaml::detail::lexical_token_t::PLAIN_SCALAR);
@@ -1628,7 +1667,7 @@ TEST_CASE("LexicalAnalyzer_BlockMapping") {
     fkyaml::detail::lexical_token token;
 
     SECTION("simple block mapping") {
-        lexer_t lexer(fkyaml::detail::input_adapter("test:\n  bool: true\n  foo: \'bar\'\n  pi: 3.14"));
+        lexer_t lexer("test:\n  bool: true\n  foo: \'bar\'\n  pi: 3.14");
 
         REQUIRE_NOTHROW(token = lexer.get_next_token());
         REQUIRE(token.type == fkyaml::detail::lexical_token_t::PLAIN_SCALAR);
@@ -1676,7 +1715,7 @@ TEST_CASE("LexicalAnalyzer_BlockMapping") {
     }
 
     SECTION("block mapping with a literal string scalar value") {
-        lexer_t lexer(fkyaml::detail::input_adapter("test: |\n  a literal scalar.\nfoo: \'bar\'\npi: 3.14"));
+        lexer_t lexer("test: |\n  a literal scalar.\nfoo: \'bar\'\npi: 3.14");
 
         REQUIRE_NOTHROW(token = lexer.get_next_token());
         REQUIRE(token.type == fkyaml::detail::lexical_token_t::PLAIN_SCALAR);
@@ -1717,7 +1756,7 @@ TEST_CASE("LexicalAnalyzer_BlockMapping") {
     }
 
     SECTION("block mapping with a folded string scalar value") {
-        lexer_t lexer(fkyaml::detail::input_adapter("test: >\n  a literal scalar.\nfoo: \'bar\'\npi: 3.14"));
+        lexer_t lexer("test: >\n  a literal scalar.\nfoo: \'bar\'\npi: 3.14");
 
         REQUIRE_NOTHROW(token = lexer.get_next_token());
         REQUIRE(token.type == fkyaml::detail::lexical_token_t::PLAIN_SCALAR);

--- a/test/unit_test/test_lexical_analyzer_class.cpp
+++ b/test/unit_test/test_lexical_analyzer_class.cpp
@@ -16,16 +16,16 @@ TEST_CASE("LexicalAnalyzer_YamlVersionDirective") {
     fkyaml::detail::lexical_token token;
 
     SECTION("valid YAML directive") {
-        using value_pair_t = std::pair<fkyaml::detail::str_view, std::string>;
+        using value_pair_t = std::pair<fkyaml::detail::str_view, fkyaml::detail::str_view>;
         auto value_pair = GENERATE(
-            value_pair_t("%YAML 1.1 ", std::string("1.1")),
-            value_pair_t("%YAML\t1.1\t", std::string("1.1")),
-            value_pair_t("%YAML 1.1\n", std::string("1.1")),
-            value_pair_t("%YAML 1.1", std::string("1.1")),
-            value_pair_t("%YAML 1.2 ", std::string("1.2")),
-            value_pair_t("%YAML\t1.2\t", std::string("1.2")),
-            value_pair_t("%YAML 1.2\n", std::string("1.2")),
-            value_pair_t("%YAML 1.2", std::string("1.2")));
+            value_pair_t("%YAML 1.1 ", "1.1"),
+            value_pair_t("%YAML\t1.1\t", "1.1"),
+            value_pair_t("%YAML 1.1\n", "1.1"),
+            value_pair_t("%YAML 1.1", "1.1"),
+            value_pair_t("%YAML 1.2 ", "1.2"),
+            value_pair_t("%YAML\t1.2\t", "1.2"),
+            value_pair_t("%YAML 1.2\n", "1.2"),
+            value_pair_t("%YAML 1.2", "1.2"));
 
         lexer_t lexer(value_pair.first);
 
@@ -76,8 +76,8 @@ TEST_CASE("LexicalAnalyzer_TagDirective") {
 
         REQUIRE_NOTHROW(token = lexer.get_next_token());
         REQUIRE(token.type == fkyaml::detail::lexical_token_t::TAG_DIRECTIVE);
-        REQUIRE(lexer.get_tag_handle() == "!");
-        REQUIRE(lexer.get_tag_prefix() == "foo");
+        REQUIRE(lexer.get_tag_handle().compare("!") == 0);
+        REQUIRE(lexer.get_tag_prefix().compare("foo") == 0);
         REQUIRE_NOTHROW(token = lexer.get_next_token());
         REQUIRE(token.type == fkyaml::detail::lexical_token_t::END_OF_BUFFER);
     }
@@ -88,8 +88,8 @@ TEST_CASE("LexicalAnalyzer_TagDirective") {
 
         REQUIRE_NOTHROW(token = lexer.get_next_token());
         REQUIRE(token.type == fkyaml::detail::lexical_token_t::TAG_DIRECTIVE);
-        REQUIRE(lexer.get_tag_handle() == "!!");
-        REQUIRE(lexer.get_tag_prefix() == "foo");
+        REQUIRE(lexer.get_tag_handle().compare("!!") == 0);
+        REQUIRE(lexer.get_tag_prefix().compare("foo") == 0);
         REQUIRE_NOTHROW(token = lexer.get_next_token());
         REQUIRE(token.type == fkyaml::detail::lexical_token_t::END_OF_BUFFER);
     }
@@ -101,8 +101,8 @@ TEST_CASE("LexicalAnalyzer_TagDirective") {
 
         REQUIRE_NOTHROW(token = lexer.get_next_token());
         REQUIRE(token.type == fkyaml::detail::lexical_token_t::TAG_DIRECTIVE);
-        REQUIRE(lexer.get_tag_handle() == "!va1id-ta9!");
-        REQUIRE(lexer.get_tag_prefix() == "foo");
+        REQUIRE(lexer.get_tag_handle().compare("!va1id-ta9!") == 0);
+        REQUIRE(lexer.get_tag_prefix().compare("foo") == 0);
         REQUIRE_NOTHROW(token = lexer.get_next_token());
         REQUIRE(token.type == fkyaml::detail::lexical_token_t::END_OF_BUFFER);
     }
@@ -184,7 +184,7 @@ TEST_CASE("LexicalAnalyzer_EndOfDirectives") {
 
     REQUIRE_NOTHROW(token = lexer.get_next_token());
     REQUIRE(token.type == fkyaml::detail::lexical_token_t::YAML_VER_DIRECTIVE);
-    REQUIRE(lexer.get_yaml_version() == "1.2");
+    REQUIRE(lexer.get_yaml_version() == fkyaml::detail::str_view("1.2"));
     REQUIRE_NOTHROW(token = lexer.get_next_token());
     REQUIRE(token.type == fkyaml::detail::lexical_token_t::END_OF_DIRECTIVES);
     REQUIRE_NOTHROW(token = lexer.get_next_token());
@@ -205,7 +205,7 @@ TEST_CASE("LexicalAnalyzer_EndOfDocuments") {
 
     REQUIRE_NOTHROW(token = lexer.get_next_token());
     REQUIRE(token.type == fkyaml::detail::lexical_token_t::YAML_VER_DIRECTIVE);
-    REQUIRE(lexer.get_yaml_version() == "1.2");
+    REQUIRE(lexer.get_yaml_version() == fkyaml::detail::str_view("1.2"));
     REQUIRE_NOTHROW(token = lexer.get_next_token());
     REQUIRE(token.type == fkyaml::detail::lexical_token_t::END_OF_DIRECTIVES);
     REQUIRE_NOTHROW(token = lexer.get_next_token());

--- a/test/unit_test/test_lexical_analyzer_class.cpp
+++ b/test/unit_test/test_lexical_analyzer_class.cpp
@@ -189,12 +189,12 @@ TEST_CASE("LexicalAnalyzer_EndOfDirectives") {
     REQUIRE(token.type == fkyaml::detail::lexical_token_t::END_OF_DIRECTIVES);
     REQUIRE_NOTHROW(token = lexer.get_next_token());
     REQUIRE(token.type == fkyaml::detail::lexical_token_t::PLAIN_SCALAR);
-    REQUIRE(std::string(token.token_begin_itr, token.token_end_itr) == "foo");
+    REQUIRE(token.str == "foo");
     REQUIRE_NOTHROW(token = lexer.get_next_token());
     REQUIRE(token.type == fkyaml::detail::lexical_token_t::KEY_SEPARATOR);
     REQUIRE_NOTHROW(token = lexer.get_next_token());
     REQUIRE(token.type == fkyaml::detail::lexical_token_t::PLAIN_SCALAR);
-    REQUIRE(std::string(token.token_begin_itr, token.token_end_itr) == "bar");
+    REQUIRE(token.str == "bar");
     REQUIRE_NOTHROW(token = lexer.get_next_token());
     REQUIRE(token.type == fkyaml::detail::lexical_token_t::END_OF_BUFFER);
 }
@@ -263,7 +263,7 @@ TEST_CASE("LexicalAnalyzer_Colon") {
         lexer_t lexer(":test");
         REQUIRE_NOTHROW(token = lexer.get_next_token());
         REQUIRE(token.type == fkyaml::detail::lexical_token_t::PLAIN_SCALAR);
-        REQUIRE(std::string(token.token_begin_itr, token.token_end_itr) == ":test");
+        REQUIRE(token.str == ":test");
     }
 
     SECTION("colon with a flow indicator in a non-flow context") {
@@ -276,8 +276,7 @@ TEST_CASE("LexicalAnalyzer_Colon") {
         lexer_t lexer(input);
         REQUIRE_NOTHROW(token = lexer.get_next_token());
         REQUIRE(token.type == fkyaml::detail::lexical_token_t::PLAIN_SCALAR);
-        fkyaml::detail::str_view token_str(token.token_begin_itr, token.token_end_itr);
-        REQUIRE(token_str == input);
+        REQUIRE(token.str == input);
     }
 
     SECTION("colon with a flow indicator in a flow context") {
@@ -305,127 +304,121 @@ TEST_CASE("LexicalAnalzer_BlockSequenceEntryPrefix") {
     REQUIRE(token.type == fkyaml::detail::lexical_token_t::SEQUENCE_BLOCK_PREFIX);
     REQUIRE_NOTHROW(token = lexer.get_next_token());
     REQUIRE(token.type == fkyaml::detail::lexical_token_t::PLAIN_SCALAR);
-    fkyaml::detail::str_view token_str(token.token_begin_itr, token.token_end_itr);
-    REQUIRE(token_str == fkyaml::detail::str_view("foo"));
+    REQUIRE(token.str == fkyaml::detail::str_view("foo"));
 }
 
 TEST_CASE("LexicalAnalyzer_PlainScalar") {
     using value_pair_t = std::pair<fkyaml::detail::str_view, fkyaml::detail::str_view>;
     auto value_pair = GENERATE(
-        value_pair_t(fkyaml::detail::str_view("test"), fkyaml::detail::str_view("test")),
-        value_pair_t(fkyaml::detail::str_view("nop"), fkyaml::detail::str_view("nop")),
-        value_pair_t(fkyaml::detail::str_view("none"), fkyaml::detail::str_view("none")),
-        value_pair_t(fkyaml::detail::str_view("?test"), fkyaml::detail::str_view("?test")),
-        value_pair_t(fkyaml::detail::str_view(".NET"), fkyaml::detail::str_view(".NET")),
-        value_pair_t(fkyaml::detail::str_view(".on"), fkyaml::detail::str_view(".on")),
-        value_pair_t(fkyaml::detail::str_view(".n"), fkyaml::detail::str_view(".n")),
-        value_pair_t(fkyaml::detail::str_view("-t"), fkyaml::detail::str_view("-t")),
-        value_pair_t(fkyaml::detail::str_view("-foo"), fkyaml::detail::str_view("-foo")),
-        value_pair_t(fkyaml::detail::str_view("-.test"), fkyaml::detail::str_view("-.test")),
-        value_pair_t(fkyaml::detail::str_view("?"), fkyaml::detail::str_view("?")),
-        value_pair_t(fkyaml::detail::str_view("--foo"), fkyaml::detail::str_view("--foo")),
-        value_pair_t(fkyaml::detail::str_view("+123"), fkyaml::detail::str_view("+123")),
-        value_pair_t(fkyaml::detail::str_view("1.2.3"), fkyaml::detail::str_view("1.2.3")),
-        value_pair_t(fkyaml::detail::str_view("foo,bar"), fkyaml::detail::str_view("foo,bar")),
-        value_pair_t(fkyaml::detail::str_view("foo[bar"), fkyaml::detail::str_view("foo[bar")),
-        value_pair_t(fkyaml::detail::str_view("foo]bar"), fkyaml::detail::str_view("foo]bar")),
-        value_pair_t(fkyaml::detail::str_view("foo{bar"), fkyaml::detail::str_view("foo{bar")),
-        value_pair_t(fkyaml::detail::str_view("foo}bar"), fkyaml::detail::str_view("foo}bar")),
-        value_pair_t(fkyaml::detail::str_view("foo:bar"), fkyaml::detail::str_view("foo:bar")),
-        value_pair_t(fkyaml::detail::str_view("foo bar"), fkyaml::detail::str_view("foo bar")),
-        value_pair_t(fkyaml::detail::str_view("foo\"bar"), fkyaml::detail::str_view("foo\"bar")),
-        value_pair_t(fkyaml::detail::str_view("foo\'s bar"), fkyaml::detail::str_view("foo\'s bar")),
-        value_pair_t(fkyaml::detail::str_view("foo\\bar"), fkyaml::detail::str_view("foo\\bar")),
-        value_pair_t(fkyaml::detail::str_view("nullValue"), fkyaml::detail::str_view("nullValue")),
-        value_pair_t(fkyaml::detail::str_view("NullValue"), fkyaml::detail::str_view("NullValue")),
-        value_pair_t(fkyaml::detail::str_view("NULL_VALUE"), fkyaml::detail::str_view("NULL_VALUE")),
-        value_pair_t(fkyaml::detail::str_view("~Value"), fkyaml::detail::str_view("~Value")),
-        value_pair_t(fkyaml::detail::str_view("trueValue"), fkyaml::detail::str_view("trueValue")),
-        value_pair_t(fkyaml::detail::str_view("TrueValue"), fkyaml::detail::str_view("TrueValue")),
-        value_pair_t(fkyaml::detail::str_view("TRUE_VALUE"), fkyaml::detail::str_view("TRUE_VALUE")),
-        value_pair_t(fkyaml::detail::str_view("falseValue"), fkyaml::detail::str_view("falseValue")),
-        value_pair_t(fkyaml::detail::str_view("FalseValue"), fkyaml::detail::str_view("FalseValue")),
-        value_pair_t(fkyaml::detail::str_view("FALSE_VALUE"), fkyaml::detail::str_view("FALSE_VALUE")),
-        value_pair_t(fkyaml::detail::str_view(".infValue"), fkyaml::detail::str_view(".infValue")),
-        value_pair_t(fkyaml::detail::str_view(".InfValue"), fkyaml::detail::str_view(".InfValue")),
-        value_pair_t(fkyaml::detail::str_view(".INF_VALUE"), fkyaml::detail::str_view(".INF_VALUE")),
-        value_pair_t(fkyaml::detail::str_view("-.infValue"), fkyaml::detail::str_view("-.infValue")),
-        value_pair_t(fkyaml::detail::str_view("-.InfValue"), fkyaml::detail::str_view("-.InfValue")),
-        value_pair_t(fkyaml::detail::str_view("-.INF_VALUE"), fkyaml::detail::str_view("-.INF_VALUE")),
-        value_pair_t(fkyaml::detail::str_view(".nanValue"), fkyaml::detail::str_view(".nanValue")),
-        value_pair_t(fkyaml::detail::str_view(".NaNValue"), fkyaml::detail::str_view(".NaNValue")),
-        value_pair_t(fkyaml::detail::str_view(".NAN_VALUE"), fkyaml::detail::str_view(".NAN_VALUE")));
+        value_pair_t("test", "test"),
+        value_pair_t("nop", "nop"),
+        value_pair_t("none", "none"),
+        value_pair_t("?test", "?test"),
+        value_pair_t(".NET", ".NET"),
+        value_pair_t(".on", ".on"),
+        value_pair_t(".n", ".n"),
+        value_pair_t("-t", "-t"),
+        value_pair_t("-foo", "-foo"),
+        value_pair_t("-.test", "-.test"),
+        value_pair_t("?", "?"),
+        value_pair_t("--foo", "--foo"),
+        value_pair_t("+123", "+123"),
+        value_pair_t("1.2.3", "1.2.3"),
+        value_pair_t("foo,bar", "foo,bar"),
+        value_pair_t("foo[bar", "foo[bar"),
+        value_pair_t("foo]bar", "foo]bar"),
+        value_pair_t("foo{bar", "foo{bar"),
+        value_pair_t("foo}bar", "foo}bar"),
+        value_pair_t("foo:bar", "foo:bar"),
+        value_pair_t("foo bar", "foo bar"),
+        value_pair_t("foo\"bar", "foo\"bar"),
+        value_pair_t("foo\'s bar", "foo\'s bar"),
+        value_pair_t("foo\\bar", "foo\\bar"),
+        value_pair_t("nullValue", "nullValue"),
+        value_pair_t("NullValue", "NullValue"),
+        value_pair_t("NULL_VALUE", "NULL_VALUE"),
+        value_pair_t("~Value", "~Value"),
+        value_pair_t("trueValue", "trueValue"),
+        value_pair_t("TrueValue", "TrueValue"),
+        value_pair_t("TRUE_VALUE", "TRUE_VALUE"),
+        value_pair_t("falseValue", "falseValue"),
+        value_pair_t("FalseValue", "FalseValue"),
+        value_pair_t("FALSE_VALUE", "FALSE_VALUE"),
+        value_pair_t(".infValue", ".infValue"),
+        value_pair_t(".InfValue", ".InfValue"),
+        value_pair_t(".INF_VALUE", ".INF_VALUE"),
+        value_pair_t("-.infValue", "-.infValue"),
+        value_pair_t("-.InfValue", "-.InfValue"),
+        value_pair_t("-.INF_VALUE", "-.INF_VALUE"),
+        value_pair_t(".nanValue", ".nanValue"),
+        value_pair_t(".NaNValue", ".NaNValue"),
+        value_pair_t(".NAN_VALUE", ".NAN_VALUE"));
 
     lexer_t lexer(value_pair.first);
     fkyaml::detail::lexical_token token;
 
     REQUIRE_NOTHROW(token = lexer.get_next_token());
     REQUIRE(token.type == fkyaml::detail::lexical_token_t::PLAIN_SCALAR);
-    fkyaml::detail::str_view token_str(token.token_begin_itr, token.token_end_itr);
-    REQUIRE(token_str == value_pair.second);
+    REQUIRE(token.str == value_pair.second);
 }
 
 TEST_CASE("LexicalAnalyzer_SingleQuotedScalar") {
     using value_pair_t = std::pair<fkyaml::detail::str_view, fkyaml::detail::str_view>;
     auto value_pair = GENERATE(
-        value_pair_t(fkyaml::detail::str_view("\'\'"), fkyaml::detail::str_view("")),
-        value_pair_t(fkyaml::detail::str_view("\'foo\"bar\'"), fkyaml::detail::str_view("foo\"bar")),
-        value_pair_t(fkyaml::detail::str_view("\'foo bar\'"), fkyaml::detail::str_view("foo bar")),
-        value_pair_t(fkyaml::detail::str_view("\'foo\'\'bar\'"), fkyaml::detail::str_view("foo\'bar")),
-        value_pair_t(fkyaml::detail::str_view("\'foo\'\'bar\' "), fkyaml::detail::str_view("foo\'bar")),
-        value_pair_t(fkyaml::detail::str_view("\'foo,bar\'"), fkyaml::detail::str_view("foo,bar")),
-        value_pair_t(fkyaml::detail::str_view("\'foo]bar\'"), fkyaml::detail::str_view("foo]bar")),
-        value_pair_t(fkyaml::detail::str_view("\'foo}bar\'"), fkyaml::detail::str_view("foo}bar")),
-        value_pair_t(fkyaml::detail::str_view("\'foo\"bar\'"), fkyaml::detail::str_view("foo\"bar")),
-        value_pair_t(fkyaml::detail::str_view("\'foo:bar\'"), fkyaml::detail::str_view("foo:bar")),
-        value_pair_t(fkyaml::detail::str_view("\'foo\\bar\'"), fkyaml::detail::str_view("foo\\bar")),
+        value_pair_t("\'\'", ""),
+        value_pair_t("\'foo\"bar\'", "foo\"bar"),
+        value_pair_t("\'foo bar\'", "foo bar"),
+        value_pair_t("\'foo\'\'bar\'", "foo\'bar"),
+        value_pair_t("\'foo\'\'bar\' ", "foo\'bar"),
+        value_pair_t("\'foo,bar\'", "foo,bar"),
+        value_pair_t("\'foo]bar\'", "foo]bar"),
+        value_pair_t("\'foo}bar\'", "foo}bar"),
+        value_pair_t("\'foo\"bar\'", "foo\"bar"),
+        value_pair_t("\'foo:bar\'", "foo:bar"),
+        value_pair_t("\'foo\\bar\'", "foo\\bar"),
 
-        value_pair_t(fkyaml::detail::str_view("\'foo\nbar\'"), fkyaml::detail::str_view("foo bar")),
-        value_pair_t(fkyaml::detail::str_view("\'foo \t\n \tbar\'"), fkyaml::detail::str_view("foo bar")),
-        value_pair_t(fkyaml::detail::str_view("\'foo\n\n \t\nbar\'"), fkyaml::detail::str_view("foo\n\nbar")),
-        value_pair_t(fkyaml::detail::str_view("\'\nfoo\n\n \t\nbar\'"), fkyaml::detail::str_view(" foo\n\nbar")),
-        value_pair_t(fkyaml::detail::str_view("\'foo\nbar\n\'"), fkyaml::detail::str_view("foo bar ")));
+        value_pair_t("\'foo\nbar\'", "foo bar"),
+        value_pair_t("\'foo \t\n \tbar\'", "foo bar"),
+        value_pair_t("\'foo\n\n \t\nbar\'", "foo\n\nbar"),
+        value_pair_t("\'\nfoo\n\n \t\nbar\'", " foo\n\nbar"),
+        value_pair_t("\'foo\nbar\n\'", "foo bar "));
 
     lexer_t lexer(value_pair.first);
     fkyaml::detail::lexical_token token;
 
     REQUIRE_NOTHROW(token = lexer.get_next_token());
     REQUIRE(token.type == fkyaml::detail::lexical_token_t::SINGLE_QUOTED_SCALAR);
-    fkyaml::detail::str_view token_str(token.token_begin_itr, token.token_end_itr);
-    REQUIRE(token_str == value_pair.second);
+    REQUIRE(token.str == value_pair.second);
 }
 
 TEST_CASE("LexicalAnalyzer_DoubleQuotedScalar") {
     using value_pair_t = std::pair<fkyaml::detail::str_view, fkyaml::detail::str_view>;
     auto value_pair = GENERATE(
-        value_pair_t(fkyaml::detail::str_view("\"\""), fkyaml::detail::str_view("")),
-        value_pair_t(fkyaml::detail::str_view("\"foo bar\""), fkyaml::detail::str_view("foo bar")),
-        value_pair_t(fkyaml::detail::str_view("\"foo\tbar\""), fkyaml::detail::str_view("foo\tbar")),
-        value_pair_t(fkyaml::detail::str_view("\"foo's bar\""), fkyaml::detail::str_view("foo's bar")),
-        value_pair_t(fkyaml::detail::str_view("\"foo:bar\""), fkyaml::detail::str_view("foo:bar")),
-        value_pair_t(fkyaml::detail::str_view("\"foo,bar\""), fkyaml::detail::str_view("foo,bar")),
-        value_pair_t(fkyaml::detail::str_view("\"foo]bar\""), fkyaml::detail::str_view("foo]bar")),
-        value_pair_t(fkyaml::detail::str_view("\"foo}bar\""), fkyaml::detail::str_view("foo}bar")),
-        value_pair_t(fkyaml::detail::str_view("\"\\x30\\x2B\\x6d\""), fkyaml::detail::str_view("0+m")),
+        value_pair_t("\"\"", ""),
+        value_pair_t("\"foo bar\"", "foo bar"),
+        value_pair_t("\"foo\tbar\"", "foo\tbar"),
+        value_pair_t("\"foo's bar\"", "foo's bar"),
+        value_pair_t("\"foo:bar\"", "foo:bar"),
+        value_pair_t("\"foo,bar\"", "foo,bar"),
+        value_pair_t("\"foo]bar\"", "foo]bar"),
+        value_pair_t("\"foo}bar\"", "foo}bar"),
+        value_pair_t("\"\\x30\\x2B\\x6d\"", "0+m"),
 
-        value_pair_t(fkyaml::detail::str_view("\"foo\nbar\""), fkyaml::detail::str_view("foo bar")),
-        value_pair_t(fkyaml::detail::str_view("\"foo \t\n \tbar\""), fkyaml::detail::str_view("foo bar")),
-        value_pair_t(fkyaml::detail::str_view("\"foo\n\n \t\nbar\""), fkyaml::detail::str_view("foo\n\nbar")),
-        value_pair_t(fkyaml::detail::str_view("\"\nfoo\n\n \t\nbar\""), fkyaml::detail::str_view(" foo\n\nbar")),
-        value_pair_t(fkyaml::detail::str_view("\"foo\nbar\n\""), fkyaml::detail::str_view("foo bar ")),
-        value_pair_t(fkyaml::detail::str_view("\"foo\\\nbar\""), fkyaml::detail::str_view("foobar")),
-        value_pair_t(fkyaml::detail::str_view("\"foo \t\\\nbar\""), fkyaml::detail::str_view("foo \tbar")),
-        value_pair_t(
-            fkyaml::detail::str_view("\"\\\n  foo \t\\\n\tbar\t  \t\\\n\""),
-            fkyaml::detail::str_view("foo \tbar\t  \t")));
+        value_pair_t("\"foo\nbar\"", "foo bar"),
+        value_pair_t("\"foo \t\n \tbar\"", "foo bar"),
+        value_pair_t("\"foo\n\n \t\nbar\"", "foo\n\nbar"),
+        value_pair_t("\"\nfoo\n\n \t\nbar\"", " foo\n\nbar"),
+        value_pair_t("\"foo\nbar\n\"", "foo bar "),
+        value_pair_t("\"foo\\\nbar\"", "foobar"),
+        value_pair_t("\"foo \t\\\nbar\"", "foo \tbar"),
+        value_pair_t("\"\\\n  foo \t\\\n\tbar\t  \t\\\n\"", "foo \tbar\t  \t"));
 
     lexer_t lexer(value_pair.first);
     fkyaml::detail::lexical_token token;
 
     REQUIRE_NOTHROW(token = lexer.get_next_token());
     REQUIRE(token.type == fkyaml::detail::lexical_token_t::DOUBLE_QUOTED_SCALAR);
-    fkyaml::detail::str_view token_str(token.token_begin_itr, token.token_end_itr);
-    REQUIRE(token_str == value_pair.second);
+    REQUIRE(token.str == value_pair.second);
 }
 
 TEST_CASE("LexicalAnalyzer_MultiByteCharString") {
@@ -482,108 +475,71 @@ TEST_CASE("LexicalAnalyzer_MultiByteCharString") {
 
     REQUIRE_NOTHROW(token = lexer.get_next_token());
     REQUIRE(token.type == fkyaml::detail::lexical_token_t::PLAIN_SCALAR);
-    fkyaml::detail::str_view token_str(token.token_begin_itr, token.token_end_itr);
-    REQUIRE(token_str == input);
+    REQUIRE(token.str == input);
 }
 
 TEST_CASE("LexicalAnalyzer_EscapedUnicodeCharacter") {
     using value_pair_t = std::pair<fkyaml::detail::str_view, std::string>;
     using char_traits_t = std::char_traits<char>;
     auto value_pair = GENERATE(
-        value_pair_t(fkyaml::detail::str_view("\"\\x00\""), std::string {char_traits_t::to_char_type(0x00)}),
-        value_pair_t(fkyaml::detail::str_view("\"\\x40\""), std::string {char_traits_t::to_char_type(0x40)}),
-        value_pair_t(fkyaml::detail::str_view("\"\\x7F\""), std::string {char_traits_t::to_char_type(0x7F)}),
-        value_pair_t(fkyaml::detail::str_view("\"\\u0000\""), std::string {char_traits_t::to_char_type(0x00)}),
-        value_pair_t(fkyaml::detail::str_view("\"\\u0040\""), std::string {char_traits_t::to_char_type(0x40)}),
-        value_pair_t(fkyaml::detail::str_view("\"\\u007F\""), std::string {char_traits_t::to_char_type(0x7F)}),
+        value_pair_t("\"\\x00\"", {char_traits_t::to_char_type(0x00)}),
+        value_pair_t("\"\\x40\"", {char_traits_t::to_char_type(0x40)}),
+        value_pair_t("\"\\x7F\"", {char_traits_t::to_char_type(0x7F)}),
+        value_pair_t("\"\\u0000\"", {char_traits_t::to_char_type(0x00)}),
+        value_pair_t("\"\\u0040\"", {char_traits_t::to_char_type(0x40)}),
+        value_pair_t("\"\\u007F\"", {char_traits_t::to_char_type(0x7F)}),
+        value_pair_t("\"\\u0080\"", {char_traits_t::to_char_type(0xC2), char_traits_t::to_char_type(0x80)}),
+        value_pair_t("\"\\u0400\"", {char_traits_t::to_char_type(0xD0), char_traits_t::to_char_type(0x80)}),
+        value_pair_t("\"\\u07FF\"", {char_traits_t::to_char_type(0xDF), char_traits_t::to_char_type(0xBF)}),
         value_pair_t(
-            fkyaml::detail::str_view("\"\\u0080\""),
-            std::string {char_traits_t::to_char_type(0xC2), char_traits_t::to_char_type(0x80)}),
+            "\"\\u0800\"",
+            {char_traits_t::to_char_type(0xE0), char_traits_t::to_char_type(0xA0), char_traits_t::to_char_type(0x80)}),
         value_pair_t(
-            fkyaml::detail::str_view("\"\\u0400\""),
-            std::string {char_traits_t::to_char_type(0xD0), char_traits_t::to_char_type(0x80)}),
+            "\"\\u8000\"",
+            {char_traits_t::to_char_type(0xE8), char_traits_t::to_char_type(0x80), char_traits_t::to_char_type(0x80)}),
         value_pair_t(
-            fkyaml::detail::str_view("\"\\u07FF\""),
-            std::string {char_traits_t::to_char_type(0xDF), char_traits_t::to_char_type(0xBF)}),
+            "\"\\uFFFF\"",
+            {char_traits_t::to_char_type(0xEF), char_traits_t::to_char_type(0xBF), char_traits_t::to_char_type(0xBF)}),
+        value_pair_t("\"\\U00000000\"", {char_traits_t::to_char_type(0x00)}),
+        value_pair_t("\"\\U00000040\"", {char_traits_t::to_char_type(0x40)}),
+        value_pair_t("\"\\U0000007F\"", {char_traits_t::to_char_type(0x7F)}),
+        value_pair_t("\"\\U00000080\"", {char_traits_t::to_char_type(0xC2), char_traits_t::to_char_type(0x80)}),
+        value_pair_t("\"\\U00000400\"", {char_traits_t::to_char_type(0xD0), char_traits_t::to_char_type(0x80)}),
+        value_pair_t("\"\\U000007FF\"", {char_traits_t::to_char_type(0xDF), char_traits_t::to_char_type(0xBF)}),
         value_pair_t(
-            fkyaml::detail::str_view("\"\\u0800\""),
-            std::string {
-                char_traits_t::to_char_type(0xE0),
-                char_traits_t::to_char_type(0xA0),
-                char_traits_t::to_char_type(0x80)}),
+            "\"\\U00000800\"",
+            {char_traits_t::to_char_type(0xE0), char_traits_t::to_char_type(0xA0), char_traits_t::to_char_type(0x80)}),
         value_pair_t(
-            fkyaml::detail::str_view("\"\\u8000\""),
-            std::string {
-                char_traits_t::to_char_type(0xE8),
-                char_traits_t::to_char_type(0x80),
-                char_traits_t::to_char_type(0x80)}),
+            "\"\\U00008000\"",
+            {char_traits_t::to_char_type(0xE8), char_traits_t::to_char_type(0x80), char_traits_t::to_char_type(0x80)}),
         value_pair_t(
-            fkyaml::detail::str_view("\"\\uFFFF\""),
-            std::string {
-                char_traits_t::to_char_type(0xEF),
-                char_traits_t::to_char_type(0xBF),
-                char_traits_t::to_char_type(0xBF)}),
-        value_pair_t(fkyaml::detail::str_view("\"\\U00000000\""), std::string {char_traits_t::to_char_type(0x00)}),
-        value_pair_t(fkyaml::detail::str_view("\"\\U00000040\""), std::string {char_traits_t::to_char_type(0x40)}),
-        value_pair_t(fkyaml::detail::str_view("\"\\U0000007F\""), std::string {char_traits_t::to_char_type(0x7F)}),
+            "\"\\U0000FFFF\"",
+            {char_traits_t::to_char_type(0xEF), char_traits_t::to_char_type(0xBF), char_traits_t::to_char_type(0xBF)}),
         value_pair_t(
-            fkyaml::detail::str_view("\"\\U00000080\""),
-            std::string {char_traits_t::to_char_type(0xC2), char_traits_t::to_char_type(0x80)}),
+            "\"\\U00010000\"",
+            {char_traits_t::to_char_type(0xF0),
+             char_traits_t::to_char_type(0x90),
+             char_traits_t::to_char_type(0x80),
+             char_traits_t::to_char_type(0x80)}),
         value_pair_t(
-            fkyaml::detail::str_view("\"\\U00000400\""),
-            std::string {char_traits_t::to_char_type(0xD0), char_traits_t::to_char_type(0x80)}),
+            "\"\\U00080000\"",
+            {char_traits_t::to_char_type(0xF2),
+             char_traits_t::to_char_type(0x80),
+             char_traits_t::to_char_type(0x80),
+             char_traits_t::to_char_type(0x80)}),
         value_pair_t(
-            fkyaml::detail::str_view("\"\\U000007FF\""),
-            std::string {char_traits_t::to_char_type(0xDF), char_traits_t::to_char_type(0xBF)}),
-        value_pair_t(
-            fkyaml::detail::str_view("\"\\U00000800\""),
-            std::string {
-                char_traits_t::to_char_type(0xE0),
-                char_traits_t::to_char_type(0xA0),
-                char_traits_t::to_char_type(0x80)}),
-        value_pair_t(
-            fkyaml::detail::str_view("\"\\U00008000\""),
-            std::string {
-                char_traits_t::to_char_type(0xE8),
-                char_traits_t::to_char_type(0x80),
-                char_traits_t::to_char_type(0x80)}),
-        value_pair_t(
-            fkyaml::detail::str_view("\"\\U0000FFFF\""),
-            std::string {
-                char_traits_t::to_char_type(0xEF),
-                char_traits_t::to_char_type(0xBF),
-                char_traits_t::to_char_type(0xBF)}),
-        value_pair_t(
-            fkyaml::detail::str_view("\"\\U00010000\""),
-            std::string {
-                char_traits_t::to_char_type(0xF0),
-                char_traits_t::to_char_type(0x90),
-                char_traits_t::to_char_type(0x80),
-                char_traits_t::to_char_type(0x80)}),
-        value_pair_t(
-            fkyaml::detail::str_view("\"\\U00080000\""),
-            std::string {
-                char_traits_t::to_char_type(0xF2),
-                char_traits_t::to_char_type(0x80),
-                char_traits_t::to_char_type(0x80),
-                char_traits_t::to_char_type(0x80)}),
-        value_pair_t(
-            fkyaml::detail::str_view("\"\\U0010FFFF\""),
-            std::string {
-                char_traits_t::to_char_type(0xF4),
-                char_traits_t::to_char_type(0x8F),
-                char_traits_t::to_char_type(0xBF),
-                char_traits_t::to_char_type(0xBF)}));
+            "\"\\U0010FFFF\"",
+            {char_traits_t::to_char_type(0xF4),
+             char_traits_t::to_char_type(0x8F),
+             char_traits_t::to_char_type(0xBF),
+             char_traits_t::to_char_type(0xBF)}));
 
-    fkyaml::detail::str_view input = value_pair.first;
-    lexer_t lexer(input);
+    lexer_t lexer(value_pair.first);
     fkyaml::detail::lexical_token token;
 
     REQUIRE_NOTHROW(token = lexer.get_next_token());
     REQUIRE(token.type == fkyaml::detail::lexical_token_t::DOUBLE_QUOTED_SCALAR);
-    fkyaml::detail::str_view token_str(token.token_begin_itr, token.token_end_itr);
-    fkyaml::detail::str_view escaped_str(value_pair.second);
-    REQUIRE(token_str == escaped_str);
+    REQUIRE(token.str == value_pair.second);
 }
 
 TEST_CASE("LexicalAnalyzer_InvalidString") {
@@ -607,138 +563,6 @@ TEST_CASE("LexicalAnalyzer_InvalidString") {
         REQUIRE_THROWS_AS(lexer.get_next_token(), fkyaml::invalid_encoding);
     }
 }
-
-// FIXME: to be deleted
-// TEST_CASE("LexicalAnalyzer_InvalidMultiByteCharString") {
-//     using char_traits_t = std::char_traits<char>;
-//     auto mb_char = GENERATE(
-//         std::string {char_traits_t::to_char_type(0x80), char_traits_t::to_char_type(0x80)},
-//         std::string {char_traits_t::to_char_type(0xC1), char_traits_t::to_char_type(0x80)},
-//         std::string {char_traits_t::to_char_type(0xC2), char_traits_t::to_char_type(0x7F)},
-//         std::string {char_traits_t::to_char_type(0xC2), char_traits_t::to_char_type(0xC0)},
-//         std::string {
-//             char_traits_t::to_char_type(0xE0), char_traits_t::to_char_type(0x7F), char_traits_t::to_char_type(0x80)},
-//         std::string {
-//             char_traits_t::to_char_type(0xE0), char_traits_t::to_char_type(0xC0), char_traits_t::to_char_type(0x80)},
-//         std::string {
-//             char_traits_t::to_char_type(0xE0), char_traits_t::to_char_type(0x80), char_traits_t::to_char_type(0x7F)},
-//         std::string {
-//             char_traits_t::to_char_type(0xE0), char_traits_t::to_char_type(0x80), char_traits_t::to_char_type(0xC0)},
-//         std::string {
-//             char_traits_t::to_char_type(0xED), char_traits_t::to_char_type(0x7F), char_traits_t::to_char_type(0x80)},
-//         std::string {
-//             char_traits_t::to_char_type(0xED), char_traits_t::to_char_type(0xA0), char_traits_t::to_char_type(0x80)},
-//         std::string {
-//             char_traits_t::to_char_type(0xED), char_traits_t::to_char_type(0x80), char_traits_t::to_char_type(0x7F)},
-//         std::string {
-//             char_traits_t::to_char_type(0xED), char_traits_t::to_char_type(0x80), char_traits_t::to_char_type(0xC0)},
-//         std::string {
-//             char_traits_t::to_char_type(0xEE), char_traits_t::to_char_type(0x7F), char_traits_t::to_char_type(0x80)},
-//         std::string {
-//             char_traits_t::to_char_type(0xEE), char_traits_t::to_char_type(0xC0), char_traits_t::to_char_type(0x80)},
-//         std::string {
-//             char_traits_t::to_char_type(0xEF), char_traits_t::to_char_type(0x80), char_traits_t::to_char_type(0x7F)},
-//         std::string {
-//             char_traits_t::to_char_type(0xEF), char_traits_t::to_char_type(0x80), char_traits_t::to_char_type(0xC0)},
-//         std::string {
-//             char_traits_t::to_char_type(0xF0),
-//             char_traits_t::to_char_type(0x8F),
-//             char_traits_t::to_char_type(0x80),
-//             char_traits_t::to_char_type(0x80)},
-//         std::string {
-//             char_traits_t::to_char_type(0xF0),
-//             char_traits_t::to_char_type(0xC0),
-//             char_traits_t::to_char_type(0x80),
-//             char_traits_t::to_char_type(0x80)},
-//         std::string {
-//             char_traits_t::to_char_type(0xF0),
-//             char_traits_t::to_char_type(0x90),
-//             char_traits_t::to_char_type(0x7F),
-//             char_traits_t::to_char_type(0x80)},
-//         std::string {
-//             char_traits_t::to_char_type(0xF0),
-//             char_traits_t::to_char_type(0x90),
-//             char_traits_t::to_char_type(0xC0),
-//             char_traits_t::to_char_type(0x80)},
-//         std::string {
-//             char_traits_t::to_char_type(0xF0),
-//             char_traits_t::to_char_type(0x90),
-//             char_traits_t::to_char_type(0x80),
-//             char_traits_t::to_char_type(0x7F)},
-//         std::string {
-//             char_traits_t::to_char_type(0xF0),
-//             char_traits_t::to_char_type(0x90),
-//             char_traits_t::to_char_type(0x80),
-//             char_traits_t::to_char_type(0xC0)},
-//         std::string {
-//             char_traits_t::to_char_type(0xF1),
-//             char_traits_t::to_char_type(0x7F),
-//             char_traits_t::to_char_type(0x80),
-//             char_traits_t::to_char_type(0x80)},
-//         std::string {
-//             char_traits_t::to_char_type(0xF1),
-//             char_traits_t::to_char_type(0xC0),
-//             char_traits_t::to_char_type(0x80),
-//             char_traits_t::to_char_type(0x80)},
-//         std::string {
-//             char_traits_t::to_char_type(0xF1),
-//             char_traits_t::to_char_type(0x80),
-//             char_traits_t::to_char_type(0x7F),
-//             char_traits_t::to_char_type(0x80)},
-//         std::string {
-//             char_traits_t::to_char_type(0xF1),
-//             char_traits_t::to_char_type(0x80),
-//             char_traits_t::to_char_type(0xC0),
-//             char_traits_t::to_char_type(0x80)},
-//         std::string {
-//             char_traits_t::to_char_type(0xF1),
-//             char_traits_t::to_char_type(0x80),
-//             char_traits_t::to_char_type(0x80),
-//             char_traits_t::to_char_type(0x7F)},
-//         std::string {
-//             char_traits_t::to_char_type(0xF1),
-//             char_traits_t::to_char_type(0x80),
-//             char_traits_t::to_char_type(0x80),
-//             char_traits_t::to_char_type(0xC0)},
-//         std::string {
-//             char_traits_t::to_char_type(0xF4),
-//             char_traits_t::to_char_type(0x7F),
-//             char_traits_t::to_char_type(0x80),
-//             char_traits_t::to_char_type(0x80)},
-//         std::string {
-//             char_traits_t::to_char_type(0xF4),
-//             char_traits_t::to_char_type(0x90),
-//             char_traits_t::to_char_type(0x80),
-//             char_traits_t::to_char_type(0x80)},
-//         std::string {
-//             char_traits_t::to_char_type(0xF4),
-//             char_traits_t::to_char_type(0x80),
-//             char_traits_t::to_char_type(0x7F),
-//             char_traits_t::to_char_type(0x80)},
-//         std::string {
-//             char_traits_t::to_char_type(0xF4),
-//             char_traits_t::to_char_type(0x80),
-//             char_traits_t::to_char_type(0xC0),
-//             char_traits_t::to_char_type(0x80)},
-//         std::string {
-//             char_traits_t::to_char_type(0xF4),
-//             char_traits_t::to_char_type(0x80),
-//             char_traits_t::to_char_type(0x80),
-//             char_traits_t::to_char_type(0x7F)},
-//         std::string {
-//             char_traits_t::to_char_type(0xF4),
-//             char_traits_t::to_char_type(0x80),
-//             char_traits_t::to_char_type(0x80),
-//             char_traits_t::to_char_type(0xC0)},
-//         std::string {
-//             char_traits_t::to_char_type(0xF5),
-//             char_traits_t::to_char_type(0x80),
-//             char_traits_t::to_char_type(0x80),
-//             char_traits_t::to_char_type(0x80)});
-
-//     fkyaml::detail::str_view input = mb_char;
-//     REQUIRE_THROWS_AS(lexer_t(input), fkyaml::invalid_encoding);
-// }
 
 TEST_CASE("LexicalAnalyzer_UnescapedControlCharacter") {
     auto unescaped_char = GENERATE(
@@ -787,7 +611,7 @@ TEST_CASE("LexicalAnalyzer_LiteralStringScalar") {
 
         REQUIRE_NOTHROW(token = lexer.get_next_token());
         REQUIRE(token.type == fkyaml::detail::lexical_token_t::BLOCK_SCALAR);
-        REQUIRE(std::string(token.token_begin_itr, token.token_end_itr) == "");
+        REQUIRE(token.str == "");
     }
 
     SECTION("empty literal string scalar with clip chomping") {
@@ -797,7 +621,7 @@ TEST_CASE("LexicalAnalyzer_LiteralStringScalar") {
 
         REQUIRE_NOTHROW(token = lexer.get_next_token());
         REQUIRE(token.type == fkyaml::detail::lexical_token_t::BLOCK_SCALAR);
-        REQUIRE(std::string(token.token_begin_itr, token.token_end_itr) == "");
+        REQUIRE(token.str == "");
     }
 
     SECTION("empty literal string scalar with keep chomping") {
@@ -807,7 +631,7 @@ TEST_CASE("LexicalAnalyzer_LiteralStringScalar") {
 
         REQUIRE_NOTHROW(token = lexer.get_next_token());
         REQUIRE(token.type == fkyaml::detail::lexical_token_t::BLOCK_SCALAR);
-        REQUIRE(std::string(token.token_begin_itr, token.token_end_itr) == "\n");
+        REQUIRE(token.str == "\n");
     }
 
     SECTION("literal string scalar with 0 indent level.") {
@@ -834,7 +658,7 @@ TEST_CASE("LexicalAnalyzer_LiteralStringScalar") {
 
         REQUIRE_NOTHROW(token = lexer.get_next_token());
         REQUIRE(token.type == fkyaml::detail::lexical_token_t::BLOCK_SCALAR);
-        REQUIRE(std::string(token.token_begin_itr, token.token_end_itr) == "  foo\nbar\n");
+        REQUIRE(token.str == "  foo\nbar\n");
     }
 
     SECTION("literal string scalar") {
@@ -845,7 +669,7 @@ TEST_CASE("LexicalAnalyzer_LiteralStringScalar") {
 
         REQUIRE_NOTHROW(token = lexer.get_next_token());
         REQUIRE(token.type == fkyaml::detail::lexical_token_t::BLOCK_SCALAR);
-        REQUIRE(std::string(token.token_begin_itr, token.token_end_itr) == "foo\nbar\n");
+        REQUIRE(token.str == "foo\nbar\n");
     }
 
     SECTION("literal string scalar with implicit indentation and strip chomping") {
@@ -860,7 +684,7 @@ TEST_CASE("LexicalAnalyzer_LiteralStringScalar") {
 
         REQUIRE_NOTHROW(token = lexer.get_next_token());
         REQUIRE(token.type == fkyaml::detail::lexical_token_t::BLOCK_SCALAR);
-        REQUIRE(std::string(token.token_begin_itr, token.token_end_itr) == "\nfoo\nbar\n\nbaz");
+        REQUIRE(token.str == "\nfoo\nbar\n\nbaz");
     }
 
     SECTION("literal string scalar with explicit indentation and strip chomping") {
@@ -874,7 +698,7 @@ TEST_CASE("LexicalAnalyzer_LiteralStringScalar") {
 
         REQUIRE_NOTHROW(token = lexer.get_next_token());
         REQUIRE(token.type == fkyaml::detail::lexical_token_t::BLOCK_SCALAR);
-        REQUIRE(std::string(token.token_begin_itr, token.token_end_itr) == "foo\n  bar\n\nbaz");
+        REQUIRE(token.str == "foo\n  bar\n\nbaz");
     }
 
     SECTION("literal string scalar with implicit indentation and clip chomping") {
@@ -889,7 +713,7 @@ TEST_CASE("LexicalAnalyzer_LiteralStringScalar") {
 
         REQUIRE_NOTHROW(token = lexer.get_next_token());
         REQUIRE(token.type == fkyaml::detail::lexical_token_t::BLOCK_SCALAR);
-        REQUIRE(std::string(token.token_begin_itr, token.token_end_itr) == "\nfoo\nbar\n\nbaz\n");
+        REQUIRE(token.str == "\nfoo\nbar\n\nbaz\n");
     }
 
     SECTION("literal string scalar with explicit indentation and clip chomping") {
@@ -903,7 +727,7 @@ TEST_CASE("LexicalAnalyzer_LiteralStringScalar") {
 
         REQUIRE_NOTHROW(token = lexer.get_next_token());
         REQUIRE(token.type == fkyaml::detail::lexical_token_t::BLOCK_SCALAR);
-        REQUIRE(std::string(token.token_begin_itr, token.token_end_itr) == "foo\n  bar\n\nbaz\n");
+        REQUIRE(token.str == "foo\n  bar\n\nbaz\n");
     }
 
     SECTION("literal string scalar with clip chomping and no trailing newlines") {
@@ -916,7 +740,7 @@ TEST_CASE("LexicalAnalyzer_LiteralStringScalar") {
 
         REQUIRE_NOTHROW(token = lexer.get_next_token());
         REQUIRE(token.type == fkyaml::detail::lexical_token_t::BLOCK_SCALAR);
-        REQUIRE(std::string(token.token_begin_itr, token.token_end_itr) == "foo\n  bar\n\nbaz");
+        REQUIRE(token.str == "foo\n  bar\n\nbaz");
     }
 
     SECTION("literal string scalar with implicit indentation and keep chomping") {
@@ -931,7 +755,7 @@ TEST_CASE("LexicalAnalyzer_LiteralStringScalar") {
 
         REQUIRE_NOTHROW(token = lexer.get_next_token());
         REQUIRE(token.type == fkyaml::detail::lexical_token_t::BLOCK_SCALAR);
-        REQUIRE(std::string(token.token_begin_itr, token.token_end_itr) == "\nfoo\nbar\n\nbaz\n\n");
+        REQUIRE(token.str == "\nfoo\nbar\n\nbaz\n\n");
     }
 
     SECTION("literal string scalar with explicit indentation and keep chomping") {
@@ -945,7 +769,7 @@ TEST_CASE("LexicalAnalyzer_LiteralStringScalar") {
 
         REQUIRE_NOTHROW(token = lexer.get_next_token());
         REQUIRE(token.type == fkyaml::detail::lexical_token_t::BLOCK_SCALAR);
-        REQUIRE(std::string(token.token_begin_itr, token.token_end_itr) == "foo\n  bar\n\nbaz\n\n");
+        REQUIRE(token.str == "foo\n  bar\n\nbaz\n\n");
     }
 
     SECTION("literal string scalar with trailing spaces/tabs after the block scalar header.") {
@@ -957,7 +781,7 @@ TEST_CASE("LexicalAnalyzer_LiteralStringScalar") {
 
         REQUIRE_NOTHROW(token = lexer.get_next_token());
         REQUIRE(token.type == fkyaml::detail::lexical_token_t::BLOCK_SCALAR);
-        REQUIRE(std::string(token.token_begin_itr, token.token_end_itr) == "foo\n");
+        REQUIRE(token.str == "foo\n");
     }
 
     SECTION("literal string scalar with invalid block scalar headers") {
@@ -985,7 +809,7 @@ TEST_CASE("LexicalAnalyzer_FoldedString") {
 
         REQUIRE_NOTHROW(token = lexer.get_next_token());
         REQUIRE(token.type == fkyaml::detail::lexical_token_t::BLOCK_SCALAR);
-        REQUIRE(std::string(token.token_begin_itr, token.token_end_itr) == "");
+        REQUIRE(token.str.empty());
     }
 
     SECTION("empty folded string scalar with clip chomping") {
@@ -995,7 +819,7 @@ TEST_CASE("LexicalAnalyzer_FoldedString") {
 
         REQUIRE_NOTHROW(token = lexer.get_next_token());
         REQUIRE(token.type == fkyaml::detail::lexical_token_t::BLOCK_SCALAR);
-        REQUIRE(std::string(token.token_begin_itr, token.token_end_itr) == "");
+        REQUIRE(token.str == "");
     }
 
     SECTION("empty folded string scalar with keep chomping") {
@@ -1005,7 +829,7 @@ TEST_CASE("LexicalAnalyzer_FoldedString") {
 
         REQUIRE_NOTHROW(token = lexer.get_next_token());
         REQUIRE(token.type == fkyaml::detail::lexical_token_t::BLOCK_SCALAR);
-        REQUIRE(std::string(token.token_begin_itr, token.token_end_itr) == "\n");
+        REQUIRE(token.str == "\n");
     }
 
     SECTION("folded string scalar with 0 indent level") {
@@ -1032,7 +856,7 @@ TEST_CASE("LexicalAnalyzer_FoldedString") {
 
         REQUIRE_NOTHROW(token = lexer.get_next_token());
         REQUIRE(token.type == fkyaml::detail::lexical_token_t::BLOCK_SCALAR);
-        REQUIRE(std::string(token.token_begin_itr, token.token_end_itr) == "\n  foo\nbar\n");
+        REQUIRE(token.str == "\n  foo\nbar\n");
     }
 
     SECTION("folded string scalar with the non-first line being more indented than the indicated level") {
@@ -1043,7 +867,7 @@ TEST_CASE("LexicalAnalyzer_FoldedString") {
 
         REQUIRE_NOTHROW(token = lexer.get_next_token());
         REQUIRE(token.type == fkyaml::detail::lexical_token_t::BLOCK_SCALAR);
-        REQUIRE(std::string(token.token_begin_itr, token.token_end_itr) == "foo\n  bar\n");
+        REQUIRE(token.str == "foo\n  bar\n");
     }
 
     SECTION("folded string scalar") {
@@ -1057,7 +881,7 @@ TEST_CASE("LexicalAnalyzer_FoldedString") {
 
         REQUIRE_NOTHROW(token = lexer.get_next_token());
         REQUIRE(token.type == fkyaml::detail::lexical_token_t::BLOCK_SCALAR);
-        REQUIRE(std::string(token.token_begin_itr, token.token_end_itr) == "foo\n\nbar\n");
+        REQUIRE(token.str == "foo\n\nbar\n");
     }
 
     SECTION("folded string scalar with implicit indentation and strip chomping") {
@@ -1070,7 +894,7 @@ TEST_CASE("LexicalAnalyzer_FoldedString") {
 
         REQUIRE_NOTHROW(token = lexer.get_next_token());
         REQUIRE(token.type == fkyaml::detail::lexical_token_t::BLOCK_SCALAR);
-        REQUIRE(std::string(token.token_begin_itr, token.token_end_itr) == "foo bar");
+        REQUIRE(token.str == "foo bar");
     }
 
     SECTION("folded string scalar with implicit indentation and clip chomping") {
@@ -1083,7 +907,7 @@ TEST_CASE("LexicalAnalyzer_FoldedString") {
 
         REQUIRE_NOTHROW(token = lexer.get_next_token());
         REQUIRE(token.type == fkyaml::detail::lexical_token_t::BLOCK_SCALAR);
-        REQUIRE(std::string(token.token_begin_itr, token.token_end_itr) == "foo bar\n");
+        REQUIRE(token.str == "foo bar\n");
     }
 
     SECTION("folded string scalar with implicit indentation and keep chomping") {
@@ -1096,7 +920,7 @@ TEST_CASE("LexicalAnalyzer_FoldedString") {
 
         REQUIRE_NOTHROW(token = lexer.get_next_token());
         REQUIRE(token.type == fkyaml::detail::lexical_token_t::BLOCK_SCALAR);
-        REQUIRE(std::string(token.token_begin_itr, token.token_end_itr) == "foo bar\n\n");
+        REQUIRE(token.str == "foo bar\n\n");
     }
 
     SECTION("folded string scalar with trailing spaces/tabs/comments after the block scalar header.") {
@@ -1108,7 +932,7 @@ TEST_CASE("LexicalAnalyzer_FoldedString") {
 
         REQUIRE_NOTHROW(token = lexer.get_next_token());
         REQUIRE(token.type == fkyaml::detail::lexical_token_t::BLOCK_SCALAR);
-        REQUIRE(std::string(token.token_begin_itr, token.token_end_itr) == "foo\n");
+        REQUIRE(token.str == "foo\n");
     }
 
     SECTION("folded string scalar with invalid block scalar headers") {
@@ -1148,8 +972,7 @@ TEST_CASE("LexicalAnalyzer_Anchor") {
 
         REQUIRE_NOTHROW(token = lexer.get_next_token());
         REQUIRE(token.type == fkyaml::detail::lexical_token_t::ANCHOR_PREFIX);
-        fkyaml::detail::str_view token_str(token.token_begin_itr, token.token_end_itr);
-        REQUIRE(token_str == test_data.second);
+        REQUIRE(token.str == test_data.second);
     }
 
     SECTION("invalid anchor name") {
@@ -1191,8 +1014,7 @@ TEST_CASE("LexicalAnalyzer_Alias") {
 
         REQUIRE_NOTHROW(token = lexer.get_next_token());
         REQUIRE(token.type == fkyaml::detail::lexical_token_t::ALIAS_PREFIX);
-        fkyaml::detail::str_view token_str(token.token_begin_itr, token.token_end_itr);
-        REQUIRE_NOTHROW(token_str == test_data.second);
+        REQUIRE_NOTHROW(token.str == test_data.second);
     }
 
     SECTION("invalid anchor name") {
@@ -1232,13 +1054,11 @@ TEST_CASE("LexicalAnalyzer_Tag") {
         lexer_t lexer(input);
         REQUIRE_NOTHROW(token = lexer.get_next_token());
         REQUIRE(token.type == fkyaml::detail::lexical_token_t::TAG_PREFIX);
-        REQUIRE(
-            fkyaml::detail::str_view(token.token_begin_itr, token.token_end_itr) == input.substr(0, input.size() - 4));
+        REQUIRE(token.str == input.substr(0, input.size() - 4));
 
         REQUIRE_NOTHROW(token = lexer.get_next_token());
         REQUIRE(token.type == fkyaml::detail::lexical_token_t::PLAIN_SCALAR);
-        REQUIRE(
-            fkyaml::detail::str_view(token.token_begin_itr, token.token_end_itr) == fkyaml::detail::str_view("tag"));
+        REQUIRE(token.str == "tag");
     }
 
     SECTION("valid tag name (not followed by a value)") {
@@ -1251,7 +1071,7 @@ TEST_CASE("LexicalAnalyzer_Tag") {
         lexer_t lexer(input);
         REQUIRE_NOTHROW(token = lexer.get_next_token());
         REQUIRE(token.type == fkyaml::detail::lexical_token_t::TAG_PREFIX);
-        REQUIRE(fkyaml::detail::str_view(token.token_begin_itr, token.token_end_itr) == input);
+        REQUIRE(token.str == input);
     }
 
     SECTION("invalid tag names") {
@@ -1282,14 +1102,14 @@ TEST_CASE("LexicalAnalyzer_KeyBooleanValuePair") {
 
     REQUIRE_NOTHROW(token = lexer.get_next_token());
     REQUIRE(token.type == fkyaml::detail::lexical_token_t::PLAIN_SCALAR);
-    REQUIRE(std::string(token.token_begin_itr, token.token_end_itr) == "test");
+    REQUIRE(token.str == "test");
 
     REQUIRE_NOTHROW(token = lexer.get_next_token());
     REQUIRE(token.type == fkyaml::detail::lexical_token_t::KEY_SEPARATOR);
 
     REQUIRE_NOTHROW(token = lexer.get_next_token());
     REQUIRE(token.type == fkyaml::detail::lexical_token_t::PLAIN_SCALAR);
-    REQUIRE(std::string(token.token_begin_itr, token.token_end_itr) == "true");
+    REQUIRE(token.str == "true");
 
     REQUIRE_NOTHROW(token = lexer.get_next_token());
     REQUIRE(token.type == fkyaml::detail::lexical_token_t::END_OF_BUFFER);
@@ -1301,14 +1121,14 @@ TEST_CASE("LexicalAnalyzer_KeyIntegerValuePair") {
 
     REQUIRE_NOTHROW(token = lexer.get_next_token());
     REQUIRE(token.type == fkyaml::detail::lexical_token_t::PLAIN_SCALAR);
-    REQUIRE(std::string(token.token_begin_itr, token.token_end_itr) == "test");
+    REQUIRE(token.str == "test");
 
     REQUIRE_NOTHROW(token = lexer.get_next_token());
     REQUIRE(token.type == fkyaml::detail::lexical_token_t::KEY_SEPARATOR);
 
     REQUIRE_NOTHROW(token = lexer.get_next_token());
     REQUIRE(token.type == fkyaml::detail::lexical_token_t::PLAIN_SCALAR);
-    REQUIRE(std::string(token.token_begin_itr, token.token_end_itr) == "-5784");
+    REQUIRE(token.str == "-5784");
 
     REQUIRE_NOTHROW(token = lexer.get_next_token());
     REQUIRE(token.type == fkyaml::detail::lexical_token_t::END_OF_BUFFER);
@@ -1320,14 +1140,14 @@ TEST_CASE("LexicalAnalyzer_KeyFloatNumberValuePair") {
 
     REQUIRE_NOTHROW(token = lexer.get_next_token());
     REQUIRE(token.type == fkyaml::detail::lexical_token_t::PLAIN_SCALAR);
-    REQUIRE(std::string(token.token_begin_itr, token.token_end_itr) == "test");
+    REQUIRE(token.str == "test");
 
     REQUIRE_NOTHROW(token = lexer.get_next_token());
     REQUIRE(token.type == fkyaml::detail::lexical_token_t::KEY_SEPARATOR);
 
     REQUIRE_NOTHROW(token = lexer.get_next_token());
     REQUIRE(token.type == fkyaml::detail::lexical_token_t::PLAIN_SCALAR);
-    REQUIRE(std::string(token.token_begin_itr, token.token_end_itr) == "-5.58e-3");
+    REQUIRE(token.str == "-5.58e-3");
 
     REQUIRE_NOTHROW(token = lexer.get_next_token());
     REQUIRE(token.type == fkyaml::detail::lexical_token_t::END_OF_BUFFER);
@@ -1339,14 +1159,14 @@ TEST_CASE("LexicalAnalyzer_KeyStringValuePair") {
 
     REQUIRE_NOTHROW(token = lexer.get_next_token());
     REQUIRE(token.type == fkyaml::detail::lexical_token_t::PLAIN_SCALAR);
-    REQUIRE(std::string(token.token_begin_itr, token.token_end_itr) == "test");
+    REQUIRE(token.str == "test");
 
     REQUIRE_NOTHROW(token = lexer.get_next_token());
     REQUIRE(token.type == fkyaml::detail::lexical_token_t::KEY_SEPARATOR);
 
     REQUIRE_NOTHROW(token = lexer.get_next_token());
     REQUIRE(token.type == fkyaml::detail::lexical_token_t::DOUBLE_QUOTED_SCALAR);
-    REQUIRE(std::string(token.token_begin_itr, token.token_end_itr) == "some value");
+    REQUIRE(token.str == "some value");
 
     REQUIRE_NOTHROW(token = lexer.get_next_token());
     REQUIRE(token.type == fkyaml::detail::lexical_token_t::END_OF_BUFFER);
@@ -1360,7 +1180,7 @@ TEST_CASE("LexicalAnalyzer_FlowSequence") {
 
         REQUIRE_NOTHROW(token = lexer.get_next_token());
         REQUIRE(token.type == fkyaml::detail::lexical_token_t::PLAIN_SCALAR);
-        REQUIRE(std::string(token.token_begin_itr, token.token_end_itr) == "test");
+        REQUIRE(token.str == "test");
 
         REQUIRE_NOTHROW(token = lexer.get_next_token());
         REQUIRE(token.type == fkyaml::detail::lexical_token_t::KEY_SEPARATOR);
@@ -1370,14 +1190,14 @@ TEST_CASE("LexicalAnalyzer_FlowSequence") {
 
         REQUIRE_NOTHROW(token = lexer.get_next_token());
         REQUIRE(token.type == fkyaml::detail::lexical_token_t::PLAIN_SCALAR);
-        REQUIRE(std::string(token.token_begin_itr, token.token_end_itr) == "foo");
+        REQUIRE(token.str == "foo");
 
         REQUIRE_NOTHROW(token = lexer.get_next_token());
         REQUIRE(token.type == fkyaml::detail::lexical_token_t::VALUE_SEPARATOR);
 
         REQUIRE_NOTHROW(token = lexer.get_next_token());
         REQUIRE(token.type == fkyaml::detail::lexical_token_t::PLAIN_SCALAR);
-        REQUIRE(std::string(token.token_begin_itr, token.token_end_itr) == "bar");
+        REQUIRE(token.str == "bar");
 
         REQUIRE_NOTHROW(token = lexer.get_next_token());
         REQUIRE(token.type == fkyaml::detail::lexical_token_t::SEQUENCE_FLOW_END);
@@ -1391,7 +1211,7 @@ TEST_CASE("LexicalAnalyzer_FlowSequence") {
 
         REQUIRE_NOTHROW(token = lexer.get_next_token());
         REQUIRE(token.type == fkyaml::detail::lexical_token_t::PLAIN_SCALAR);
-        REQUIRE(std::string(token.token_begin_itr, token.token_end_itr) == "test");
+        REQUIRE(token.str == "test");
 
         REQUIRE_NOTHROW(token = lexer.get_next_token());
         REQUIRE(token.type == fkyaml::detail::lexical_token_t::KEY_SEPARATOR);
@@ -1404,28 +1224,28 @@ TEST_CASE("LexicalAnalyzer_FlowSequence") {
 
         REQUIRE_NOTHROW(token = lexer.get_next_token());
         REQUIRE(token.type == fkyaml::detail::lexical_token_t::PLAIN_SCALAR);
-        REQUIRE(std::string(token.token_begin_itr, token.token_end_itr) == "foo");
+        REQUIRE(token.str == "foo");
 
         REQUIRE_NOTHROW(token = lexer.get_next_token());
         REQUIRE(token.type == fkyaml::detail::lexical_token_t::KEY_SEPARATOR);
 
         REQUIRE_NOTHROW(token = lexer.get_next_token());
         REQUIRE(token.type == fkyaml::detail::lexical_token_t::PLAIN_SCALAR);
-        REQUIRE(std::string(token.token_begin_itr, token.token_end_itr) == "one");
+        REQUIRE(token.str == "one");
 
         REQUIRE_NOTHROW(token = lexer.get_next_token());
         REQUIRE(token.type == fkyaml::detail::lexical_token_t::VALUE_SEPARATOR);
 
         REQUIRE_NOTHROW(token = lexer.get_next_token());
         REQUIRE(token.type == fkyaml::detail::lexical_token_t::PLAIN_SCALAR);
-        REQUIRE(std::string(token.token_begin_itr, token.token_end_itr) == "bar");
+        REQUIRE(token.str == "bar");
 
         REQUIRE_NOTHROW(token = lexer.get_next_token());
         REQUIRE(token.type == fkyaml::detail::lexical_token_t::KEY_SEPARATOR);
 
         REQUIRE_NOTHROW(token = lexer.get_next_token());
         REQUIRE(token.type == fkyaml::detail::lexical_token_t::PLAIN_SCALAR);
-        REQUIRE(std::string(token.token_begin_itr, token.token_end_itr) == "false");
+        REQUIRE(token.str == "false");
 
         REQUIRE_NOTHROW(token = lexer.get_next_token());
         REQUIRE(token.type == fkyaml::detail::lexical_token_t::MAPPING_FLOW_END);
@@ -1438,28 +1258,28 @@ TEST_CASE("LexicalAnalyzer_FlowSequence") {
 
         REQUIRE_NOTHROW(token = lexer.get_next_token());
         REQUIRE(token.type == fkyaml::detail::lexical_token_t::PLAIN_SCALAR);
-        REQUIRE(std::string(token.token_begin_itr, token.token_end_itr) == "foo");
+        REQUIRE(token.str == "foo");
 
         REQUIRE_NOTHROW(token = lexer.get_next_token());
         REQUIRE(token.type == fkyaml::detail::lexical_token_t::KEY_SEPARATOR);
 
         REQUIRE_NOTHROW(token = lexer.get_next_token());
         REQUIRE(token.type == fkyaml::detail::lexical_token_t::PLAIN_SCALAR);
-        REQUIRE(std::string(token.token_begin_itr, token.token_end_itr) == "two");
+        REQUIRE(token.str == "two");
 
         REQUIRE_NOTHROW(token = lexer.get_next_token());
         REQUIRE(token.type == fkyaml::detail::lexical_token_t::VALUE_SEPARATOR);
 
         REQUIRE_NOTHROW(token = lexer.get_next_token());
         REQUIRE(token.type == fkyaml::detail::lexical_token_t::PLAIN_SCALAR);
-        REQUIRE(std::string(token.token_begin_itr, token.token_end_itr) == "bar");
+        REQUIRE(token.str == "bar");
 
         REQUIRE_NOTHROW(token = lexer.get_next_token());
         REQUIRE(token.type == fkyaml::detail::lexical_token_t::KEY_SEPARATOR);
 
         REQUIRE_NOTHROW(token = lexer.get_next_token());
         REQUIRE(token.type == fkyaml::detail::lexical_token_t::PLAIN_SCALAR);
-        REQUIRE(std::string(token.token_begin_itr, token.token_end_itr) == "true");
+        REQUIRE(token.str == "true");
 
         REQUIRE_NOTHROW(token = lexer.get_next_token());
         REQUIRE(token.type == fkyaml::detail::lexical_token_t::MAPPING_FLOW_END);
@@ -1480,7 +1300,7 @@ TEST_CASE("LexicalAnalyzer_FlowMapping") {
 
         REQUIRE_NOTHROW(token = lexer.get_next_token());
         REQUIRE(token.type == fkyaml::detail::lexical_token_t::PLAIN_SCALAR);
-        REQUIRE(std::string(token.token_begin_itr, token.token_end_itr) == "test");
+        REQUIRE(token.str == "test");
 
         REQUIRE_NOTHROW(token = lexer.get_next_token());
         REQUIRE(token.type == fkyaml::detail::lexical_token_t::KEY_SEPARATOR);
@@ -1490,43 +1310,42 @@ TEST_CASE("LexicalAnalyzer_FlowMapping") {
 
         REQUIRE_NOTHROW(token = lexer.get_next_token());
         REQUIRE(token.type == fkyaml::detail::lexical_token_t::PLAIN_SCALAR);
-        REQUIRE(std::string(token.token_begin_itr, token.token_end_itr) == "bool");
+        REQUIRE(token.str == "bool");
 
         REQUIRE_NOTHROW(token = lexer.get_next_token());
         REQUIRE(token.type == fkyaml::detail::lexical_token_t::KEY_SEPARATOR);
 
         REQUIRE_NOTHROW(token = lexer.get_next_token());
         REQUIRE(token.type == fkyaml::detail::lexical_token_t::PLAIN_SCALAR);
-        REQUIRE(std::string(token.token_begin_itr, token.token_end_itr) == "true");
+        REQUIRE(token.str == "true");
 
         REQUIRE_NOTHROW(token = lexer.get_next_token());
         REQUIRE(token.type == fkyaml::detail::lexical_token_t::VALUE_SEPARATOR);
 
         REQUIRE_NOTHROW(token = lexer.get_next_token());
         REQUIRE(token.type == fkyaml::detail::lexical_token_t::PLAIN_SCALAR);
-        REQUIRE(std::string(token.token_begin_itr, token.token_end_itr) == "foo :b");
+        REQUIRE(token.str == "foo :b");
 
         REQUIRE_NOTHROW(token = lexer.get_next_token());
         REQUIRE(token.type == fkyaml::detail::lexical_token_t::KEY_SEPARATOR);
 
         REQUIRE_NOTHROW(token = lexer.get_next_token());
         REQUIRE(token.type == fkyaml::detail::lexical_token_t::PLAIN_SCALAR);
-        REQUIRE(std::string(token.token_begin_itr, token.token_end_itr) == "bar");
+        REQUIRE(token.str == "bar");
 
         REQUIRE_NOTHROW(token = lexer.get_next_token());
         REQUIRE(token.type == fkyaml::detail::lexical_token_t::VALUE_SEPARATOR);
 
         REQUIRE_NOTHROW(token = lexer.get_next_token());
         REQUIRE(token.type == fkyaml::detail::lexical_token_t::PLAIN_SCALAR);
-        REQUIRE(std::string(token.token_begin_itr, token.token_end_itr) == "pi");
+        REQUIRE(token.str == "pi");
 
         REQUIRE_NOTHROW(token = lexer.get_next_token());
         REQUIRE(token.type == fkyaml::detail::lexical_token_t::KEY_SEPARATOR);
 
         REQUIRE_NOTHROW(token = lexer.get_next_token());
         REQUIRE(token.type == fkyaml::detail::lexical_token_t::PLAIN_SCALAR);
-        REQUIRE_NOTHROW(std::string(token.token_begin_itr, token.token_end_itr));
-        REQUIRE(std::string(token.token_begin_itr, token.token_end_itr) == "3.14");
+        REQUIRE(token.str == "3.14");
 
         REQUIRE_NOTHROW(token = lexer.get_next_token());
         REQUIRE(token.type == fkyaml::detail::lexical_token_t::MAPPING_FLOW_END);
@@ -1540,7 +1359,7 @@ TEST_CASE("LexicalAnalyzer_FlowMapping") {
 
         REQUIRE_NOTHROW(token = lexer.get_next_token());
         REQUIRE(token.type == fkyaml::detail::lexical_token_t::PLAIN_SCALAR);
-        REQUIRE(std::string(token.token_begin_itr, token.token_end_itr) == "test");
+        REQUIRE(token.str == "test");
 
         REQUIRE_NOTHROW(token = lexer.get_next_token());
         REQUIRE(token.type == fkyaml::detail::lexical_token_t::KEY_SEPARATOR);
@@ -1550,14 +1369,14 @@ TEST_CASE("LexicalAnalyzer_FlowMapping") {
 
         REQUIRE_NOTHROW(token = lexer.get_next_token());
         REQUIRE(token.type == fkyaml::detail::lexical_token_t::PLAIN_SCALAR);
-        REQUIRE(std::string(token.token_begin_itr, token.token_end_itr) == "foo");
+        REQUIRE(token.str == "foo");
 
         REQUIRE_NOTHROW(token = lexer.get_next_token());
         REQUIRE(token.type == fkyaml::detail::lexical_token_t::KEY_SEPARATOR);
 
         REQUIRE_NOTHROW(token = lexer.get_next_token());
         REQUIRE(token.type == fkyaml::detail::lexical_token_t::PLAIN_SCALAR);
-        REQUIRE(std::string(token.token_begin_itr, token.token_end_itr) == "bar baz");
+        REQUIRE(token.str == "bar baz");
 
         REQUIRE_NOTHROW(token = lexer.get_next_token());
         REQUIRE(token.type == fkyaml::detail::lexical_token_t::MAPPING_FLOW_END);
@@ -1575,7 +1394,7 @@ TEST_CASE("LexicalAnalyzer_BlockSequence") {
 
         REQUIRE_NOTHROW(token = lexer.get_next_token());
         REQUIRE(token.type == fkyaml::detail::lexical_token_t::PLAIN_SCALAR);
-        REQUIRE(std::string(token.token_begin_itr, token.token_end_itr) == "test");
+        REQUIRE(token.str == "test");
 
         REQUIRE_NOTHROW(token = lexer.get_next_token());
         REQUIRE(token.type == fkyaml::detail::lexical_token_t::KEY_SEPARATOR);
@@ -1585,14 +1404,14 @@ TEST_CASE("LexicalAnalyzer_BlockSequence") {
 
         REQUIRE_NOTHROW(token = lexer.get_next_token());
         REQUIRE(token.type == fkyaml::detail::lexical_token_t::PLAIN_SCALAR);
-        REQUIRE(std::string(token.token_begin_itr, token.token_end_itr) == "foo");
+        REQUIRE(token.str == "foo");
 
         REQUIRE_NOTHROW(token = lexer.get_next_token());
         REQUIRE(token.type == fkyaml::detail::lexical_token_t::SEQUENCE_BLOCK_PREFIX);
 
         REQUIRE_NOTHROW(token = lexer.get_next_token());
         REQUIRE(token.type == fkyaml::detail::lexical_token_t::PLAIN_SCALAR);
-        REQUIRE(std::string(token.token_begin_itr, token.token_end_itr) == "bar");
+        REQUIRE(token.str == "bar");
 
         REQUIRE_NOTHROW(token = lexer.get_next_token());
         REQUIRE(token.type == fkyaml::detail::lexical_token_t::END_OF_BUFFER);
@@ -1603,7 +1422,7 @@ TEST_CASE("LexicalAnalyzer_BlockSequence") {
 
         REQUIRE_NOTHROW(token = lexer.get_next_token());
         REQUIRE(token.type == fkyaml::detail::lexical_token_t::PLAIN_SCALAR);
-        REQUIRE(std::string(token.token_begin_itr, token.token_end_itr) == "test");
+        REQUIRE(token.str == "test");
 
         REQUIRE_NOTHROW(token = lexer.get_next_token());
         REQUIRE(token.type == fkyaml::detail::lexical_token_t::KEY_SEPARATOR);
@@ -1613,50 +1432,50 @@ TEST_CASE("LexicalAnalyzer_BlockSequence") {
 
         REQUIRE_NOTHROW(token = lexer.get_next_token());
         REQUIRE(token.type == fkyaml::detail::lexical_token_t::PLAIN_SCALAR);
-        REQUIRE(std::string(token.token_begin_itr, token.token_end_itr) == "foo");
+        REQUIRE(token.str == "foo");
 
         REQUIRE_NOTHROW(token = lexer.get_next_token());
         REQUIRE(token.type == fkyaml::detail::lexical_token_t::KEY_SEPARATOR);
 
         REQUIRE_NOTHROW(token = lexer.get_next_token());
         REQUIRE(token.type == fkyaml::detail::lexical_token_t::PLAIN_SCALAR);
-        REQUIRE(std::string(token.token_begin_itr, token.token_end_itr) == "one");
+        REQUIRE(token.str == "one");
 
         REQUIRE_NOTHROW(token = lexer.get_next_token());
         REQUIRE(token.type == fkyaml::detail::lexical_token_t::PLAIN_SCALAR);
-        REQUIRE(std::string(token.token_begin_itr, token.token_end_itr) == "bar");
+        REQUIRE(token.str == "bar");
 
         REQUIRE_NOTHROW(token = lexer.get_next_token());
         REQUIRE(token.type == fkyaml::detail::lexical_token_t::KEY_SEPARATOR);
 
         REQUIRE_NOTHROW(token = lexer.get_next_token());
         REQUIRE(token.type == fkyaml::detail::lexical_token_t::PLAIN_SCALAR);
-        REQUIRE(std::string(token.token_begin_itr, token.token_end_itr) == "false");
+        REQUIRE(token.str == "false");
 
         REQUIRE_NOTHROW(token = lexer.get_next_token());
         REQUIRE(token.type == fkyaml::detail::lexical_token_t::SEQUENCE_BLOCK_PREFIX);
 
         REQUIRE_NOTHROW(token = lexer.get_next_token());
         REQUIRE(token.type == fkyaml::detail::lexical_token_t::PLAIN_SCALAR);
-        REQUIRE(std::string(token.token_begin_itr, token.token_end_itr) == "foo");
+        REQUIRE(token.str == "foo");
 
         REQUIRE_NOTHROW(token = lexer.get_next_token());
         REQUIRE(token.type == fkyaml::detail::lexical_token_t::KEY_SEPARATOR);
 
         REQUIRE_NOTHROW(token = lexer.get_next_token());
         REQUIRE(token.type == fkyaml::detail::lexical_token_t::PLAIN_SCALAR);
-        REQUIRE(std::string(token.token_begin_itr, token.token_end_itr) == "two");
+        REQUIRE(token.str == "two");
 
         REQUIRE_NOTHROW(token = lexer.get_next_token());
         REQUIRE(token.type == fkyaml::detail::lexical_token_t::PLAIN_SCALAR);
-        REQUIRE(std::string(token.token_begin_itr, token.token_end_itr) == "bar");
+        REQUIRE(token.str == "bar");
 
         REQUIRE_NOTHROW(token = lexer.get_next_token());
         REQUIRE(token.type == fkyaml::detail::lexical_token_t::KEY_SEPARATOR);
 
         REQUIRE_NOTHROW(token = lexer.get_next_token());
         REQUIRE(token.type == fkyaml::detail::lexical_token_t::PLAIN_SCALAR);
-        REQUIRE(std::string(token.token_begin_itr, token.token_end_itr) == "true");
+        REQUIRE(token.str == "true");
 
         REQUIRE_NOTHROW(token = lexer.get_next_token());
         REQUIRE(token.type == fkyaml::detail::lexical_token_t::END_OF_BUFFER);
@@ -1671,44 +1490,43 @@ TEST_CASE("LexicalAnalyzer_BlockMapping") {
 
         REQUIRE_NOTHROW(token = lexer.get_next_token());
         REQUIRE(token.type == fkyaml::detail::lexical_token_t::PLAIN_SCALAR);
-        REQUIRE(std::string(token.token_begin_itr, token.token_end_itr) == "test");
+        REQUIRE(token.str == "test");
 
         REQUIRE_NOTHROW(token = lexer.get_next_token());
         REQUIRE(token.type == fkyaml::detail::lexical_token_t::KEY_SEPARATOR);
 
         REQUIRE_NOTHROW(token = lexer.get_next_token());
         REQUIRE(token.type == fkyaml::detail::lexical_token_t::PLAIN_SCALAR);
-        REQUIRE(std::string(token.token_begin_itr, token.token_end_itr) == "bool");
+        REQUIRE(token.str == "bool");
 
         REQUIRE_NOTHROW(token = lexer.get_next_token());
         REQUIRE(token.type == fkyaml::detail::lexical_token_t::KEY_SEPARATOR);
 
         REQUIRE_NOTHROW(token = lexer.get_next_token());
         REQUIRE(token.type == fkyaml::detail::lexical_token_t::PLAIN_SCALAR);
-        REQUIRE(std::string(token.token_begin_itr, token.token_end_itr) == "true");
+        REQUIRE(token.str == "true");
 
         REQUIRE_NOTHROW(token = lexer.get_next_token());
         REQUIRE(token.type == fkyaml::detail::lexical_token_t::PLAIN_SCALAR);
-        REQUIRE(std::string(token.token_begin_itr, token.token_end_itr) == "foo");
+        REQUIRE(token.str == "foo");
 
         REQUIRE_NOTHROW(token = lexer.get_next_token());
         REQUIRE(token.type == fkyaml::detail::lexical_token_t::KEY_SEPARATOR);
 
         REQUIRE_NOTHROW(token = lexer.get_next_token());
         REQUIRE(token.type == fkyaml::detail::lexical_token_t::SINGLE_QUOTED_SCALAR);
-        REQUIRE(std::string(token.token_begin_itr, token.token_end_itr) == "bar");
+        REQUIRE(token.str == "bar");
 
         REQUIRE_NOTHROW(token = lexer.get_next_token());
         REQUIRE(token.type == fkyaml::detail::lexical_token_t::PLAIN_SCALAR);
-        REQUIRE(std::string(token.token_begin_itr, token.token_end_itr) == "pi");
+        REQUIRE(token.str == "pi");
 
         REQUIRE_NOTHROW(token = lexer.get_next_token());
         REQUIRE(token.type == fkyaml::detail::lexical_token_t::KEY_SEPARATOR);
 
         REQUIRE_NOTHROW(token = lexer.get_next_token());
         REQUIRE(token.type == fkyaml::detail::lexical_token_t::PLAIN_SCALAR);
-        REQUIRE_NOTHROW(std::string(token.token_begin_itr, token.token_end_itr));
-        REQUIRE(std::string(token.token_begin_itr, token.token_end_itr) == "3.14");
+        REQUIRE(token.str == "3.14");
 
         REQUIRE_NOTHROW(token = lexer.get_next_token());
         REQUIRE(token.type == fkyaml::detail::lexical_token_t::END_OF_BUFFER);
@@ -1719,37 +1537,36 @@ TEST_CASE("LexicalAnalyzer_BlockMapping") {
 
         REQUIRE_NOTHROW(token = lexer.get_next_token());
         REQUIRE(token.type == fkyaml::detail::lexical_token_t::PLAIN_SCALAR);
-        REQUIRE(std::string(token.token_begin_itr, token.token_end_itr) == "test");
+        REQUIRE(token.str == "test");
 
         REQUIRE_NOTHROW(token = lexer.get_next_token());
         REQUIRE(token.type == fkyaml::detail::lexical_token_t::KEY_SEPARATOR);
 
         REQUIRE_NOTHROW(token = lexer.get_next_token());
         REQUIRE(token.type == fkyaml::detail::lexical_token_t::BLOCK_SCALAR);
-        REQUIRE(std::string(token.token_begin_itr, token.token_end_itr) == "a literal scalar.\n");
+        REQUIRE(token.str == "a literal scalar.\n");
 
         REQUIRE_NOTHROW(token = lexer.get_next_token());
         REQUIRE(token.type == fkyaml::detail::lexical_token_t::PLAIN_SCALAR);
-        REQUIRE(std::string(token.token_begin_itr, token.token_end_itr) == "foo");
+        REQUIRE(token.str == "foo");
 
         REQUIRE_NOTHROW(token = lexer.get_next_token());
         REQUIRE(token.type == fkyaml::detail::lexical_token_t::KEY_SEPARATOR);
 
         REQUIRE_NOTHROW(token = lexer.get_next_token());
         REQUIRE(token.type == fkyaml::detail::lexical_token_t::SINGLE_QUOTED_SCALAR);
-        REQUIRE(std::string(token.token_begin_itr, token.token_end_itr) == "bar");
+        REQUIRE(token.str == "bar");
 
         REQUIRE_NOTHROW(token = lexer.get_next_token());
         REQUIRE(token.type == fkyaml::detail::lexical_token_t::PLAIN_SCALAR);
-        REQUIRE(std::string(token.token_begin_itr, token.token_end_itr) == "pi");
+        REQUIRE(token.str == "pi");
 
         REQUIRE_NOTHROW(token = lexer.get_next_token());
         REQUIRE(token.type == fkyaml::detail::lexical_token_t::KEY_SEPARATOR);
 
         REQUIRE_NOTHROW(token = lexer.get_next_token());
         REQUIRE(token.type == fkyaml::detail::lexical_token_t::PLAIN_SCALAR);
-        REQUIRE_NOTHROW(std::string(token.token_begin_itr, token.token_end_itr));
-        REQUIRE(std::string(token.token_begin_itr, token.token_end_itr) == "3.14");
+        REQUIRE(token.str == "3.14");
 
         REQUIRE_NOTHROW(token = lexer.get_next_token());
         REQUIRE(token.type == fkyaml::detail::lexical_token_t::END_OF_BUFFER);
@@ -1760,37 +1577,36 @@ TEST_CASE("LexicalAnalyzer_BlockMapping") {
 
         REQUIRE_NOTHROW(token = lexer.get_next_token());
         REQUIRE(token.type == fkyaml::detail::lexical_token_t::PLAIN_SCALAR);
-        REQUIRE(std::string(token.token_begin_itr, token.token_end_itr) == "test");
+        REQUIRE(token.str == "test");
 
         REQUIRE_NOTHROW(token = lexer.get_next_token());
         REQUIRE(token.type == fkyaml::detail::lexical_token_t::KEY_SEPARATOR);
 
         REQUIRE_NOTHROW(token = lexer.get_next_token());
         REQUIRE(token.type == fkyaml::detail::lexical_token_t::BLOCK_SCALAR);
-        REQUIRE(std::string(token.token_begin_itr, token.token_end_itr) == "a literal scalar.\n");
+        REQUIRE(token.str == "a literal scalar.\n");
 
         REQUIRE_NOTHROW(token = lexer.get_next_token());
         REQUIRE(token.type == fkyaml::detail::lexical_token_t::PLAIN_SCALAR);
-        REQUIRE(std::string(token.token_begin_itr, token.token_end_itr) == "foo");
+        REQUIRE(token.str == "foo");
 
         REQUIRE_NOTHROW(token = lexer.get_next_token());
         REQUIRE(token.type == fkyaml::detail::lexical_token_t::KEY_SEPARATOR);
 
         REQUIRE_NOTHROW(token = lexer.get_next_token());
         REQUIRE(token.type == fkyaml::detail::lexical_token_t::SINGLE_QUOTED_SCALAR);
-        REQUIRE(std::string(token.token_begin_itr, token.token_end_itr) == "bar");
+        REQUIRE(token.str == "bar");
 
         REQUIRE_NOTHROW(token = lexer.get_next_token());
         REQUIRE(token.type == fkyaml::detail::lexical_token_t::PLAIN_SCALAR);
-        REQUIRE(std::string(token.token_begin_itr, token.token_end_itr) == "pi");
+        REQUIRE(token.str == "pi");
 
         REQUIRE_NOTHROW(token = lexer.get_next_token());
         REQUIRE(token.type == fkyaml::detail::lexical_token_t::KEY_SEPARATOR);
 
         REQUIRE_NOTHROW(token = lexer.get_next_token());
         REQUIRE(token.type == fkyaml::detail::lexical_token_t::PLAIN_SCALAR);
-        REQUIRE_NOTHROW(std::string(token.token_begin_itr, token.token_end_itr));
-        REQUIRE(std::string(token.token_begin_itr, token.token_end_itr) == "3.14");
+        REQUIRE(token.str == "3.14");
 
         REQUIRE_NOTHROW(token = lexer.get_next_token());
         REQUIRE(token.type == fkyaml::detail::lexical_token_t::END_OF_BUFFER);

--- a/test/unit_test/test_position_tracker_class.cpp
+++ b/test/unit_test/test_position_tracker_class.cpp
@@ -13,7 +13,7 @@
 #include <fkYAML/node.hpp>
 
 TEST_CASE("PositionTracker_InitialState") {
-    std::string input = "test";
+    fkyaml::detail::str_view input = "test";
     fkyaml::detail::position_tracker pos_tracker {};
     pos_tracker.set_target_buffer(input);
 
@@ -26,7 +26,7 @@ TEST_CASE("PositionTracker_MultipleLines") {
     fkyaml::detail::position_tracker pos_tracker {};
 
     SECTION("first character is not a newline code") {
-        std::string input = "test\nfoo";
+        fkyaml::detail::str_view input = "test\nfoo";
         pos_tracker.set_target_buffer(input);
 
         REQUIRE(pos_tracker.get_cur_pos() == 0);
@@ -60,7 +60,7 @@ TEST_CASE("PositionTracker_MultipleLines") {
     }
 
     SECTION("first character is a newline code") {
-        std::string input = "\ntest\nfoo";
+        fkyaml::detail::str_view input = "\ntest\nfoo";
         pos_tracker.set_target_buffer(input);
 
         REQUIRE(pos_tracker.get_cur_pos() == 0);

--- a/test/unit_test/test_scalar_scanner_class.cpp
+++ b/test/unit_test/test_scalar_scanner_class.cpp
@@ -11,104 +11,108 @@
 #include <fkYAML/node.hpp>
 
 TEST_CASE("ScalarScanner_Empty") {
-    std::string token = "";
+    fkyaml::detail::str_view token = "";
     REQUIRE(fkyaml::detail::scalar_scanner::scan(token.begin(), token.end()) == fkyaml::node_type::STRING);
 }
 
 TEST_CASE("ScalarScanner_NullValue") {
-    auto token = GENERATE(std::string("~"), std::string("null"), std::string("Null"), std::string("NULL"));
+    auto token = GENERATE(
+        fkyaml::detail::str_view("~"),
+        fkyaml::detail::str_view("null"),
+        fkyaml::detail::str_view("Null"),
+        fkyaml::detail::str_view("NULL"));
     REQUIRE(fkyaml::detail::scalar_scanner::scan(token.begin(), token.end()) == fkyaml::node_type::NULL_OBJECT);
 }
 
 TEST_CASE("ScalarScanner_BooleanValue") {
     auto token = GENERATE(
-        std::string("true"),
-        std::string("True"),
-        std::string("TRUE"),
-        std::string("false"),
-        std::string("False"),
-        std::string("FALSE"));
+        fkyaml::detail::str_view("true"),
+        fkyaml::detail::str_view("True"),
+        fkyaml::detail::str_view("TRUE"),
+        fkyaml::detail::str_view("false"),
+        fkyaml::detail::str_view("False"),
+        fkyaml::detail::str_view("FALSE"));
     REQUIRE(fkyaml::detail::scalar_scanner::scan(token.begin(), token.end()) == fkyaml::node_type::BOOLEAN);
 }
 
 TEST_CASE("ScalarScanner_IntegerNumberValue") {
     auto token = GENERATE(
-        std::string("-1234"),
-        std::string("-853259"),
-        std::string("-1"),
-        std::string("0"),
-        std::string("643"),
-        std::string("+120"),
-        std::string("0o27"),
-        std::string("0o5"),
-        std::string("0o77772"),
-        std::string("0o672"),
-        std::string("0xA04F"),
-        std::string("0xa7F3"),
-        std::string("0xFf29Bc"));
+        fkyaml::detail::str_view("-1234"),
+        fkyaml::detail::str_view("-853259"),
+        fkyaml::detail::str_view("-1"),
+        fkyaml::detail::str_view("0"),
+        fkyaml::detail::str_view("643"),
+        fkyaml::detail::str_view("+120"),
+        fkyaml::detail::str_view("0o27"),
+        fkyaml::detail::str_view("0o5"),
+        fkyaml::detail::str_view("0o77772"),
+        fkyaml::detail::str_view("0o672"),
+        fkyaml::detail::str_view("0xA04F"),
+        fkyaml::detail::str_view("0xa7F3"),
+        fkyaml::detail::str_view("0xFf29Bc"));
     REQUIRE(fkyaml::detail::scalar_scanner::scan(token.begin(), token.end()) == fkyaml::node_type::INTEGER);
 }
 
 TEST_CASE("ScalarScanner_FloatNumberValue") {
     auto token = GENERATE(
-        std::string(".inf"),
-        std::string(".Inf"),
-        std::string(".INF"),
-        std::string(".nan"),
-        std::string(".NaN"),
-        std::string(".NAN"),
-        std::string("-.inf"),
-        std::string("-.Inf"),
-        std::string("-.INF"),
-        std::string("+.inf"),
-        std::string("+.Inf"),
-        std::string("+.INF"),
-        std::string("-1.234"),
-        std::string("-21."),
-        std::string("567.8"),
-        std::string("123."),
-        std::string("0.24"),
-        std::string("0."),
-        std::string("9.8e-3"),
-        std::string("3.95E3"),
-        std::string("1.863e+3"));
+        fkyaml::detail::str_view(".inf"),
+        fkyaml::detail::str_view(".Inf"),
+        fkyaml::detail::str_view(".INF"),
+        fkyaml::detail::str_view(".nan"),
+        fkyaml::detail::str_view(".NaN"),
+        fkyaml::detail::str_view(".NAN"),
+        fkyaml::detail::str_view("-.inf"),
+        fkyaml::detail::str_view("-.Inf"),
+        fkyaml::detail::str_view("-.INF"),
+        fkyaml::detail::str_view("+.inf"),
+        fkyaml::detail::str_view("+.Inf"),
+        fkyaml::detail::str_view("+.INF"),
+        fkyaml::detail::str_view("-1.234"),
+        fkyaml::detail::str_view("-21."),
+        fkyaml::detail::str_view("567.8"),
+        fkyaml::detail::str_view("123."),
+        fkyaml::detail::str_view("0.24"),
+        fkyaml::detail::str_view("0."),
+        fkyaml::detail::str_view("9.8e-3"),
+        fkyaml::detail::str_view("3.95E3"),
+        fkyaml::detail::str_view("1.863e+3"));
     REQUIRE(fkyaml::detail::scalar_scanner::scan(token.begin(), token.end()) == fkyaml::node_type::FLOAT);
 }
 
 TEST_CASE("ScalarScanner_StringValue") {
     auto token = GENERATE(
-        std::string("nullValue"),
-        std::string("NullValue"),
-        std::string("NULL_VALUE"),
-        std::string("~Value"),
-        std::string("trueValue"),
-        std::string("TrueValue"),
-        std::string("TRUE_VALUE"),
-        std::string("falseValue"),
-        std::string("falsy"),
-        std::string("FalseValue"),
-        std::string("Falsy"),
-        std::string("FALSE_VALUE"),
-        std::string(".infValue"),
-        std::string(".InfValue"),
-        std::string(".INFValue"),
-        std::string(".nanValue"),
-        std::string(".NaNValue"),
-        std::string(".NANValue"),
-        std::string("-.infValue"),
-        std::string("-.InfValue"),
-        std::string("-.INFValue"),
-        std::string(".foo"),
-        std::string("abc"),
-        std::string("0th"),
-        std::string("0123"),
-        std::string("1.2.3"),
-        std::string("1.23e"),
-        std::string("1.2e-z"),
-        std::string("1.non-digit"),
-        std::string("-.foo"),
-        std::string("1exe"),
-        std::string("0oabc"),
-        std::string("0xyz"));
+        fkyaml::detail::str_view("nullValue"),
+        fkyaml::detail::str_view("NullValue"),
+        fkyaml::detail::str_view("NULL_VALUE"),
+        fkyaml::detail::str_view("~Value"),
+        fkyaml::detail::str_view("trueValue"),
+        fkyaml::detail::str_view("TrueValue"),
+        fkyaml::detail::str_view("TRUE_VALUE"),
+        fkyaml::detail::str_view("falseValue"),
+        fkyaml::detail::str_view("falsy"),
+        fkyaml::detail::str_view("FalseValue"),
+        fkyaml::detail::str_view("Falsy"),
+        fkyaml::detail::str_view("FALSE_VALUE"),
+        fkyaml::detail::str_view(".infValue"),
+        fkyaml::detail::str_view(".InfValue"),
+        fkyaml::detail::str_view(".INFValue"),
+        fkyaml::detail::str_view(".nanValue"),
+        fkyaml::detail::str_view(".NaNValue"),
+        fkyaml::detail::str_view(".NANValue"),
+        fkyaml::detail::str_view("-.infValue"),
+        fkyaml::detail::str_view("-.InfValue"),
+        fkyaml::detail::str_view("-.INFValue"),
+        fkyaml::detail::str_view(".foo"),
+        fkyaml::detail::str_view("abc"),
+        fkyaml::detail::str_view("0th"),
+        fkyaml::detail::str_view("0123"),
+        fkyaml::detail::str_view("1.2.3"),
+        fkyaml::detail::str_view("1.23e"),
+        fkyaml::detail::str_view("1.2e-z"),
+        fkyaml::detail::str_view("1.non-digit"),
+        fkyaml::detail::str_view("-.foo"),
+        fkyaml::detail::str_view("1exe"),
+        fkyaml::detail::str_view("0oabc"),
+        fkyaml::detail::str_view("0xyz"));
     REQUIRE(fkyaml::detail::scalar_scanner::scan(token.begin(), token.end()) == fkyaml::node_type::STRING);
 }

--- a/test/unit_test/test_str_view_class.cpp
+++ b/test/unit_test/test_str_view_class.cpp
@@ -1,0 +1,137 @@
+//  _______   __ __   __  _____   __  __  __
+// |   __| |_/  |  \_/  |/  _  \ /  \/  \|  |     fkYAML: A C++ header-only YAML library (supporting code)
+// |   __|  _  < \_   _/|  ___  |    _   |  |___  version 0.3.11
+// |__|  |_| \__|  |_|  |_|   |_|___||___|______| https://github.com/fktn-k/fkYAML
+//
+// SPDX-FileCopyrightText: 2023-2024 Kensuke Fukutani <fktn.dev@gmail.com>
+// SPDX-License-Identifier: MIT
+
+#include <string>
+
+#include <catch2/catch.hpp>
+
+#include <fkYAML/detail/str_view.hpp>
+
+TEST_CASE("StrView_GeneralUseCase") {
+    const char str[] = "hello world!";
+    fkyaml::detail::str_view sv = str;
+    REQUIRE(sv.compare("hello world!") == 0);
+    REQUIRE(sv.size() == 12);
+    REQUIRE(sv.length() == 12);
+    REQUIRE(sv.begin() == &str[0]);
+    REQUIRE(sv.end() == &str[12]);
+
+    std::string str2 = "HELLO WORLD!";
+    sv = str2;
+    REQUIRE(sv.compare("HELLO WORLD!") == 0);
+    REQUIRE(sv.size() == 12);
+    REQUIRE(sv.length() == 12);
+    REQUIRE(sv.begin() == str2.data());
+    REQUIRE(sv.end() == str2.data() + 12);
+
+    fkyaml::detail::str_view sv2 = sv;
+    REQUIRE(sv2.compare("HELLO WORLD!") == 0);
+    REQUIRE(sv2.size() == 12);
+    REQUIRE(sv2.length() == 12);
+    REQUIRE(sv2.begin() == str2.data());
+    REQUIRE(sv2.end() == str2.data() + 12);
+}
+
+TEST_CASE("StrView_DefaultCtor") {
+    fkyaml::detail::str_view sv;
+    REQUIRE(sv.data() == nullptr);
+    REQUIRE(sv.size() == 0);
+    REQUIRE(sv.length() == 0);
+    REQUIRE(sv.empty());
+}
+
+TEST_CASE("StrView_MaxSize") {
+    fkyaml::detail::str_view sv = "foo";
+    REQUIRE(sv.max_size() == std::numeric_limits<ptrdiff_t>::max());
+}
+
+TEST_CASE("StrView_SubscriptOperator") {
+    fkyaml::detail::str_view sv = "foo";
+    REQUIRE(sv.size() == 3);
+    REQUIRE(sv[0] == 'f');
+    REQUIRE(sv[1] == 'o');
+    REQUIRE(sv[2] == 'o');
+}
+
+TEST_CASE("StrView_At") {
+    fkyaml::detail::str_view sv = "foo";
+    REQUIRE(sv.size() == 3);
+    REQUIRE(sv.at(0) == 'f');
+    REQUIRE(sv.at(1) == 'o');
+    REQUIRE(sv.at(2) == 'o');
+    REQUIRE_THROWS_AS(sv.at(3), fkyaml::out_of_range);
+    REQUIRE_THROWS_AS(sv.at(4), fkyaml::out_of_range);
+}
+
+TEST_CASE("StrView_Front") {
+    const char str[] = "foo";
+    fkyaml::detail::str_view sv = str;
+    REQUIRE(sv.front() == 'f');
+    REQUIRE(&sv.front() == &str[0]);
+}
+
+TEST_CASE("StrView_Back") {
+    const char str[] = "bar";
+    fkyaml::detail::str_view sv = str;
+    REQUIRE(sv.back() == 'r');
+    REQUIRE(&sv.back() == &str[2]);
+}
+
+TEST_CASE("StrView_Data") {
+    const char str[] = "bar";
+    fkyaml::detail::str_view sv = str;
+    REQUIRE(sv.data() == str);
+
+    fkyaml::detail::str_view sv2 {};
+    REQUIRE(sv2.data() == nullptr);
+}
+
+TEST_CASE("StrView_RemovePrefix") {
+    const char str[] = "bar";
+    fkyaml::detail::str_view sv = str;
+    REQUIRE(sv.data() == str);
+    REQUIRE(sv.size() == 3);
+    sv.remove_prefix(1);
+    REQUIRE(sv.data() == str + 1);
+    REQUIRE(sv.size() == 2);
+}
+
+TEST_CASE("StrView_RemoveSuffix") {
+    const char str[] = "bar";
+    fkyaml::detail::str_view sv = str;
+    REQUIRE(sv.data() == str);
+    REQUIRE(sv.size() == 3);
+    sv.remove_suffix(1);
+    REQUIRE(sv.data() == str);
+    REQUIRE(sv.size() == 2);
+}
+
+TEST_CASE("StrView_Swap") {
+    fkyaml::detail::str_view sv = "foo";
+    fkyaml::detail::str_view sv2 = "barr";
+    const char* p_sv_data = sv.data();
+    const char* p_sv2_data = sv2.data();
+
+    sv.swap(sv2);
+    REQUIRE(sv.size() == 4);
+    REQUIRE(sv.data() == p_sv2_data);
+    REQUIRE(sv2.size() == 3);
+    REQUIRE(sv2.data() == p_sv_data);
+}
+
+TEST_CASE("StrView_Copy") {
+    fkyaml::detail::str_view sv = "xxxxxxxxxx";
+    std::string buffer(10, 'a');
+
+    sv.copy(buffer.data(), 4);
+    REQUIRE(buffer == "xxxxaaaaaa");
+
+    buffer = "bbbbbbbbbbbbbbbbbbbb";
+    sv.copy(buffer.data(), 20 /*intentionally too large*/);
+    REQUIRE(buffer == "xxxxxxxxxxbbbbbbbbbb");
+}

--- a/test/unit_test/test_str_view_class.cpp
+++ b/test/unit_test/test_str_view_class.cpp
@@ -98,16 +98,17 @@ TEST_CASE("StrView_MoveAssignmentOperator") {
 TEST_CASE("StrView_ReverseIterators") {
     const char str[] = "hello world!";
     fkyaml::detail::str_view sv = str;
+    const char* p_str = &str[0];
 
     REQUIRE(&*sv.rbegin() == &str[11]);
-    REQUIRE(sv.rend().operator->() == (&str[0] - 1));
+    REQUIRE(sv.rend().operator->() == (p_str - 1));
     REQUIRE(&*sv.crbegin() == &str[11]);
-    REQUIRE(sv.crend().operator->() == (&str[0] - 1));
+    REQUIRE(sv.crend().operator->() == (p_str - 1));
 }
 
 TEST_CASE("StrView_MaxSize") {
     fkyaml::detail::str_view sv = "foo";
-    REQUIRE(sv.max_size() == std::numeric_limits<ptrdiff_t>::max());
+    REQUIRE(sv.max_size() == static_cast<size_t>(std::numeric_limits<ptrdiff_t>::max()));
 }
 
 TEST_CASE("StrView_SubscriptOperator") {

--- a/test/unit_test/test_str_view_class.cpp
+++ b/test/unit_test/test_str_view_class.cpp
@@ -207,29 +207,33 @@ TEST_CASE("StrView_Substr") {
 }
 
 TEST_CASE("StrView_Compare") {
-    constexpr std::size_t long_str_size = static_cast<std::size_t>(std::numeric_limits<int>::max()) + 4u;
-    char* p_long_str = new char[long_str_size] {};
-    for (std::size_t i = 0; i < long_str_size - 1; i++) {
-        p_long_str[i] = 'a';
-    }
-    p_long_str[long_str_size - 1] = '\0';
-    fkyaml::detail::str_view view(p_long_str, long_str_size - 1);
-
     fkyaml::detail::str_view sv = "a";
     REQUIRE(sv.compare("a") == 0);
     REQUIRE(sv.compare("b") == -1);
     REQUIRE(sv.compare("`") == 1);
-    REQUIRE(sv.compare(p_long_str) == std::numeric_limits<int>::min());
-    fkyaml::detail::str_view view_4a = "aaaa";
-    REQUIRE(view.compare(long_str_size - 1u - 4u, 4u, view_4a.data()) == 0);
-    REQUIRE(view.compare(long_str_size - 1u - 4u, 4u, view_4a.data(), view_4a.size()) == 0);
-    REQUIRE(view.compare(long_str_size - 1u - 4u, 4u, view_4a, 0, view_4a.size()) == 0);
-    REQUIRE(view.compare(long_str_size - 1u - 4u, 4u, view_4a) == 0);
-    REQUIRE(sv.compare(view) == std::numeric_limits<int>::min());
-    REQUIRE(view.compare(sv) == std::numeric_limits<int>::max());
 
-    delete[] p_long_str;
-    p_long_str = nullptr;
+    // skip checks of comparisons with a large string object if int == ptrdiff_t
+    if (static_cast<std::ptrdiff_t>(std::numeric_limits<int>::max()) < std::numeric_limits<std::ptrdiff_t>::max()) {
+        constexpr std::size_t long_str_size = static_cast<std::size_t>(std::numeric_limits<int>::max()) + 4u;
+        char* p_long_str = (char*)std::malloc(long_str_size);
+        for (std::size_t i = 0; i < long_str_size - 1; i++) {
+            p_long_str[i] = 'a';
+        }
+        p_long_str[long_str_size - 1] = '\0';
+        fkyaml::detail::str_view view(p_long_str, long_str_size - 1);
+
+        REQUIRE(sv.compare(p_long_str) == std::numeric_limits<int>::min());
+        fkyaml::detail::str_view view_4a = "aaaa";
+        REQUIRE(view.compare(long_str_size - 1u - 4u, 4u, view_4a.data()) == 0);
+        REQUIRE(view.compare(long_str_size - 1u - 4u, 4u, view_4a.data(), view_4a.size()) == 0);
+        REQUIRE(view.compare(long_str_size - 1u - 4u, 4u, view_4a, 0, view_4a.size()) == 0);
+        REQUIRE(view.compare(long_str_size - 1u - 4u, 4u, view_4a) == 0);
+        REQUIRE(sv.compare(view) == std::numeric_limits<int>::min());
+        REQUIRE(view.compare(sv) == std::numeric_limits<int>::max());
+
+        std::free(p_long_str);
+        p_long_str = nullptr;
+    }
 }
 
 TEST_CASE("StrView_StartsWith") {

--- a/test/unit_test/test_str_view_class.cpp
+++ b/test/unit_test/test_str_view_class.cpp
@@ -6,36 +6,13 @@
 // SPDX-FileCopyrightText: 2023-2024 Kensuke Fukutani <fktn.dev@gmail.com>
 // SPDX-License-Identifier: MIT
 
+#include <cstring>
 #include <string>
+#include <sstream>
 
 #include <catch2/catch.hpp>
 
 #include <fkYAML/detail/str_view.hpp>
-
-TEST_CASE("StrView_GeneralUseCase") {
-    const char str[] = "hello world!";
-    fkyaml::detail::str_view sv = str;
-    REQUIRE(sv.compare("hello world!") == 0);
-    REQUIRE(sv.size() == 12);
-    REQUIRE(sv.length() == 12);
-    REQUIRE(sv.begin() == &str[0]);
-    REQUIRE(sv.end() == &str[12]);
-
-    std::string str2 = "HELLO WORLD!";
-    sv = str2;
-    REQUIRE(sv.compare("HELLO WORLD!") == 0);
-    REQUIRE(sv.size() == 12);
-    REQUIRE(sv.length() == 12);
-    REQUIRE(sv.begin() == str2.data());
-    REQUIRE(sv.end() == str2.data() + 12);
-
-    fkyaml::detail::str_view sv2 = sv;
-    REQUIRE(sv2.compare("HELLO WORLD!") == 0);
-    REQUIRE(sv2.size() == 12);
-    REQUIRE(sv2.length() == 12);
-    REQUIRE(sv2.begin() == str2.data());
-    REQUIRE(sv2.end() == str2.data() + 12);
-}
 
 TEST_CASE("StrView_DefaultCtor") {
     fkyaml::detail::str_view sv;
@@ -43,6 +20,89 @@ TEST_CASE("StrView_DefaultCtor") {
     REQUIRE(sv.size() == 0);
     REQUIRE(sv.length() == 0);
     REQUIRE(sv.empty());
+}
+
+TEST_CASE("StrView_CharPtrCtor") {
+    const char str[] = "hello world!";
+    const char* p_str = &str[0];
+    fkyaml::detail::str_view sv(p_str);
+
+    REQUIRE(sv.compare("hello world!") == 0);
+    REQUIRE(sv.size() == 12);
+    REQUIRE(sv.length() == 12);
+    REQUIRE(sv.begin() == &str[0]);
+    REQUIRE(sv.end() == &str[0] + 12);
+}
+
+TEST_CASE("StrView_StdStringCtor") {
+    std::string str = "hello world!";
+    fkyaml::detail::str_view sv(str);
+
+    REQUIRE(sv.compare("hello world!") == 0);
+    REQUIRE(sv.size() == 12);
+    REQUIRE(sv.length() == 12);
+    REQUIRE(sv.begin() == str.data());
+    REQUIRE(sv.end() == str.data() + 12);
+}
+
+TEST_CASE("StrView_CopyCtor") {
+    const char str[] = "hello world!";
+    fkyaml::detail::str_view view = str;
+    fkyaml::detail::str_view sv(view);
+
+    REQUIRE(sv.compare("hello world!") == 0);
+    REQUIRE(sv.size() == 12);
+    REQUIRE(sv.length() == 12);
+    REQUIRE(sv.begin() == &str[0]);
+    REQUIRE(sv.end() == &str[0] + 12);
+}
+
+TEST_CASE("StrView_MoveCtor") {
+    const char str[] = "hello world!";
+    fkyaml::detail::str_view view = str;
+    fkyaml::detail::str_view sv(std::move(view));
+
+    REQUIRE(sv.compare("hello world!") == 0);
+    REQUIRE(sv.size() == 12);
+    REQUIRE(sv.length() == 12);
+    REQUIRE(sv.begin() == &str[0]);
+    REQUIRE(sv.end() == &str[0] + 12);
+}
+
+TEST_CASE("StrView_CopyAssignmentOperator") {
+    const char str[] = "hello world!";
+    fkyaml::detail::str_view view = str;
+    fkyaml::detail::str_view sv {};
+    sv = view;
+
+    REQUIRE(sv.compare("hello world!") == 0);
+    REQUIRE(sv.size() == 12);
+    REQUIRE(sv.length() == 12);
+    REQUIRE(sv.begin() == &str[0]);
+    REQUIRE(sv.end() == &str[0] + 12);
+}
+
+TEST_CASE("StrView_MoveAssignmentOperator") {
+    const char str[] = "hello world!";
+    fkyaml::detail::str_view view = str;
+    fkyaml::detail::str_view sv {};
+    sv = std::move(view);
+
+    REQUIRE(sv.compare("hello world!") == 0);
+    REQUIRE(sv.size() == 12);
+    REQUIRE(sv.length() == 12);
+    REQUIRE(sv.begin() == &str[0]);
+    REQUIRE(sv.end() == &str[0] + 12);
+}
+
+TEST_CASE("StrView_ReverseIterators") {
+    const char str[] = "hello world!";
+    fkyaml::detail::str_view sv = str;
+
+    REQUIRE(&*sv.rbegin() == &str[11]);
+    REQUIRE(sv.rend().operator->() == (&str[0] - 1));
+    REQUIRE(&*sv.crbegin() == &str[11]);
+    REQUIRE(sv.crend().operator->() == (&str[0] - 1));
 }
 
 TEST_CASE("StrView_MaxSize") {
@@ -126,12 +186,207 @@ TEST_CASE("StrView_Swap") {
 
 TEST_CASE("StrView_Copy") {
     fkyaml::detail::str_view sv = "xxxxxxxxxx";
-    std::string buffer(10, 'a');
+    char buffer[] = "aaaaaaaaaa";
 
-    sv.copy(buffer.data(), 4);
-    REQUIRE(buffer == "xxxxaaaaaa");
+    sv.copy(buffer, 4);
+    REQUIRE(std::strncmp(buffer, "xxxxaaaaaa", sizeof(buffer)) == 0);
 
-    buffer = "bbbbbbbbbbbbbbbbbbbb";
-    sv.copy(buffer.data(), 20 /*intentionally too large*/);
-    REQUIRE(buffer == "xxxxxxxxxxbbbbbbbbbb");
+    char buffer1[] = "bbbbbbbbbbbbbbbbbbbb";
+    sv.copy(buffer1, 20 /*intentionally too large*/);
+    REQUIRE(std::strncmp(buffer1, "xxxxxxxxxxbbbbbbbbbb", sizeof(buffer1)) == 0);
+
+    REQUIRE_THROWS_AS(sv.copy(buffer, 4, sv.length() + 1), fkyaml::out_of_range);
+}
+
+TEST_CASE("StrView_Substr") {
+    fkyaml::detail::str_view sv = "xxxxxxxxxx";
+
+    REQUIRE(sv.substr(4) == "xxxxxx");
+    REQUIRE(sv.substr(3, 2) == "xx");
+    REQUIRE_THROWS_AS(sv.substr(20), fkyaml::out_of_range);
+}
+
+TEST_CASE("StrView_Compare") {
+    std::string long_str(static_cast<std::size_t>(std::numeric_limits<int>::max()) + 4u, 'a');
+    fkyaml::detail::str_view view = long_str;
+
+    fkyaml::detail::str_view sv = "a";
+    REQUIRE(sv.compare("a") == 0);
+    REQUIRE(sv.compare("b") == -1);
+    REQUIRE(sv.compare("`") == 1);
+    REQUIRE(sv.compare(long_str.data()) == std::numeric_limits<int>::min());
+    fkyaml::detail::str_view view_4a = "aaaa";
+    REQUIRE(view.compare(long_str.size() - 4u, 4u, view_4a.data()) == 0);
+    REQUIRE(view.compare(long_str.size() - 4u, 4u, view_4a.data(), view_4a.size()) == 0);
+    REQUIRE(view.compare(long_str.size() - 4u, 4u, view_4a, 0, view_4a.size()) == 0);
+    REQUIRE(view.compare(long_str.size() - 4u, 4u, view_4a) == 0);
+    REQUIRE(sv.compare(view) == std::numeric_limits<int>::min());
+    REQUIRE(view.compare(sv) == std::numeric_limits<int>::max());
+}
+
+TEST_CASE("StrView_StartsWith") {
+    fkyaml::detail::str_view view_4a = "aaaa";
+    fkyaml::detail::str_view sv = "aaaa";
+
+    REQUIRE(sv.starts_with(view_4a));
+    REQUIRE(sv.starts_with('a'));
+    REQUIRE(sv.starts_with(view_4a.data()));
+}
+
+TEST_CASE("StrView_EndsWith") {
+    fkyaml::detail::str_view view_4a = "aaaa";
+    fkyaml::detail::str_view sv = "aaaa";
+
+    REQUIRE(sv.ends_with(view_4a));
+    REQUIRE(sv.ends_with('a'));
+    REQUIRE(sv.ends_with(view_4a.data()));
+}
+
+TEST_CASE("StrView_Contains") {
+    fkyaml::detail::str_view sv = "aaaa";
+    fkyaml::detail::str_view view = "aa";
+
+    REQUIRE(sv.contains(view));
+    REQUIRE(sv.contains("a"));
+    REQUIRE(sv.contains('a'));
+}
+
+TEST_CASE("StrView_Find") {
+    fkyaml::detail::str_view sv = "aaaabbcd";
+
+    REQUIRE(sv.find('a', 0) == 0);
+    REQUIRE(sv.find('a', sv.size()) == fkyaml::detail::str_view::npos);
+    REQUIRE(sv.find('e', 0) == fkyaml::detail::str_view::npos);
+
+    REQUIRE(sv.find("aa", 0, 2) == 0);
+    REQUIRE(sv.find("aa", 2, 2) == 2);
+    REQUIRE(sv.find("aa", 2, 0) == 2);
+    REQUIRE(sv.find("aa", sv.size() + 1, 0) == fkyaml::detail::str_view::npos);
+    REQUIRE(sv.find("aa", sv.size() + 1, 2) == fkyaml::detail::str_view::npos);
+    REQUIRE(sv.find("bcd", 0, 3) == 5);
+    REQUIRE(sv.find("efg", 0, 3) == fkyaml::detail::str_view::npos);
+    REQUIRE(sv.find("aaaabbcde", 0, 9) == fkyaml::detail::str_view::npos);
+}
+
+TEST_CASE("StrView_ReverseFind") {
+    fkyaml::detail::str_view sv = "aaaabbcd";
+
+    REQUIRE(sv.rfind('a') == 3);
+    REQUIRE(sv.rfind('a', 0) == 0);
+    REQUIRE(sv.rfind('e') == fkyaml::detail::str_view::npos);
+
+    fkyaml::detail::str_view empty_sv = "";
+    REQUIRE(empty_sv.rfind('a', 0));
+
+    REQUIRE(sv.rfind("aaaa", 0) == 0);
+    REQUIRE(sv.rfind("aaaa", 0, 4) == 0);
+    REQUIRE(sv.rfind("aaaa", 0, sv.size() + 1) == fkyaml::detail::str_view::npos);
+    REQUIRE(sv.rfind("efg", 2, 3) == fkyaml::detail::str_view::npos);
+}
+
+TEST_CASE("StrView_FindFirstOf") {
+    fkyaml::detail::str_view sv = "aaaabbcd";
+
+    REQUIRE(sv.find_first_of('b', 2) == 4);
+    REQUIRE(sv.find_first_of("abc") == 0);
+    REQUIRE(sv.find_first_of("abc", 0, 3) == 0);
+    REQUIRE(sv.find_first_of("abc", 0, 0) == fkyaml::detail::str_view::npos);
+    REQUIRE(sv.find_first_of("efg", 0, 3) == fkyaml::detail::str_view::npos);
+    REQUIRE(sv.find_first_of(fkyaml::detail::str_view {"abc"}) == 0);
+}
+
+TEST_CASE("StrView_FindLastOf") {
+    fkyaml::detail::str_view sv = "aaaabbcd";
+
+    REQUIRE(sv.find_last_of('a') == 3);
+    REQUIRE(sv.find_last_of("a") == 3);
+    REQUIRE(sv.find_last_of("a", 0, 1) == 0);
+    REQUIRE(sv.find_last_of("a", 0, sv.size() + 1) == fkyaml::detail::str_view::npos);
+    REQUIRE(sv.find_last_of(fkyaml::detail::str_view {"aa"}) == 3);
+}
+
+TEST_CASE("StrView_FindFirstNotOf") {
+    fkyaml::detail::str_view sv = "aaaabbcd";
+
+    REQUIRE(sv.find_first_not_of('a') == 4);
+    REQUIRE(sv.find_first_not_of('a', sv.size()) == fkyaml::detail::str_view::npos);
+
+    REQUIRE(sv.find_first_not_of("a") == 4);
+    REQUIRE(sv.find_first_not_of("a", 3) == 4);
+    REQUIRE(sv.find_first_not_of("a", sv.size()) == fkyaml::detail::str_view::npos);
+    REQUIRE(sv.find_first_not_of(fkyaml::detail::str_view {"a"}) == 4);
+}
+
+TEST_CASE("StrView_FindLastNotOf") {
+    fkyaml::detail::str_view sv = "aaaabbcd";
+
+    REQUIRE(sv.find_last_not_of('d') == 6);
+    REQUIRE(sv.find_last_not_of('b', 5) == 3);
+    fkyaml::detail::str_view empty_sv = "";
+    REQUIRE(empty_sv.find_last_not_of('b') == fkyaml::detail::str_view::npos);
+
+    REQUIRE(sv.find_last_not_of("bcd") == 3);
+    REQUIRE(sv.find_last_not_of("bcd", 5) == 3);
+    REQUIRE(empty_sv.find_last_not_of("bcd") == fkyaml::detail::str_view::npos);
+    REQUIRE(sv.find_last_not_of(fkyaml::detail::str_view {"bcd"}) == 3);
+}
+
+TEST_CASE("StrView_EqualToOperator") {
+    fkyaml::detail::str_view sv0 = "abc";
+    fkyaml::detail::str_view sv1 = "abc";
+    std::string str = "abc";
+    const char arr[] = "abc";
+    REQUIRE(sv0 == sv1);
+    REQUIRE(sv0 == str);
+    REQUIRE(str == sv0);
+    REQUIRE(sv0 == arr);
+    REQUIRE(arr == sv0);
+}
+
+TEST_CASE("StrView_NotEqualToOperator") {
+    fkyaml::detail::str_view sv0 = "abc";
+    fkyaml::detail::str_view sv1 = "edf";
+    std::string str = "edf";
+    const char arr[] = "edf";
+    REQUIRE(sv0 != sv1);
+    REQUIRE(sv0 != str);
+    REQUIRE(str != sv0);
+    REQUIRE(sv0 != arr);
+    REQUIRE(arr != sv0);
+}
+
+TEST_CASE("StrView_LessThanOperator") {
+    fkyaml::detail::str_view sv = "a";
+    REQUIRE_FALSE(sv < fkyaml::detail::str_view {"a"});
+    REQUIRE(sv < fkyaml::detail::str_view {"b"});
+    REQUIRE_FALSE(sv < fkyaml::detail::str_view {"`"});
+}
+
+TEST_CASE("StrView_LessThanOrEqualToOperator") {
+    fkyaml::detail::str_view sv = "a";
+    REQUIRE(sv <= fkyaml::detail::str_view {"a"});
+    REQUIRE(sv <= fkyaml::detail::str_view {"b"});
+    REQUIRE_FALSE(sv <= fkyaml::detail::str_view {"`"});
+}
+
+TEST_CASE("StrView_GreaterThanOperator") {
+    fkyaml::detail::str_view sv = "a";
+    REQUIRE_FALSE(sv > fkyaml::detail::str_view {"a"});
+    REQUIRE_FALSE(sv > fkyaml::detail::str_view {"b"});
+    REQUIRE(sv > fkyaml::detail::str_view {"`"});
+}
+
+TEST_CASE("StrView_GreaterThanOrEqualToOperator") {
+    fkyaml::detail::str_view sv = "a";
+    REQUIRE(sv >= fkyaml::detail::str_view {"a"});
+    REQUIRE_FALSE(sv >= fkyaml::detail::str_view {"b"});
+    REQUIRE(sv >= fkyaml::detail::str_view {"`"});
+}
+
+TEST_CASE("StrView_InsertionOperator") {
+    std::ostringstream ss {};
+    fkyaml::detail::str_view sv = "abc";
+    REQUIRE(ss.str().empty());
+    ss << sv;
+    REQUIRE(ss.str() == "abc");
 }

--- a/test/unit_test/test_str_view_class.cpp
+++ b/test/unit_test/test_str_view_class.cpp
@@ -207,21 +207,29 @@ TEST_CASE("StrView_Substr") {
 }
 
 TEST_CASE("StrView_Compare") {
-    std::string long_str(static_cast<std::size_t>(std::numeric_limits<int>::max()) + 4u, 'a');
-    fkyaml::detail::str_view view = long_str;
+    constexpr std::size_t long_str_size = static_cast<std::size_t>(std::numeric_limits<int>::max()) + 4u;
+    char* p_long_str = new char[long_str_size] {};
+    for (std::size_t i = 0; i < long_str_size - 1; i++) {
+        p_long_str[i] = 'a';
+    }
+    p_long_str[long_str_size - 1] = '\0';
+    fkyaml::detail::str_view view(p_long_str, long_str_size - 1);
 
     fkyaml::detail::str_view sv = "a";
     REQUIRE(sv.compare("a") == 0);
     REQUIRE(sv.compare("b") == -1);
     REQUIRE(sv.compare("`") == 1);
-    REQUIRE(sv.compare(long_str.data()) == std::numeric_limits<int>::min());
+    REQUIRE(sv.compare(p_long_str) == std::numeric_limits<int>::min());
     fkyaml::detail::str_view view_4a = "aaaa";
-    REQUIRE(view.compare(long_str.size() - 4u, 4u, view_4a.data()) == 0);
-    REQUIRE(view.compare(long_str.size() - 4u, 4u, view_4a.data(), view_4a.size()) == 0);
-    REQUIRE(view.compare(long_str.size() - 4u, 4u, view_4a, 0, view_4a.size()) == 0);
-    REQUIRE(view.compare(long_str.size() - 4u, 4u, view_4a) == 0);
+    REQUIRE(view.compare(long_str_size - 1u - 4u, 4u, view_4a.data()) == 0);
+    REQUIRE(view.compare(long_str_size - 1u - 4u, 4u, view_4a.data(), view_4a.size()) == 0);
+    REQUIRE(view.compare(long_str_size - 1u - 4u, 4u, view_4a, 0, view_4a.size()) == 0);
+    REQUIRE(view.compare(long_str_size - 1u - 4u, 4u, view_4a) == 0);
     REQUIRE(sv.compare(view) == std::numeric_limits<int>::min());
     REQUIRE(view.compare(sv) == std::numeric_limits<int>::max());
+
+    delete[] p_long_str;
+    p_long_str = nullptr;
 }
 
 TEST_CASE("StrView_StartsWith") {

--- a/test/unit_test/test_str_view_class.cpp
+++ b/test/unit_test/test_str_view_class.cpp
@@ -98,12 +98,11 @@ TEST_CASE("StrView_MoveAssignmentOperator") {
 TEST_CASE("StrView_ReverseIterators") {
     const char str[] = "hello world!";
     fkyaml::detail::str_view sv = str;
-    const char* p_str = &str[0];
 
     REQUIRE(&*sv.rbegin() == &str[11]);
-    REQUIRE(sv.rend().operator->() == (p_str - 1));
+    REQUIRE(sv.rend().operator->() + 1 == &str[0]);
     REQUIRE(&*sv.crbegin() == &str[11]);
-    REQUIRE(sv.crend().operator->() == (p_str - 1));
+    REQUIRE(sv.crend().operator->() + 1 == &str[0]);
 }
 
 TEST_CASE("StrView_MaxSize") {

--- a/test/unit_test/test_str_view_class.cpp
+++ b/test/unit_test/test_str_view_class.cpp
@@ -12,7 +12,7 @@
 
 #include <catch2/catch.hpp>
 
-#include <fkYAML/detail/str_view.hpp>
+#include <fkYAML/node.hpp>
 
 TEST_CASE("StrView_DefaultCtor") {
     fkyaml::detail::str_view sv;

--- a/test/unit_test/test_uri_encoding_class.cpp
+++ b/test/unit_test/test_uri_encoding_class.cpp
@@ -21,7 +21,7 @@ TEST_CASE("URIEncoding_Validate") {
             std::string("0123456789"),
             std::string("ABCDEFGHIJKLMNOPQRSTUVWXYZ"),
             std::string("abcdefghijklmnopqrstuvwxyz"));
-        REQUIRE(fkyaml::detail::uri_encoding::validate(input.begin(), input.end()));
+        REQUIRE(fkyaml::detail::uri_encoding::validate(input.c_str(), input.c_str() + input.size()));
     }
 
     SECTION("invalid URI characters") {
@@ -76,6 +76,6 @@ TEST_CASE("URIEncoding_Validate") {
             std::string("`"),
             std::string("|"),
             std::string("\x7F"));
-        REQUIRE_FALSE(fkyaml::detail::uri_encoding::validate(input.begin(), input.end()));
+        REQUIRE_FALSE(fkyaml::detail::uri_encoding::validate(input.c_str(), input.c_str() + input.size()));
     }
 }

--- a/test/unit_test/test_utf_encodings.cpp
+++ b/test/unit_test/test_utf_encodings.cpp
@@ -144,13 +144,19 @@ TEST_CASE("UTF8_Validate") {
             fkyaml::detail::utf8::validate({uint8_t(0xF0u), uint8_t(0xBFu), uint8_t(0xBFu), uint8_t(0xBFu)}) == true);
 
         REQUIRE(
+            fkyaml::detail::utf8::validate({uint8_t(0xF0u), uint8_t(0x8Fu), uint8_t(0x80u), uint8_t(0x80u)}) == false);
+        REQUIRE(
             fkyaml::detail::utf8::validate({uint8_t(0xF0u), uint8_t(0xC0u), uint8_t(0xBFu), uint8_t(0xBFu)}) == false);
         REQUIRE(
             fkyaml::detail::utf8::validate({uint8_t(0xF0u), uint8_t(0xC1u), uint8_t(0xBFu), uint8_t(0xBFu)}) == false);
         REQUIRE(
+            fkyaml::detail::utf8::validate({uint8_t(0xF0u), uint8_t(0xBFu), uint8_t(0x7Fu), uint8_t(0xBFu)}) == false);
+        REQUIRE(
             fkyaml::detail::utf8::validate({uint8_t(0xF0u), uint8_t(0xBFu), uint8_t(0xC0u), uint8_t(0xBFu)}) == false);
         REQUIRE(
             fkyaml::detail::utf8::validate({uint8_t(0xF0u), uint8_t(0xBFu), uint8_t(0xC1u), uint8_t(0xBFu)}) == false);
+        REQUIRE(
+            fkyaml::detail::utf8::validate({uint8_t(0xF0u), uint8_t(0xBFu), uint8_t(0xBFu), uint8_t(0x7Fu)}) == false);
         REQUIRE(
             fkyaml::detail::utf8::validate({uint8_t(0xF0u), uint8_t(0xBFu), uint8_t(0xBFu), uint8_t(0xC0u)}) == false);
         REQUIRE(

--- a/test/unit_test/test_yaml_escaper_class.cpp
+++ b/test/unit_test/test_yaml_escaper_class.cpp
@@ -14,7 +14,7 @@
 
 TEST_CASE("YamlEscaper_Unescape") {
     SECTION("valid escape sequence") {
-        using test_data_t = std::pair<std::string, std::string>;
+        using test_data_t = std::pair<fkyaml::detail::str_view, std::string>;
         auto test_data = GENERATE(
             test_data_t {"\\a", "\a"},
             test_data_t {"\\b", "\b"},
@@ -44,20 +44,20 @@ TEST_CASE("YamlEscaper_Unescape") {
             test_data_t {"\\U0000007F", {char(0x7F)}});
 
         std::string buff {};
-        auto begin_itr = test_data.first.cbegin();
-        auto end_itr = test_data.first.cend();
+        auto begin_itr = test_data.first.begin();
+        auto end_itr = test_data.first.end();
         REQUIRE(fkyaml::detail::yaml_escaper::unescape(begin_itr, end_itr, buff));
         REQUIRE(buff == test_data.second);
     }
 
     SECTION("invalid escape sequence") {
         auto input = GENERATE(
-            std::string("\\Q"),
-            std::string("\\xw"),
-            std::string("\\x+"),
-            std::string("\\u="),
-            std::string("\\U^"),
-            std::string("\\x{"));
+            fkyaml::detail::str_view("\\Q"),
+            fkyaml::detail::str_view("\\xw"),
+            fkyaml::detail::str_view("\\x+"),
+            fkyaml::detail::str_view("\\u="),
+            fkyaml::detail::str_view("\\U^"),
+            fkyaml::detail::str_view("\\x{"));
 
         std::string buff {};
         auto begin_itr = input.cbegin();
@@ -66,7 +66,7 @@ TEST_CASE("YamlEscaper_Unescape") {
     }
 
     SECTION("invalid UTF encoding") {
-        std::string input = "\\U00110000";
+        fkyaml::detail::str_view input = "\\U00110000";
         auto begin_itr = input.cbegin();
         auto end_itr = input.cend();
         std::string buff {};
@@ -116,8 +116,7 @@ TEST_CASE("YamlEscaper_Escape") {
         test_data_t {{char(0xE2u), char(0x80u), char(0xA9u)}, "\\P"});
 
     bool is_escaped = false;
-    auto begin_itr = test_data.first.cbegin();
-    auto end_itr = test_data.first.cend();
-    REQUIRE(fkyaml::detail::yaml_escaper::escape(begin_itr, end_itr, is_escaped) == test_data.second);
+    fkyaml::detail::str_view input = test_data.first;
+    REQUIRE(fkyaml::detail::yaml_escaper::escape(input.begin(), input.end(), is_escaped) == test_data.second);
     REQUIRE(is_escaped);
 }

--- a/tool/benchmark/result_debug.log
+++ b/tool/benchmark/result_debug.log
@@ -1,7 +1,7 @@
 -------------------------------------------------------------------------------------
 Benchmark                           Time             CPU   Iterations UserCounters...
 -------------------------------------------------------------------------------------
-bm_fkyaml_parse                121413 ns       121413 ns         5836 bytes_per_second=35.2759Mi/s items_per_second=8.23636k/s
+bm_fkyaml_parse                121413 ns       121413 ns         5836 bytes_per_second=39.1517Mi/s items_per_second=9.14129k/s
 bm_yamlcpp_parse              4963184 ns      4963204 ns          141 bytes_per_second=883.651Ki/s items_per_second=201.483/s
 bm_libfyaml_parse              595741 ns       595744 ns         1185 bytes_per_second=7.18924Mi/s items_per_second=1.67857k/s
 bm_rapidyaml_parse_inplace     238052 ns       238052 ns         3007 bytes_per_second=17.9916Mi/s items_per_second=4.20075k/s

--- a/tool/benchmark/result_release.log
+++ b/tool/benchmark/result_release.log
@@ -1,7 +1,7 @@
 -------------------------------------------------------------------------------------
 Benchmark                           Time             CPU   Iterations UserCounters...
 -------------------------------------------------------------------------------------
-bm_fkyaml_parse                105774 ns       105775 ns         6662 bytes_per_second=40.4911Mi/s items_per_second=9.45402k/s
+bm_fkyaml_parse                105774 ns       105775 ns         6662 bytes_per_second=41.0509Mi/s items_per_second=9.58472k/s
 bm_yamlcpp_parse               579017 ns       579019 ns         1202 bytes_per_second=7.39692Mi/s items_per_second=1.72706k/s
 bm_libfyaml_parse              137681 ns       137669 ns         5726 bytes_per_second=31.1104Mi/s items_per_second=7.26379k/s
 bm_rapidyaml_parse_inplace      29092 ns        29092 ns        24046 bytes_per_second=147.221Mi/s items_per_second=34.3737k/s


### PR DESCRIPTION
This PR has significantly reduced the number & size of string copies and subsequent heap allocations during parsing of YAML sources by the following major changes:
* use `fkyaml::detail::str_view` class which is newly implemented as a minimal implementation of `std::string_view` (since C++17) even when the library is built with C++11 or C++14 so that inspections into YAML sources are executed more effectively
* avoid copying YAML sources into a `std::string` object if they don't contain CR newline codes and are an array/container which has contiguous byte array to store actual characters (like `char [N]`, `std::vector` or `std::string`)
* reduced unnecessary `std::string` instanciations during the parsing

As a result of the above changes, the benchmark scores of this library has increased by 0.5MiB/s (when parsing tool/benchmark/macos.yml file with the same environment described in README.md):  

|last benchmark score|benchmark score after the changes|
|---|---|
|40.491 MiB/s|41.051 MiB/s|

---

## Pull Request Checklist

Read the [CONTRIBUTING.md](https://github.com/fktn-k/fkYAML/blob/develop/CONTRIBUTING.md) file for detailed information.  

- [x] Changes are described in the pull request or in a referenced [issue](https://github.com/fktn-k/fkYAML/issues).
- [x] The test suite compiles and runs without any error.
- [x] [The code coverage](https://coveralls.io/github/fktn-k/fkYAML) on your branch is 100%.
- [x] The documentation is updated if you added/changed a feature.

## Please don't

- The C++11 support varies between different **compilers** and versions. Please note the [list of supported compilers](https://github.com/fktn-k/fkYAML/blob/develop/README.md#supported-compilers). Some compilers like GCC 4.7 (and earlier), Clang 3.3 (and earlier), or Microsoft Visual Studio 13.0 and earlier are known not to work due to missing or incomplete C++11 support. Please refrain from proposing changes that work around these compiler's limitations with `#ifdef`s or other means.
- Please refrain from proposing changes that would **break [YAML](https://yaml.org/) specifications**. If you propose a conformant extension of YAML to be supported by the library, please motivate this extension.
- Please do not open pull requests that address **multiple issues**.
