### PR TITLE
Fix URI validation for tag shorthands

### DIFF
--- a/include/fkYAML/detail/input/lexical_analyzer.hpp
+++ b/include/fkYAML/detail/input/lexical_analyzer.hpp
@@ -629,16 +629,24 @@ private:
                 // See the "Tag Shorthands" section in https://yaml.org/spec/1.2.2/#691-node-tags.
                 emit_error("named handle has no suffix.");
             }
+        }
 
-            // get the position of the beginning of a suffix. (!handle!suffix)
-            std::size_t last_tag_prefix_pos = token.str.find_last_of('!');
-            FK_YAML_ASSERT(last_tag_prefix_pos != str_view::npos);
+        // get the position of last tag prefix character (!) to extract body of tag shorthands.
+        // tag shorthand is either primary(!tag), secondary(!!tag) or named(!handle!tag).
+        std::size_t last_tag_prefix_pos = token.str.find_last_of('!');
+        FK_YAML_ASSERT(last_tag_prefix_pos != str_view::npos);
 
-            str_view tag_uri = token.str.substr(last_tag_prefix_pos + 1);
-            bool is_valid_uri = uri_encoding::validate(tag_uri.begin(), tag_uri.end());
-            if FK_YAML_UNLIKELY (!is_valid_uri) {
-                emit_error("Invalid URI character is found in a named tag handle.");
-            }
+        str_view tag_uri = token.str.substr(last_tag_prefix_pos + 1);
+        bool is_valid_uri = uri_encoding::validate(tag_uri.begin(), tag_uri.end());
+        if FK_YAML_UNLIKELY (!is_valid_uri) {
+            emit_error("Invalid URI character is found in a named tag handle.");
+        }
+
+        // Tag shorthands cannot contain flow indicators({}[],).
+        // See the "Tag Shorthands" section in https://yaml.org/spec/1.2.2/#691-node-tags.
+        std::size_t invalid_char_pos = tag_uri.find_first_of("{}[],");
+        if (invalid_char_pos != str_view::npos) {
+            emit_error("Tag shorthand cannot contain flow indicators({}[],).");
         }
     }
 

--- a/test/unit_test/test_lexical_analyzer_class.cpp
+++ b/test/unit_test/test_lexical_analyzer_class.cpp
@@ -1105,7 +1105,22 @@ TEST_CASE("LexicalAnalyzer_Tag") {
             fkyaml::detail::str_view("!<%f:oo> tag"),
             fkyaml::detail::str_view("!<!%f:oo> tag"),
             fkyaml::detail::str_view("!foo! tag"),
-            fkyaml::detail::str_view("!foo!%f:oo tag"));
+            fkyaml::detail::str_view("!foo!%f:oo tag"),
+            fkyaml::detail::str_view("!foo{ tag"),
+            fkyaml::detail::str_view("!foo} tag"),
+            fkyaml::detail::str_view("!foo[ tag"),
+            fkyaml::detail::str_view("!foo] tag"),
+            fkyaml::detail::str_view("!foo, tag"),
+            fkyaml::detail::str_view("!!foo{ tag"),
+            fkyaml::detail::str_view("!!foo} tag"),
+            fkyaml::detail::str_view("!!foo[ tag"),
+            fkyaml::detail::str_view("!!foo] tag"),
+            fkyaml::detail::str_view("!!foo, tag"),
+            fkyaml::detail::str_view("!foo!bar{ tag"),
+            fkyaml::detail::str_view("!foo!bar} tag"),
+            fkyaml::detail::str_view("!foo!bar[ tag"),
+            fkyaml::detail::str_view("!foo!bar] tag"),
+            fkyaml::detail::str_view("!foo!bar, tag"));
 
         fkyaml::detail::lexical_analyzer lexer(input);
         REQUIRE_THROWS_AS(token = lexer.get_next_token(), fkyaml::parse_error);


### PR DESCRIPTION
The current deserialization feature cannot detect invalid flow indicators contained in tag shorthands, either primary(!tag), secondary(!!tag) or named(!handle!tag), though the spec explicitly defines them as invalid characters when they appear in a tag shorthand in the "Tag Shorthands" section of https://yaml.org/spec/1.2.2/#691-node-tags.  
```yaml
!!str, this tag: is invalid
```

To fix it, this PR has corrected related implementations in the lexer, and test cases have also been added to validate the changes.  

---

## Pull Request Checklist

Read the [CONTRIBUTING.md](https://github.com/fktn-k/fkYAML/blob/develop/CONTRIBUTING.md) file for detailed information.  

- [x] Changes are described in the pull request or in a referenced [issue](https://github.com/fktn-k/fkYAML/issues).
- [x] The test suite compiles and runs without any error.
- [x] [The code coverage](https://coveralls.io/github/fktn-k/fkYAML) on your branch is 100%.
- [x] The documentation is updated if you added/changed a feature.

## Please don't

- The C++11 support varies between different **compilers** and versions. Please note the [list of supported compilers](https://github.com/fktn-k/fkYAML/blob/develop/README.md#supported-compilers). Some compilers like GCC 4.7 (and earlier), Clang 3.3 (and earlier), or Microsoft Visual Studio 13.0 and earlier are known not to work due to missing or incomplete C++11 support. Please refrain from proposing changes that work around these compiler's limitations with `#ifdef`s or other means.
- Please refrain from proposing changes that would **break [YAML](https://yaml.org/) specifications**. If you propose a conformant extension of YAML to be supported by the library, please motivate this extension.
- Please do not open pull requests that address **multiple issues**.
