### PR TITLE
Fix compile warnings/errors when benchmarker app is compiled with msvc

### DIFF
--- a/tool/benchmark/CMakeLists.txt
+++ b/tool/benchmark/CMakeLists.txt
@@ -71,6 +71,12 @@ target_compile_options(
     >
 )
 
+target_compile_options(
+  ryml
+  PUBLIC
+    $<$<CXX_COMPILER_ID:MSVC>: /wd4819>
+)
+
 target_link_libraries(
   benchmarker
   PRIVATE

--- a/tool/benchmark/main.cpp
+++ b/tool/benchmark/main.cpp
@@ -6,6 +6,13 @@
 // SPDX-FileCopyrightText: 2023-2024 Kensuke Fukutani <fktn.dev@gmail.com>
 // SPDX-License-Identifier: MIT
 
+#ifdef _MSC_VER
+// suppress the C4996 warning against the usage of fopen().
+#define _CRT_SECURE_NO_WARNINGS
+#endif
+
+#include <cassert>
+#include <cstring>
 #include <string>
 
 #include <benchmark/benchmark.h>
@@ -94,7 +101,7 @@ void bm_rapidyaml_parse_inplace(benchmark::State& st) {
         // ryml::parse_in_place() modifies the contents of `in_place_buff` during parsing.
         // Without the following copy, the second (and subsequent) parsing would fail.
         assert(in_place_buff.size() == test_src.size());
-        std::memcpy(in_place_buff.data(), test_src.data(), in_place_buff.size());
+        std::memcpy(&in_place_buff[0], &test_src[0], in_place_buff.size());
 
         ryml::Tree tree = ryml::parse_in_place(c4_test_src);
     }


### PR DESCRIPTION
This PR has fixed warnings and errors when compiling the benchmarking app with MSVC compilers and made it just work.  
No other changes have been made.  
No benchmarking results on Windows is uploaded yet, and please hold on for a while.  

---

## Pull Request Checklist

Read the [CONTRIBUTING.md](https://github.com/fktn-k/fkYAML/blob/develop/CONTRIBUTING.md) file for detailed information.  

- [x] Changes are described in the pull request or in a referenced [issue](https://github.com/fktn-k/fkYAML/issues).
- [x] The test suite compiles and runs without any error.
- [x] [The code coverage](https://coveralls.io/github/fktn-k/fkYAML) on your branch is 100%.
- [x] The documentation is updated if you added/changed a feature.

## Please don't

- The C++11 support varies between different **compilers** and versions. Please note the [list of supported compilers](https://github.com/fktn-k/fkYAML/blob/develop/README.md#supported-compilers). Some compilers like GCC 4.7 (and earlier), Clang 3.3 (and earlier), or Microsoft Visual Studio 13.0 and earlier are known not to work due to missing or incomplete C++11 support. Please refrain from proposing changes that work around these compiler's limitations with `#ifdef`s or other means.
- Please refrain from proposing changes that would **break [YAML](https://yaml.org/) specifications**. If you propose a conformant extension of YAML to be supported by the library, please motivate this extension.
- Please do not open pull requests that address **multiple issues**.
