### PR TITLE
Fix float scalar serialization when a float is actually an integer

### DIFF
--- a/include/fkYAML/detail/conversions/to_string.hpp
+++ b/include/fkYAML/detail/conversions/to_string.hpp
@@ -78,6 +78,13 @@ inline enable_if_t<std::is_floating_point<FloatType>::value> to_string(FloatType
     std::ostringstream oss;
     oss << f;
     s = oss.str();
+
+    // If `f` is actually an integer, ".0" must be appended. The result would cause roundtrip issue otherwise.
+    // https://github.com/fktn-k/fkYAML/issues/405
+    FloatType diff = f - std::floor(f);
+    if (diff < std::numeric_limits<FloatType>::min()) {
+        s += ".0";
+    }
 }
 
 FK_YAML_DETAIL_NAMESPACE_END

--- a/single_include/fkYAML/node.hpp
+++ b/single_include/fkYAML/node.hpp
@@ -9570,6 +9570,13 @@ inline enable_if_t<std::is_floating_point<FloatType>::value> to_string(FloatType
     std::ostringstream oss;
     oss << f;
     s = oss.str();
+
+    // If `f` is actually an integer, ".0" must be appended. The result would cause roundtrip issue otherwise.
+    // https://github.com/fktn-k/fkYAML/issues/405
+    FloatType diff = f - std::floor(f);
+    if (diff < std::numeric_limits<FloatType>::min()) {
+        s += ".0";
+    }
 }
 
 FK_YAML_DETAIL_NAMESPACE_END

--- a/test/unit_test/test_serializer_class.cpp
+++ b/test/unit_test/test_serializer_class.cpp
@@ -50,9 +50,14 @@ TEST_CASE("Serializer_IntegerNode") {
     REQUIRE(serializer.serialize(node_str_pair.first) == node_str_pair.second);
 }
 
-TEST_CASE("SerializeClassTest_FloatNumberNode", "[SerializeClassTest]") {
+TEST_CASE("SerializeClassTest_FloatNode", "[SerializeClassTest]") {
     using node_str_pair_t = std::pair<fkyaml::node, std::string>;
     auto node_str_pair = GENERATE(
+        node_str_pair_t(0.0, "0.0"),
+        node_str_pair_t(-2.0, "-2.0"),
+        node_str_pair_t(2.0, "2.0"),
+        node_str_pair_t(-2.10, "-2.1"),
+        node_str_pair_t(2.10, "2.1"),
         node_str_pair_t(3.14, "3.14"),
         node_str_pair_t(-53.97, "-53.97"),
         node_str_pair_t(std::numeric_limits<fkyaml::node::float_number_type>::infinity(), ".inf"),


### PR DESCRIPTION
This PR fixes #405 by appending ".0" during float scalar serialization when a float is actually an integer. Without the appending, the serialization result would be interpreted as an integer scalar on using it as the input of deserialization.  

---

## Pull Request Checklist

Read the [CONTRIBUTING.md](https://github.com/fktn-k/fkYAML/blob/develop/CONTRIBUTING.md) file for detailed information.  

- [x] Changes are described in the pull request or in a referenced [issue](https://github.com/fktn-k/fkYAML/issues).
- [x] The test suite compiles and runs without any error.
- [x] [The code coverage](https://coveralls.io/github/fktn-k/fkYAML) on your branch is 100%.
- [x] The documentation is updated if you added/changed a feature.

## Please don't

- The C++11 support varies between different **compilers** and versions. Please note the [list of supported compilers](https://github.com/fktn-k/fkYAML/blob/develop/README.md#supported-compilers). Some compilers like GCC 4.7 (and earlier), Clang 3.3 (and earlier), or Microsoft Visual Studio 13.0 and earlier are known not to work due to missing or incomplete C++11 support. Please refrain from proposing changes that work around these compiler's limitations with `#ifdef`s or other means.
- Please refrain from proposing changes that would **break [YAML](https://yaml.org/) specifications**. If you propose a conformant extension of YAML to be supported by the library, please motivate this extension.
- Please do not open pull requests that address **multiple issues**.
