### PR TITLE
Accept % as first scalar character

### DIFF
--- a/include/fkYAML/detail/input/lexical_analyzer.hpp
+++ b/include/fkYAML/detail/input/lexical_analyzer.hpp
@@ -164,6 +164,8 @@ public:
                 token.type = scan_directive();
             }
             else {
+                // The '%' character can be safely used as the first character in document contents.
+                // See https://yaml.org/spec/1.2.2/#912-document-markers for more details.
                 scan_scalar(token);
             }
             return token;
@@ -291,6 +293,8 @@ public:
         return m_tag_prefix;
     }
 
+    /// @brief Toggles the context state between flow and block.
+    /// @param is_flow_context true: flow context, false: block context
     void set_context_state(bool is_flow_context) noexcept {
         m_state &= ~flow_context_bit;
         if (is_flow_context) {
@@ -298,6 +302,8 @@ public:
         }
     }
 
+    /// @brief Toggles the document state between directive and content.
+    /// @param is_directive true: directive, false: content
     void set_document_state(bool is_directive) noexcept {
         m_state &= ~document_directive_bit;
         if (is_directive) {

--- a/single_include/fkYAML/node.hpp
+++ b/single_include/fkYAML/node.hpp
@@ -4047,6 +4047,15 @@ struct lexical_token {
     str_view str {};
 };
 
+namespace {
+
+// whether the current context is flow(1) or block(0)
+const uint32_t flow_context_bit = 1u << 0u;
+// whether the curent document part is directive(1) or content(0)
+const uint32_t document_directive_bit = 1u << 1u;
+
+} // anonymous namespace
+
 /// @brief A class which lexically analizes YAML formatted inputs.
 class lexical_analyzer {
 private:
@@ -4120,7 +4129,7 @@ public:
             case ']':
             case '{':
             case '}':
-                if (m_flow_context_depth > 0) {
+                if (m_state & flow_context_bit) {
                     // the above characters are not "safe" to be followed in a flow context.
                     // See https://yaml.org/spec/1.2.2/#733-plain-style for more details.
                     break;
@@ -4167,7 +4176,12 @@ public:
             scan_comment();
             return get_next_token();
         case '%': // directive prefix
-            token.type = scan_directive();
+            if (m_state & document_directive_bit) {
+                token.type = scan_directive();
+            }
+            else {
+                scan_scalar(token);
+            }
             return token;
         case '-': {
             char next = *(m_cur_itr + 1);
@@ -4197,22 +4211,18 @@ public:
             return token;
         }
         case '[': // sequence flow begin
-            m_flow_context_depth++;
             ++m_cur_itr;
             token.type = lexical_token_t::SEQUENCE_FLOW_BEGIN;
             return token;
         case ']': // sequence flow end
-            m_flow_context_depth = (m_flow_context_depth > 0) ? m_flow_context_depth - 1 : 0;
             ++m_cur_itr;
             token.type = lexical_token_t::SEQUENCE_FLOW_END;
             return token;
         case '{': // mapping flow begin
-            m_flow_context_depth++;
             ++m_cur_itr;
             token.type = lexical_token_t::MAPPING_FLOW_BEGIN;
             return token;
         case '}': // mapping flow end
-            m_flow_context_depth = (m_flow_context_depth > 0) ? m_flow_context_depth - 1 : 0;
             ++m_cur_itr;
             token.type = lexical_token_t::MAPPING_FLOW_END;
             return token;
@@ -4295,6 +4305,20 @@ public:
     /// @return str_view A tag prefix.
     str_view get_tag_prefix() const noexcept {
         return m_tag_prefix;
+    }
+
+    void set_context_state(bool is_flow_context) noexcept {
+        m_state &= ~flow_context_bit;
+        if (is_flow_context) {
+            m_state |= flow_context_bit;
+        }
+    }
+
+    void set_document_state(bool is_directive) noexcept {
+        m_state &= ~document_directive_bit;
+        if (is_directive) {
+            m_state |= document_directive_bit;
+        }
     }
 
 private:
@@ -4966,15 +4990,15 @@ private:
             check_filters.append("\"\\");
             pfn_is_allowed = &lexical_analyzer::is_allowed_double;
         }
-        else if (m_flow_context_depth == 0) {
-            // plain scalar outside flow contexts
-            check_filters.append(" :");
-            pfn_is_allowed = &lexical_analyzer::is_allowed_plain;
-        }
-        else {
+        else if (m_state & flow_context_bit) {
             // plain scalar inside flow contexts
             check_filters.append(" :{}[],");
             pfn_is_allowed = &lexical_analyzer::is_allowed_plain_flow;
+        }
+        else {
+            // plain scalar outside flow contexts
+            check_filters.append(" :");
+            pfn_is_allowed = &lexical_analyzer::is_allowed_plain;
         }
 
         // scan the contents of a string scalar token.
@@ -5410,7 +5434,7 @@ private:
     /// The beginning line of the last lexical token. (zero origin)
     uint32_t m_last_token_begin_line {0};
     /// The current depth of flow context.
-    uint32_t m_flow_context_depth {0};
+    uint32_t m_state {0};
 };
 
 FK_YAML_DETAIL_NAMESPACE_END
@@ -6404,6 +6428,7 @@ private:
         }
         case lexical_token_t::SEQUENCE_FLOW_BEGIN:
             ++m_flow_context_depth;
+            lexer.set_context_state(true);
             root = basic_node_type::sequence();
             apply_directive_set(root);
             apply_node_properties(root);
@@ -6413,6 +6438,7 @@ private:
             break;
         case lexical_token_t::MAPPING_FLOW_BEGIN:
             ++m_flow_context_depth;
+            lexer.set_context_state(true);
             root = basic_node_type::mapping();
             apply_directive_set(root);
             apply_node_properties(root);
@@ -6460,6 +6486,7 @@ private:
     /// @param last_type The variable to store the last lexical token type.
     void deserialize_directives(lexer_type& lexer, lexical_token& last_token) {
         bool lacks_end_of_directives_marker = false;
+        lexer.set_document_state(true);
 
         for (;;) {
             lexical_token token = lexer.get_next_token();
@@ -6539,6 +6566,7 @@ private:
                 }
                 // end the parsing of directives if the other tokens are found.
                 last_token = token;
+                lexer.set_document_state(false);
                 return;
             }
         }
@@ -6750,11 +6778,6 @@ private:
 
                 continue;
             }
-            // just ignore directives
-            case lexical_token_t::YAML_VER_DIRECTIVE:
-            case lexical_token_t::TAG_DIRECTIVE:
-            case lexical_token_t::INVALID_DIRECTIVE:
-                break;
             case lexical_token_t::ANCHOR_PREFIX:
             case lexical_token_t::TAG_PREFIX:
                 deserialize_node_properties(lexer, token, line, indent);
@@ -6789,6 +6812,8 @@ private:
             }
             case lexical_token_t::SEQUENCE_FLOW_BEGIN:
                 if (m_flow_context_depth == 0) {
+                    lexer.set_context_state(true);
+
                     uint32_t pop_num = 0;
                     if (indent == 0) {
                         pop_num = static_cast<uint32_t>(m_context_stack.size() - 1);
@@ -6864,7 +6889,10 @@ private:
                 if FK_YAML_UNLIKELY (m_flow_context_depth == 0) {
                     throw parse_error("Flow sequence ending is found outside the flow context.", line, indent);
                 }
-                --m_flow_context_depth;
+
+                if (--m_flow_context_depth == 0) {
+                    lexer.set_context_state(false);
+                }
 
                 // find the corresponding flow sequence beginning.
                 auto itr = std::find_if( // LCOV_EXCL_LINE
@@ -6931,6 +6959,8 @@ private:
             }
             case lexical_token_t::MAPPING_FLOW_BEGIN:
                 if (m_flow_context_depth == 0) {
+                    lexer.set_context_state(true);
+
                     uint32_t pop_num = 0;
                     if (indent == 0) {
                         pop_num = static_cast<uint32_t>(m_context_stack.size() - 1);
@@ -7009,7 +7039,10 @@ private:
                 if FK_YAML_UNLIKELY (m_flow_context_depth == 0) {
                     throw parse_error("Flow mapping ending is found outside the flow context.", line, indent);
                 }
-                --m_flow_context_depth;
+
+                if (--m_flow_context_depth == 0) {
+                    lexer.set_context_state(false);
+                }
 
                 // find the corresponding flow mapping beginning.
                 auto itr = std::find_if( // LCOV_EXCL_LINE
@@ -7098,6 +7131,11 @@ private:
             case lexical_token_t::END_OF_DOCUMENT:
                 last_type = token.type;
                 return;
+            // no way to come here while lexically analyzing document contents.
+            case lexical_token_t::YAML_VER_DIRECTIVE: // LCOV_EXCL_LINE
+            case lexical_token_t::TAG_DIRECTIVE:      // LCOV_EXCL_LINE
+            case lexical_token_t::INVALID_DIRECTIVE:  // LCOV_EXCL_LINE
+                break;                                // LCOV_EXCL_LINE
             }
 
             token = lexer.get_next_token();

--- a/single_include/fkYAML/node.hpp
+++ b/single_include/fkYAML/node.hpp
@@ -4180,6 +4180,8 @@ public:
                 token.type = scan_directive();
             }
             else {
+                // The '%' character can be safely used as the first character in document contents.
+                // See https://yaml.org/spec/1.2.2/#912-document-markers for more details.
                 scan_scalar(token);
             }
             return token;
@@ -4307,6 +4309,8 @@ public:
         return m_tag_prefix;
     }
 
+    /// @brief Toggles the context state between flow and block.
+    /// @param is_flow_context true: flow context, false: block context
     void set_context_state(bool is_flow_context) noexcept {
         m_state &= ~flow_context_bit;
         if (is_flow_context) {
@@ -4314,6 +4318,8 @@ public:
         }
     }
 
+    /// @brief Toggles the document state between directive and content.
+    /// @param is_directive true: directive, false: content
     void set_document_state(bool is_directive) noexcept {
         m_state &= ~document_directive_bit;
         if (is_directive) {

--- a/test/unit_test/test_deserializer_class.cpp
+++ b/test/unit_test/test_deserializer_class.cpp
@@ -1942,19 +1942,24 @@ TEST_CASE("Deserializer_YAMLVerDirective") {
         REQUIRE(foo_node.get_value_ref<std::string&>() == "one");
     }
 
-    SECTION("YAML directive in the content to be ignored") {
+    SECTION("YAML directive in the content is a valid scalar") {
         REQUIRE_NOTHROW(
-            root = deserializer.deserialize(fkyaml::detail::input_adapter("foo: bar\n%YAML 1.1\ntrue: 123")));
+            root = deserializer.deserialize(fkyaml::detail::input_adapter("foo: bar\n%YAML 1.1: is valid\ntrue: 123")));
 
         REQUIRE(root.get_yaml_version_type() == fkyaml::yaml_version_type::VERSION_1_2);
         REQUIRE(root.is_mapping());
-        REQUIRE(root.size() == 2);
+        REQUIRE(root.size() == 3);
         REQUIRE(root.contains("foo"));
+        REQUIRE(root.contains("%YAML 1.1"));
         REQUIRE(root.contains(true));
 
         fkyaml::node& foo_node = root["foo"];
         REQUIRE(foo_node.is_string());
         REQUIRE(foo_node.get_value_ref<std::string&>() == "bar");
+
+        fkyaml::node& yaml11_node = root["%YAML 1.1"];
+        REQUIRE(yaml11_node.is_string());
+        REQUIRE(yaml11_node.get_value_ref<std::string&>() == "is valid");
 
         fkyaml::node& true_node = root[true];
         REQUIRE(true_node.is_integer());


### PR DESCRIPTION
The current deserializer doesn't properly handle the '%' character based on whether it processes document directives or contents.  
As the spec specifies [here](https://yaml.org/spec/1.2.2/#912-document-markers), if it processes document directives, '%' as the first character should be interpretted as the beginning of a directive; and if it processes document contents, '%' can be used as the first character of a scalar:  
```yaml
%YAML 1.2
---
%this key: is valid # the first '%' is not the beginning of a directive
```

So, this PR has modified the lexer so it can properly decide whether '%' is the beginning of a directive or the first character of a scalar.  

---

## Pull Request Checklist

Read the [CONTRIBUTING.md](https://github.com/fktn-k/fkYAML/blob/develop/CONTRIBUTING.md) file for detailed information.  

- [x] Changes are described in the pull request or in a referenced [issue](https://github.com/fktn-k/fkYAML/issues).
- [x] The test suite compiles and runs without any error.
- [x] [The code coverage](https://coveralls.io/github/fktn-k/fkYAML) on your branch is 100%.
- [x] The documentation is updated if you added/changed a feature.

## Please don't

- The C++11 support varies between different **compilers** and versions. Please note the [list of supported compilers](https://github.com/fktn-k/fkYAML/blob/develop/README.md#supported-compilers). Some compilers like GCC 4.7 (and earlier), Clang 3.3 (and earlier), or Microsoft Visual Studio 13.0 and earlier are known not to work due to missing or incomplete C++11 support. Please refrain from proposing changes that work around these compiler's limitations with `#ifdef`s or other means.
- Please refrain from proposing changes that would **break [YAML](https://yaml.org/) specifications**. If you propose a conformant extension of YAML to be supported by the library, please motivate this extension.
- Please do not open pull requests that address **multiple issues**.
