### PR TITLE
Optimized scalar parsing

### DIFF
--- a/README.md
+++ b/README.md
@@ -147,36 +147,36 @@ The following tables are created from the benchmarking results in the following 
 
 ### Parsing [ubuntu.yml](https://github.com/fktn-k/fkYAML/blob/develop/tool/benchmark/cases/ubuntu.yml)
 
-| Benchmark                          | processed bytes per second (Debug) | processed bytes per second (Release) |
-| ---------------------------------- | ---------------------------------- | ------------------------------------ |
-| fkYAML                             | 48.0896Mi/s                        | 50.4621Mi/s                          |
-| libfyaml                           | 8.39097Mi/s                        | 35.6895Mi/s                          |
-| rapidyaml<br>(with mutable buff)   | 8.9962Gi/s                         | 19.5486Gi/s                          |
-| rapidyaml<br>(with immutable buff) | 29.4563Mi/s                        | 140.742Mi/s                          |
-| yaml-cpp                           | 1.05087Mi/s                        | 8.67172Mi/s                          |
+| Benchmark                          | processed bytes per second (Release) |
+| ---------------------------------- | ------------------------------------ |
+| fkYAML                             | 55.1393Mi/s                          |
+| libfyaml                           | 34.7645Mi/s                          |
+| rapidyaml<br>(with mutable buff)   | 19.6806Gi/s                          |
+| rapidyaml<br>(with immutable buff) | 140.24Mi/s                           |
+| yaml-cpp                           | 8.75716Mi/s                          |
 
 ### Parsing [citm_catalog.json](https://github.com/fktn-k/fkYAML/blob/develop/tool/benchmark/cases/citm_catalog.json)
 
-| Benchmark                          | processed bytes per second (Debug) | processed bytes per second (Release) |
-| ---------------------------------- | ---------------------------------- | ------------------------------------ |
-| fkYAML                             | 70.6833Mi/s                        | 75.5534Mi/s                          |
-| libfyaml                           | 38.7268Mi/s                        | 51.9599Mi/s                          |
-| rapidyaml<br>(with mutable buff)   | 4.75074Gi/s                        | 16.5046Gi/s                          |
-| rapidyaml<br>(with immutable buff) | 38.7268Mi/s                        | 145.916Mi/s                          |
-| yaml-cpp                           | 2.01743Mi/s                        | 14.7372Mi/s                          |
+| Benchmark                          | processed bytes per second (Release) |
+| ---------------------------------- | ------------------------------------ |
+| fkYAML                             | 82.9931Mi/s                          |
+| libfyaml                           | 52.4308Mi/s                          |
+| rapidyaml<br>(with mutable buff)   | 30.339Gi/s                           |
+| rapidyaml<br>(with immutable buff) | 145.672Mi/s                          |
+| yaml-cpp                           | 14.238Mi/s                           |
 
 ### Parsing [citm_catalog.yml](https://github.com/fktn-k/fkYAML/blob/develop/tool/benchmark/cases/citm_catalog.yml)
 
-| Benchmark                          | processed bytes per second (Debug) | processed bytes per second (Release) |
-| ---------------------------------- | ---------------------------------- | ------------------------------------ |
-| fkYAML                             | 30.1867Mi/s                        | 32.7921Mi/s                          |
-| libfyaml                           | 6.21108Mi/s                        | 23.285Mi/s                           |
-| rapidyaml<br>(with mutable buff)   | 29.8103Gi/s                        | 29.3442Gi/s                          |
-| rapidyaml<br>(with immutable buff) | 19.1685Mi/s                        | 68.212Mi/s                           |
-| yaml-cpp                           | 808.316Ki/s                        | 6.21174Mi/s                          |
+| Benchmark                          | processed bytes per second (Release) |
+| ---------------------------------- | ------------------------------------ |
+| fkYAML                             | 35.152Mi/s                           |
+| libfyaml                           | 23.0845Mi/s                          |
+| rapidyaml<br>(with mutable buff)   | 31.117Gi/s                           |
+| rapidyaml<br>(with immutable buff) | 66.3046Mi/s                          |
+| yaml-cpp                           | 6.11709Mi/s                          |
 
-Although [rapidyaml](https://github.com/biojppm/rapidyaml) is 2-4x faster with immutable buffer and far faster with mutable buff than fkYAML as it focuses on high performance, fkYAML is in general 40% faster than [libfyaml](https://github.com/pantoniou/libfyaml) and also more than 5x faster than [yaml-cpp](https://github.com/jbeder/yaml-cpp).  
-Note that, since fkYAML deserializes scalars into native booleans or integers during the parsing, the performance could be more faster in some real use cases since there is no need for string manipulations.  
+Although [rapidyaml](https://github.com/biojppm/rapidyaml) is about 2x faster with immutable buffer and far faster with mutable buff than fkYAML as it focuses on high performance, fkYAML is in general 50% faster than [libfyaml](https://github.com/pantoniou/libfyaml) and also about 6x faster than [yaml-cpp](https://github.com/jbeder/yaml-cpp).  
+Note that, since fkYAML deserializes scalars into native booleans or integers during the parsing, the performance could be more faster in some use cases since there is no need for string manipulations.  
 
 ## License
 

--- a/include/fkYAML/detail/conversions/scalar_conv.hpp
+++ b/include/fkYAML/detail/conversions/scalar_conv.hpp
@@ -791,6 +791,11 @@ inline bool atof(CharItr begin, CharItr end, FloatType& f) noexcept(noexcept(ato
                 return true;
             }
         }
+
+        if (*p_begin == '+') {
+            // Skip the positive sign since it's sometimes not recognized as part of float value.
+            ++p_begin;
+        }
     }
     else if (len == 4) {
         bool is_inf_scalar = (std::strncmp(p_begin, ".inf", 4) == 0) || (std::strncmp(p_begin, ".Inf", 4) == 0) ||

--- a/include/fkYAML/detail/input/block_scalar_header.hpp
+++ b/include/fkYAML/detail/input/block_scalar_header.hpp
@@ -1,0 +1,31 @@
+//  _______   __ __   __  _____   __  __  __
+// |   __| |_/  |  \_/  |/  _  \ /  \/  \|  |     fkYAML: A C++ header-only YAML library
+// |   __|  _  < \_   _/|  ___  |    _   |  |___  version 0.3.12
+// |__|  |_| \__|  |_|  |_|   |_|___||___|______| https://github.com/fktn-k/fkYAML
+//
+// SPDX-FileCopyrightText: 2023-2024 Kensuke Fukutani <fktn.dev@gmail.com>
+// SPDX-License-Identifier: MIT
+
+#ifndef FK_YAML_DETAIL_INPUT_BLOCK_SCALAR_HEADER_HPP
+#define FK_YAML_DETAIL_INPUT_BLOCK_SCALAR_HEADER_HPP
+
+#include <cstdint>
+
+#include <fkYAML/detail/macros/version_macros.hpp>
+
+FK_YAML_DETAIL_NAMESPACE_BEGIN
+
+enum class chomping_indicator_t {
+    STRIP, //!< excludes final line breaks and trailing empty lines indicated by `-`.
+    CLIP,  //!< preserves final line breaks but excludes trailing empty lines. no indicator means this type.
+    KEEP,  //!< preserves final line breaks and trailing empty lines indicated by `+`.
+};
+
+struct block_scalar_header {
+    chomping_indicator_t chomp {chomping_indicator_t::CLIP};
+    uint32_t indent {0};
+};
+
+FK_YAML_DETAIL_NAMESPACE_END
+
+#endif /* FK_YAML_DETAIL_INPUT_BLOCK_SCALAR_HEADER_HPP */

--- a/include/fkYAML/detail/input/block_scalar_header.hpp
+++ b/include/fkYAML/detail/input/block_scalar_header.hpp
@@ -15,14 +15,18 @@
 
 FK_YAML_DETAIL_NAMESPACE_BEGIN
 
+/// @brief Definition of chomping indicator types.
 enum class chomping_indicator_t {
     STRIP, //!< excludes final line breaks and trailing empty lines indicated by `-`.
     CLIP,  //!< preserves final line breaks but excludes trailing empty lines. no indicator means this type.
     KEEP,  //!< preserves final line breaks and trailing empty lines indicated by `+`.
 };
 
+/// @brief Block scalar header information.
 struct block_scalar_header {
+    /// Chomping indicator type.
     chomping_indicator_t chomp {chomping_indicator_t::CLIP};
+    /// Indentation for block scalar contents.
     uint32_t indent {0};
 };
 

--- a/include/fkYAML/detail/input/deserializer.hpp
+++ b/include/fkYAML/detail/input/deserializer.hpp
@@ -240,7 +240,7 @@ private:
 
     /// @brief Deserializes the YAML directives if specified.
     /// @param lexer The lexical analyzer to be used.
-    /// @param last_type The variable to store the last lexical token type.
+    /// @param last_token Storage for last lexical token type.
     void deserialize_directives(lexer_type& lexer, lexical_token& last_token) {
         bool lacks_end_of_directives_marker = false;
         lexer.set_document_state(true);
@@ -331,7 +331,8 @@ private:
 
     /// @brief Deserializes the YAML nodes recursively.
     /// @param lexer The lexical analyzer to be used.
-    /// @param first_type The first lexical token type.
+    /// @param first_type The first lexical token.
+    /// @param last_type Storage for last lexical token type.
     void deserialize_node(lexer_type& lexer, const lexical_token& first_token, lexical_token_t& last_type) {
         lexical_token token = first_token;
         uint32_t line = lexer.get_lines_processed();
@@ -1104,9 +1105,10 @@ private:
 
     /// @brief Deserialize a detected scalar node.
     /// @param lexer The lexical analyzer to be used.
-    /// @param node A detected scalar node by a lexer.
+    /// @param node A scalar node.
     /// @param indent The current indentation width. Can be updated in this function.
     /// @param line The number of processed lines. Can be updated in this function.
+    /// @param token The storage for last lexical token.
     /// @return true if next token has already been got, false otherwise.
     bool deserialize_scalar(
         lexer_type& lexer, basic_node_type&& node, uint32_t& indent, uint32_t& line, lexical_token& token) {

--- a/include/fkYAML/detail/input/deserializer.hpp
+++ b/include/fkYAML/detail/input/deserializer.hpp
@@ -147,7 +147,7 @@ public:
         } while (type != lexical_token_t::END_OF_BUFFER);
 
         return nodes;
-    }
+    } // LCOV_EXCL_LINE
 
 private:
     /// @brief Deserialize a YAML document into a YAML node.
@@ -929,10 +929,8 @@ private:
                 apply_node_properties(node);
 
                 bool do_continue = deserialize_scalar(lexer, std::move(node), indent, line, token);
-                if (do_continue) {
-                    continue;
-                }
-                break;
+                FK_YAML_ASSERT(do_continue);
+                continue;
             }
             // these tokens end parsing the current YAML document.
             case lexical_token_t::END_OF_BUFFER: // This handles an empty input.

--- a/include/fkYAML/detail/input/deserializer.hpp
+++ b/include/fkYAML/detail/input/deserializer.hpp
@@ -929,8 +929,7 @@ private:
                 apply_directive_set(node);
                 apply_node_properties(node);
 
-                bool do_continue = deserialize_scalar(lexer, std::move(node), indent, line, token);
-                FK_YAML_ASSERT(do_continue);
+                deserialize_scalar(lexer, std::move(node), indent, line, token);
                 continue;
             }
             // these tokens end parsing the current YAML document.

--- a/include/fkYAML/detail/input/lexical_analyzer.hpp
+++ b/include/fkYAML/detail/input/lexical_analyzer.hpp
@@ -17,7 +17,6 @@
 #include <fkYAML/detail/assert.hpp>
 #include <fkYAML/detail/encodings/uri_encoding.hpp>
 #include <fkYAML/detail/encodings/utf_encodings.hpp>
-#include <fkYAML/detail/encodings/yaml_escaper.hpp>
 #include <fkYAML/detail/input/block_scalar_header.hpp>
 #include <fkYAML/detail/input/position_tracker.hpp>
 #include <fkYAML/detail/meta/stl_supplement.hpp>
@@ -832,7 +831,7 @@ private:
         std::size_t first_non_space_pos = sv.find_first_not_of(space_filter);
         if (first_non_space_pos == str_view::npos) {
             // empty block scalar
-            indent = 1; // FIXME: this is just a workaround for assertion in scalar_parser.
+            indent = static_cast<uint32_t>(sv.size());
             token = sv;
             return;
         }

--- a/include/fkYAML/detail/input/lexical_analyzer.hpp
+++ b/include/fkYAML/detail/input/lexical_analyzer.hpp
@@ -318,7 +318,6 @@ private:
     lexical_token_t scan_directive() {
         FK_YAML_ASSERT(*m_cur_itr == '%');
 
-        m_value_buffer.clear();
         m_token_begin_itr = ++m_cur_itr;
 
         bool ends_loop = false;
@@ -1082,8 +1081,6 @@ private:
     const char* m_end_itr {};
     /// The current position tracker of the input buffer.
     mutable position_tracker m_pos_tracker {};
-    /// A temporal buffer to store a string to be parsed to an actual token value.
-    std::string m_value_buffer {};
     /// The last yaml version.
     str_view m_yaml_version {};
     /// The last tag handle.

--- a/include/fkYAML/detail/input/lexical_analyzer.hpp
+++ b/include/fkYAML/detail/input/lexical_analyzer.hpp
@@ -26,8 +26,11 @@
 
 FK_YAML_DETAIL_NAMESPACE_BEGIN
 
+/// @brief Lexical token information
 struct lexical_token {
+    /// Lexical token type.
     lexical_token_t type {lexical_token_t::END_OF_BUFFER};
+    /// Lexical token contents.
     str_view str {};
 };
 
@@ -44,8 +47,7 @@ const uint32_t document_directive_bit = 1u << 1u;
 class lexical_analyzer {
 public:
     /// @brief Construct a new lexical_analyzer object.
-    /// @tparam InputAdapterType The type of the input adapter.
-    /// @param input_adapter An input adapter object.
+    /// @param input_buffer An input buffer.
     explicit lexical_analyzer(str_view input_buffer) noexcept
         : m_input_buffer(input_buffer),
           m_cur_itr(m_input_buffer.begin()),
@@ -638,6 +640,8 @@ private:
         }
     }
 
+    /// @brief Determines the range of single quoted scalar by scanning remaining input buffer contents.
+    /// @param token Storage for the range of single quoted scalar.
     void determine_single_quoted_scalar_range(str_view& token) {
         str_view sv {m_token_begin_itr, m_end_itr};
 
@@ -661,6 +665,8 @@ private:
         emit_error("Invalid end of input buffer in a single-quoted scalar token.");
     }
 
+    /// @brief Determines the range of double quoted scalar by scanning remaining input buffer contents.
+    /// @param token Storage for the range of double quoted scalar.
     void determine_double_quoted_scalar_range(str_view& token) {
         str_view sv {m_token_begin_itr, m_end_itr};
 
@@ -700,6 +706,8 @@ private:
         emit_error("Invalid end of input buffer in a double-quoted scalar token.");
     }
 
+    /// @brief Determines the range of plain scalar by scanning remaining input buffer contents.
+    /// @param token Storage for the range of plain scalar.
     void determine_plain_scalar_range(str_view& token) {
         str_view sv {m_token_begin_itr, m_end_itr};
 
@@ -938,6 +946,8 @@ private:
         }
     }
 
+    /// @brief Checks if the given scalar contains no unescaped control characters.
+    /// @param scalar Scalar contents.
     void check_scalar_content(str_view scalar) const {
         for (auto c : scalar) {
             if (0 <= c && c < 0x20) {
@@ -949,7 +959,7 @@ private:
     /// @brief Gets the metadata of a following block style string scalar.
     /// @param chomp_type A variable to store the retrieved chomping style type.
     /// @param indent A variable to store the retrieved indent size.
-    /// @return
+    /// @return Block scalar header information converted from the header line.
     block_scalar_header convert_to_block_scalar_header(str_view& line) {
         constexpr str_view comment_prefix = " #";
         std::size_t comment_begin_pos = line.find(comment_prefix);

--- a/include/fkYAML/detail/input/lexical_analyzer.hpp
+++ b/include/fkYAML/detail/input/lexical_analyzer.hpp
@@ -743,12 +743,8 @@ private:
     void determine_plain_scalar_range(str_view& token) {
         str_view sv {m_token_begin_itr, m_end_itr};
 
-        str_view check_filter {"\n :"};
-        if (m_state & flow_context_bit) {
-            check_filter = "\n :{}[],";
-        }
-
-        std::size_t pos = sv.find_first_of(check_filter);
+        constexpr str_view filter = "\n :{}[],";
+        std::size_t pos = sv.find_first_of(filter);
         if FK_YAML_UNLIKELY (pos == str_view::npos) {
             token = sv;
             m_cur_itr = m_end_itr;
@@ -814,7 +810,7 @@ private:
             case ']':
             case ',':
                 // This check is enabled only in a flow context.
-                ends_loop = true;
+                ends_loop = (m_state & flow_context_bit);
                 break;
             default:   // LCOV_EXCL_LINE
                 break; // LCOV_EXCL_LINE
@@ -824,7 +820,7 @@ private:
                 break;
             }
 
-            pos = sv.find_first_of(check_filter, pos + 1);
+            pos = sv.find_first_of(filter, pos + 1);
         } while (pos != str_view::npos);
 
         token = sv.substr(0, pos);

--- a/include/fkYAML/detail/input/lexical_analyzer.hpp
+++ b/include/fkYAML/detail/input/lexical_analyzer.hpp
@@ -77,15 +77,12 @@ public:
                 return token;
             }
 
-            switch (*m_cur_itr) {
-            case ' ':
+            if (*m_cur_itr == ' ') {
                 token.type = lexical_token_t::EXPLICIT_KEY_PREFIX;
                 return token;
-            default:
-                scan_scalar(token);
-                return token;
             }
-        case ':': { // key separator
+            break;
+        case ':': // key separator
             if (++m_cur_itr == m_end_itr) {
                 token.type = lexical_token_t::KEY_SEPARATOR;
                 return token;
@@ -95,27 +92,24 @@ public:
             case ' ':
             case '\t':
             case '\n':
-                break;
+                token.type = lexical_token_t::KEY_SEPARATOR;
+                return token;
             case ',':
             case '[':
             case ']':
             case '{':
             case '}':
                 if (m_state & flow_context_bit) {
-                    // the above characters are not "safe" to be followed in a flow context.
+                    // Flow indicators are not "safe" to be followed in a flow context.
                     // See https://yaml.org/spec/1.2.2/#733-plain-style for more details.
-                    break;
+                    token.type = lexical_token_t::KEY_SEPARATOR;
+                    return token;
                 }
-                scan_scalar(token);
-                return token;
+                break;
             default:
-                scan_scalar(token);
-                return token;
+                break;
             }
-
-            token.type = lexical_token_t::KEY_SEPARATOR;
-            return token;
-        }
+            break;
         case ',': // value separator
             ++m_cur_itr;
             token.type = lexical_token_t::VALUE_SEPARATOR;
@@ -150,13 +144,11 @@ public:
         case '%': // directive prefix
             if (m_state & document_directive_bit) {
                 token.type = scan_directive();
+                return token;
             }
-            else {
-                // The '%' character can be safely used as the first character in document contents.
-                // See https://yaml.org/spec/1.2.2/#912-document-markers for more details.
-                scan_scalar(token);
-            }
-            return token;
+            // The '%' character can be safely used as the first character in document contents.
+            // See https://yaml.org/spec/1.2.2/#912-document-markers for more details.
+            break;
         case '-': {
             char next = *(m_cur_itr + 1);
             switch (next) {
@@ -181,8 +173,7 @@ public:
                 }
             }
 
-            scan_scalar(token);
-            return token;
+            break;
         }
         case '[': // sequence flow begin
             ++m_cur_itr;
@@ -205,11 +196,28 @@ public:
         case '`':
             emit_error("Any token cannot start with grave accent(`). It is a reserved indicator for YAML.");
         case '\"':
-        case '\'':
-            scan_scalar(token);
+            ++m_token_begin_itr;
+            token.type = lexical_token_t::DOUBLE_QUOTED_SCALAR;
+            determine_double_quoted_scalar_range(token.str);
+
+            for (const auto c : token.str) {
+                if FK_YAML_UNLIKELY (0 <= c && c < 0x20) {
+                    handle_unescaped_control_char(c);
+                }
+            }
+
             return token;
-        case '+':
-            scan_scalar(token);
+        case '\'':
+            ++m_token_begin_itr;
+            token.type = lexical_token_t::SINGLE_QUOTED_SCALAR;
+            determine_single_quoted_scalar_range(token.str);
+
+            for (const auto c : token.str) {
+                if FK_YAML_UNLIKELY (0 <= c && c < 0x20) {
+                    handle_unescaped_control_char(c);
+                }
+            }
+
             return token;
         case '.': {
             bool is_available = ((m_end_itr - m_cur_itr) > 2);
@@ -221,9 +229,7 @@ public:
                     return token;
                 }
             }
-
-            scan_scalar(token);
-            return token;
+            break;
         }
         case '|':
         case '>': {
@@ -245,9 +251,19 @@ public:
             return token;
         }
         default:
-            scan_scalar(token);
-            return token;
+            break;
         }
+
+        token.type = lexical_token_t::PLAIN_SCALAR;
+        determine_plain_scalar_range(token.str);
+
+        for (const auto c : token.str) {
+            if FK_YAML_UNLIKELY (0 <= c && c < 0x20) {
+                handle_unescaped_control_char(c);
+            }
+        }
+
+        return token;
     }
 
     /// @brief Get the beginning position of a last token.
@@ -639,34 +655,6 @@ private:
         std::size_t invalid_char_pos = tag_uri.find_first_of("{}[],");
         if (invalid_char_pos != str_view::npos) {
             emit_error("Tag shorthand cannot contain flow indicators({}[],).");
-        }
-    }
-
-    /// @brief Scan a scalar token, either plain, single-quoted or double-quoted.
-    /// @param token The token into which the scan result is written.
-    /// @return lexical_token_t The lexical token type for strings.
-    void scan_scalar(lexical_token& token) {
-        switch (*m_token_begin_itr) {
-        case '\'':
-            ++m_token_begin_itr;
-            token.type = lexical_token_t::SINGLE_QUOTED_SCALAR;
-            determine_single_quoted_scalar_range(token.str);
-            break;
-        case '\"':
-            ++m_token_begin_itr;
-            token.type = lexical_token_t::DOUBLE_QUOTED_SCALAR;
-            determine_double_quoted_scalar_range(token.str);
-            break;
-        default:
-            token.type = lexical_token_t::PLAIN_SCALAR;
-            determine_plain_scalar_range(token.str);
-            break;
-        }
-
-        for (const auto c : token.str) {
-            if FK_YAML_UNLIKELY (0 <= c && c < 0x20) {
-                handle_unescaped_control_char(c);
-            }
         }
     }
 

--- a/include/fkYAML/detail/input/lexical_analyzer.hpp
+++ b/include/fkYAML/detail/input/lexical_analyzer.hpp
@@ -670,6 +670,10 @@ private:
             break;
         default:
             token.type = lexical_token_t::PLAIN_SCALAR;
+            if ((m_state & flow_context_bit) == 0) {
+                determine_plain_scalar_range(token.str);
+                return;
+            }
             break;
         }
 
@@ -715,6 +719,83 @@ private:
 
         m_cur_itr = m_end_itr; // update for error information
         emit_error("Invalid end of input buffer in a single-quoted scalar token.");
+    }
+
+    void determine_plain_scalar_range(str_view& token) {
+        str_view sv {m_token_begin_itr, m_end_itr};
+
+        str_view check_filter {"\n :"};
+
+        std::size_t pos = sv.find_first_of(check_filter);
+        if FK_YAML_UNLIKELY (pos == str_view::npos) {
+            token = sv;
+            for (const auto c : token) {
+                if FK_YAML_UNLIKELY (0 <= c && c < 0x20) {
+                    handle_unescaped_control_char(c);
+                }
+            }
+            m_cur_itr = m_end_itr;
+            return;
+        }
+
+        bool ends_loop = false;
+        do {
+            switch (sv[pos]) {
+            case '\n':
+                ends_loop = true;
+                break;
+            case ' ':
+                if FK_YAML_UNLIKELY (pos == sv.size() - 1) {
+                    // trim trailing space.
+                    ends_loop = true;
+                    break;
+                }
+
+                // Allow a space in a plain scalar only if the space is surrounded by non-space characters, but not
+                // followed by the comment prefix " #".
+                // See https://yaml.org/spec/1.2.2/#733-plain-style for more details.
+                switch (sv[pos + 1]) {
+                case ' ':
+                case '\t':
+                case '\n':
+                case '#':
+                    ends_loop = true;
+                    break;
+                default:
+                    break;
+                }
+                break;
+            case ':':
+                if FK_YAML_LIKELY (pos < sv.size() - 1) {
+                    switch (sv[pos + 1]) {
+                    case ' ':
+                    case '\t':
+                    case '\n':
+                        ends_loop = true;
+                        break;
+                    default:
+                        break;
+                    }
+                }
+                break;
+            default:   // LCOV_EXCL_LINE
+                break; // LCOV_EXCL_LINE
+            }
+
+            if (ends_loop) {
+                break;
+            }
+
+            pos = sv.find_first_of(check_filter, pos + 1);
+        } while (pos != str_view::npos);
+
+        token = sv.substr(0, pos);
+        for (const auto c : token) {
+            if FK_YAML_UNLIKELY (0 <= c && c < 0x20) {
+                handle_unescaped_control_char(c);
+            }
+        }
+        m_cur_itr = token.end();
     }
 
     /// @brief Check if the given character is allowed in a double-quoted scalar token.
@@ -803,55 +884,6 @@ private:
         }
     }
 
-    /// @brief Check if the given character is allowed in a plain scalar token outside a flow context.
-    /// @param c The character to be checked.
-    /// @return true if the given character is allowed, false otherwise.
-    bool is_allowed_plain(char c, bool& /*unused*/) {
-        switch (c) {
-        case '\n':
-            return false;
-
-        case ' ': {
-            // Allow a space in a plain scalar only if the space is surrounded by non-space characters.
-            // See https://yaml.org/spec/1.2.2/#733-plain-style for more details.
-
-            switch (*(m_cur_itr + 1)) {
-            case ':': {
-                // " :" is permitted in a plain style string token, but not when followed by a space.
-                char peeked = *(m_cur_itr + 2);
-                if (peeked == ' ') {
-                    return false;
-                }
-                return true;
-            }
-            case ' ':
-            case '\n':
-            case '#':
-            case '\\':
-                return false;
-            }
-
-            return true;
-        }
-
-        case ':': {
-            // A colon as a key separator must be followed by
-            // * a white space or
-            // * a newline code.
-            switch (*(m_cur_itr + 1)) {
-            case ' ':
-            case '\t':
-            case '\n':
-                return false;
-            }
-            return true;
-        }
-
-        default:         // LCOV_EXCL_LINE
-            return true; // LCOV_EXCL_LINE
-        }
-    }
-
     /// @brief Check if the given character is allowed in a plain scalar token inside a flow context.
     /// @param c The character to be checked.
     /// @return true if the given character is allowed, false otherwise.
@@ -926,9 +958,8 @@ private:
     /// @return true if mutated scalar contents is stored in m_value_buffer, false otherwise.
     bool extract_string_token(bool needs_last_double_quote) {
         // change behaviors depending on the type of a coming string scalar token.
-        // * single quoted
         // * double quoted
-        // * plain
+        // * plain (flow)
 
         std::string check_filters {"\n"};
         bool (lexical_analyzer::*pfn_is_allowed)(char, bool&) = nullptr;
@@ -937,15 +968,10 @@ private:
             check_filters.append("\"\\");
             pfn_is_allowed = &lexical_analyzer::is_allowed_double;
         }
-        else if (m_state & flow_context_bit) {
+        else {
             // plain scalar inside flow contexts
             check_filters.append(" :{}[],");
             pfn_is_allowed = &lexical_analyzer::is_allowed_plain_flow;
-        }
-        else {
-            // plain scalar outside flow contexts
-            check_filters.append(" :");
-            pfn_is_allowed = &lexical_analyzer::is_allowed_plain;
         }
 
         // scan the contents of a string scalar token.

--- a/include/fkYAML/detail/input/scalar_parser.hpp
+++ b/include/fkYAML/detail/input/scalar_parser.hpp
@@ -6,8 +6,8 @@
 // SPDX-FileCopyrightText: 2023-2024 Kensuke Fukutani <fktn.dev@gmail.com>
 // SPDX-License-Identifier: MIT
 
-#ifndef FK_YAML_DETAIL_INPUT_SCALAR_PARSER_HPP_
-#define FK_YAML_DETAIL_INPUT_SCALAR_PARSER_HPP_
+#ifndef FK_YAML_DETAIL_INPUT_SCALAR_PARSER_HPP
+#define FK_YAML_DETAIL_INPUT_SCALAR_PARSER_HPP
 
 #include <fkYAML/detail/macros/version_macros.hpp>
 #include <fkYAML/detail/assert.hpp>
@@ -55,9 +55,11 @@ public:
     /// @brief Destroys a scalar_parser object.
     ~scalar_parser() noexcept = default;
 
-    scalar_parser(const scalar_parser&) noexcept = default;
+    // std::string's copy constructor/assignment operator may throw a exception.
+    scalar_parser(const scalar_parser&) = default;
+    scalar_parser& operator=(const scalar_parser&) = default;
+
     scalar_parser(scalar_parser&&) noexcept = default;
-    scalar_parser& operator=(const scalar_parser&) noexcept = default;
     scalar_parser& operator=(scalar_parser&&) noexcept = default;
 
     /// @brief Parses a token into a flow scalar (either plain, single quoted or double quoted)
@@ -538,4 +540,4 @@ private:
 
 FK_YAML_DETAIL_NAMESPACE_END
 
-#endif /* FK_YAML_DETAIL_INPUT_SCALAR_PARSER_HPP_ */
+#endif /* FK_YAML_DETAIL_INPUT_SCALAR_PARSER_HPP */

--- a/include/fkYAML/detail/input/scalar_parser.hpp
+++ b/include/fkYAML/detail/input/scalar_parser.hpp
@@ -85,7 +85,8 @@ private:
             return token;
         }
 
-        std::size_t pos = token.find_first_of("\'\n");
+        constexpr str_view filter = "\'\n";
+        std::size_t pos = token.find_first_of(filter);
         if (pos == str_view::npos) {
             return token;
         }
@@ -110,7 +111,7 @@ private:
                 process_line_folding(token, pos);
             }
 
-            pos = token.find_first_of("\'\n");
+            pos = token.find_first_of(filter);
         } while (pos != str_view::npos);
 
         if (!token.empty()) {
@@ -125,7 +126,8 @@ private:
             return token;
         }
 
-        std::size_t pos = token.find_first_of("\\\n");
+        constexpr str_view filter = "\\\n";
+        std::size_t pos = token.find_first_of(filter);
         if (pos == str_view::npos) {
             return token;
         }
@@ -160,7 +162,7 @@ private:
                 process_line_folding(token, pos);
             }
 
-            pos = token.find_first_of("\\\n");
+            pos = token.find_first_of(filter);
         } while (pos != str_view::npos);
 
         if (!token.empty()) {

--- a/include/fkYAML/detail/input/scalar_parser.hpp
+++ b/include/fkYAML/detail/input/scalar_parser.hpp
@@ -1,0 +1,158 @@
+//  _______   __ __   __  _____   __  __  __
+// |   __| |_/  |  \_/  |/  _  \ /  \/  \|  |     fkYAML: A C++ header-only YAML library
+// |   __|  _  < \_   _/|  ___  |    _   |  |___  version 0.3.12
+// |__|  |_| \__|  |_|  |_|   |_|___||___|______| https://github.com/fktn-k/fkYAML
+//
+// SPDX-FileCopyrightText: 2023-2024 Kensuke Fukutani <fktn.dev@gmail.com>
+// SPDX-License-Identifier: MIT
+
+#ifndef FK_YAML_DETAIL_INPUT_SCALAR_PARSER_HPP_
+#define FK_YAML_DETAIL_INPUT_SCALAR_PARSER_HPP_
+
+#include <fkYAML/detail/macros/version_macros.hpp>
+#include <fkYAML/detail/assert.hpp>
+#include <fkYAML/detail/conversions/scalar_conv.hpp>
+#include <fkYAML/detail/input/scalar_scanner.hpp>
+#include <fkYAML/detail/input/tag_t.hpp>
+#include <fkYAML/detail/meta/node_traits.hpp>
+#include <fkYAML/detail/str_view.hpp>
+#include <fkYAML/detail/types/lexical_token_t.hpp>
+#include <fkYAML/exception.hpp>
+#include <fkYAML/node_type.hpp>
+
+FK_YAML_DETAIL_NAMESPACE_BEGIN
+
+template <typename BasicNodeType>
+class scalar_parser {
+    static_assert(is_basic_node<BasicNodeType>::value, "scalar_parser only accepts basic_node<...>");
+
+public:
+    using basic_node_type = BasicNodeType;
+
+private:
+    /** A type for boolean node values. */
+    using boolean_type = typename basic_node_type::boolean_type;
+    /** A type for integer node values. */
+    using integer_type = typename basic_node_type::integer_type;
+    /** A type for floating point node values. */
+    using float_number_type = typename basic_node_type::float_number_type;
+    /** A type for string node values. */
+    using string_type = typename basic_node_type::string_type;
+
+public:
+    scalar_parser(uint32_t line, uint32_t indent) noexcept
+        : m_line(line),
+          m_indent(indent) {
+    }
+
+    ~scalar_parser() noexcept = default;
+
+    scalar_parser(const scalar_parser&) noexcept = default;
+    scalar_parser(scalar_parser&&) noexcept = default;
+    scalar_parser& operator=(const scalar_parser&) noexcept = default;
+    scalar_parser& operator=(scalar_parser&&) noexcept = default;
+
+    basic_node_type parse(lexical_token_t lex_type, tag_t tag_type, str_view token) {
+        FK_YAML_ASSERT(
+            lex_type == lexical_token_t::PLAIN_SCALAR || lex_type == lexical_token_t::SINGLE_QUOTED_SCALAR ||
+            lex_type == lexical_token_t::DOUBLE_QUOTED_SCALAR || lex_type == lexical_token_t::BLOCK_SCALAR);
+        FK_YAML_ASSERT(tag_type != tag_t::SEQUENCE && tag_type != tag_t::MAPPING);
+
+        node_type value_type = decide_value_type(lex_type, tag_type, token);
+        return create_scalar_node(value_type, token);
+    }
+
+private:
+    node_type decide_value_type(lexical_token_t lex_type, tag_t tag_type, str_view token) const noexcept {
+        node_type value_type {node_type::STRING};
+        if (lex_type == lexical_token_t::PLAIN_SCALAR) {
+            value_type = scalar_scanner::scan(token.begin(), token.end());
+        }
+
+        switch (tag_type) {
+        case tag_t::NULL_VALUE:
+            value_type = node_type::NULL_OBJECT;
+            break;
+        case tag_t::BOOLEAN:
+            value_type = node_type::BOOLEAN;
+            break;
+        case tag_t::INTEGER:
+            value_type = node_type::INTEGER;
+            break;
+        case tag_t::FLOATING_NUMBER:
+            value_type = node_type::FLOAT;
+            break;
+        case tag_t::STRING:
+            value_type = node_type::STRING;
+            break;
+        case tag_t::NON_SPECIFIC:
+            // scalars with the non-specific tag is resolved to a string tag.
+            // See the "Non-Specific Tags" section in https://yaml.org/spec/1.2.2/#691-node-tags.
+            value_type = node_type::STRING;
+            break;
+        case tag_t::NONE:
+        case tag_t::CUSTOM_TAG:
+        default:
+            break;
+        }
+
+        return value_type;
+    }
+
+    basic_node_type create_scalar_node(node_type type, str_view token) const {
+        basic_node_type node {};
+
+        switch (type) {
+        case node_type::NULL_OBJECT: {
+            std::nullptr_t null = nullptr;
+            bool converted = detail::aton(token.begin(), token.end(), null);
+            if FK_YAML_UNLIKELY (!converted) {
+                throw parse_error("Failed to convert a scalar to a null.", m_line, m_indent);
+            }
+            // The above `node` variable is already null, so no instance creation is needed.
+            break;
+        }
+        case node_type::BOOLEAN: {
+            boolean_type boolean = static_cast<boolean_type>(false);
+            bool converted = detail::atob(token.begin(), token.end(), boolean);
+            if FK_YAML_UNLIKELY (!converted) {
+                throw parse_error("Failed to convert a scalar to a boolean.", m_line, m_indent);
+            }
+            node = basic_node_type(boolean);
+            break;
+        }
+        case node_type::INTEGER: {
+            integer_type integer = 0;
+            bool converted = detail::atoi(token.begin(), token.end(), integer);
+            if FK_YAML_UNLIKELY (!converted) {
+                throw parse_error("Failed to convert a scalar to an integer.", m_line, m_indent);
+            }
+            node = basic_node_type(integer);
+            break;
+        }
+        case node_type::FLOAT: {
+            float_number_type float_val = 0;
+            bool converted = detail::atof(token.begin(), token.end(), float_val);
+            if FK_YAML_UNLIKELY (!converted) {
+                throw parse_error("Failed to convert a scalar to a floating point value", m_line, m_indent);
+            }
+            node = basic_node_type(float_val);
+            break;
+        }
+        case node_type::STRING:
+            node = basic_node_type(std::string(token.begin(), token.end()));
+            break;
+        default:   // LCOV_EXCL_LINE
+            break; // LCOV_EXCL_LINE
+        }
+
+        return node;
+    }
+
+    uint32_t m_line {0};
+    uint32_t m_indent {0};
+};
+
+FK_YAML_DETAIL_NAMESPACE_END
+
+#endif /* FK_YAML_DETAIL_INPUT_SCALAR_PARSER_HPP_ */

--- a/include/fkYAML/detail/input/scalar_parser.hpp
+++ b/include/fkYAML/detail/input/scalar_parser.hpp
@@ -87,6 +87,8 @@ private:
             return token;
         }
 
+        m_use_owned_buffer = true;
+
         if (m_buffer.capacity() < token.size()) {
             m_buffer.reserve(token.size());
         }
@@ -219,7 +221,13 @@ private:
             break;
         }
         case node_type::STRING:
-            node = basic_node_type(std::string(token.begin(), token.end()));
+            if (m_use_owned_buffer) {
+                node = basic_node_type(std::move(m_buffer));
+                m_use_owned_buffer = false;
+            }
+            else {
+                node = basic_node_type(std::string(token.begin(), token.end()));
+            }
             break;
         default:   // LCOV_EXCL_LINE
             break; // LCOV_EXCL_LINE
@@ -230,6 +238,7 @@ private:
 
     uint32_t m_line {0};
     uint32_t m_indent {0};
+    bool m_use_owned_buffer {false};
     std::string m_buffer {};
 };
 

--- a/include/fkYAML/detail/input/scalar_scanner.hpp
+++ b/include/fkYAML/detail/input/scalar_scanner.hpp
@@ -45,7 +45,7 @@ public:
     /// @param begin The iterator to the first element of the scalar.
     /// @param end The iterator to the past-the-end element of the scalar.
     /// @return A detected scalar value type.
-    static node_type scan(const char* begin, const char* end) {
+    static node_type scan(const char* begin, const char* end) noexcept {
         if (begin == end) {
             return node_type::STRING;
         }
@@ -130,7 +130,7 @@ private:
     /// @param itr The iterator to the first element of the scalar.
     /// @param len The length of the scalar contents.
     /// @return A detected scalar value type.
-    static node_type scan_possible_number_token(const char* itr, uint32_t len) {
+    static node_type scan_possible_number_token(const char* itr, uint32_t len) noexcept {
         FK_YAML_ASSERT(len > 0);
 
         switch (*itr) {
@@ -159,7 +159,7 @@ private:
     /// @param itr The iterator to the past-the-negative-sign element of the scalar.
     /// @param len The length of the scalar contents left unscanned.
     /// @return A detected scalar value type.
-    static node_type scan_negative_number(const char* itr, uint32_t len) {
+    static node_type scan_negative_number(const char* itr, uint32_t len) noexcept {
         FK_YAML_ASSERT(len > 0);
 
         if (is_digit(*itr)) {
@@ -173,7 +173,7 @@ private:
     /// @param itr The iterator to the past-the-zero element of the scalar.
     /// @param len The length of the scalar left unscanned.
     /// @return A detected scalar value type.
-    static node_type scan_after_zero_at_first(const char* itr, uint32_t len) {
+    static node_type scan_after_zero_at_first(const char* itr, uint32_t len) noexcept {
         FK_YAML_ASSERT(len > 0);
 
         if (is_digit(*itr)) {
@@ -205,7 +205,7 @@ private:
     /// @param len The length of the scalar left unscanned.
     /// @param has_decimal_point Whether a decimal point has already been found in the previous part.
     /// @return A detected scalar value type.
-    static node_type scan_decimal_number(const char* itr, uint32_t len, bool has_decimal_point) {
+    static node_type scan_decimal_number(const char* itr, uint32_t len, bool has_decimal_point) noexcept {
         FK_YAML_ASSERT(len > 0);
 
         if (is_digit(*itr)) {
@@ -238,7 +238,7 @@ private:
     /// @param len The length of the scalar left unscanned.
     /// @param has_decimal_point Whether the decimal point has already been found in the previous part.
     /// @return A detected scalar value type.
-    static node_type scan_after_decimal_point(const char* itr, uint32_t len, bool has_decimal_point) {
+    static node_type scan_after_decimal_point(const char* itr, uint32_t len, bool has_decimal_point) noexcept {
         FK_YAML_ASSERT(len > 0);
 
         if (is_digit(*itr)) {
@@ -253,7 +253,7 @@ private:
     /// @param len The length of the scalar left unscanned.
     /// @param has_decimal_point Whether the decimal point has already been found in the previous part.
     /// @return A detected scalar value type.
-    static node_type scan_after_exponent(const char* itr, uint32_t len, bool has_decimal_point) {
+    static node_type scan_after_exponent(const char* itr, uint32_t len, bool has_decimal_point) noexcept {
         FK_YAML_ASSERT(len > 0);
 
         if (is_digit(*itr)) {
@@ -273,7 +273,7 @@ private:
     /// @param itr The iterator to the octal-number element of the scalar.
     /// @param len The length of the scalar left unscanned.
     /// @return A detected scalar value type.
-    static node_type scan_octal_number(const char* itr, uint32_t len) {
+    static node_type scan_octal_number(const char* itr, uint32_t len) noexcept {
         FK_YAML_ASSERT(len > 0);
 
         switch (*itr) {
@@ -295,7 +295,7 @@ private:
     /// @param itr The iterator to the hexadecimal-number element of the scalar.
     /// @param len The length of the scalar left unscanned.
     /// @return A detected scalar value type.
-    static node_type scan_hexadecimal_number(const char* itr, uint32_t len) {
+    static node_type scan_hexadecimal_number(const char* itr, uint32_t len) noexcept {
         FK_YAML_ASSERT(len > 0);
 
         if (is_xdigit(*itr)) {

--- a/include/fkYAML/detail/input/tag_t.hpp
+++ b/include/fkYAML/detail/input/tag_t.hpp
@@ -13,7 +13,7 @@
 
 FK_YAML_DETAIL_NAMESPACE_BEGIN
 
-/// @brief Definition of YAML directive sets.
+/// @brief Definition of YAML tag types.
 enum class tag_t {
     NONE,            //!< Represents a non-specific tag "?".
     NON_SPECIFIC,    //!< Represents a non-specific tag "!".

--- a/include/fkYAML/detail/input/tag_t.hpp
+++ b/include/fkYAML/detail/input/tag_t.hpp
@@ -15,7 +15,8 @@ FK_YAML_DETAIL_NAMESPACE_BEGIN
 
 /// @brief Definition of YAML directive sets.
 enum class tag_t {
-    NON_SPECIFIC,    //!< Represents a non-specific tag.
+    NONE,            //!< Represents a non-specific tag "?".
+    NON_SPECIFIC,    //!< Represents a non-specific tag "!".
     CUSTOM_TAG,      //!< Represents a custom tag
     SEQUENCE,        //!< Represents a sequence tag.
     MAPPING,         //!< Represents a mapping tag.

--- a/include/fkYAML/detail/macros/cpp_config_macros.hpp
+++ b/include/fkYAML/detail/macros/cpp_config_macros.hpp
@@ -60,6 +60,13 @@
 #define FK_YAML_INLINE_VAR
 #endif
 
+// switch usage of constexpr keyward depending on active C++ standard.
+#if defined(FK_YAML_HAS_CXX_17)
+#define FK_YAML_CXX17_CONSTEXPR constexpr
+#else
+#define FK_YAML_CXX17_CONSTEXPR
+#endif
+
 // Detect __has_* macros.
 // The following macros replace redundant `defined(__has_*) && __has_*(...)`.
 

--- a/include/fkYAML/detail/str_view.hpp
+++ b/include/fkYAML/detail/str_view.hpp
@@ -69,24 +69,42 @@ public:
     static constexpr size_type npos = static_cast<size_type>(-1);
 
     /// Constructs a basic_str_view object.
-    basic_str_view() noexcept = default;
+    constexpr basic_str_view() noexcept = default;
 
     /// Destroys a basic_str_view object.
     ~basic_str_view() noexcept = default;
 
     /// @brief Copy constructs a basic_str_view object.
     /// @param _ A basic_str_view object to copy from.
-    basic_str_view(const basic_str_view&) noexcept = default;
+    constexpr basic_str_view(const basic_str_view&) noexcept = default;
 
     /// @brief Move constructs a basic_str_view object.
     /// @param _ A basic_str_view object to move from.
-    basic_str_view(basic_str_view&&) noexcept = default;
+    constexpr basic_str_view(basic_str_view&&) noexcept = default;
 
     /// @brief Constructs a basic_str_view object from a pointer to a character sequence.
+    /// @note std::char_traits::length() is constexpr from C++17.
     /// @param p_str A pointer to a character sequence. (Must be null-terminated, or an undefined behavior.)
-    basic_str_view(const value_type* p_str) noexcept
+    template <
+        typename CharPtrT,
+        enable_if_t<
+            disjunction<std::is_same<CharPtrT, value_type*>, std::is_same<CharPtrT, const value_type*>>::value, int> =
+            0>
+    FK_YAML_CXX17_CONSTEXPR basic_str_view(CharPtrT p_str) noexcept
         : m_len(traits_type::length(p_str)),
           mp_str(p_str) {
+    }
+
+    /// @brief Constructs a basic_str_view object from a C-style char array.
+    /// @note
+    /// This constructor assumes the last element is the null character ('\0'). If that's not desirable, consider using
+    /// one of the other overloads.
+    /// @tparam N The size of a C-style char array.
+    /// @param str A C-style char array. (Must be null-terminated)
+    template <std::size_t N>
+    constexpr basic_str_view(const value_type (&str)[N]) noexcept
+        : m_len(N - 1),
+          mp_str(&str[0]) {
     }
 
     /// @brief Construction from a null pointer is forbidden.
@@ -95,7 +113,7 @@ public:
     /// @brief Constructs a basic_str_view object from a pointer to a character sequence and its size.
     /// @param p_str A pointer to a character sequence. (May or may not be null-terminated.)
     /// @param len The length of a character sequence.
-    basic_str_view(const value_type* p_str, size_type len) noexcept
+    constexpr basic_str_view(const value_type* p_str, size_type len) noexcept
         : m_len(len),
           mp_str(p_str) {
     }

--- a/include/fkYAML/detail/str_view.hpp
+++ b/include/fkYAML/detail/str_view.hpp
@@ -114,7 +114,7 @@ public:
             int> = 0>
     basic_str_view(ItrType first, ItrType last) noexcept
         : m_len(last - first),
-          mp_str(m_len > 0 ? &*first : nullptr) {
+          mp_str(&*first) {
     }
 
     /// @brief Constructs a basic_str_view object from a compatible std::basic_string object.

--- a/include/fkYAML/detail/types/lexical_token_t.hpp
+++ b/include/fkYAML/detail/types/lexical_token_t.hpp
@@ -33,7 +33,8 @@ enum class lexical_token_t {
     PLAIN_SCALAR,          //!< plain (unquoted) scalars
     SINGLE_QUOTED_SCALAR,  //!< single-quoted scalars
     DOUBLE_QUOTED_SCALAR,  //!< double-quoted scalars
-    BLOCK_SCALAR,          //!< block style scalars
+    BLOCK_LITERAL_SCALAR,  //!< block literal style scalars
+    BLOCK_FOLDED_SCALAR,   //!< block folded style scalars
     END_OF_DIRECTIVES,     //!< the end of declaration of directives specified by `---`.
     END_OF_DOCUMENT,       //!< the end of a YAML document specified by `...`.
 };

--- a/single_include/fkYAML/node.hpp
+++ b/single_include/fkYAML/node.hpp
@@ -2099,6 +2099,40 @@ FK_YAML_DETAIL_NAMESPACE_END
 
 #endif /* FK_YAML_DETAIL_ENCODINGS_YAML_ESCAPER_HPP */
 
+// #include <fkYAML/detail/input/block_scalar_header.hpp>
+//  _______   __ __   __  _____   __  __  __
+// |   __| |_/  |  \_/  |/  _  \ /  \/  \|  |     fkYAML: A C++ header-only YAML library
+// |   __|  _  < \_   _/|  ___  |    _   |  |___  version 0.3.12
+// |__|  |_| \__|  |_|  |_|   |_|___||___|______| https://github.com/fktn-k/fkYAML
+//
+// SPDX-FileCopyrightText: 2023-2024 Kensuke Fukutani <fktn.dev@gmail.com>
+// SPDX-License-Identifier: MIT
+
+#ifndef FK_YAML_DETAIL_INPUT_BLOCK_SCALAR_HEADER_HPP
+#define FK_YAML_DETAIL_INPUT_BLOCK_SCALAR_HEADER_HPP
+
+#include <cstdint>
+
+// #include <fkYAML/detail/macros/version_macros.hpp>
+
+
+FK_YAML_DETAIL_NAMESPACE_BEGIN
+
+enum class chomping_indicator_t {
+    STRIP, //!< excludes final line breaks and trailing empty lines indicated by `-`.
+    CLIP,  //!< preserves final line breaks but excludes trailing empty lines. no indicator means this type.
+    KEEP,  //!< preserves final line breaks and trailing empty lines indicated by `+`.
+};
+
+struct block_scalar_header {
+    chomping_indicator_t chomp {chomping_indicator_t::CLIP};
+    uint32_t indent {0};
+};
+
+FK_YAML_DETAIL_NAMESPACE_END
+
+#endif /* FK_YAML_DETAIL_INPUT_BLOCK_SCALAR_HEADER_HPP */
+
 // #include <fkYAML/detail/input/position_tracker.hpp>
 //  _______   __ __   __  _____   __  __  __
 // |   __| |_/  |  \_/  |/  _  \ /  \/  \|  |     fkYAML: A C++ header-only YAML library
@@ -3217,7 +3251,8 @@ enum class lexical_token_t {
     PLAIN_SCALAR,          //!< plain (unquoted) scalars
     SINGLE_QUOTED_SCALAR,  //!< single-quoted scalars
     DOUBLE_QUOTED_SCALAR,  //!< double-quoted scalars
-    BLOCK_SCALAR,          //!< block style scalars
+    BLOCK_LITERAL_SCALAR,  //!< block literal style scalars
+    BLOCK_FOLDED_SCALAR,   //!< block folded style scalars
     END_OF_DIRECTIVES,     //!< the end of declaration of directives specified by `---`.
     END_OF_DOCUMENT,       //!< the end of a YAML document specified by `...`.
 };
@@ -3247,18 +3282,6 @@ const uint32_t document_directive_bit = 1u << 1u;
 
 /// @brief A class which lexically analyzes YAML formatted inputs.
 class lexical_analyzer {
-private:
-    enum class block_style_indicator_t {
-        LITERAL, //!< keeps newlines inside the block as they are indicated by a pipe `|`.
-        FOLDED,  //!< replaces newlines inside the block with spaces indicated by a right angle bracket `>`.
-    };
-
-    enum class chomping_indicator_t {
-        STRIP, //!< excludes final line breaks and trailing empty lines indicated by `-`.
-        KEEP,  //!< preserves final line breaks but excludes trailing empty lines. no indicator means this type.
-        CLIP,  //!< preserves final line breaks and trailing empty lines indicated by `+`.
-    };
-
 public:
     /// @brief Construct a new lexical_analyzer object.
     /// @tparam InputAdapterType The type of the input adapter.
@@ -3442,24 +3465,23 @@ public:
             scan_scalar(token);
             return token;
         }
-        case '|': {
-            chomping_indicator_t chomp_type = chomping_indicator_t::KEEP;
-            uint32_t indent = 0;
-            ++m_cur_itr;
-            get_block_style_metadata(chomp_type, indent);
-            scan_block_style_string_token(block_style_indicator_t::LITERAL, chomp_type, indent);
-            token.type = lexical_token_t::BLOCK_SCALAR;
-            token.str = m_value_buffer;
-            return token;
-        }
+        case '|':
         case '>': {
-            chomping_indicator_t chomp_type = chomping_indicator_t::KEEP;
-            uint32_t indent = 0;
-            ++m_cur_itr;
-            get_block_style_metadata(chomp_type, indent);
-            scan_block_style_string_token(block_style_indicator_t::FOLDED, chomp_type, indent);
-            token.type = lexical_token_t::BLOCK_SCALAR;
-            token.str = m_value_buffer;
+            str_view sv {m_token_begin_itr, m_end_itr};
+            std::size_t header_end_pos = sv.find('\n');
+            if (header_end_pos == str_view::npos) {
+                header_end_pos = sv.size();
+            }
+
+            FK_YAML_ASSERT(!sv.empty());
+            token.type = (sv[0] == '|') ? lexical_token_t::BLOCK_LITERAL_SCALAR : lexical_token_t::BLOCK_FOLDED_SCALAR;
+
+            str_view header_line = sv.substr(1, header_end_pos - 1);
+            m_block_scalar_header = convert_to_block_scalar_header(header_line);
+
+            m_token_begin_itr = sv.begin() + (header_end_pos + 1);
+            scan_block_style_string_token(m_block_scalar_header.indent, token.str);
+
             return token;
         }
         default:
@@ -3496,6 +3518,12 @@ public:
     /// @return str_view A tag prefix.
     str_view get_tag_prefix() const noexcept {
         return m_tag_prefix;
+    }
+
+    /// @brief Get block scalar header information.
+    /// @return block_scalar_header Block scalar header information.
+    block_scalar_header get_block_scalar_header() const noexcept {
+        return m_block_scalar_header;
     }
 
     /// @brief Toggles the context state between flow and block.
@@ -4036,198 +4064,80 @@ private:
     /// @param style The style of the given token, either literal or folded.
     /// @param chomp The chomping indicator type of the given token, either strip, keep or clip.
     /// @param indent The indent size specified for the given token.
-    void scan_block_style_string_token(block_style_indicator_t style, chomping_indicator_t chomp, uint32_t indent) {
-        m_value_buffer.clear();
+    void scan_block_style_string_token(uint32_t& indent, str_view& token) {
+        str_view sv {m_token_begin_itr, m_end_itr};
 
         // Handle leading all-space lines.
-        for (char current = 0; m_cur_itr != m_end_itr; ++m_cur_itr) {
-            current = *m_cur_itr;
-
-            if (current == ' ') {
-                continue;
-            }
-
-            if (current == '\n') {
-                m_value_buffer.push_back('\n');
-                continue;
-            }
-
-            break;
-        }
-
-        if (m_cur_itr == m_end_itr) {
-            if (chomp != chomping_indicator_t::KEEP) {
-                m_value_buffer.clear();
-            }
+        constexpr str_view space_filter = " \t\n";
+        std::size_t first_non_space_pos = sv.find_first_not_of(space_filter);
+        if (first_non_space_pos == str_view::npos) {
+            // empty block scalar
+            indent = 1; // FIXME: this is just a workaround for assertion in scalar_parser.
+            token = sv;
             return;
         }
 
-        m_pos_tracker.update_position(m_cur_itr);
-        uint32_t cur_indent = m_pos_tracker.get_cur_pos_in_line();
-
-        // TODO: preserve and compare the last indentation with `cur_indent`
-        if (indent == 0) {
-            indent = cur_indent;
-        }
-        else if FK_YAML_UNLIKELY (cur_indent < indent) {
-            emit_error("A block style scalar is less indented than the indicated level.");
-        }
-
-        uint32_t chars_in_line = 0;
-        bool is_extra_indented = false;
-        m_token_begin_itr = m_cur_itr;
-        if (cur_indent > indent) {
-            if (style == block_style_indicator_t::FOLDED) {
-                m_value_buffer.push_back('\n');
-                is_extra_indented = true;
+        // get indentation of the first non-space character.
+        std::size_t last_newline_pos = sv.substr(0, first_non_space_pos).find_last_of('\n');
+        if (last_newline_pos == str_view::npos) {
+            // first_non_space_pos in on the first line.
+            uint32_t cur_indent = static_cast<uint32_t>(first_non_space_pos);
+            if (indent == 0) {
+                indent = cur_indent;
+            }
+            else if FK_YAML_UNLIKELY (cur_indent < indent) {
+                emit_error("A block style scalar is less indented than the indicated level.");
             }
 
-            uint32_t diff = cur_indent - indent;
-            m_token_begin_itr -= diff;
-            chars_in_line = diff;
+            last_newline_pos = 0;
+        }
+        else {
+            FK_YAML_ASSERT(last_newline_pos < first_non_space_pos);
+            uint32_t cur_indent = static_cast<uint32_t>(first_non_space_pos - last_newline_pos - 1);
+
+            // TODO: preserve and compare the last indentation with `cur_indent`
+            if (indent == 0) {
+                indent = cur_indent;
+            }
+            else if FK_YAML_UNLIKELY (cur_indent < indent) {
+                emit_error("A block style scalar is less indented than the indicated level.");
+            }
         }
 
-        for (; m_cur_itr != m_end_itr; ++m_cur_itr) {
-            char current = *m_cur_itr;
-            if (current == '\n') {
-                if (style == block_style_indicator_t::LITERAL) {
-                    if (chars_in_line == 0) {
-                        m_value_buffer.push_back('\n');
-                    }
-                    else {
-                        m_value_buffer.append(m_token_begin_itr, m_cur_itr + 1);
-                    }
-                }
-                // block_style_indicator_t::FOLDED
-                else if (chars_in_line == 0) {
-                    // Just append a newline if the current line is empty.
-                    m_value_buffer.push_back('\n');
-                }
-                else if (is_extra_indented) {
-                    // A line being more indented is not folded.
-                    m_value_buffer.append(m_token_begin_itr, m_cur_itr + 1);
-                }
-                else {
-                    m_value_buffer.append(m_token_begin_itr, m_cur_itr);
+        last_newline_pos = sv.find('\n', first_non_space_pos + 1);
+        if (last_newline_pos == str_view::npos) {
+            last_newline_pos = sv.size();
+        }
 
-                    // Append a newline if the next line is empty.
-                    bool is_end_of_token = false;
-                    bool is_next_empty = false;
-                    for (uint32_t i = 0; i < indent; i++) {
-                        if (++m_cur_itr == m_end_itr) {
-                            is_end_of_token = true;
-                            break;
-                        }
+        while (last_newline_pos < sv.size()) {
+            std::size_t cur_line_end_pos = sv.find('\n', last_newline_pos + 1);
+            if (cur_line_end_pos == str_view::npos) {
+                cur_line_end_pos = sv.size();
+            }
 
-                        char c = *m_cur_itr;
-                        if (c == ' ') {
-                            continue;
-                        }
-
-                        if (c == '\n') {
-                            is_next_empty = true;
-                            break;
-                        }
-
-                        is_end_of_token = true;
-                        break;
-                    }
-
-                    if (is_end_of_token) {
-                        m_value_buffer.push_back('\n');
-                        chars_in_line = 0;
-                        break;
-                    }
-
-                    if (is_next_empty) {
-                        m_value_buffer.push_back('\n');
-                        chars_in_line = 0;
-                        continue;
-                    }
-
-                    switch (char next = *(m_cur_itr + 1)) {
-                    case '\n':
-                        ++m_cur_itr;
-                        m_value_buffer.push_back(next);
-                        break;
-                    case ' ':
-                        // The next line is more indented, so a newline will be appended in the coming loops.
-                        break;
-                    default:
-                        m_value_buffer.push_back(' ');
-                        break;
-                    }
-                }
-
-                // Reset the values for the next line.
-                m_token_begin_itr = m_cur_itr + 1;
-                chars_in_line = 0;
-                is_extra_indented = false;
-
+            std::size_t cur_line_content_begin_pos = sv.find_first_not_of(' ', last_newline_pos + 1);
+            if (cur_line_content_begin_pos == str_view::npos) {
+                last_newline_pos = cur_line_end_pos;
                 continue;
             }
 
-            // Handle indentation
-            if (chars_in_line == 0) {
-                m_pos_tracker.update_position(m_cur_itr);
-                cur_indent = m_pos_tracker.get_cur_pos_in_line();
-                if (cur_indent < indent) {
-                    if (current != ' ') {
-                        // Interpret less indented non-space characters as the start of the next token.
-                        break;
-                    }
-                    // skip a space if not yet indented enough
-                    continue;
-                }
-
-                if (current == ' ' && style == block_style_indicator_t::FOLDED) {
-                    // A line being more indented is not folded.
-                    m_value_buffer.push_back('\n');
-                    is_extra_indented = true;
-                }
-                m_token_begin_itr = m_cur_itr;
-            }
-
-            ++chars_in_line;
-        }
-
-        if (chars_in_line > 0) {
-            m_value_buffer.append(m_token_begin_itr, m_cur_itr);
-        }
-
-        // Manipulate the trailing line endings chomping indicator type.
-        switch (chomp) {
-        case chomping_indicator_t::STRIP:
-            while (!m_value_buffer.empty()) {
-                // Empty strings are handled above, so no check for the case.
-                char last = m_value_buffer.back();
-                if (last != '\n') {
-                    break;
-                }
-                m_value_buffer.pop_back();
-            }
-            break;
-        case chomping_indicator_t::CLIP: {
-            char last = m_value_buffer.back();
-            if (last != '\n') {
-                // No need to chomp the trailing newlines.
+            FK_YAML_ASSERT(last_newline_pos < cur_line_content_begin_pos);
+            uint32_t cur_indent = static_cast<uint32_t>(cur_line_content_begin_pos - last_newline_pos - 1);
+            if (cur_indent < indent && sv[cur_line_content_begin_pos] != '\n') {
+                // Interpret less indented non-space characters as the start of the next token.
                 break;
             }
-            uint32_t buf_size = static_cast<uint32_t>(m_value_buffer.size());
-            while (buf_size > 1) {
-                // Strings with only newlines are handled above, so no check for the case.
-                char second_last = m_value_buffer[buf_size - 2];
-                if (second_last != '\n') {
-                    break;
-                }
-                m_value_buffer.pop_back();
-                --buf_size;
-            }
-            break;
+
+            last_newline_pos = cur_line_end_pos;
         }
-        case chomping_indicator_t::KEEP:
-            break;
+
+        // include last newline character if not all characters have been consumed yet.
+        if (last_newline_pos < sv.size()) {
+            ++last_newline_pos;
         }
+
+        token = sv.substr(0, last_newline_pos);
+        m_cur_itr = token.end();
     }
 
     /// @brief Handle unescaped control characters.
@@ -4304,23 +4214,32 @@ private:
     /// @brief Gets the metadata of a following block style string scalar.
     /// @param chomp_type A variable to store the retrieved chomping style type.
     /// @param indent A variable to store the retrieved indent size.
-    void get_block_style_metadata(chomping_indicator_t& chomp_type, uint32_t& indent) {
-        chomp_type = chomping_indicator_t::CLIP;
-        indent = 0;
+    /// @return
+    block_scalar_header convert_to_block_scalar_header(str_view& line) {
+        constexpr str_view comment_prefix = " #";
+        std::size_t comment_begin_pos = line.find(comment_prefix);
+        if (comment_begin_pos != str_view::npos) {
+            line = line.substr(0, comment_begin_pos);
+        }
 
-        while (m_cur_itr != m_end_itr) {
-            switch (*m_cur_itr) {
+        if (line.empty()) {
+            return {};
+        }
+
+        block_scalar_header header {};
+        for (const char c : line) {
+            switch (c) {
             case '-':
-                if FK_YAML_UNLIKELY (chomp_type != chomping_indicator_t::CLIP) {
+                if FK_YAML_UNLIKELY (header.chomp != chomping_indicator_t::CLIP) {
                     emit_error("Too many block chomping indicators specified.");
                 }
-                chomp_type = chomping_indicator_t::STRIP;
+                header.chomp = chomping_indicator_t::STRIP;
                 break;
             case '+':
-                if FK_YAML_UNLIKELY (chomp_type != chomping_indicator_t::CLIP) {
+                if FK_YAML_UNLIKELY (header.chomp != chomping_indicator_t::CLIP) {
                     emit_error("Too many block chomping indicators specified.");
                 }
-                chomp_type = chomping_indicator_t::KEEP;
+                header.chomp = chomping_indicator_t::KEEP;
                 break;
             case '0':
                 emit_error("An indentation level for a block scalar cannot be 0.");
@@ -4333,26 +4252,20 @@ private:
             case '7':
             case '8':
             case '9':
-                if FK_YAML_UNLIKELY (indent > 0) {
+                if FK_YAML_UNLIKELY (header.indent > 0) {
                     emit_error("Invalid indentation level for a block scalar. It must be between 1 and 9.");
                 }
-                indent = static_cast<char>(*m_cur_itr - '0');
+                header.indent = static_cast<char>(c - '0');
                 break;
             case ' ':
             case '\t':
                 break;
-            case '\n':
-                ++m_cur_itr;
-                return;
-            case '#':
-                skip_until_line_end();
-                return;
             default:
                 emit_error("Invalid character found in a block scalar header.");
             }
-
-            ++m_cur_itr;
         }
+
+        return header;
     }
 
     /// @brief Skip white spaces (half-width spaces and tabs) from the current position.
@@ -4416,6 +4329,8 @@ private:
     str_view m_tag_handle {};
     /// The last tag prefix.
     str_view m_tag_prefix {};
+    /// The last block scalar header.
+    block_scalar_header m_block_scalar_header {};
     /// The beginning position of the last lexical token. (zero origin)
     uint32_t m_last_token_begin_pos {0};
     /// The beginning line of the last lexical token. (zero origin)
@@ -5280,6 +5195,8 @@ FK_YAML_DETAIL_NAMESPACE_END
 
 #endif /* FK_YAML_CONVERSIONS_SCALAR_CONV_HPP */
 
+// #include <fkYAML/detail/input/block_scalar_header.hpp>
+
 // #include <fkYAML/detail/input/scalar_scanner.hpp>
 //  _______   __ __   __  _____   __  __  __
 // |   __| |_/  |  \_/  |/  _  \ /  \/  \|  |     fkYAML: A C++ header-only YAML library
@@ -5673,19 +5590,36 @@ public:
     scalar_parser& operator=(const scalar_parser&) noexcept = default;
     scalar_parser& operator=(scalar_parser&&) noexcept = default;
 
-    basic_node_type parse(lexical_token_t lex_type, tag_t tag_type, str_view token) {
+    basic_node_type parse_flow(lexical_token_t lex_type, tag_t tag_type, str_view token) {
         FK_YAML_ASSERT(
             lex_type == lexical_token_t::PLAIN_SCALAR || lex_type == lexical_token_t::SINGLE_QUOTED_SCALAR ||
-            lex_type == lexical_token_t::DOUBLE_QUOTED_SCALAR || lex_type == lexical_token_t::BLOCK_SCALAR);
+            lex_type == lexical_token_t::DOUBLE_QUOTED_SCALAR);
         FK_YAML_ASSERT(tag_type != tag_t::SEQUENCE && tag_type != tag_t::MAPPING);
 
-        token = parse_scalar_token(lex_type, token);
+        token = parse_flow_scalar_token(lex_type, token);
+        node_type value_type = decide_value_type(lex_type, tag_type, token);
+        return create_scalar_node(value_type, token);
+    }
+
+    basic_node_type parse_block(
+        lexical_token_t lex_type, tag_t tag_type, str_view token, const block_scalar_header& header) {
+        FK_YAML_ASSERT(
+            lex_type == lexical_token_t::BLOCK_LITERAL_SCALAR || lex_type == lexical_token_t::BLOCK_FOLDED_SCALAR);
+        FK_YAML_ASSERT(tag_type != tag_t::SEQUENCE && tag_type != tag_t::MAPPING);
+
+        if (lex_type == lexical_token_t::BLOCK_LITERAL_SCALAR) {
+            token = parse_block_literal_scalar(token, header);
+        }
+        else {
+            token = parse_block_folded_scalar(token, header);
+        }
+
         node_type value_type = decide_value_type(lex_type, tag_type, token);
         return create_scalar_node(value_type, token);
     }
 
 private:
-    str_view parse_scalar_token(lexical_token_t lex_type, str_view token) {
+    str_view parse_flow_scalar_token(lexical_token_t lex_type, str_view token) {
         switch (lex_type) {
         case lexical_token_t::SINGLE_QUOTED_SCALAR:
             token = parse_single_quoted_scalar(token);
@@ -5791,6 +5725,147 @@ private:
         }
 
         return {m_buffer};
+    }
+
+    str_view parse_block_literal_scalar(str_view token, const block_scalar_header& header) {
+        FK_YAML_ASSERT(header.indent > 0);
+
+        if FK_YAML_UNLIKELY (token.empty()) {
+            return token;
+        }
+
+        m_use_owned_buffer = true;
+        m_buffer.reserve(token.size());
+
+        std::size_t cur_line_begin_pos = 0;
+        do {
+            bool has_newline_at_end = true;
+            std::size_t cur_line_end_pos = token.find('\n', cur_line_begin_pos);
+            if (cur_line_end_pos == str_view::npos) {
+                has_newline_at_end = false;
+                cur_line_end_pos = token.size();
+            }
+
+            std::size_t line_size = cur_line_end_pos - cur_line_begin_pos;
+            str_view line = token.substr(cur_line_begin_pos, line_size);
+
+            if (line.size() > header.indent) {
+                m_buffer.append(line.begin() + header.indent, line.end());
+            }
+
+            if (!has_newline_at_end) {
+                break;
+            }
+
+            m_buffer.push_back('\n');
+            cur_line_begin_pos = cur_line_end_pos + 1;
+        } while (cur_line_begin_pos < token.size());
+
+        process_chomping(header.chomp);
+
+        return {m_buffer};
+    }
+
+    str_view parse_block_folded_scalar(str_view token, const block_scalar_header& header) {
+        FK_YAML_ASSERT(header.indent > 0);
+
+        if FK_YAML_UNLIKELY (token.empty()) {
+            return token;
+        }
+
+        m_use_owned_buffer = true;
+        m_buffer.reserve(token.size());
+
+        std::size_t cur_line_begin_pos = 0;
+        bool prev_line_has_content = false;
+        do {
+            bool has_newline_at_end = true;
+            std::size_t cur_line_end_pos = token.find('\n', cur_line_begin_pos);
+            if (cur_line_end_pos == str_view::npos) {
+                has_newline_at_end = false;
+                cur_line_end_pos = token.size();
+            }
+
+            std::size_t line_size = cur_line_end_pos - cur_line_begin_pos;
+            str_view line = token.substr(cur_line_begin_pos, line_size);
+
+            if (line.size() <= header.indent) {
+                // empty or less-indented lines are turned into a newline
+                m_buffer.push_back('\n');
+                prev_line_has_content = false;
+                continue;
+            }
+            else {
+                if (prev_line_has_content) {
+                    m_buffer.push_back(' ');
+                    // `prev_line_has_content` is not set to false since the current line also has contents.
+                }
+
+                m_buffer.append(line.begin(), line.end());
+
+                std::size_t non_space_pos = line.find_first_not_of(' ');
+                if (non_space_pos > header.indent && has_newline_at_end) {
+                    // more-indented lines are not folded.
+                    m_buffer.push_back('\n');
+                }
+            }
+
+            if (!has_newline_at_end) {
+                break;
+            }
+
+            cur_line_begin_pos = cur_line_end_pos + 1;
+        } while (cur_line_begin_pos < token.size());
+
+        std::size_t non_break_pos = m_buffer.find_last_not_of('\n');
+        if (non_break_pos != std::string::npos) {
+            // The final content line break are not folded.
+            m_buffer.push_back('\n');
+        }
+
+        process_chomping(header.chomp);
+
+        return {m_buffer};
+    }
+
+    void process_chomping(chomping_indicator_t chomp) {
+        if (!m_buffer.empty()) {
+            switch (chomp) {
+            case chomping_indicator_t::STRIP: {
+                std::size_t content_end_pos = m_buffer.find_last_not_of('\n');
+                if (content_end_pos == std::string::npos) {
+                    // if the scalar has no content line, all lines are considered as trailing empty lines.
+                    m_buffer.clear();
+                    break;
+                }
+
+                // remove all trailing newlines.
+                m_buffer.erase(content_end_pos);
+
+                break;
+            }
+            case chomping_indicator_t::CLIP: {
+                std::size_t content_end_pos = m_buffer.find_last_not_of('\n');
+                if (content_end_pos == std::string::npos) {
+                    // if the scalar has no content line, all lines are considered as trailing empty lines.
+                    m_buffer.clear();
+                    break;
+                }
+
+                if (content_end_pos == m_buffer.size() - 1) {
+                    // no trailing empty lines
+                    break;
+                }
+
+                // remove all trailing empty lines.
+                m_buffer.erase(content_end_pos + 1);
+
+                break;
+            }
+            case chomping_indicator_t::KEEP:
+                break;
+            }
+        }
     }
 
     void process_line_folding(str_view& token, std::size_t newline_pos) noexcept {
@@ -7254,7 +7329,8 @@ private:
             case lexical_token_t::PLAIN_SCALAR:
             case lexical_token_t::SINGLE_QUOTED_SCALAR:
             case lexical_token_t::DOUBLE_QUOTED_SCALAR:
-            case lexical_token_t::BLOCK_SCALAR: {
+            case lexical_token_t::BLOCK_LITERAL_SCALAR:
+            case lexical_token_t::BLOCK_FOLDED_SCALAR: {
                 bool do_continue = deserialize_scalar(lexer, indent, line, token);
                 if (do_continue) {
                     continue;
@@ -7432,17 +7508,17 @@ private:
     }
 
     /// @brief Creates a YAML scalar node with the retrieved token information by the lexer.
-    /// @param lexer The lexical analyzer to be used.
     /// @param type The type of the last lexical token.
     /// @param indent The last indent size.
     /// @param line The last line.
+    /// @param lexer The lexical analyzer to be used.
     /// @return The created YAML scalar node.
-    basic_node_type create_scalar_node(const lexical_token& token, uint32_t indent, uint32_t line) {
+    basic_node_type create_scalar_node(const lexical_token& token, uint32_t indent, uint32_t line, lexer_type& lexer) {
         lexical_token_t type = token.type;
         FK_YAML_ASSERT(
             type == lexical_token_t::PLAIN_SCALAR || type == lexical_token_t::SINGLE_QUOTED_SCALAR ||
-            type == lexical_token_t::DOUBLE_QUOTED_SCALAR || type == lexical_token_t::BLOCK_SCALAR ||
-            type == lexical_token_t::ALIAS_PREFIX);
+            type == lexical_token_t::DOUBLE_QUOTED_SCALAR || type == lexical_token_t::BLOCK_LITERAL_SCALAR ||
+            type == lexical_token_t::BLOCK_FOLDED_SCALAR || type == lexical_token_t::ALIAS_PREFIX);
 
         if (type == lexical_token_t::ALIAS_PREFIX) {
             if FK_YAML_UNLIKELY (m_needs_tag_impl) {
@@ -7472,7 +7548,22 @@ private:
             tag_type = tag_resolver_type::resolve_tag(m_tag_name, mp_meta);
         }
 
-        basic_node_type node = scalar_parser_type(line, indent).parse(type, tag_type, token.str);
+        basic_node_type node {};
+        switch (type) {
+        case lexical_token_t::PLAIN_SCALAR:
+        case lexical_token_t::SINGLE_QUOTED_SCALAR:
+        case lexical_token_t::DOUBLE_QUOTED_SCALAR:
+            node = scalar_parser_type(line, indent).parse_flow(type, tag_type, token.str);
+            break;
+        case lexical_token_t::BLOCK_LITERAL_SCALAR:
+        case lexical_token_t::BLOCK_FOLDED_SCALAR:
+            node = scalar_parser_type(line, indent)
+                       .parse_block(type, tag_type, token.str, lexer.get_block_scalar_header());
+            break;
+        default:
+            break;
+        }
+
         apply_directive_set(node);
         apply_node_properties(node);
 
@@ -7486,7 +7577,7 @@ private:
     /// @param line The number of processed lines. Can be updated in this function.
     /// @return true if next token has already been got, false otherwise.
     bool deserialize_scalar(lexer_type& lexer, uint32_t& indent, uint32_t& line, lexical_token& token) {
-        basic_node_type node = create_scalar_node(token, indent, line);
+        basic_node_type node = create_scalar_node(token, indent, line, lexer);
 
         if (mp_current_node->is_mapping()) {
             add_new_key(std::move(node), line, indent);

--- a/single_include/fkYAML/node.hpp
+++ b/single_include/fkYAML/node.hpp
@@ -3834,25 +3834,27 @@ private:
     /// @param token The token into which the scan result is written.
     /// @return lexical_token_t The lexical token type for strings.
     void scan_scalar(lexical_token& token) {
-        m_value_buffer.clear();
-
-        bool needs_last_double_quote = false;
         switch (*m_token_begin_itr) {
         case '\'':
             ++m_token_begin_itr;
             token.type = lexical_token_t::SINGLE_QUOTED_SCALAR;
             determine_single_quoted_scalar_range(token.str);
-            return;
+            break;
         case '\"':
-            needs_last_double_quote = true;
             ++m_token_begin_itr;
             token.type = lexical_token_t::DOUBLE_QUOTED_SCALAR;
             determine_double_quoted_scalar_range(token.str);
-            return;
+            break;
         default:
             token.type = lexical_token_t::PLAIN_SCALAR;
             determine_plain_scalar_range(token.str);
-            return;
+            break;
+        }
+
+        for (const auto c : token.str) {
+            if FK_YAML_UNLIKELY (0 <= c && c < 0x20) {
+                handle_unescaped_control_char(c);
+            }
         }
     }
 
@@ -3861,14 +3863,10 @@ private:
 
         std::size_t pos = sv.find('\'');
         while (pos != str_view::npos) {
-            if (pos == sv.size() - 1 || sv[pos + 1] != '\'') {
+            FK_YAML_ASSERT(pos < sv.size());
+            if FK_YAML_LIKELY (pos == sv.size() - 1 || sv[pos + 1] != '\'') {
                 // closing single quote is found.
                 token = {m_token_begin_itr, pos};
-                for (const auto c : token) {
-                    if FK_YAML_UNLIKELY (0 <= c && c < 0x20) {
-                        handle_unescaped_control_char(c);
-                    }
-                }
                 m_cur_itr = sv.begin() + (pos + 1);
                 return;
             }
@@ -3888,8 +3886,10 @@ private:
 
         std::size_t pos = sv.find('\"');
         while (pos != str_view::npos) {
+            FK_YAML_ASSERT(pos < sv.size());
+
             bool is_closed = true;
-            if (pos > 0) {
+            if FK_YAML_LIKELY (pos > 0) {
                 // Double quotation marks can be escaped by a preceding backslash and the number of backslashes matters
                 // to determine if the found double quotation mark is escaped since the backslash itself can also be
                 // escaped:
@@ -3909,11 +3909,6 @@ private:
             if (is_closed) {
                 // closing double quote is found.
                 token = {m_token_begin_itr, pos};
-                for (const auto c : token) {
-                    if FK_YAML_UNLIKELY (0 <= c && c < 0x20) {
-                        handle_unescaped_control_char(c);
-                    }
-                }
                 m_cur_itr = sv.begin() + (pos + 1);
                 return;
             }
@@ -3936,17 +3931,13 @@ private:
         std::size_t pos = sv.find_first_of(check_filter);
         if FK_YAML_UNLIKELY (pos == str_view::npos) {
             token = sv;
-            for (const auto c : token) {
-                if FK_YAML_UNLIKELY (0 <= c && c < 0x20) {
-                    handle_unescaped_control_char(c);
-                }
-            }
             m_cur_itr = m_end_itr;
             return;
         }
 
         bool ends_loop = false;
         do {
+            FK_YAML_ASSERT(pos < sv.size());
             switch (sv[pos]) {
             case '\n':
                 ends_loop = true;
@@ -3985,7 +3976,7 @@ private:
                 }
                 break;
             case ':':
-                if FK_YAML_LIKELY (pos < sv.size() - 1) {
+                if FK_YAML_LIKELY (pos + 1 < sv.size()) {
                     switch (sv[pos + 1]) {
                     case ' ':
                     case '\t':
@@ -4017,148 +4008,7 @@ private:
         } while (pos != str_view::npos);
 
         token = sv.substr(0, pos);
-        for (const auto c : token) {
-            if FK_YAML_UNLIKELY (0 <= c && c < 0x20) {
-                handle_unescaped_control_char(c);
-            }
-        }
         m_cur_itr = token.end();
-    }
-
-    /// @brief Check if the given character is allowed in a double-quoted scalar token.
-    /// @param c The character to be checked.
-    /// @param is_value_buffer_used true is assigned when mutated scalar contents is written into m_value_buffer.
-    /// @return true if the given character is allowed, false otherwise.
-    bool is_allowed_double(char c, bool& is_value_buffer_used) {
-        switch (c) {
-        case '\n': {
-            is_value_buffer_used = true;
-
-            // discard trailing white spaces which precedes the line break in the current line.
-            auto before_trailing_spaces_itr = m_cur_itr - 1;
-            bool ends_loop = false;
-            while (before_trailing_spaces_itr != m_token_begin_itr) {
-                switch (*before_trailing_spaces_itr) {
-                case ' ':
-                case '\t':
-                    --before_trailing_spaces_itr;
-                    break;
-                default:
-                    ends_loop = true;
-                    break;
-                }
-
-                if (ends_loop) {
-                    break;
-                }
-            }
-            m_value_buffer.append(m_token_begin_itr, before_trailing_spaces_itr + 1);
-
-            // move to the beginning of the next line.
-            ++m_cur_itr;
-
-            // apply line folding according to the number of following empty lines.
-            m_pos_tracker.update_position(m_cur_itr);
-            uint32_t line_after_line_break = m_pos_tracker.get_lines_read();
-            skip_white_spaces_and_newline_codes();
-            m_pos_tracker.update_position(m_cur_itr);
-            uint32_t trailing_empty_lines = m_pos_tracker.get_lines_read() - line_after_line_break;
-            if (trailing_empty_lines > 0) {
-                m_value_buffer.append(trailing_empty_lines, '\n');
-            }
-            else {
-                m_value_buffer.push_back(' ');
-            }
-
-            m_token_begin_itr = (m_cur_itr == m_end_itr || *m_cur_itr == '\"') ? m_cur_itr-- : m_cur_itr;
-            return true;
-        }
-
-        case '\"':
-            if (is_value_buffer_used) {
-                m_value_buffer.append(m_token_begin_itr, m_cur_itr++);
-            }
-            return false;
-
-        case '\\':
-            is_value_buffer_used = true;
-
-            m_value_buffer.append(m_token_begin_itr, m_cur_itr);
-
-            // Handle escaped characters.
-            // See https://yaml.org/spec/1.2.2/#57-escaped-characters for more details.
-
-            c = *(m_cur_itr + 1);
-            if (c != '\n') {
-                bool is_valid_escaping = yaml_escaper::unescape(m_cur_itr, m_end_itr, m_value_buffer);
-                if FK_YAML_UNLIKELY (!is_valid_escaping) {
-                    emit_error("Unsupported escape sequence is found in a string token.");
-                }
-
-                m_token_begin_itr = m_cur_itr + 1;
-                return true;
-            }
-
-            // move until the next non-space character is found.
-            m_cur_itr += 2;
-            skip_white_spaces();
-
-            m_token_begin_itr = (m_cur_itr == m_end_itr || *m_cur_itr == '\"') ? m_cur_itr-- : m_cur_itr;
-            return true;
-
-        default:         // LCOV_EXCL_LINE
-            return true; // LCOV_EXCL_LINE
-        }
-    }
-
-    /// @brief Extracts a string token, either plain, single-quoted or double-quoted, from the input buffer.
-    /// @return true if mutated scalar contents is stored in m_value_buffer, false otherwise.
-    bool extract_string_token(bool needs_last_double_quote) {
-        // change behaviors depending on the type of a coming string scalar token.
-        // * double quoted
-        // * plain (flow)
-
-        FK_YAML_ASSERT(needs_last_double_quote);
-        std::string check_filters {"\n\"\\"};
-
-        // scan the contents of a string scalar token.
-
-        bool is_value_buffer_used = false;
-        for (; m_cur_itr != m_end_itr; ++m_cur_itr) {
-            char current = *m_cur_itr;
-            uint32_t num_bytes = utf8::get_num_bytes(static_cast<uint8_t>(current));
-            if FK_YAML_LIKELY (num_bytes == 1) {
-                auto ret = check_filters.find(current);
-                if (ret != std::string::npos) {
-                    bool is_allowed = is_allowed_double(current, is_value_buffer_used);
-                    if (!is_allowed) {
-                        return is_value_buffer_used;
-                    }
-
-                    continue;
-                }
-
-                // Handle unescaped control characters.
-                if FK_YAML_UNLIKELY (static_cast<uint8_t>(current) <= 0x1F) {
-                    handle_unescaped_control_char(current);
-                    continue;
-                }
-
-                continue;
-            }
-
-            // Multi-byte characters are already validated while creating an input handler.
-            // So just advance the iterator.
-            m_cur_itr += num_bytes - 1;
-        }
-
-        // Handle the end of input buffer.
-
-        if FK_YAML_UNLIKELY (needs_last_double_quote) {
-            emit_error("Invalid end of input buffer in a double-quoted string token.");
-        }
-
-        return is_value_buffer_used;
     }
 
     /// @brief Scan a block style string token either in the literal or folded style.
@@ -5847,46 +5697,17 @@ private:
         }
 
         do {
+            FK_YAML_ASSERT(pos < token.size());
+            FK_YAML_ASSERT(token[pos] == '\'' || token[pos] == '\n');
+
             if (token[pos] == '\'') {
                 // unescape escaped single quote. ('' -> ')
                 FK_YAML_ASSERT(pos + 1 < token.size());
                 m_buffer.append(token.begin(), token.begin() + (pos + 1));
                 token.remove_prefix(pos + 2); // move next to the escaped single quote.
-                pos = token.find_first_of("\'\n");
-                continue;
-            }
-
-            // process line folding
-
-            // discard trailing white spaces which precedes the line break in the current line.
-            std::size_t last_non_space_pos = token.substr(0, pos).find_last_not_of(" \t");
-            if (last_non_space_pos == str_view::npos) {
-                m_buffer.append(token.begin(), pos);
             }
             else {
-                m_buffer.append(token.begin(), last_non_space_pos + 1);
-            }
-            token.remove_prefix(pos + 1); // move next to the LF
-
-            uint32_t empty_line_counts = 0;
-            do {
-                std::size_t non_space_pos = token.find_first_not_of(" \t");
-                if (non_space_pos == str_view::npos || token[non_space_pos] != '\n') {
-                    if (non_space_pos == str_view::npos) {
-                        non_space_pos = token.size();
-                    }
-                    token.remove_prefix(non_space_pos);
-                    break;
-                }
-
-                ++empty_line_counts;
-            } while (true);
-
-            if (empty_line_counts > 0) {
-                m_buffer.append(empty_line_counts, '\n');
-            }
-            else {
-                m_buffer.push_back(' ');
+                process_line_folding(token, pos);
             }
 
             pos = token.find_first_of("\'\n");
@@ -5916,6 +5737,9 @@ private:
         }
 
         do {
+            FK_YAML_ASSERT(pos < token.size());
+            FK_YAML_ASSERT(token[pos] == '\\' || token[pos] == '\n');
+
             if (token[pos] == '\\') {
                 FK_YAML_ASSERT(pos + 1 < token.size());
                 if (token[pos + 1] != '\n') {
@@ -5930,12 +5754,11 @@ private:
 
                     // `p_escape_begin` points to the last element of the escape sequence.
                     token.remove_prefix((p_escape_begin - token.begin()) + 1);
-                    pos = token.find_first_of("\\\n");
-                    continue;
                 }
             }
-
-            process_line_folding(token, pos);
+            else {
+                process_line_folding(token, pos);
+            }
 
             pos = token.find_first_of("\\\n");
         } while (pos != str_view::npos);
@@ -5948,7 +5771,7 @@ private:
     }
 
     void process_line_folding(str_view& token, std::size_t newline_pos) noexcept {
-        // remove trailing spaces before a newline.
+        // discard trailing white spaces which precedes the line break in the current line.
         std::size_t last_non_space_pos = token.substr(0, newline_pos).find_last_not_of(" \t");
         if (last_non_space_pos == str_view::npos) {
             m_buffer.append(token.begin(), newline_pos);

--- a/single_include/fkYAML/node.hpp
+++ b/single_include/fkYAML/node.hpp
@@ -7336,13 +7336,64 @@ private:
                 }
                 m_flow_token_state = flow_token_state_t::NEEDS_VALUE_OR_SUFFIX;
                 break;
-            case lexical_token_t::ALIAS_PREFIX:
+            case lexical_token_t::ALIAS_PREFIX: {
+                if FK_YAML_UNLIKELY (m_needs_tag_impl) {
+                    throw parse_error("Tag cannot be specified to an alias node", line, indent);
+                }
+
+                const std::string token_str = std::string(token.str.begin(), token.str.end());
+
+                uint32_t anchor_counts = static_cast<uint32_t>(mp_meta->anchor_table.count(token_str));
+                if FK_YAML_UNLIKELY (anchor_counts == 0) {
+                    throw parse_error("The given anchor name must appear prior to the alias node.", line, indent);
+                }
+
+                basic_node_type node {};
+                node.m_attrs |= detail::node_attr_bits::alias_bit;
+                node.m_prop.anchor = std::move(token_str);
+                detail::node_attr_bits::set_anchor_offset(anchor_counts - 1, node.m_attrs);
+
+                apply_directive_set(node);
+                apply_node_properties(node);
+
+                bool should_continue = deserialize_scalar(lexer, std::move(node), indent, line, token);
+                if (should_continue) {
+                    continue;
+                }
+                break;
+            }
             case lexical_token_t::PLAIN_SCALAR:
             case lexical_token_t::SINGLE_QUOTED_SCALAR:
-            case lexical_token_t::DOUBLE_QUOTED_SCALAR:
+            case lexical_token_t::DOUBLE_QUOTED_SCALAR: {
+                tag_t tag_type {tag_t::NONE};
+                if (m_needs_tag_impl) {
+                    tag_type = tag_resolver_type::resolve_tag(m_tag_name, mp_meta);
+                }
+
+                basic_node_type node = scalar_parser_type(line, indent).parse_flow(token.type, tag_type, token.str);
+                apply_directive_set(node);
+                apply_node_properties(node);
+
+                bool do_continue = deserialize_scalar(lexer, std::move(node), indent, line, token);
+                if (do_continue) {
+                    continue;
+                }
+                break;
+            }
             case lexical_token_t::BLOCK_LITERAL_SCALAR:
             case lexical_token_t::BLOCK_FOLDED_SCALAR: {
-                bool do_continue = deserialize_scalar(lexer, indent, line, token);
+                tag_t tag_type {tag_t::NONE};
+                if (m_needs_tag_impl) {
+                    tag_type = tag_resolver_type::resolve_tag(m_tag_name, mp_meta);
+                }
+
+                basic_node_type node =
+                    scalar_parser_type(line, indent)
+                        .parse_block(token.type, tag_type, token.str, lexer.get_block_scalar_header());
+                apply_directive_set(node);
+                apply_node_properties(node);
+
+                bool do_continue = deserialize_scalar(lexer, std::move(node), indent, line, token);
                 if (do_continue) {
                     continue;
                 }
@@ -7518,78 +7569,14 @@ private:
         }
     }
 
-    /// @brief Creates a YAML scalar node with the retrieved token information by the lexer.
-    /// @param type The type of the last lexical token.
-    /// @param indent The last indent size.
-    /// @param line The last line.
-    /// @param lexer The lexical analyzer to be used.
-    /// @return The created YAML scalar node.
-    basic_node_type create_scalar_node(const lexical_token& token, uint32_t indent, uint32_t line, lexer_type& lexer) {
-        lexical_token_t type = token.type;
-        FK_YAML_ASSERT(
-            type == lexical_token_t::PLAIN_SCALAR || type == lexical_token_t::SINGLE_QUOTED_SCALAR ||
-            type == lexical_token_t::DOUBLE_QUOTED_SCALAR || type == lexical_token_t::BLOCK_LITERAL_SCALAR ||
-            type == lexical_token_t::BLOCK_FOLDED_SCALAR || type == lexical_token_t::ALIAS_PREFIX);
-
-        if (type == lexical_token_t::ALIAS_PREFIX) {
-            if FK_YAML_UNLIKELY (m_needs_tag_impl) {
-                throw parse_error("Tag cannot be specified to an alias node", line, indent);
-            }
-
-            const std::string token_str = std::string(token.str.begin(), token.str.end());
-
-            uint32_t anchor_counts = static_cast<uint32_t>(mp_meta->anchor_table.count(token_str));
-            if FK_YAML_UNLIKELY (anchor_counts == 0) {
-                throw parse_error("The given anchor name must appear prior to the alias node.", line, indent);
-            }
-
-            basic_node_type node {};
-            node.m_attrs |= detail::node_attr_bits::alias_bit;
-            node.m_prop.anchor = std::move(token_str);
-            detail::node_attr_bits::set_anchor_offset(anchor_counts - 1, node.m_attrs);
-
-            apply_directive_set(node);
-            apply_node_properties(node);
-
-            return node;
-        }
-
-        tag_t tag_type {tag_t::NONE};
-        if (m_needs_tag_impl) {
-            tag_type = tag_resolver_type::resolve_tag(m_tag_name, mp_meta);
-        }
-
-        basic_node_type node {};
-        switch (type) {
-        case lexical_token_t::PLAIN_SCALAR:
-        case lexical_token_t::SINGLE_QUOTED_SCALAR:
-        case lexical_token_t::DOUBLE_QUOTED_SCALAR:
-            node = scalar_parser_type(line, indent).parse_flow(type, tag_type, token.str);
-            break;
-        case lexical_token_t::BLOCK_LITERAL_SCALAR:
-        case lexical_token_t::BLOCK_FOLDED_SCALAR:
-            node = scalar_parser_type(line, indent)
-                       .parse_block(type, tag_type, token.str, lexer.get_block_scalar_header());
-            break;
-        default:
-            break;
-        }
-
-        apply_directive_set(node);
-        apply_node_properties(node);
-
-        return node;
-    }
-
     /// @brief Deserialize a detected scalar node.
     /// @param lexer The lexical analyzer to be used.
     /// @param node A detected scalar node by a lexer.
     /// @param indent The current indentation width. Can be updated in this function.
     /// @param line The number of processed lines. Can be updated in this function.
     /// @return true if next token has already been got, false otherwise.
-    bool deserialize_scalar(lexer_type& lexer, uint32_t& indent, uint32_t& line, lexical_token& token) {
-        basic_node_type node = create_scalar_node(token, indent, line, lexer);
-
+    bool deserialize_scalar(
+        lexer_type& lexer, basic_node_type&& node, uint32_t& indent, uint32_t& line, lexical_token& token) {
         if (mp_current_node->is_mapping()) {
             add_new_key(std::move(node), line, indent);
             return false;

--- a/single_include/fkYAML/node.hpp
+++ b/single_include/fkYAML/node.hpp
@@ -5870,6 +5870,8 @@ private:
             return token;
         }
 
+        m_use_owned_buffer = true;
+
         if (m_buffer.capacity() < token.size()) {
             m_buffer.reserve(token.size());
         }
@@ -6002,7 +6004,13 @@ private:
             break;
         }
         case node_type::STRING:
-            node = basic_node_type(std::string(token.begin(), token.end()));
+            if (m_use_owned_buffer) {
+                node = basic_node_type(std::move(m_buffer));
+                m_use_owned_buffer = false;
+            }
+            else {
+                node = basic_node_type(std::string(token.begin(), token.end()));
+            }
             break;
         default:   // LCOV_EXCL_LINE
             break; // LCOV_EXCL_LINE
@@ -6013,6 +6021,7 @@ private:
 
     uint32_t m_line {0};
     uint32_t m_indent {0};
+    bool m_use_owned_buffer {false};
     std::string m_buffer {};
 };
 

--- a/single_include/fkYAML/node.hpp
+++ b/single_include/fkYAML/node.hpp
@@ -3990,8 +3990,8 @@ FK_YAML_DETAIL_NAMESPACE_END
 // SPDX-FileCopyrightText: 2023-2024 Kensuke Fukutani <fktn.dev@gmail.com>
 // SPDX-License-Identifier: MIT
 
-#ifndef FK_YAML_DETAIL_INPUT_SCALAR_PARSER_HPP_
-#define FK_YAML_DETAIL_INPUT_SCALAR_PARSER_HPP_
+#ifndef FK_YAML_DETAIL_INPUT_SCALAR_PARSER_HPP
+#define FK_YAML_DETAIL_INPUT_SCALAR_PARSER_HPP
 
 // #include <fkYAML/detail/macros/version_macros.hpp>
 
@@ -5583,9 +5583,11 @@ public:
     /// @brief Destroys a scalar_parser object.
     ~scalar_parser() noexcept = default;
 
-    scalar_parser(const scalar_parser&) noexcept = default;
+    // std::string's copy constructor/assignment operator may throw a exception.
+    scalar_parser(const scalar_parser&) = default;
+    scalar_parser& operator=(const scalar_parser&) = default;
+
     scalar_parser(scalar_parser&&) noexcept = default;
-    scalar_parser& operator=(const scalar_parser&) noexcept = default;
     scalar_parser& operator=(scalar_parser&&) noexcept = default;
 
     /// @brief Parses a token into a flow scalar (either plain, single quoted or double quoted)
@@ -6066,7 +6068,7 @@ private:
 
 FK_YAML_DETAIL_NAMESPACE_END
 
-#endif /* FK_YAML_DETAIL_INPUT_SCALAR_PARSER_HPP_ */
+#endif /* FK_YAML_DETAIL_INPUT_SCALAR_PARSER_HPP */
 
 // #include <fkYAML/detail/input/tag_resolver.hpp>
 //  _______   __ __   __  _____   __  __  __
@@ -7446,8 +7448,7 @@ private:
                 apply_directive_set(node);
                 apply_node_properties(node);
 
-                bool do_continue = deserialize_scalar(lexer, std::move(node), indent, line, token);
-                FK_YAML_ASSERT(do_continue);
+                deserialize_scalar(lexer, std::move(node), indent, line, token);
                 continue;
             }
             // these tokens end parsing the current YAML document.

--- a/single_include/fkYAML/node.hpp
+++ b/single_include/fkYAML/node.hpp
@@ -1750,355 +1750,6 @@ FK_YAML_DETAIL_NAMESPACE_END
 
 #endif /* FK_YAML_DETAIL_ENCODINGS_UTF_ENCODINGS_HPP */
 
-// #include <fkYAML/detail/encodings/yaml_escaper.hpp>
-//  _______   __ __   __  _____   __  __  __
-// |   __| |_/  |  \_/  |/  _  \ /  \/  \|  |     fkYAML: A C++ header-only YAML library
-// |   __|  _  < \_   _/|  ___  |    _   |  |___  version 0.3.12
-// |__|  |_| \__|  |_|  |_|   |_|___||___|______| https://github.com/fktn-k/fkYAML
-//
-// SPDX-FileCopyrightText: 2023-2024 Kensuke Fukutani <fktn.dev@gmail.com>
-// SPDX-License-Identifier: MIT
-
-#ifndef FK_YAML_DETAIL_ENCODINGS_YAML_ESCAPER_HPP
-#define FK_YAML_DETAIL_ENCODINGS_YAML_ESCAPER_HPP
-
-#include <string>
-
-// #include <fkYAML/detail/macros/version_macros.hpp>
-
-// #include <fkYAML/detail/assert.hpp>
-
-// #include <fkYAML/detail/encodings/utf_encodings.hpp>
-
-// #include <fkYAML/exception.hpp>
-
-
-FK_YAML_DETAIL_NAMESPACE_BEGIN
-
-class yaml_escaper {
-    using iterator = ::std::string::const_iterator;
-
-public:
-    static bool unescape(const char*& begin, const char* end, std::string& buff) {
-        FK_YAML_ASSERT(*begin == '\\' && std::distance(begin, end) > 0);
-        bool ret = true;
-
-        switch (*++begin) {
-        case 'a':
-            buff.push_back('\a');
-            break;
-        case 'b':
-            buff.push_back('\b');
-            break;
-        case 't':
-        case char(0x09):
-            buff.push_back('\t');
-            break;
-        case 'n':
-            buff.push_back('\n');
-            break;
-        case 'v':
-            buff.push_back('\v');
-            break;
-        case 'f':
-            buff.push_back('\f');
-            break;
-        case 'r':
-            buff.push_back('\r');
-            break;
-        case 'e':
-            buff.push_back(char(0x1B));
-            break;
-        case ' ':
-            buff.push_back(' ');
-            break;
-        case '\"':
-            buff.push_back('\"');
-            break;
-        case '/':
-            buff.push_back('/');
-            break;
-        case '\\':
-            buff.push_back('\\');
-            break;
-        case 'N': // next line
-            unescape_escaped_unicode(0x85u, buff);
-            break;
-        case '_': // non-breaking space
-            unescape_escaped_unicode(0xA0u, buff);
-            break;
-        case 'L': // line separator
-            unescape_escaped_unicode(0x2028u, buff);
-            break;
-        case 'P': // paragraph separator
-            unescape_escaped_unicode(0x2029u, buff);
-            break;
-        case 'x': {
-            char32_t codepoint {0};
-            ret = extract_codepoint(begin, end, 1, codepoint);
-            if FK_YAML_LIKELY (ret) {
-                unescape_escaped_unicode(codepoint, buff);
-            }
-            break;
-        }
-        case 'u': {
-            char32_t codepoint {0};
-            ret = extract_codepoint(begin, end, 2, codepoint);
-            if FK_YAML_LIKELY (ret) {
-                unescape_escaped_unicode(codepoint, buff);
-            }
-            break;
-        }
-        case 'U': {
-            char32_t codepoint {0};
-            ret = extract_codepoint(begin, end, 4, codepoint);
-            if FK_YAML_LIKELY (ret) {
-                unescape_escaped_unicode(codepoint, buff);
-            }
-            break;
-        }
-        default:
-            // Unsupported escape sequence is found in a string token.
-            ret = false;
-            break;
-        }
-
-        return ret;
-    }
-
-    static ::std::string escape(const char* begin, const char* end, bool& is_escaped) {
-        ::std::string escaped {};
-        escaped.reserve(std::distance(begin, end));
-        for (; begin != end; ++begin) {
-            switch (*begin) {
-            case 0x01:
-                escaped += "\\u0001";
-                is_escaped = true;
-                break;
-            case 0x02:
-                escaped += "\\u0002";
-                is_escaped = true;
-                break;
-            case 0x03:
-                escaped += "\\u0003";
-                is_escaped = true;
-                break;
-            case 0x04:
-                escaped += "\\u0004";
-                is_escaped = true;
-                break;
-            case 0x05:
-                escaped += "\\u0005";
-                is_escaped = true;
-                break;
-            case 0x06:
-                escaped += "\\u0006";
-                is_escaped = true;
-                break;
-            case '\a':
-                escaped += "\\a";
-                is_escaped = true;
-                break;
-            case '\b':
-                escaped += "\\b";
-                is_escaped = true;
-                break;
-            case '\t':
-                escaped += "\\t";
-                is_escaped = true;
-                break;
-            case '\n':
-                escaped += "\\n";
-                is_escaped = true;
-                break;
-            case '\v':
-                escaped += "\\v";
-                is_escaped = true;
-                break;
-            case '\f':
-                escaped += "\\f";
-                is_escaped = true;
-                break;
-            case '\r':
-                escaped += "\\r";
-                is_escaped = true;
-                break;
-            case 0x0E:
-                escaped += "\\u000E";
-                is_escaped = true;
-                break;
-            case 0x0F:
-                escaped += "\\u000F";
-                is_escaped = true;
-                break;
-            case 0x10:
-                escaped += "\\u0010";
-                is_escaped = true;
-                break;
-            case 0x11:
-                escaped += "\\u0011";
-                is_escaped = true;
-                break;
-            case 0x12:
-                escaped += "\\u0012";
-                is_escaped = true;
-                break;
-            case 0x13:
-                escaped += "\\u0013";
-                is_escaped = true;
-                break;
-            case 0x14:
-                escaped += "\\u0014";
-                is_escaped = true;
-                break;
-            case 0x15:
-                escaped += "\\u0015";
-                is_escaped = true;
-                break;
-            case 0x16:
-                escaped += "\\u0016";
-                is_escaped = true;
-                break;
-            case 0x17:
-                escaped += "\\u0017";
-                is_escaped = true;
-                break;
-            case 0x18:
-                escaped += "\\u0018";
-                is_escaped = true;
-                break;
-            case 0x19:
-                escaped += "\\u0019";
-                is_escaped = true;
-                break;
-            case 0x1A:
-                escaped += "\\u001A";
-                is_escaped = true;
-                break;
-            case 0x1B:
-                escaped += "\\e";
-                is_escaped = true;
-                break;
-            case 0x1C:
-                escaped += "\\u001C";
-                is_escaped = true;
-                break;
-            case 0x1D:
-                escaped += "\\u001D";
-                is_escaped = true;
-                break;
-            case 0x1E:
-                escaped += "\\u001E";
-                is_escaped = true;
-                break;
-            case 0x1F:
-                escaped += "\\u001F";
-                is_escaped = true;
-                break;
-            case '\"':
-                escaped += "\\\"";
-                is_escaped = true;
-                break;
-            case '\\':
-                escaped += "\\\\";
-                is_escaped = true;
-                break;
-            default:
-                int diff = static_cast<int>(std::distance(begin, end));
-                if (diff > 1) {
-                    if (*begin == char(0xC2u) && *(begin + 1) == char(0x85u)) {
-                        escaped += "\\N";
-                        std::advance(begin, 1);
-                        is_escaped = true;
-                        break;
-                    }
-                    else if (*begin == char(0xC2u) && *(begin + 1) == char(0xA0u)) {
-                        escaped += "\\_";
-                        std::advance(begin, 1);
-                        is_escaped = true;
-                        break;
-                    }
-
-                    if (diff > 2) {
-                        if (*begin == char(0xE2u) && *(begin + 1) == char(0x80u) && *(begin + 2) == char(0xA8u)) {
-                            escaped += "\\L";
-                            std::advance(begin, 2);
-                            is_escaped = true;
-                            break;
-                        }
-                        if (*begin == char(0xE2u) && *(begin + 1) == char(0x80u) && *(begin + 2) == char(0xA9u)) {
-                            escaped += "\\P";
-                            std::advance(begin, 2);
-                            is_escaped = true;
-                            break;
-                        }
-                    }
-                }
-                escaped += *begin;
-                break;
-            }
-        }
-        return escaped;
-    } // LCOV_EXCL_LINE
-
-private:
-    static bool convert_hexchar_to_byte(char source, uint8_t& byte) {
-        if ('0' <= source && source <= '9') {
-            // NOLINTNEXTLINE(bugprone-narrowing-conversions,cppcoreguidelines-narrowing-conversions)
-            byte = static_cast<uint8_t>(source - char('0'));
-            return true;
-        }
-
-        if ('A' <= source && source <= 'F') {
-            // NOLINTNEXTLINE(bugprone-narrowing-conversions,cppcoreguidelines-narrowing-conversions)
-            byte = static_cast<uint8_t>(source - 'A' + 10);
-            return true;
-        }
-
-        if ('a' <= source && source <= 'f') {
-            // NOLINTNEXTLINE(bugprone-narrowing-conversions,cppcoreguidelines-narrowing-conversions)
-            byte = static_cast<uint8_t>(source - 'a' + 10);
-            return true;
-        }
-
-        // The given character is not hexadecimal.
-        return false;
-    }
-
-    static bool extract_codepoint(const char*& begin, const char* end, int bytes_to_read, char32_t& codepoint) {
-        bool has_enough_room = static_cast<int>(std::distance(begin, end)) >= (bytes_to_read - 1);
-        if (!has_enough_room) {
-            return false;
-        }
-
-        int read_size = bytes_to_read * 2;
-        uint8_t byte {0};
-        codepoint = 0;
-
-        for (int i = read_size - 1; i >= 0; i--) {
-            bool is_valid = convert_hexchar_to_byte(*++begin, byte);
-            if (!is_valid) {
-                return false;
-            }
-            // NOLINTNEXTLINE(bugprone-narrowing-conversions,cppcoreguidelines-narrowing-conversions)
-            codepoint |= static_cast<char32_t>(byte << (4 * i));
-        }
-
-        return true;
-    }
-
-    static void unescape_escaped_unicode(char32_t codepoint, std::string& buff) {
-        std::array<uint8_t, 4> encode_buff {};
-        uint32_t encoded_size {0};
-        utf8::from_utf32(codepoint, encode_buff, encoded_size);
-        buff.append(reinterpret_cast<char*>(encode_buff.data()), encoded_size);
-    }
-};
-
-FK_YAML_DETAIL_NAMESPACE_END
-
-#endif /* FK_YAML_DETAIL_ENCODINGS_YAML_ESCAPER_HPP */
-
 // #include <fkYAML/detail/input/block_scalar_header.hpp>
 //  _______   __ __   __  _____   __  __  __
 // |   __| |_/  |  \_/  |/  _  \ /  \/  \|  |     fkYAML: A C++ header-only YAML library
@@ -3557,7 +3208,6 @@ private:
     lexical_token_t scan_directive() {
         FK_YAML_ASSERT(*m_cur_itr == '%');
 
-        m_value_buffer.clear();
         m_token_begin_itr = ++m_cur_itr;
 
         bool ends_loop = false;
@@ -4072,7 +3722,7 @@ private:
         std::size_t first_non_space_pos = sv.find_first_not_of(space_filter);
         if (first_non_space_pos == str_view::npos) {
             // empty block scalar
-            indent = 1; // FIXME: this is just a workaround for assertion in scalar_parser.
+            indent = static_cast<uint32_t>(sv.size());
             token = sv;
             return;
         }
@@ -4321,8 +3971,6 @@ private:
     const char* m_end_itr {};
     /// The current position tracker of the input buffer.
     mutable position_tracker m_pos_tracker {};
-    /// A temporal buffer to store a string to be parsed to an actual token value.
-    std::string m_value_buffer {};
     /// The last yaml version.
     str_view m_yaml_version {};
     /// The last tag handle.
@@ -5195,6 +4843,355 @@ FK_YAML_DETAIL_NAMESPACE_END
 
 #endif /* FK_YAML_CONVERSIONS_SCALAR_CONV_HPP */
 
+// #include <fkYAML/detail/encodings/yaml_escaper.hpp>
+//  _______   __ __   __  _____   __  __  __
+// |   __| |_/  |  \_/  |/  _  \ /  \/  \|  |     fkYAML: A C++ header-only YAML library
+// |   __|  _  < \_   _/|  ___  |    _   |  |___  version 0.3.12
+// |__|  |_| \__|  |_|  |_|   |_|___||___|______| https://github.com/fktn-k/fkYAML
+//
+// SPDX-FileCopyrightText: 2023-2024 Kensuke Fukutani <fktn.dev@gmail.com>
+// SPDX-License-Identifier: MIT
+
+#ifndef FK_YAML_DETAIL_ENCODINGS_YAML_ESCAPER_HPP
+#define FK_YAML_DETAIL_ENCODINGS_YAML_ESCAPER_HPP
+
+#include <string>
+
+// #include <fkYAML/detail/macros/version_macros.hpp>
+
+// #include <fkYAML/detail/assert.hpp>
+
+// #include <fkYAML/detail/encodings/utf_encodings.hpp>
+
+// #include <fkYAML/exception.hpp>
+
+
+FK_YAML_DETAIL_NAMESPACE_BEGIN
+
+class yaml_escaper {
+    using iterator = ::std::string::const_iterator;
+
+public:
+    static bool unescape(const char*& begin, const char* end, std::string& buff) {
+        FK_YAML_ASSERT(*begin == '\\' && std::distance(begin, end) > 0);
+        bool ret = true;
+
+        switch (*++begin) {
+        case 'a':
+            buff.push_back('\a');
+            break;
+        case 'b':
+            buff.push_back('\b');
+            break;
+        case 't':
+        case char(0x09):
+            buff.push_back('\t');
+            break;
+        case 'n':
+            buff.push_back('\n');
+            break;
+        case 'v':
+            buff.push_back('\v');
+            break;
+        case 'f':
+            buff.push_back('\f');
+            break;
+        case 'r':
+            buff.push_back('\r');
+            break;
+        case 'e':
+            buff.push_back(char(0x1B));
+            break;
+        case ' ':
+            buff.push_back(' ');
+            break;
+        case '\"':
+            buff.push_back('\"');
+            break;
+        case '/':
+            buff.push_back('/');
+            break;
+        case '\\':
+            buff.push_back('\\');
+            break;
+        case 'N': // next line
+            unescape_escaped_unicode(0x85u, buff);
+            break;
+        case '_': // non-breaking space
+            unescape_escaped_unicode(0xA0u, buff);
+            break;
+        case 'L': // line separator
+            unescape_escaped_unicode(0x2028u, buff);
+            break;
+        case 'P': // paragraph separator
+            unescape_escaped_unicode(0x2029u, buff);
+            break;
+        case 'x': {
+            char32_t codepoint {0};
+            ret = extract_codepoint(begin, end, 1, codepoint);
+            if FK_YAML_LIKELY (ret) {
+                unescape_escaped_unicode(codepoint, buff);
+            }
+            break;
+        }
+        case 'u': {
+            char32_t codepoint {0};
+            ret = extract_codepoint(begin, end, 2, codepoint);
+            if FK_YAML_LIKELY (ret) {
+                unescape_escaped_unicode(codepoint, buff);
+            }
+            break;
+        }
+        case 'U': {
+            char32_t codepoint {0};
+            ret = extract_codepoint(begin, end, 4, codepoint);
+            if FK_YAML_LIKELY (ret) {
+                unescape_escaped_unicode(codepoint, buff);
+            }
+            break;
+        }
+        default:
+            // Unsupported escape sequence is found in a string token.
+            ret = false;
+            break;
+        }
+
+        return ret;
+    }
+
+    static ::std::string escape(const char* begin, const char* end, bool& is_escaped) {
+        ::std::string escaped {};
+        escaped.reserve(std::distance(begin, end));
+        for (; begin != end; ++begin) {
+            switch (*begin) {
+            case 0x01:
+                escaped += "\\u0001";
+                is_escaped = true;
+                break;
+            case 0x02:
+                escaped += "\\u0002";
+                is_escaped = true;
+                break;
+            case 0x03:
+                escaped += "\\u0003";
+                is_escaped = true;
+                break;
+            case 0x04:
+                escaped += "\\u0004";
+                is_escaped = true;
+                break;
+            case 0x05:
+                escaped += "\\u0005";
+                is_escaped = true;
+                break;
+            case 0x06:
+                escaped += "\\u0006";
+                is_escaped = true;
+                break;
+            case '\a':
+                escaped += "\\a";
+                is_escaped = true;
+                break;
+            case '\b':
+                escaped += "\\b";
+                is_escaped = true;
+                break;
+            case '\t':
+                escaped += "\\t";
+                is_escaped = true;
+                break;
+            case '\n':
+                escaped += "\\n";
+                is_escaped = true;
+                break;
+            case '\v':
+                escaped += "\\v";
+                is_escaped = true;
+                break;
+            case '\f':
+                escaped += "\\f";
+                is_escaped = true;
+                break;
+            case '\r':
+                escaped += "\\r";
+                is_escaped = true;
+                break;
+            case 0x0E:
+                escaped += "\\u000E";
+                is_escaped = true;
+                break;
+            case 0x0F:
+                escaped += "\\u000F";
+                is_escaped = true;
+                break;
+            case 0x10:
+                escaped += "\\u0010";
+                is_escaped = true;
+                break;
+            case 0x11:
+                escaped += "\\u0011";
+                is_escaped = true;
+                break;
+            case 0x12:
+                escaped += "\\u0012";
+                is_escaped = true;
+                break;
+            case 0x13:
+                escaped += "\\u0013";
+                is_escaped = true;
+                break;
+            case 0x14:
+                escaped += "\\u0014";
+                is_escaped = true;
+                break;
+            case 0x15:
+                escaped += "\\u0015";
+                is_escaped = true;
+                break;
+            case 0x16:
+                escaped += "\\u0016";
+                is_escaped = true;
+                break;
+            case 0x17:
+                escaped += "\\u0017";
+                is_escaped = true;
+                break;
+            case 0x18:
+                escaped += "\\u0018";
+                is_escaped = true;
+                break;
+            case 0x19:
+                escaped += "\\u0019";
+                is_escaped = true;
+                break;
+            case 0x1A:
+                escaped += "\\u001A";
+                is_escaped = true;
+                break;
+            case 0x1B:
+                escaped += "\\e";
+                is_escaped = true;
+                break;
+            case 0x1C:
+                escaped += "\\u001C";
+                is_escaped = true;
+                break;
+            case 0x1D:
+                escaped += "\\u001D";
+                is_escaped = true;
+                break;
+            case 0x1E:
+                escaped += "\\u001E";
+                is_escaped = true;
+                break;
+            case 0x1F:
+                escaped += "\\u001F";
+                is_escaped = true;
+                break;
+            case '\"':
+                escaped += "\\\"";
+                is_escaped = true;
+                break;
+            case '\\':
+                escaped += "\\\\";
+                is_escaped = true;
+                break;
+            default:
+                int diff = static_cast<int>(std::distance(begin, end));
+                if (diff > 1) {
+                    if (*begin == char(0xC2u) && *(begin + 1) == char(0x85u)) {
+                        escaped += "\\N";
+                        std::advance(begin, 1);
+                        is_escaped = true;
+                        break;
+                    }
+                    else if (*begin == char(0xC2u) && *(begin + 1) == char(0xA0u)) {
+                        escaped += "\\_";
+                        std::advance(begin, 1);
+                        is_escaped = true;
+                        break;
+                    }
+
+                    if (diff > 2) {
+                        if (*begin == char(0xE2u) && *(begin + 1) == char(0x80u) && *(begin + 2) == char(0xA8u)) {
+                            escaped += "\\L";
+                            std::advance(begin, 2);
+                            is_escaped = true;
+                            break;
+                        }
+                        if (*begin == char(0xE2u) && *(begin + 1) == char(0x80u) && *(begin + 2) == char(0xA9u)) {
+                            escaped += "\\P";
+                            std::advance(begin, 2);
+                            is_escaped = true;
+                            break;
+                        }
+                    }
+                }
+                escaped += *begin;
+                break;
+            }
+        }
+        return escaped;
+    } // LCOV_EXCL_LINE
+
+private:
+    static bool convert_hexchar_to_byte(char source, uint8_t& byte) {
+        if ('0' <= source && source <= '9') {
+            // NOLINTNEXTLINE(bugprone-narrowing-conversions,cppcoreguidelines-narrowing-conversions)
+            byte = static_cast<uint8_t>(source - char('0'));
+            return true;
+        }
+
+        if ('A' <= source && source <= 'F') {
+            // NOLINTNEXTLINE(bugprone-narrowing-conversions,cppcoreguidelines-narrowing-conversions)
+            byte = static_cast<uint8_t>(source - 'A' + 10);
+            return true;
+        }
+
+        if ('a' <= source && source <= 'f') {
+            // NOLINTNEXTLINE(bugprone-narrowing-conversions,cppcoreguidelines-narrowing-conversions)
+            byte = static_cast<uint8_t>(source - 'a' + 10);
+            return true;
+        }
+
+        // The given character is not hexadecimal.
+        return false;
+    }
+
+    static bool extract_codepoint(const char*& begin, const char* end, int bytes_to_read, char32_t& codepoint) {
+        bool has_enough_room = static_cast<int>(std::distance(begin, end)) >= (bytes_to_read - 1);
+        if (!has_enough_room) {
+            return false;
+        }
+
+        int read_size = bytes_to_read * 2;
+        uint8_t byte {0};
+        codepoint = 0;
+
+        for (int i = read_size - 1; i >= 0; i--) {
+            bool is_valid = convert_hexchar_to_byte(*++begin, byte);
+            if (!is_valid) {
+                return false;
+            }
+            // NOLINTNEXTLINE(bugprone-narrowing-conversions,cppcoreguidelines-narrowing-conversions)
+            codepoint |= static_cast<char32_t>(byte << (4 * i));
+        }
+
+        return true;
+    }
+
+    static void unescape_escaped_unicode(char32_t codepoint, std::string& buff) {
+        std::array<uint8_t, 4> encode_buff {};
+        uint32_t encoded_size {0};
+        utf8::from_utf32(codepoint, encode_buff, encoded_size);
+        buff.append(reinterpret_cast<char*>(encode_buff.data()), encoded_size);
+    }
+};
+
+FK_YAML_DETAIL_NAMESPACE_END
+
+#endif /* FK_YAML_DETAIL_ENCODINGS_YAML_ESCAPER_HPP */
+
 // #include <fkYAML/detail/input/block_scalar_header.hpp>
 
 // #include <fkYAML/detail/input/scalar_scanner.hpp>
@@ -5699,8 +5696,9 @@ private:
 
             if (token[pos] == '\\') {
                 FK_YAML_ASSERT(pos + 1 < token.size());
+                m_buffer.append(token.begin(), token.begin() + pos);
+
                 if (token[pos + 1] != '\n') {
-                    m_buffer.append(token.begin(), token.begin() + pos);
                     token.remove_prefix(pos);
                     const char* p_escape_begin = token.begin();
                     bool is_valid_escaping = yaml_escaper::unescape(p_escape_begin, token.end(), m_buffer);
@@ -5711,6 +5709,13 @@ private:
 
                     // `p_escape_begin` points to the last element of the escape sequence.
                     token.remove_prefix((p_escape_begin - token.begin()) + 1);
+                }
+                else {
+                    std::size_t non_space_pos = token.find_first_not_of(" \t", pos + 2);
+                    if (non_space_pos == str_view::npos) {
+                        non_space_pos = token.size();
+                    }
+                    token.remove_prefix(non_space_pos);
                 }
             }
             else {
@@ -5839,8 +5844,13 @@ private:
                     break;
                 }
 
-                // remove all trailing newlines.
-                m_buffer.erase(content_end_pos);
+                if (content_end_pos == m_buffer.size() - 1) {
+                    // no last content line break nor trailing empty lines.
+                    break;
+                }
+
+                // remove the last content line break and all trailing empty lines.
+                m_buffer.erase(content_end_pos + 1);
 
                 break;
             }
@@ -5858,7 +5868,7 @@ private:
                 }
 
                 // remove all trailing empty lines.
-                m_buffer.erase(content_end_pos + 1);
+                m_buffer.erase(content_end_pos + 2);
 
                 break;
             }
@@ -5870,7 +5880,7 @@ private:
 
     void process_line_folding(str_view& token, std::size_t newline_pos) noexcept {
         // discard trailing white spaces which precedes the line break in the current line.
-        std::size_t last_non_space_pos = token.substr(0, newline_pos).find_last_not_of(" \t");
+        std::size_t last_non_space_pos = token.substr(0, newline_pos + 1).find_last_not_of(" \t");
         if (last_non_space_pos == str_view::npos) {
             m_buffer.append(token.begin(), newline_pos);
         }
@@ -5892,6 +5902,7 @@ private:
                 break;
             }
 
+            token.remove_prefix(non_space_pos + 1);
             ++empty_line_counts;
         } while (true);
 

--- a/test/unit_test/CMakeLists.txt
+++ b/test/unit_test/CMakeLists.txt
@@ -230,6 +230,7 @@ add_executable(
   test_ordered_map_class.cpp
   test_position_tracker_class.cpp
   test_scalar_conv.cpp
+  test_scalar_parser_class.cpp
   test_scalar_scanner_class.cpp
   test_serializer_class.cpp
   test_str_view_class.cpp

--- a/test/unit_test/test_lexical_analyzer_class.cpp
+++ b/test/unit_test/test_lexical_analyzer_class.cpp
@@ -330,58 +330,58 @@ TEST_CASE("LexicalAnalzer_BlockSequenceEntryPrefix") {
 }
 
 TEST_CASE("LexicalAnalyzer_PlainScalar") {
-    using value_pair_t = std::pair<fkyaml::detail::str_view, fkyaml::detail::str_view>;
-    auto value_pair = GENERATE(
-        value_pair_t("test", "test"),
-        value_pair_t("nop", "nop"),
-        value_pair_t("none", "none"),
-        value_pair_t("?test", "?test"),
-        value_pair_t(".NET", ".NET"),
-        value_pair_t(".on", ".on"),
-        value_pair_t(".n", ".n"),
-        value_pair_t("-t", "-t"),
-        value_pair_t("-foo", "-foo"),
-        value_pair_t("-.test", "-.test"),
-        value_pair_t("?", "?"),
-        value_pair_t("--foo", "--foo"),
-        value_pair_t("+123", "+123"),
-        value_pair_t("1.2.3", "1.2.3"),
-        value_pair_t("foo,bar", "foo,bar"),
-        value_pair_t("foo[bar", "foo[bar"),
-        value_pair_t("foo]bar", "foo]bar"),
-        value_pair_t("foo{bar", "foo{bar"),
-        value_pair_t("foo}bar", "foo}bar"),
-        value_pair_t("foo:bar", "foo:bar"),
-        value_pair_t("foo bar", "foo bar"),
-        value_pair_t("foo\"bar", "foo\"bar"),
-        value_pair_t("foo\'s bar", "foo\'s bar"),
-        value_pair_t("foo\\bar", "foo\\bar"),
-        value_pair_t("nullValue", "nullValue"),
-        value_pair_t("NullValue", "NullValue"),
-        value_pair_t("NULL_VALUE", "NULL_VALUE"),
-        value_pair_t("~Value", "~Value"),
-        value_pair_t("trueValue", "trueValue"),
-        value_pair_t("TrueValue", "TrueValue"),
-        value_pair_t("TRUE_VALUE", "TRUE_VALUE"),
-        value_pair_t("falseValue", "falseValue"),
-        value_pair_t("FalseValue", "FalseValue"),
-        value_pair_t("FALSE_VALUE", "FALSE_VALUE"),
-        value_pair_t(".infValue", ".infValue"),
-        value_pair_t(".InfValue", ".InfValue"),
-        value_pair_t(".INF_VALUE", ".INF_VALUE"),
-        value_pair_t("-.infValue", "-.infValue"),
-        value_pair_t("-.InfValue", "-.InfValue"),
-        value_pair_t("-.INF_VALUE", "-.INF_VALUE"),
-        value_pair_t(".nanValue", ".nanValue"),
-        value_pair_t(".NaNValue", ".NaNValue"),
-        value_pair_t(".NAN_VALUE", ".NAN_VALUE"));
+    auto input = GENERATE(
+        fkyaml::detail::str_view("test"),
+        fkyaml::detail::str_view("nop"),
+        fkyaml::detail::str_view("none"),
+        fkyaml::detail::str_view("?test"),
+        fkyaml::detail::str_view(".NET"),
+        fkyaml::detail::str_view(".on"),
+        fkyaml::detail::str_view(".n"),
+        fkyaml::detail::str_view("-t"),
+        fkyaml::detail::str_view("-foo"),
+        fkyaml::detail::str_view("-.test"),
+        fkyaml::detail::str_view("?"),
+        fkyaml::detail::str_view("--foo"),
+        fkyaml::detail::str_view("+123"),
+        fkyaml::detail::str_view("1.2.3"),
+        fkyaml::detail::str_view("foo,bar"),
+        fkyaml::detail::str_view("foo[bar"),
+        fkyaml::detail::str_view("foo]bar"),
+        fkyaml::detail::str_view("foo{bar"),
+        fkyaml::detail::str_view("foo}bar"),
+        fkyaml::detail::str_view("foo:bar"),
+        fkyaml::detail::str_view("foo bar"),
+        fkyaml::detail::str_view("foo\"bar"),
+        fkyaml::detail::str_view("foo\'s bar"),
+        fkyaml::detail::str_view("foo\\bar"),
+        fkyaml::detail::str_view("nullValue"),
+        fkyaml::detail::str_view("NullValue"),
+        fkyaml::detail::str_view("NULL_VALUE"),
+        fkyaml::detail::str_view("~Value"),
+        fkyaml::detail::str_view("trueValue"),
+        fkyaml::detail::str_view("TrueValue"),
+        fkyaml::detail::str_view("TRUE_VALUE"),
+        fkyaml::detail::str_view("falseValue"),
+        fkyaml::detail::str_view("FalseValue"),
+        fkyaml::detail::str_view("FALSE_VALUE"),
+        fkyaml::detail::str_view(".infValue"),
+        fkyaml::detail::str_view(".InfValue"),
+        fkyaml::detail::str_view(".INF_VALUE"),
+        fkyaml::detail::str_view("-.infValue"),
+        fkyaml::detail::str_view("-.InfValue"),
+        fkyaml::detail::str_view("-.INF_VALUE"),
+        fkyaml::detail::str_view(".nanValue"),
+        fkyaml::detail::str_view(".NaNValue"),
+        fkyaml::detail::str_view(".NAN_VALUE"));
 
-    fkyaml::detail::lexical_analyzer lexer(value_pair.first);
+    fkyaml::detail::lexical_analyzer lexer(input);
     fkyaml::detail::lexical_token token;
 
     REQUIRE_NOTHROW(token = lexer.get_next_token());
     REQUIRE(token.type == fkyaml::detail::lexical_token_t::PLAIN_SCALAR);
-    REQUIRE(token.str == value_pair.second);
+    REQUIRE(token.str.begin() == input.begin());
+    REQUIRE(token.str.end() == input.end());
 }
 
 TEST_CASE("LexicalAnalyzer_SingleQuotedScalar") {
@@ -415,33 +415,34 @@ TEST_CASE("LexicalAnalyzer_SingleQuotedScalar") {
 }
 
 TEST_CASE("LexicalAnalyzer_DoubleQuotedScalar") {
-    using value_pair_t = std::pair<fkyaml::detail::str_view, fkyaml::detail::str_view>;
-    auto value_pair = GENERATE(
-        value_pair_t("\"\"", ""),
-        value_pair_t("\"foo bar\"", "foo bar"),
-        value_pair_t("\"foo\tbar\"", "foo\tbar"),
-        value_pair_t("\"foo's bar\"", "foo's bar"),
-        value_pair_t("\"foo:bar\"", "foo:bar"),
-        value_pair_t("\"foo,bar\"", "foo,bar"),
-        value_pair_t("\"foo]bar\"", "foo]bar"),
-        value_pair_t("\"foo}bar\"", "foo}bar"),
-        value_pair_t("\"\\x30\\x2B\\x6d\"", "0+m"),
+    auto input = GENERATE(
+        fkyaml::detail::str_view("\"\""),
+        fkyaml::detail::str_view("\"\\\"\""),
+        fkyaml::detail::str_view("\"foo bar\""),
+        fkyaml::detail::str_view("\"foo\tbar\""),
+        fkyaml::detail::str_view("\"foo's bar\""),
+        fkyaml::detail::str_view("\"foo:bar\""),
+        fkyaml::detail::str_view("\"foo,bar\""),
+        fkyaml::detail::str_view("\"foo]bar\""),
+        fkyaml::detail::str_view("\"foo}bar\""),
+        fkyaml::detail::str_view("\"\\x30\\x2B\\x6d\""),
 
-        value_pair_t("\"foo\nbar\"", "foo bar"),
-        value_pair_t("\"foo \t\n \tbar\"", "foo bar"),
-        value_pair_t("\"foo\n\n \t\nbar\"", "foo\n\nbar"),
-        value_pair_t("\"\nfoo\n\n \t\nbar\"", " foo\n\nbar"),
-        value_pair_t("\"foo\nbar\n\"", "foo bar "),
-        value_pair_t("\"foo\\\nbar\"", "foobar"),
-        value_pair_t("\"foo \t\\\nbar\"", "foo \tbar"),
-        value_pair_t("\"\\\n  foo \t\\\n\tbar\t  \t\\\n\"", "foo \tbar\t  \t"));
+        fkyaml::detail::str_view("\"foo\nbar\""),
+        fkyaml::detail::str_view("\"foo \t\n \tbar\""),
+        fkyaml::detail::str_view("\"foo\n\n \t\nbar\""),
+        fkyaml::detail::str_view("\"\nfoo\n\n \t\nbar\""),
+        fkyaml::detail::str_view("\"foo\nbar\n\""),
+        fkyaml::detail::str_view("\"foo\\\nbar\""),
+        fkyaml::detail::str_view("\"foo \t\\\nbar\""),
+        fkyaml::detail::str_view("\"\\\n  foo \t\\\n\tbar\t  \t\\\n\""));
 
-    fkyaml::detail::lexical_analyzer lexer(value_pair.first);
+    fkyaml::detail::lexical_analyzer lexer(input);
     fkyaml::detail::lexical_token token;
 
     REQUIRE_NOTHROW(token = lexer.get_next_token());
     REQUIRE(token.type == fkyaml::detail::lexical_token_t::DOUBLE_QUOTED_SCALAR);
-    REQUIRE(token.str == value_pair.second);
+    REQUIRE(token.str.begin() == input.begin() + 1);
+    REQUIRE(token.str.end() == input.end() - 1);
 }
 
 TEST_CASE("LexicalAnalyzer_MultiByteCharString") {
@@ -504,87 +505,46 @@ TEST_CASE("LexicalAnalyzer_MultiByteCharString") {
 TEST_CASE("LexicalAnalyzer_EscapedUnicodeCharacter") {
     using value_pair_t = std::pair<fkyaml::detail::str_view, std::string>;
     using char_traits_t = std::char_traits<char>;
-    auto value_pair = GENERATE(
-        value_pair_t("\"\\x00\"", {char_traits_t::to_char_type(0x00)}),
-        value_pair_t("\"\\x40\"", {char_traits_t::to_char_type(0x40)}),
-        value_pair_t("\"\\x7F\"", {char_traits_t::to_char_type(0x7F)}),
-        value_pair_t("\"\\u0000\"", {char_traits_t::to_char_type(0x00)}),
-        value_pair_t("\"\\u0040\"", {char_traits_t::to_char_type(0x40)}),
-        value_pair_t("\"\\u007F\"", {char_traits_t::to_char_type(0x7F)}),
-        value_pair_t("\"\\u0080\"", {char_traits_t::to_char_type(0xC2), char_traits_t::to_char_type(0x80)}),
-        value_pair_t("\"\\u0400\"", {char_traits_t::to_char_type(0xD0), char_traits_t::to_char_type(0x80)}),
-        value_pair_t("\"\\u07FF\"", {char_traits_t::to_char_type(0xDF), char_traits_t::to_char_type(0xBF)}),
-        value_pair_t(
-            "\"\\u0800\"",
-            {char_traits_t::to_char_type(0xE0), char_traits_t::to_char_type(0xA0), char_traits_t::to_char_type(0x80)}),
-        value_pair_t(
-            "\"\\u8000\"",
-            {char_traits_t::to_char_type(0xE8), char_traits_t::to_char_type(0x80), char_traits_t::to_char_type(0x80)}),
-        value_pair_t(
-            "\"\\uFFFF\"",
-            {char_traits_t::to_char_type(0xEF), char_traits_t::to_char_type(0xBF), char_traits_t::to_char_type(0xBF)}),
-        value_pair_t("\"\\U00000000\"", {char_traits_t::to_char_type(0x00)}),
-        value_pair_t("\"\\U00000040\"", {char_traits_t::to_char_type(0x40)}),
-        value_pair_t("\"\\U0000007F\"", {char_traits_t::to_char_type(0x7F)}),
-        value_pair_t("\"\\U00000080\"", {char_traits_t::to_char_type(0xC2), char_traits_t::to_char_type(0x80)}),
-        value_pair_t("\"\\U00000400\"", {char_traits_t::to_char_type(0xD0), char_traits_t::to_char_type(0x80)}),
-        value_pair_t("\"\\U000007FF\"", {char_traits_t::to_char_type(0xDF), char_traits_t::to_char_type(0xBF)}),
-        value_pair_t(
-            "\"\\U00000800\"",
-            {char_traits_t::to_char_type(0xE0), char_traits_t::to_char_type(0xA0), char_traits_t::to_char_type(0x80)}),
-        value_pair_t(
-            "\"\\U00008000\"",
-            {char_traits_t::to_char_type(0xE8), char_traits_t::to_char_type(0x80), char_traits_t::to_char_type(0x80)}),
-        value_pair_t(
-            "\"\\U0000FFFF\"",
-            {char_traits_t::to_char_type(0xEF), char_traits_t::to_char_type(0xBF), char_traits_t::to_char_type(0xBF)}),
-        value_pair_t(
-            "\"\\U00010000\"",
-            {char_traits_t::to_char_type(0xF0),
-             char_traits_t::to_char_type(0x90),
-             char_traits_t::to_char_type(0x80),
-             char_traits_t::to_char_type(0x80)}),
-        value_pair_t(
-            "\"\\U00080000\"",
-            {char_traits_t::to_char_type(0xF2),
-             char_traits_t::to_char_type(0x80),
-             char_traits_t::to_char_type(0x80),
-             char_traits_t::to_char_type(0x80)}),
-        value_pair_t(
-            "\"\\U0010FFFF\"",
-            {char_traits_t::to_char_type(0xF4),
-             char_traits_t::to_char_type(0x8F),
-             char_traits_t::to_char_type(0xBF),
-             char_traits_t::to_char_type(0xBF)}));
+    auto input = GENERATE(
+        fkyaml::detail::str_view("\"\\x00\""),
+        fkyaml::detail::str_view("\"\\x40\""),
+        fkyaml::detail::str_view("\"\\x7F\""),
+        fkyaml::detail::str_view("\"\\u0000\""),
+        fkyaml::detail::str_view("\"\\u0040\""),
+        fkyaml::detail::str_view("\"\\u007F\""),
+        fkyaml::detail::str_view("\"\\u0080\""),
+        fkyaml::detail::str_view("\"\\u0400\""),
+        fkyaml::detail::str_view("\"\\u07FF\""),
+        fkyaml::detail::str_view("\"\\u0800\""),
+        fkyaml::detail::str_view("\"\\u8000\""),
+        fkyaml::detail::str_view("\"\\uFFFF\""),
+        fkyaml::detail::str_view("\"\\U00000000\""),
+        fkyaml::detail::str_view("\"\\U00000040\""),
+        fkyaml::detail::str_view("\"\\U0000007F\""),
+        fkyaml::detail::str_view("\"\\U00000080\""),
+        fkyaml::detail::str_view("\"\\U00000400\""),
+        fkyaml::detail::str_view("\"\\U000007FF\""),
+        fkyaml::detail::str_view("\"\\U00000800\""),
+        fkyaml::detail::str_view("\"\\U00008000\""),
+        fkyaml::detail::str_view("\"\\U0000FFFF\""),
+        fkyaml::detail::str_view("\"\\U00010000\""),
+        fkyaml::detail::str_view("\"\\U00080000\""),
+        fkyaml::detail::str_view("\"\\U0010FFFF\""));
 
-    fkyaml::detail::lexical_analyzer lexer(value_pair.first);
+    fkyaml::detail::lexical_analyzer lexer(input);
     fkyaml::detail::lexical_token token;
 
     REQUIRE_NOTHROW(token = lexer.get_next_token());
     REQUIRE(token.type == fkyaml::detail::lexical_token_t::DOUBLE_QUOTED_SCALAR);
-    REQUIRE(token.str == value_pair.second);
+    REQUIRE(token.str.begin() == input.begin() + 1);
+    REQUIRE(token.str.end() == input.end() - 1);
 }
 
-TEST_CASE("LexicalAnalyzer_InvalidString") {
-    SECTION("parse error") {
-        auto buffer = GENERATE(
-            fkyaml::detail::str_view("\"test"),
-            fkyaml::detail::str_view("\'test"),
-            fkyaml::detail::str_view("\"\\xw\""),
-            fkyaml::detail::str_view("\"\\x+\""),
-            fkyaml::detail::str_view("\"\\x=\""),
-            fkyaml::detail::str_view("\"\\x^\""),
-            fkyaml::detail::str_view("\"\\x{\""),
-            fkyaml::detail::str_view("\"\\Q\""));
+TEST_CASE("LexicalAnalyzer_UnclosedQuotedString") {
+    auto buffer = GENERATE(fkyaml::detail::str_view("\"test"), fkyaml::detail::str_view("\'test"));
 
-        fkyaml::detail::lexical_analyzer lexer(buffer);
-        REQUIRE_THROWS_AS(lexer.get_next_token(), fkyaml::parse_error);
-    }
-
-    SECTION("invalid encoding") {
-        fkyaml::detail::lexical_analyzer lexer("\"\\U00110000\"");
-        REQUIRE_THROWS_AS(lexer.get_next_token(), fkyaml::invalid_encoding);
-    }
+    fkyaml::detail::lexical_analyzer lexer(buffer);
+    REQUIRE_THROWS_AS(lexer.get_next_token(), fkyaml::parse_error);
 }
 
 TEST_CASE("LexicalAnalyzer_UnescapedControlCharacter") {

--- a/test/unit_test/test_lexical_analyzer_class.cpp
+++ b/test/unit_test/test_lexical_analyzer_class.cpp
@@ -503,8 +503,6 @@ TEST_CASE("LexicalAnalyzer_MultiByteCharString") {
 }
 
 TEST_CASE("LexicalAnalyzer_EscapedUnicodeCharacter") {
-    using value_pair_t = std::pair<fkyaml::detail::str_view, std::string>;
-    using char_traits_t = std::char_traits<char>;
     auto input = GENERATE(
         fkyaml::detail::str_view("\"\\x00\""),
         fkyaml::detail::str_view("\"\\x40\""),
@@ -597,6 +595,7 @@ TEST_CASE("LexicalAnalyzer_LiteralStringScalar") {
         REQUIRE(token.str.begin() == &input[3]);
         REQUIRE(token.str.end() == &input[0] + 6);
         REQUIRE(lexer.get_block_scalar_header().chomp == fkyaml::detail::chomping_indicator_t::STRIP);
+        REQUIRE(lexer.get_block_scalar_header().indent == 3); // lexer returns content size if empty.
     }
 
     SECTION("empty literal string scalar with clip chomping") {
@@ -609,6 +608,7 @@ TEST_CASE("LexicalAnalyzer_LiteralStringScalar") {
         REQUIRE(token.str.begin() == &input[2]);
         REQUIRE(token.str.end() == &input[0] + 5);
         REQUIRE(lexer.get_block_scalar_header().chomp == fkyaml::detail::chomping_indicator_t::CLIP);
+        REQUIRE(lexer.get_block_scalar_header().indent == 3); // lexer returns content size if empty.
     }
 
     SECTION("empty literal string scalar with keep chomping") {
@@ -621,6 +621,7 @@ TEST_CASE("LexicalAnalyzer_LiteralStringScalar") {
         REQUIRE(token.str.begin() == &input[3]);
         REQUIRE(token.str.end() == &input[0] + 6);
         REQUIRE(lexer.get_block_scalar_header().chomp == fkyaml::detail::chomping_indicator_t::KEEP);
+        REQUIRE(lexer.get_block_scalar_header().indent == 3); // lexer returns content size if empty.
     }
 
     SECTION("literal string scalar with 0 indent level.") {
@@ -831,7 +832,7 @@ TEST_CASE("LexicalAnalyzer_FoldedString") {
         REQUIRE(token.str.begin() == &input[3]);
         REQUIRE(token.str.end() == &input[0] + 6);
         REQUIRE(lexer.get_block_scalar_header().chomp == fkyaml::detail::chomping_indicator_t::STRIP);
-        REQUIRE(lexer.get_block_scalar_header().indent == 1);
+        REQUIRE(lexer.get_block_scalar_header().indent == 3); // lexer returns content size if empty.
     }
 
     SECTION("empty folded string scalar with clip chomping") {
@@ -844,7 +845,7 @@ TEST_CASE("LexicalAnalyzer_FoldedString") {
         REQUIRE(token.str.begin() == &input[2]);
         REQUIRE(token.str.end() == &input[0] + 5);
         REQUIRE(lexer.get_block_scalar_header().chomp == fkyaml::detail::chomping_indicator_t::CLIP);
-        REQUIRE(lexer.get_block_scalar_header().indent == 1);
+        REQUIRE(lexer.get_block_scalar_header().indent == 3); // lexer returns content size if empty.
     }
 
     SECTION("empty folded string scalar with keep chomping") {
@@ -857,7 +858,7 @@ TEST_CASE("LexicalAnalyzer_FoldedString") {
         REQUIRE(token.str.begin() == &input[3]);
         REQUIRE(token.str.end() == &input[0] + 6);
         REQUIRE(lexer.get_block_scalar_header().chomp == fkyaml::detail::chomping_indicator_t::KEEP);
-        REQUIRE(lexer.get_block_scalar_header().indent == 1);
+        REQUIRE(lexer.get_block_scalar_header().indent == 3); // lexer returns content size if empty.
     }
 
     SECTION("folded string scalar with 0 indent level") {

--- a/test/unit_test/test_lexical_analyzer_class.cpp
+++ b/test/unit_test/test_lexical_analyzer_class.cpp
@@ -385,32 +385,33 @@ TEST_CASE("LexicalAnalyzer_PlainScalar") {
 }
 
 TEST_CASE("LexicalAnalyzer_SingleQuotedScalar") {
-    using value_pair_t = std::pair<fkyaml::detail::str_view, fkyaml::detail::str_view>;
+    using value_pair_t = std::pair<fkyaml::detail::str_view, uint32_t /*end offset*/>;
     auto value_pair = GENERATE(
-        value_pair_t("\'\'", ""),
-        value_pair_t("\'foo\"bar\'", "foo\"bar"),
-        value_pair_t("\'foo bar\'", "foo bar"),
-        value_pair_t("\'foo\'\'bar\'", "foo\'bar"),
-        value_pair_t("\'foo\'\'bar\' ", "foo\'bar"),
-        value_pair_t("\'foo,bar\'", "foo,bar"),
-        value_pair_t("\'foo]bar\'", "foo]bar"),
-        value_pair_t("\'foo}bar\'", "foo}bar"),
-        value_pair_t("\'foo\"bar\'", "foo\"bar"),
-        value_pair_t("\'foo:bar\'", "foo:bar"),
-        value_pair_t("\'foo\\bar\'", "foo\\bar"),
+        value_pair_t("\'\'", 1),
+        value_pair_t("\'foo\"bar\'", 1),
+        value_pair_t("\'foo bar\'", 1),
+        value_pair_t("\'foo\'\'bar\'", 1),
+        value_pair_t("\'foo\'\'bar\' ", 2),
+        value_pair_t("\'foo,bar\'", 1),
+        value_pair_t("\'foo]bar\'", 1),
+        value_pair_t("\'foo}bar\'", 1),
+        value_pair_t("\'foo\"bar\'", 1),
+        value_pair_t("\'foo:bar\'", 1),
+        value_pair_t("\'foo\\bar\'", 1),
 
-        value_pair_t("\'foo\nbar\'", "foo bar"),
-        value_pair_t("\'foo \t\n \tbar\'", "foo bar"),
-        value_pair_t("\'foo\n\n \t\nbar\'", "foo\n\nbar"),
-        value_pair_t("\'\nfoo\n\n \t\nbar\'", " foo\n\nbar"),
-        value_pair_t("\'foo\nbar\n\'", "foo bar "));
+        value_pair_t("\'foo\nbar\'", 1),
+        value_pair_t("\'foo \t\n \tbar\'", 1),
+        value_pair_t("\'foo\n\n \t\nbar\'", 1),
+        value_pair_t("\'\nfoo\n\n \t\nbar\'", 1),
+        value_pair_t("\'foo\nbar\n\'", 1));
 
     fkyaml::detail::lexical_analyzer lexer(value_pair.first);
     fkyaml::detail::lexical_token token;
 
     REQUIRE_NOTHROW(token = lexer.get_next_token());
     REQUIRE(token.type == fkyaml::detail::lexical_token_t::SINGLE_QUOTED_SCALAR);
-    REQUIRE(token.str == value_pair.second);
+    REQUIRE(token.str.begin() == value_pair.first.begin() + 1);
+    REQUIRE(token.str.end() == value_pair.first.end() - value_pair.second);
 }
 
 TEST_CASE("LexicalAnalyzer_DoubleQuotedScalar") {

--- a/test/unit_test/test_lexical_analyzer_class.cpp
+++ b/test/unit_test/test_lexical_analyzer_class.cpp
@@ -593,8 +593,10 @@ TEST_CASE("LexicalAnalyzer_LiteralStringScalar") {
         fkyaml::detail::lexical_analyzer lexer(input);
 
         REQUIRE_NOTHROW(token = lexer.get_next_token());
-        REQUIRE(token.type == fkyaml::detail::lexical_token_t::BLOCK_SCALAR);
-        REQUIRE(token.str == "");
+        REQUIRE(token.type == fkyaml::detail::lexical_token_t::BLOCK_LITERAL_SCALAR);
+        REQUIRE(token.str.begin() == &input[3]);
+        REQUIRE(token.str.end() == &input[0] + 6);
+        REQUIRE(lexer.get_block_scalar_header().chomp == fkyaml::detail::chomping_indicator_t::STRIP);
     }
 
     SECTION("empty literal string scalar with clip chomping") {
@@ -603,8 +605,10 @@ TEST_CASE("LexicalAnalyzer_LiteralStringScalar") {
         fkyaml::detail::lexical_analyzer lexer(input);
 
         REQUIRE_NOTHROW(token = lexer.get_next_token());
-        REQUIRE(token.type == fkyaml::detail::lexical_token_t::BLOCK_SCALAR);
-        REQUIRE(token.str == "");
+        REQUIRE(token.type == fkyaml::detail::lexical_token_t::BLOCK_LITERAL_SCALAR);
+        REQUIRE(token.str.begin() == &input[2]);
+        REQUIRE(token.str.end() == &input[0] + 5);
+        REQUIRE(lexer.get_block_scalar_header().chomp == fkyaml::detail::chomping_indicator_t::CLIP);
     }
 
     SECTION("empty literal string scalar with keep chomping") {
@@ -613,8 +617,10 @@ TEST_CASE("LexicalAnalyzer_LiteralStringScalar") {
         fkyaml::detail::lexical_analyzer lexer(input);
 
         REQUIRE_NOTHROW(token = lexer.get_next_token());
-        REQUIRE(token.type == fkyaml::detail::lexical_token_t::BLOCK_SCALAR);
-        REQUIRE(token.str == "\n");
+        REQUIRE(token.type == fkyaml::detail::lexical_token_t::BLOCK_LITERAL_SCALAR);
+        REQUIRE(token.str.begin() == &input[3]);
+        REQUIRE(token.str.end() == &input[0] + 6);
+        REQUIRE(lexer.get_block_scalar_header().chomp == fkyaml::detail::chomping_indicator_t::KEEP);
     }
 
     SECTION("literal string scalar with 0 indent level.") {
@@ -640,8 +646,11 @@ TEST_CASE("LexicalAnalyzer_LiteralStringScalar") {
         fkyaml::detail::lexical_analyzer lexer(input);
 
         REQUIRE_NOTHROW(token = lexer.get_next_token());
-        REQUIRE(token.type == fkyaml::detail::lexical_token_t::BLOCK_SCALAR);
-        REQUIRE(token.str == "  foo\nbar\n");
+        REQUIRE(token.type == fkyaml::detail::lexical_token_t::BLOCK_LITERAL_SCALAR);
+        REQUIRE(token.str.begin() == &input[3]);
+        REQUIRE(token.str.end() == &input[0] + 17);
+        REQUIRE(lexer.get_block_scalar_header().chomp == fkyaml::detail::chomping_indicator_t::CLIP);
+        REQUIRE(lexer.get_block_scalar_header().indent == 2);
     }
 
     SECTION("literal string scalar") {
@@ -651,8 +660,11 @@ TEST_CASE("LexicalAnalyzer_LiteralStringScalar") {
         fkyaml::detail::lexical_analyzer lexer(input);
 
         REQUIRE_NOTHROW(token = lexer.get_next_token());
-        REQUIRE(token.type == fkyaml::detail::lexical_token_t::BLOCK_SCALAR);
-        REQUIRE(token.str == "foo\nbar\n");
+        REQUIRE(token.type == fkyaml::detail::lexical_token_t::BLOCK_LITERAL_SCALAR);
+        REQUIRE(token.str.begin() == &input[2]);
+        REQUIRE(token.str.end() == &input[0] + 14);
+        REQUIRE(lexer.get_block_scalar_header().chomp == fkyaml::detail::chomping_indicator_t::CLIP);
+        REQUIRE(lexer.get_block_scalar_header().indent == 2);
     }
 
     SECTION("literal string scalar with implicit indentation and strip chomping") {
@@ -666,8 +678,11 @@ TEST_CASE("LexicalAnalyzer_LiteralStringScalar") {
         fkyaml::detail::lexical_analyzer lexer(input);
 
         REQUIRE_NOTHROW(token = lexer.get_next_token());
-        REQUIRE(token.type == fkyaml::detail::lexical_token_t::BLOCK_SCALAR);
-        REQUIRE(token.str == "\nfoo\nbar\n\nbaz");
+        REQUIRE(token.type == fkyaml::detail::lexical_token_t::BLOCK_LITERAL_SCALAR);
+        REQUIRE(token.str.begin() == &input[3]);
+        REQUIRE(token.str.end() == &input[0] + 24);
+        REQUIRE(lexer.get_block_scalar_header().chomp == fkyaml::detail::chomping_indicator_t::STRIP);
+        REQUIRE(lexer.get_block_scalar_header().indent == 2);
     }
 
     SECTION("literal string scalar with explicit indentation and strip chomping") {
@@ -680,8 +695,11 @@ TEST_CASE("LexicalAnalyzer_LiteralStringScalar") {
         fkyaml::detail::lexical_analyzer lexer(input);
 
         REQUIRE_NOTHROW(token = lexer.get_next_token());
-        REQUIRE(token.type == fkyaml::detail::lexical_token_t::BLOCK_SCALAR);
-        REQUIRE(token.str == "foo\n  bar\n\nbaz");
+        REQUIRE(token.type == fkyaml::detail::lexical_token_t::BLOCK_LITERAL_SCALAR);
+        REQUIRE(token.str.begin() == &input[4]);
+        REQUIRE(token.str.end() == &input[0] + 26);
+        REQUIRE(lexer.get_block_scalar_header().chomp == fkyaml::detail::chomping_indicator_t::STRIP);
+        REQUIRE(lexer.get_block_scalar_header().indent == 2);
     }
 
     SECTION("literal string scalar with implicit indentation and clip chomping") {
@@ -695,8 +713,11 @@ TEST_CASE("LexicalAnalyzer_LiteralStringScalar") {
         fkyaml::detail::lexical_analyzer lexer(input);
 
         REQUIRE_NOTHROW(token = lexer.get_next_token());
-        REQUIRE(token.type == fkyaml::detail::lexical_token_t::BLOCK_SCALAR);
-        REQUIRE(token.str == "\nfoo\nbar\n\nbaz\n");
+        REQUIRE(token.type == fkyaml::detail::lexical_token_t::BLOCK_LITERAL_SCALAR);
+        REQUIRE(token.str.begin() == &input[2]);
+        REQUIRE(token.str.end() == &input[0] + 23);
+        REQUIRE(lexer.get_block_scalar_header().chomp == fkyaml::detail::chomping_indicator_t::CLIP);
+        REQUIRE(lexer.get_block_scalar_header().indent == 2);
     }
 
     SECTION("literal string scalar with explicit indentation and clip chomping") {
@@ -709,8 +730,11 @@ TEST_CASE("LexicalAnalyzer_LiteralStringScalar") {
         fkyaml::detail::lexical_analyzer lexer(input);
 
         REQUIRE_NOTHROW(token = lexer.get_next_token());
-        REQUIRE(token.type == fkyaml::detail::lexical_token_t::BLOCK_SCALAR);
-        REQUIRE(token.str == "foo\n  bar\n\nbaz\n");
+        REQUIRE(token.type == fkyaml::detail::lexical_token_t::BLOCK_LITERAL_SCALAR);
+        REQUIRE(token.str.begin() == &input[3]);
+        REQUIRE(token.str.end() == &input[0] + 25);
+        REQUIRE(lexer.get_block_scalar_header().chomp == fkyaml::detail::chomping_indicator_t::CLIP);
+        REQUIRE(lexer.get_block_scalar_header().indent == 2);
     }
 
     SECTION("literal string scalar with clip chomping and no trailing newlines") {
@@ -722,8 +746,11 @@ TEST_CASE("LexicalAnalyzer_LiteralStringScalar") {
         fkyaml::detail::lexical_analyzer lexer(input);
 
         REQUIRE_NOTHROW(token = lexer.get_next_token());
-        REQUIRE(token.type == fkyaml::detail::lexical_token_t::BLOCK_SCALAR);
-        REQUIRE(token.str == "foo\n  bar\n\nbaz");
+        REQUIRE(token.type == fkyaml::detail::lexical_token_t::BLOCK_LITERAL_SCALAR);
+        REQUIRE(token.str.begin() == &input[3]);
+        REQUIRE(token.str.end() == &input[0] + 23);
+        REQUIRE(lexer.get_block_scalar_header().chomp == fkyaml::detail::chomping_indicator_t::CLIP);
+        REQUIRE(lexer.get_block_scalar_header().indent == 2);
     }
 
     SECTION("literal string scalar with implicit indentation and keep chomping") {
@@ -737,8 +764,11 @@ TEST_CASE("LexicalAnalyzer_LiteralStringScalar") {
         fkyaml::detail::lexical_analyzer lexer(input);
 
         REQUIRE_NOTHROW(token = lexer.get_next_token());
-        REQUIRE(token.type == fkyaml::detail::lexical_token_t::BLOCK_SCALAR);
-        REQUIRE(token.str == "\nfoo\nbar\n\nbaz\n\n");
+        REQUIRE(token.type == fkyaml::detail::lexical_token_t::BLOCK_LITERAL_SCALAR);
+        REQUIRE(token.str.begin() == &input[3]);
+        REQUIRE(token.str.end() == &input[0] + 24);
+        REQUIRE(lexer.get_block_scalar_header().chomp == fkyaml::detail::chomping_indicator_t::KEEP);
+        REQUIRE(lexer.get_block_scalar_header().indent == 2);
     }
 
     SECTION("literal string scalar with explicit indentation and keep chomping") {
@@ -751,8 +781,11 @@ TEST_CASE("LexicalAnalyzer_LiteralStringScalar") {
         fkyaml::detail::lexical_analyzer lexer(input);
 
         REQUIRE_NOTHROW(token = lexer.get_next_token());
-        REQUIRE(token.type == fkyaml::detail::lexical_token_t::BLOCK_SCALAR);
-        REQUIRE(token.str == "foo\n  bar\n\nbaz\n\n");
+        REQUIRE(token.type == fkyaml::detail::lexical_token_t::BLOCK_LITERAL_SCALAR);
+        REQUIRE(token.str.begin() == &input[4]);
+        REQUIRE(token.str.end() == &input[0] + 26);
+        REQUIRE(lexer.get_block_scalar_header().chomp == fkyaml::detail::chomping_indicator_t::KEEP);
+        REQUIRE(lexer.get_block_scalar_header().indent == 2);
     }
 
     SECTION("literal string scalar with trailing spaces/tabs after the block scalar header.") {
@@ -763,8 +796,11 @@ TEST_CASE("LexicalAnalyzer_LiteralStringScalar") {
         fkyaml::detail::lexical_analyzer lexer(input);
 
         REQUIRE_NOTHROW(token = lexer.get_next_token());
-        REQUIRE(token.type == fkyaml::detail::lexical_token_t::BLOCK_SCALAR);
-        REQUIRE(token.str == "foo\n");
+        REQUIRE(token.type == fkyaml::detail::lexical_token_t::BLOCK_LITERAL_SCALAR);
+        REQUIRE(token.str.begin() == &input[0] + input.find('\n') + 1);
+        REQUIRE(token.str.end() == &input[0] + input.size());
+        REQUIRE(lexer.get_block_scalar_header().chomp == fkyaml::detail::chomping_indicator_t::CLIP);
+        REQUIRE(lexer.get_block_scalar_header().indent == 2);
     }
 
     SECTION("literal string scalar with invalid block scalar headers") {
@@ -791,8 +827,11 @@ TEST_CASE("LexicalAnalyzer_FoldedString") {
         fkyaml::detail::lexical_analyzer lexer(input);
 
         REQUIRE_NOTHROW(token = lexer.get_next_token());
-        REQUIRE(token.type == fkyaml::detail::lexical_token_t::BLOCK_SCALAR);
-        REQUIRE(token.str.empty());
+        REQUIRE(token.type == fkyaml::detail::lexical_token_t::BLOCK_FOLDED_SCALAR);
+        REQUIRE(token.str.begin() == &input[3]);
+        REQUIRE(token.str.end() == &input[0] + 6);
+        REQUIRE(lexer.get_block_scalar_header().chomp == fkyaml::detail::chomping_indicator_t::STRIP);
+        REQUIRE(lexer.get_block_scalar_header().indent == 1);
     }
 
     SECTION("empty folded string scalar with clip chomping") {
@@ -801,8 +840,11 @@ TEST_CASE("LexicalAnalyzer_FoldedString") {
         fkyaml::detail::lexical_analyzer lexer(input);
 
         REQUIRE_NOTHROW(token = lexer.get_next_token());
-        REQUIRE(token.type == fkyaml::detail::lexical_token_t::BLOCK_SCALAR);
-        REQUIRE(token.str == "");
+        REQUIRE(token.type == fkyaml::detail::lexical_token_t::BLOCK_FOLDED_SCALAR);
+        REQUIRE(token.str.begin() == &input[2]);
+        REQUIRE(token.str.end() == &input[0] + 5);
+        REQUIRE(lexer.get_block_scalar_header().chomp == fkyaml::detail::chomping_indicator_t::CLIP);
+        REQUIRE(lexer.get_block_scalar_header().indent == 1);
     }
 
     SECTION("empty folded string scalar with keep chomping") {
@@ -811,8 +853,11 @@ TEST_CASE("LexicalAnalyzer_FoldedString") {
         fkyaml::detail::lexical_analyzer lexer(input);
 
         REQUIRE_NOTHROW(token = lexer.get_next_token());
-        REQUIRE(token.type == fkyaml::detail::lexical_token_t::BLOCK_SCALAR);
-        REQUIRE(token.str == "\n");
+        REQUIRE(token.type == fkyaml::detail::lexical_token_t::BLOCK_FOLDED_SCALAR);
+        REQUIRE(token.str.begin() == &input[3]);
+        REQUIRE(token.str.end() == &input[0] + 6);
+        REQUIRE(lexer.get_block_scalar_header().chomp == fkyaml::detail::chomping_indicator_t::KEEP);
+        REQUIRE(lexer.get_block_scalar_header().indent == 1);
     }
 
     SECTION("folded string scalar with 0 indent level") {
@@ -838,8 +883,11 @@ TEST_CASE("LexicalAnalyzer_FoldedString") {
         fkyaml::detail::lexical_analyzer lexer(input);
 
         REQUIRE_NOTHROW(token = lexer.get_next_token());
-        REQUIRE(token.type == fkyaml::detail::lexical_token_t::BLOCK_SCALAR);
-        REQUIRE(token.str == "\n  foo\nbar\n");
+        REQUIRE(token.type == fkyaml::detail::lexical_token_t::BLOCK_FOLDED_SCALAR);
+        REQUIRE(token.str.begin() == &input[3]);
+        REQUIRE(token.str.end() == &input[0] + 17);
+        REQUIRE(lexer.get_block_scalar_header().chomp == fkyaml::detail::chomping_indicator_t::CLIP);
+        REQUIRE(lexer.get_block_scalar_header().indent == 2);
     }
 
     SECTION("folded string scalar with the non-first line being more indented than the indicated level") {
@@ -849,8 +897,11 @@ TEST_CASE("LexicalAnalyzer_FoldedString") {
         fkyaml::detail::lexical_analyzer lexer(input);
 
         REQUIRE_NOTHROW(token = lexer.get_next_token());
-        REQUIRE(token.type == fkyaml::detail::lexical_token_t::BLOCK_SCALAR);
-        REQUIRE(token.str == "foo\n  bar\n");
+        REQUIRE(token.type == fkyaml::detail::lexical_token_t::BLOCK_FOLDED_SCALAR);
+        REQUIRE(token.str.begin() == &input[3]);
+        REQUIRE(token.str.end() == &input[0] + 17);
+        REQUIRE(lexer.get_block_scalar_header().chomp == fkyaml::detail::chomping_indicator_t::CLIP);
+        REQUIRE(lexer.get_block_scalar_header().indent == 2);
     }
 
     SECTION("folded string scalar") {
@@ -863,8 +914,11 @@ TEST_CASE("LexicalAnalyzer_FoldedString") {
         fkyaml::detail::lexical_analyzer lexer(input);
 
         REQUIRE_NOTHROW(token = lexer.get_next_token());
-        REQUIRE(token.type == fkyaml::detail::lexical_token_t::BLOCK_SCALAR);
-        REQUIRE(token.str == "foo\n\nbar\n");
+        REQUIRE(token.type == fkyaml::detail::lexical_token_t::BLOCK_FOLDED_SCALAR);
+        REQUIRE(token.str.begin() == &input[2]);
+        REQUIRE(token.str.end() == &input[0] + 20);
+        REQUIRE(lexer.get_block_scalar_header().chomp == fkyaml::detail::chomping_indicator_t::CLIP);
+        REQUIRE(lexer.get_block_scalar_header().indent == 2);
     }
 
     SECTION("folded string scalar with implicit indentation and strip chomping") {
@@ -876,8 +930,11 @@ TEST_CASE("LexicalAnalyzer_FoldedString") {
         fkyaml::detail::lexical_analyzer lexer(input);
 
         REQUIRE_NOTHROW(token = lexer.get_next_token());
-        REQUIRE(token.type == fkyaml::detail::lexical_token_t::BLOCK_SCALAR);
-        REQUIRE(token.str == "foo bar");
+        REQUIRE(token.type == fkyaml::detail::lexical_token_t::BLOCK_FOLDED_SCALAR);
+        REQUIRE(token.str.begin() == &input[3]);
+        REQUIRE(token.str.end() == &input[0] + 18);
+        REQUIRE(lexer.get_block_scalar_header().chomp == fkyaml::detail::chomping_indicator_t::STRIP);
+        REQUIRE(lexer.get_block_scalar_header().indent == 2);
     }
 
     SECTION("folded string scalar with implicit indentation and clip chomping") {
@@ -889,8 +946,11 @@ TEST_CASE("LexicalAnalyzer_FoldedString") {
         fkyaml::detail::lexical_analyzer lexer(input);
 
         REQUIRE_NOTHROW(token = lexer.get_next_token());
-        REQUIRE(token.type == fkyaml::detail::lexical_token_t::BLOCK_SCALAR);
-        REQUIRE(token.str == "foo bar\n");
+        REQUIRE(token.type == fkyaml::detail::lexical_token_t::BLOCK_FOLDED_SCALAR);
+        REQUIRE(token.str.begin() == &input[2]);
+        REQUIRE(token.str.end() == &input[0] + 18);
+        REQUIRE(lexer.get_block_scalar_header().chomp == fkyaml::detail::chomping_indicator_t::CLIP);
+        REQUIRE(lexer.get_block_scalar_header().indent == 2);
     }
 
     SECTION("folded string scalar with implicit indentation and keep chomping") {
@@ -902,8 +962,11 @@ TEST_CASE("LexicalAnalyzer_FoldedString") {
         fkyaml::detail::lexical_analyzer lexer(input);
 
         REQUIRE_NOTHROW(token = lexer.get_next_token());
-        REQUIRE(token.type == fkyaml::detail::lexical_token_t::BLOCK_SCALAR);
-        REQUIRE(token.str == "foo bar\n\n");
+        REQUIRE(token.type == fkyaml::detail::lexical_token_t::BLOCK_FOLDED_SCALAR);
+        REQUIRE(token.str.begin() == &input[3]);
+        REQUIRE(token.str.end() == &input[0] + 18);
+        REQUIRE(lexer.get_block_scalar_header().chomp == fkyaml::detail::chomping_indicator_t::KEEP);
+        REQUIRE(lexer.get_block_scalar_header().indent == 2);
     }
 
     SECTION("folded string scalar with trailing spaces/tabs/comments after the block scalar header.") {
@@ -914,8 +977,11 @@ TEST_CASE("LexicalAnalyzer_FoldedString") {
         fkyaml::detail::lexical_analyzer lexer(input);
 
         REQUIRE_NOTHROW(token = lexer.get_next_token());
-        REQUIRE(token.type == fkyaml::detail::lexical_token_t::BLOCK_SCALAR);
-        REQUIRE(token.str == "foo\n");
+        REQUIRE(token.type == fkyaml::detail::lexical_token_t::BLOCK_FOLDED_SCALAR);
+        REQUIRE(token.str.begin() == &input[0] + input.find('\n') + 1);
+        REQUIRE(token.str.end() == &input[0] + input.size());
+        REQUIRE(lexer.get_block_scalar_header().chomp == fkyaml::detail::chomping_indicator_t::CLIP);
+        REQUIRE(lexer.get_block_scalar_header().indent == 2);
     }
 
     SECTION("folded string scalar with invalid block scalar headers") {
@@ -1539,7 +1605,8 @@ TEST_CASE("LexicalAnalyzer_BlockMapping") {
     }
 
     SECTION("block mapping with a literal string scalar value") {
-        fkyaml::detail::lexical_analyzer lexer("test: |\n  a literal scalar.\nfoo: \'bar\'\npi: 3.14");
+        char input[] = "test: |\n  a block literal scalar.\nfoo: \'bar\'\npi: 3.14";
+        fkyaml::detail::lexical_analyzer lexer(input);
 
         REQUIRE_NOTHROW(token = lexer.get_next_token());
         REQUIRE(token.type == fkyaml::detail::lexical_token_t::PLAIN_SCALAR);
@@ -1549,8 +1616,11 @@ TEST_CASE("LexicalAnalyzer_BlockMapping") {
         REQUIRE(token.type == fkyaml::detail::lexical_token_t::KEY_SEPARATOR);
 
         REQUIRE_NOTHROW(token = lexer.get_next_token());
-        REQUIRE(token.type == fkyaml::detail::lexical_token_t::BLOCK_SCALAR);
-        REQUIRE(token.str == "a literal scalar.\n");
+        REQUIRE(token.type == fkyaml::detail::lexical_token_t::BLOCK_LITERAL_SCALAR);
+        REQUIRE(token.str.begin() == &input[8]);
+        REQUIRE(token.str.end() == &input[34]);
+        REQUIRE(lexer.get_block_scalar_header().chomp == fkyaml::detail::chomping_indicator_t::CLIP);
+        REQUIRE(lexer.get_block_scalar_header().indent == 2);
 
         REQUIRE_NOTHROW(token = lexer.get_next_token());
         REQUIRE(token.type == fkyaml::detail::lexical_token_t::PLAIN_SCALAR);
@@ -1579,7 +1649,8 @@ TEST_CASE("LexicalAnalyzer_BlockMapping") {
     }
 
     SECTION("block mapping with a folded string scalar value") {
-        fkyaml::detail::lexical_analyzer lexer("test: >\n  a literal scalar.\nfoo: \'bar\'\npi: 3.14");
+        char input[] = "test: >\n  a block folded scalar.\nfoo: \'bar\'\npi: 3.14";
+        fkyaml::detail::lexical_analyzer lexer(input);
 
         REQUIRE_NOTHROW(token = lexer.get_next_token());
         REQUIRE(token.type == fkyaml::detail::lexical_token_t::PLAIN_SCALAR);
@@ -1589,8 +1660,11 @@ TEST_CASE("LexicalAnalyzer_BlockMapping") {
         REQUIRE(token.type == fkyaml::detail::lexical_token_t::KEY_SEPARATOR);
 
         REQUIRE_NOTHROW(token = lexer.get_next_token());
-        REQUIRE(token.type == fkyaml::detail::lexical_token_t::BLOCK_SCALAR);
-        REQUIRE(token.str == "a literal scalar.\n");
+        REQUIRE(token.type == fkyaml::detail::lexical_token_t::BLOCK_FOLDED_SCALAR);
+        REQUIRE(token.str.begin() == &input[8]);
+        REQUIRE(token.str.end() == &input[33]);
+        REQUIRE(lexer.get_block_scalar_header().chomp == fkyaml::detail::chomping_indicator_t::CLIP);
+        REQUIRE(lexer.get_block_scalar_header().indent == 2);
 
         REQUIRE_NOTHROW(token = lexer.get_next_token());
         REQUIRE(token.type == fkyaml::detail::lexical_token_t::PLAIN_SCALAR);

--- a/test/unit_test/test_scalar_parser_class.cpp
+++ b/test/unit_test/test_scalar_parser_class.cpp
@@ -1,0 +1,352 @@
+//  _______   __ __   __  _____   __  __  __
+// |   __| |_/  |  \_/  |/  _  \ /  \/  \|  |     fkYAML: A C++ header-only YAML library (supporting code)
+// |   __|  _  < \_   _/|  ___  |    _   |  |___  version 0.3.12
+// |__|  |_| \__|  |_|  |_|   |_|___||___|______| https://github.com/fktn-k/fkYAML
+//
+// SPDX-FileCopyrightText: 2023-2024 Kensuke Fukutani <fktn.dev@gmail.com>
+// SPDX-License-Identifier: MIT
+
+#include <catch2/catch.hpp>
+
+#include <fkYAML/node.hpp>
+
+TEST_CASE("ScalarParser_FlowPlainScalar_string") {
+    fkyaml::node node {};
+    fkyaml::detail::scalar_parser<fkyaml::node> scalar_parser {0, 0};
+    fkyaml::detail::tag_t tag_type {fkyaml::detail::tag_t::NONE};
+
+    SECTION("plain: normal contents") {
+        fkyaml::detail::lexical_token_t lex_type {fkyaml::detail::lexical_token_t::PLAIN_SCALAR};
+
+        auto token = GENERATE(
+            fkyaml::detail::str_view("test"),
+            fkyaml::detail::str_view("nop"),
+            fkyaml::detail::str_view("none"),
+            fkyaml::detail::str_view("?test"),
+            fkyaml::detail::str_view(".NET"),
+            fkyaml::detail::str_view(".on"),
+            fkyaml::detail::str_view(".n"),
+            fkyaml::detail::str_view("-t"),
+            fkyaml::detail::str_view("-foo"),
+            fkyaml::detail::str_view("-.test"),
+            fkyaml::detail::str_view("?"),
+            fkyaml::detail::str_view("--foo"),
+            fkyaml::detail::str_view("1.2.3"),
+            fkyaml::detail::str_view("foo,bar"),
+            fkyaml::detail::str_view("foo[bar"),
+            fkyaml::detail::str_view("foo]bar"),
+            fkyaml::detail::str_view("foo{bar"),
+            fkyaml::detail::str_view("foo}bar"),
+            fkyaml::detail::str_view("foo:bar"),
+            fkyaml::detail::str_view("foo bar"),
+            fkyaml::detail::str_view("foo\"bar"),
+            fkyaml::detail::str_view("foo\'s bar"),
+            fkyaml::detail::str_view("foo\\bar"),
+            fkyaml::detail::str_view("nullValue"),
+            fkyaml::detail::str_view("NullValue"),
+            fkyaml::detail::str_view("NULL_VALUE"),
+            fkyaml::detail::str_view("~Value"),
+            fkyaml::detail::str_view("trueValue"),
+            fkyaml::detail::str_view("TrueValue"),
+            fkyaml::detail::str_view("TRUE_VALUE"),
+            fkyaml::detail::str_view("falseValue"),
+            fkyaml::detail::str_view("FalseValue"),
+            fkyaml::detail::str_view("FALSE_VALUE"),
+            fkyaml::detail::str_view(".infValue"),
+            fkyaml::detail::str_view(".InfValue"),
+            fkyaml::detail::str_view(".INF_VALUE"),
+            fkyaml::detail::str_view("-.infValue"),
+            fkyaml::detail::str_view("-.InfValue"),
+            fkyaml::detail::str_view("-.INF_VALUE"),
+            fkyaml::detail::str_view(".nanValue"),
+            fkyaml::detail::str_view(".NaNValue"),
+            fkyaml::detail::str_view(".NAN_VALUE"));
+
+        REQUIRE_NOTHROW(node = scalar_parser.parse_flow(lex_type, tag_type, token));
+        REQUIRE(node.is_string());
+        REQUIRE(node.get_value_ref<std::string&>() == token);
+    }
+
+    SECTION("single quoted: single line contents") {
+        fkyaml::detail::lexical_token_t lex_type {fkyaml::detail::lexical_token_t::SINGLE_QUOTED_SCALAR};
+        using test_data_t = std::pair<fkyaml::detail::str_view, std::string>;
+        auto test_data = GENERATE(
+            test_data_t("", ""),
+            test_data_t("foo\"bar", "foo\"bar"),
+            test_data_t("foo bar", "foo bar"),
+            test_data_t("foo\'\'bar", "foo\'bar"),
+            test_data_t("foo,bar", "foo,bar"),
+            test_data_t("foo]bar", "foo]bar"),
+            test_data_t("foo}bar", "foo}bar"),
+            test_data_t("foo\"bar", "foo\"bar"),
+            test_data_t("foo:bar", "foo:bar"),
+            test_data_t("foo\\bar", "foo\\bar"));
+
+        REQUIRE_NOTHROW(node = scalar_parser.parse_flow(lex_type, tag_type, test_data.first));
+        REQUIRE(node.is_string());
+        REQUIRE(node.get_value_ref<std::string&>() == test_data.second);
+    }
+
+    SECTION("single quoted: multiline contents") {
+        fkyaml::detail::lexical_token_t lex_type {fkyaml::detail::lexical_token_t::SINGLE_QUOTED_SCALAR};
+        using test_data_t = std::pair<fkyaml::detail::str_view, std::string>;
+        auto test_data = GENERATE(
+            test_data_t("foo\nbar", "foo bar"),
+            test_data_t("foo \t\n \tbar", "foo bar"),
+            test_data_t("foo\n\n \t\nbar", "foo\n\nbar"),
+            test_data_t("\nfoo\n\n \t\nbar", " foo\n\nbar"),
+            test_data_t("foo\nbar\n", "foo bar "));
+
+        REQUIRE_NOTHROW(node = scalar_parser.parse_flow(lex_type, tag_type, test_data.first));
+        REQUIRE(node.is_string());
+        REQUIRE(node.get_value_ref<std::string&>() == test_data.second);
+    }
+
+    SECTION("double quoted: single line contents") {
+        fkyaml::detail::lexical_token_t lex_type {fkyaml::detail::lexical_token_t::DOUBLE_QUOTED_SCALAR};
+        using test_data_t = std::pair<fkyaml::detail::str_view, std::string>;
+        auto test_data = GENERATE(
+            test_data_t("", ""),
+            test_data_t("foo bar", "foo bar"),
+            test_data_t("foo\tbar", "foo\tbar"),
+            test_data_t("foo's bar", "foo's bar"),
+            test_data_t("foo:bar", "foo:bar"),
+            test_data_t("foo,bar", "foo,bar"),
+            test_data_t("foo]bar", "foo]bar"),
+            test_data_t("foo}bar", "foo}bar"),
+            test_data_t("\\x30\\x2B\\x6d", "0+m"));
+
+        REQUIRE_NOTHROW(node = scalar_parser.parse_flow(lex_type, tag_type, test_data.first));
+        REQUIRE(node.is_string());
+        REQUIRE(node.get_value_ref<std::string&>() == test_data.second);
+    }
+
+    SECTION("double quoted: multiline contents") {
+        fkyaml::detail::lexical_token_t lex_type {fkyaml::detail::lexical_token_t::DOUBLE_QUOTED_SCALAR};
+        using test_data_t = std::pair<fkyaml::detail::str_view, std::string>;
+        auto test_data = GENERATE(
+            test_data_t("foo\nbar", "foo bar"),
+            test_data_t("foo \t\n \tbar", "foo bar"),
+            test_data_t("foo\n\n \t\nbar", "foo\n\nbar"),
+            test_data_t("\nfoo\n\n \t\nbar", " foo\n\nbar"),
+            test_data_t("foo\nbar\n", "foo bar "),
+            test_data_t("foo\\\nbar", "foobar"),
+            test_data_t("foo \t\\\nbar", "foo \tbar"),
+            test_data_t("\\\n  foo \t\\\n\tbar\t  \t\\\n", "foo \tbar\t  \t"));
+
+        REQUIRE_NOTHROW(node = scalar_parser.parse_flow(lex_type, tag_type, test_data.first));
+        REQUIRE(node.is_string());
+        REQUIRE(node.get_value_ref<std::string&>() == test_data.second);
+    }
+
+    SECTION("double quoted: escaped unicode characters") {
+        fkyaml::detail::lexical_token_t lex_type {fkyaml::detail::lexical_token_t::DOUBLE_QUOTED_SCALAR};
+        using test_data_t = std::pair<fkyaml::detail::str_view, std::string>;
+        auto to_char = [](int c) { return std::char_traits<char>::to_char_type(c); };
+
+        auto test_data = GENERATE_REF(
+            test_data_t("\\x00", {to_char(0x00)}),
+            test_data_t("\\x40", {to_char(0x40)}),
+            test_data_t("\\x7F", {to_char(0x7F)}),
+            test_data_t("\\u0000", {to_char(0x00)}),
+            test_data_t("\\u0040", {to_char(0x40)}),
+            test_data_t("\\u007F", {to_char(0x7F)}),
+            test_data_t("\\u0080", {to_char(0xC2), to_char(0x80)}),
+            test_data_t("\\u0400", {to_char(0xD0), to_char(0x80)}),
+            test_data_t("\\u07FF", {to_char(0xDF), to_char(0xBF)}),
+            test_data_t("\\u0800", {to_char(0xE0), to_char(0xA0), to_char(0x80)}),
+            test_data_t("\\u8000", {to_char(0xE8), to_char(0x80), to_char(0x80)}),
+            test_data_t("\\uFFFF", {to_char(0xEF), to_char(0xBF), to_char(0xBF)}),
+            test_data_t("\\U00000000", {to_char(0x00)}),
+            test_data_t("\\U00000040", {to_char(0x40)}),
+            test_data_t("\\U0000007F", {to_char(0x7F)}),
+            test_data_t("\\U00000080", {to_char(0xC2), to_char(0x80)}),
+            test_data_t("\\U00000400", {to_char(0xD0), to_char(0x80)}),
+            test_data_t("\\U000007FF", {to_char(0xDF), to_char(0xBF)}),
+            test_data_t("\\U00000800", {to_char(0xE0), to_char(0xA0), to_char(0x80)}),
+            test_data_t("\\U00008000", {to_char(0xE8), to_char(0x80), to_char(0x80)}),
+            test_data_t("\\U0000FFFF", {to_char(0xEF), to_char(0xBF), to_char(0xBF)}),
+            test_data_t("\\U00010000", {to_char(0xF0), to_char(0x90), to_char(0x80), to_char(0x80)}),
+            test_data_t("\\U00080000", {to_char(0xF2), to_char(0x80), to_char(0x80), to_char(0x80)}),
+            test_data_t("\\U0010FFFF", {to_char(0xF4), to_char(0x8F), to_char(0xBF), to_char(0xBF)}));
+
+        REQUIRE_NOTHROW(node = scalar_parser.parse_flow(lex_type, tag_type, test_data.first));
+        REQUIRE(node.is_string());
+        REQUIRE(node.get_value_ref<std::string&>() == test_data.second);
+    }
+
+    SECTION("double quoted: invalid unicode escapings") {
+        fkyaml::detail::lexical_token_t lex_type {fkyaml::detail::lexical_token_t::DOUBLE_QUOTED_SCALAR};
+        auto token = GENERATE(
+            fkyaml::detail::str_view("\\xw"),
+            fkyaml::detail::str_view("\\x+"),
+            fkyaml::detail::str_view("\\x="),
+            fkyaml::detail::str_view("\\x^"),
+            fkyaml::detail::str_view("\\x{"),
+            fkyaml::detail::str_view("\\Q"));
+
+        REQUIRE_THROWS_AS(scalar_parser.parse_flow(lex_type, tag_type, token), fkyaml::parse_error);
+    }
+}
+
+TEST_CASE("ScalarParser_BlockLiteralScalar") {
+    fkyaml::node node {};
+    fkyaml::detail::scalar_parser<fkyaml::node> scalar_parser {0, 0};
+    fkyaml::detail::lexical_token_t lex_type {fkyaml::detail::lexical_token_t::BLOCK_LITERAL_SCALAR};
+    fkyaml::detail::tag_t tag_type {fkyaml::detail::tag_t::NONE};
+    fkyaml::detail::block_scalar_header header {};
+
+    SECTION("empty literal string scalar with strip chomping") {
+        fkyaml::detail::str_view token = "  \n";
+        header.chomp = fkyaml::detail::chomping_indicator_t::STRIP;
+        header.indent = 3;
+
+        REQUIRE_NOTHROW(node = scalar_parser.parse_block(lex_type, tag_type, token, header));
+        REQUIRE(node.is_string());
+        REQUIRE(node.get_value_ref<std::string&>() == "");
+    }
+
+    SECTION("empty literal string scalar with clip chomping") {
+        fkyaml::detail::str_view token = "  \n";
+        header.chomp = fkyaml::detail::chomping_indicator_t::CLIP;
+        header.indent = 3;
+
+        REQUIRE_NOTHROW(node = scalar_parser.parse_block(lex_type, tag_type, token, header));
+        REQUIRE(node.is_string());
+        REQUIRE(node.get_value_ref<std::string&>() == "");
+    }
+
+    SECTION("empty literal string scalar with keep chomping") {
+        fkyaml::detail::str_view token = "  \n";
+        header.chomp = fkyaml::detail::chomping_indicator_t::KEEP;
+        header.indent = 3;
+
+        REQUIRE_NOTHROW(node = scalar_parser.parse_block(lex_type, tag_type, token, header));
+        REQUIRE(node.is_string());
+        REQUIRE(node.get_value_ref<std::string&>() == "\n");
+    }
+
+    SECTION("literal scalar with the first line being more indented than the indicated level") {
+        fkyaml::detail::str_view token = "    foo\n"
+                                         "  bar\n";
+        header.chomp = fkyaml::detail::chomping_indicator_t::CLIP;
+        header.indent = 2;
+
+        REQUIRE_NOTHROW(node = scalar_parser.parse_block(lex_type, tag_type, token, header));
+        REQUIRE(node.is_string());
+        REQUIRE(node.get_value_ref<std::string&>() == "  foo\nbar\n");
+    }
+
+    SECTION("literal string scalar") {
+        fkyaml::detail::str_view token = "  foo\n"
+                                         "  bar\n";
+        header.chomp = fkyaml::detail::chomping_indicator_t::CLIP;
+        header.indent = 2;
+
+        REQUIRE_NOTHROW(node = scalar_parser.parse_block(lex_type, tag_type, token, header));
+        REQUIRE(node.is_string());
+        REQUIRE(node.get_value_ref<std::string&>() == "foo\nbar\n");
+    }
+
+    SECTION("literal string scalar with implicit indentation and strip chomping") {
+        fkyaml::detail::str_view token = "\n"
+                                         "  foo\n"
+                                         "  bar\n"
+                                         "\n"
+                                         "  baz\n"
+                                         "\n";
+        header.chomp = fkyaml::detail::chomping_indicator_t::STRIP;
+        header.indent = 2;
+
+        REQUIRE_NOTHROW(node = scalar_parser.parse_block(lex_type, tag_type, token, header));
+        REQUIRE(node.is_string());
+        REQUIRE(node.get_value_ref<std::string&>() == "\nfoo\nbar\n\nbaz");
+    }
+
+    SECTION("literal string scalar with explicit indentation and strip chomping") {
+        fkyaml::detail::str_view token = "\n"
+                                         "  foo\n"
+                                         "    bar\n"
+                                         "\n"
+                                         "  baz\n"
+                                         "\n";
+        header.chomp = fkyaml::detail::chomping_indicator_t::STRIP;
+        header.indent = 2;
+
+        REQUIRE_NOTHROW(node = scalar_parser.parse_block(lex_type, tag_type, token, header));
+        REQUIRE(node.is_string());
+        REQUIRE(node.get_value_ref<std::string&>() == "\nfoo\n  bar\n\nbaz");
+    }
+
+    SECTION("literal string scalar with implicit indentation and clip chomping") {
+        fkyaml::detail::str_view token = "\n"
+                                         "  foo\n"
+                                         "  bar\n"
+                                         "\n"
+                                         "  baz\n"
+                                         "\n";
+        header.chomp = fkyaml::detail::chomping_indicator_t::CLIP;
+        header.indent = 2;
+
+        REQUIRE_NOTHROW(node = scalar_parser.parse_block(lex_type, tag_type, token, header));
+        REQUIRE(node.is_string());
+        REQUIRE(node.get_value_ref<std::string&>() == "\nfoo\nbar\n\nbaz\n");
+    }
+
+    SECTION("literal string scalar with explicit indentation and clip chomping") {
+        fkyaml::detail::str_view token = "\n"
+                                         "  foo\n"
+                                         "    bar\n"
+                                         "\n"
+                                         "  baz\n"
+                                         "\n";
+        header.chomp = fkyaml::detail::chomping_indicator_t::STRIP;
+        header.indent = 2;
+
+        REQUIRE_NOTHROW(node = scalar_parser.parse_block(lex_type, tag_type, token, header));
+        REQUIRE(node.is_string());
+        REQUIRE(node.get_value_ref<std::string&>() == "\nfoo\n  bar\n\nbaz");
+    }
+
+    SECTION("literal string scalar with clip chomping and no trailing newlines") {
+        fkyaml::detail::str_view token = "  foo\n"
+                                         "  bar\n"
+                                         "\n"
+                                         "  baz";
+        header.chomp = fkyaml::detail::chomping_indicator_t::STRIP;
+        header.indent = 2;
+
+        REQUIRE_NOTHROW(node = scalar_parser.parse_block(lex_type, tag_type, token, header));
+        REQUIRE(node.is_string());
+        REQUIRE(node.get_value_ref<std::string&>() == "foo\nbar\n\nbaz");
+    }
+
+    SECTION("literal string scalar with implicit indentation and keep chomping") {
+        fkyaml::detail::str_view token = "\n"
+                                         "  foo\n"
+                                         "  bar\n"
+                                         "\n"
+                                         "  baz\n"
+                                         "\n";
+        header.chomp = fkyaml::detail::chomping_indicator_t::KEEP;
+        header.indent = 2;
+
+        REQUIRE_NOTHROW(node = scalar_parser.parse_block(lex_type, tag_type, token, header));
+        REQUIRE(node.is_string());
+        REQUIRE(node.get_value_ref<std::string&>() == "\nfoo\nbar\n\nbaz\n\n");
+    }
+
+    SECTION("literal string scalar with explicit indentation and keep chomping") {
+        fkyaml::detail::str_view token = "  foo\n"
+                                         "    bar\n"
+                                         "\n"
+                                         "  baz\n"
+                                         "\n";
+        header.chomp = fkyaml::detail::chomping_indicator_t::KEEP;
+        header.indent = 2;
+
+        REQUIRE_NOTHROW(node = scalar_parser.parse_block(lex_type, tag_type, token, header));
+        REQUIRE(node.is_string());
+        REQUIRE(node.get_value_ref<std::string&>() == "foo\n  bar\n\nbaz\n\n");
+    }
+}

--- a/test/unit_test/test_scalar_parser_class.cpp
+++ b/test/unit_test/test_scalar_parser_class.cpp
@@ -10,6 +10,188 @@
 
 #include <fkYAML/node.hpp>
 
+TEST_CASE("ScalarParser_FlowPlainScalar_null") {
+    fkyaml::node node {};
+    fkyaml::detail::scalar_parser<fkyaml::node> scalar_parser {0, 0};
+    fkyaml::detail::lexical_token_t lex_type {fkyaml::detail::lexical_token_t::PLAIN_SCALAR};
+    fkyaml::detail::tag_t tag_type {fkyaml::detail::tag_t::NONE};
+
+    SECTION("not tagged") {
+        auto token = GENERATE(
+            fkyaml::detail::str_view("null"),
+            fkyaml::detail::str_view("Null"),
+            fkyaml::detail::str_view("NULL"),
+            fkyaml::detail::str_view("~"));
+
+        REQUIRE_NOTHROW(node = scalar_parser.parse_flow(lex_type, tag_type, token));
+        REQUIRE(node.is_null());
+    }
+
+    SECTION("tagged") {
+        tag_type = fkyaml::detail::tag_t::NULL_VALUE;
+
+        auto token = GENERATE(
+            fkyaml::detail::str_view("null"),
+            fkyaml::detail::str_view("Null"),
+            fkyaml::detail::str_view("NULL"),
+            fkyaml::detail::str_view("~"));
+
+        REQUIRE_NOTHROW(node = scalar_parser.parse_flow(lex_type, tag_type, token));
+        REQUIRE(node.is_null());
+    }
+}
+
+TEST_CASE("ScalarParser_FlowPlainScalar_boolean") {
+    fkyaml::node node {};
+    fkyaml::detail::scalar_parser<fkyaml::node> scalar_parser {0, 0};
+    fkyaml::detail::lexical_token_t lex_type {fkyaml::detail::lexical_token_t::PLAIN_SCALAR};
+    fkyaml::detail::tag_t tag_type {fkyaml::detail::tag_t::NONE};
+
+    using test_data_t = std::pair<fkyaml::detail::str_view, bool>;
+
+    SECTION("not tagged") {
+        auto test_data = GENERATE(
+            test_data_t("true", true),
+            test_data_t("True", true),
+            test_data_t("TRUE", true),
+            test_data_t("false", false),
+            test_data_t("False", false),
+            test_data_t("FALSE", false));
+
+        REQUIRE_NOTHROW(node = scalar_parser.parse_flow(lex_type, tag_type, test_data.first));
+        REQUIRE(node.is_boolean());
+        REQUIRE(node.get_value<bool>() == test_data.second);
+    }
+
+    SECTION("tagged") {
+        tag_type = fkyaml::detail::tag_t::BOOLEAN;
+
+        auto test_data = GENERATE(
+            test_data_t("true", true),
+            test_data_t("True", true),
+            test_data_t("TRUE", true),
+            test_data_t("false", false),
+            test_data_t("False", false),
+            test_data_t("FALSE", false));
+
+        REQUIRE_NOTHROW(node = scalar_parser.parse_flow(lex_type, tag_type, test_data.first));
+        REQUIRE(node.is_boolean());
+        REQUIRE(node.get_value<bool>() == test_data.second);
+    }
+}
+
+TEST_CASE("ScalarParser_FlowPlainScalar_integer") {
+    fkyaml::node node {};
+    fkyaml::detail::scalar_parser<fkyaml::node> scalar_parser {0, 0};
+    fkyaml::detail::lexical_token_t lex_type {fkyaml::detail::lexical_token_t::PLAIN_SCALAR};
+    fkyaml::detail::tag_t tag_type {fkyaml::detail::tag_t::NONE};
+
+    using test_data_t = std::pair<fkyaml::detail::str_view, int>;
+
+    SECTION("not tagged") {
+        auto test_data =
+            GENERATE(test_data_t("123", 123), test_data_t("-123", -123), test_data_t("0", 0), test_data_t("+456", 456));
+
+        REQUIRE_NOTHROW(node = scalar_parser.parse_flow(lex_type, tag_type, test_data.first));
+        REQUIRE(node.is_integer());
+        REQUIRE(node.get_value<int>() == test_data.second);
+    }
+
+    SECTION("tagged") {
+        tag_type = fkyaml::detail::tag_t::INTEGER;
+
+        auto test_data = GENERATE(
+            test_data_t("123", 123),
+            test_data_t("-123", -123),
+            test_data_t("0", 0),
+            test_data_t("+456", 456),
+            test_data_t("0o456", 0456),
+            test_data_t("0xA0f", 0xA0f));
+
+        REQUIRE_NOTHROW(node = scalar_parser.parse_flow(lex_type, tag_type, test_data.first));
+        REQUIRE(node.is_integer());
+        REQUIRE(node.get_value<int>() == test_data.second);
+    }
+}
+
+TEST_CASE("ScalarParser_FlowPlainScalar_float") {
+    fkyaml::node node {};
+    fkyaml::detail::scalar_parser<fkyaml::node> scalar_parser {0, 0};
+    fkyaml::detail::lexical_token_t lex_type {fkyaml::detail::lexical_token_t::PLAIN_SCALAR};
+    fkyaml::detail::tag_t tag_type {fkyaml::detail::tag_t::NONE};
+
+    using test_data_t = std::pair<fkyaml::detail::str_view, float>;
+
+    SECTION("normal values: not tagged") {
+        auto test_data = GENERATE(
+            test_data_t("1.23", 1.23f),
+            test_data_t("-1.23", -1.23f),
+            test_data_t("0.", 0.f),
+            test_data_t("+4.56", 4.56f),
+            test_data_t("4.5e3", 4.5e3f),
+            test_data_t("+4.5e3", 4.5e3f),
+            test_data_t("-4.5e3", -4.5e3f),
+            test_data_t("-4.5e-3", -4.5e-3f),
+            test_data_t("4.5E3", 4.5e3f),
+            test_data_t("+4.5E3", 4.5e3f),
+            test_data_t("-4.5E3", -4.5e3f),
+            test_data_t("-4.5E-3", -4.5e-3f));
+
+        REQUIRE_NOTHROW(node = scalar_parser.parse_flow(lex_type, tag_type, test_data.first));
+        REQUIRE(node.is_float_number());
+        REQUIRE(node.get_value<float>() == test_data.second);
+    }
+
+    SECTION("infinities: not tagged") {
+        auto token = GENERATE(
+            fkyaml::detail::str_view(".inf"),
+            fkyaml::detail::str_view("+.inf"),
+            fkyaml::detail::str_view("-.inf"),
+            fkyaml::detail::str_view(".Inf"),
+            fkyaml::detail::str_view("+.Inf"),
+            fkyaml::detail::str_view("-.Inf"),
+            fkyaml::detail::str_view(".INF"),
+            fkyaml::detail::str_view("+.INF"),
+            fkyaml::detail::str_view("-.INF"));
+
+        REQUIRE_NOTHROW(node = scalar_parser.parse_flow(lex_type, tag_type, token));
+        REQUIRE(node.is_float_number());
+        REQUIRE(std::isinf(node.get_value<float>()));
+    }
+
+    SECTION("NaNs: not tagged") {
+        auto token = GENERATE(
+            fkyaml::detail::str_view(".nan"), fkyaml::detail::str_view(".NaN"), fkyaml::detail::str_view(".NAN"));
+
+        REQUIRE_NOTHROW(node = scalar_parser.parse_flow(lex_type, tag_type, token));
+        REQUIRE(node.is_float_number());
+        REQUIRE(std::isnan(node.get_value<float>()));
+    }
+
+    SECTION("normal values: tagged") {
+        tag_type = fkyaml::detail::tag_t::FLOATING_NUMBER;
+
+        auto test_data = GENERATE(
+            test_data_t("1.23", 1.23f),
+            test_data_t("-1.23", -1.23f),
+            test_data_t("0.", 0.f),
+            test_data_t("+4.56", 4.56f),
+            test_data_t("4.5e3", 4.5e3f),
+            test_data_t("+4.5e3", 4.5e3f),
+            test_data_t("-4.5e3", -4.5e3f),
+            test_data_t("-4.5e-3", -4.5e-3f),
+            test_data_t("4.5E3", 4.5e3f),
+            test_data_t("+4.5E3", 4.5e3f),
+            test_data_t("-4.5E3", -4.5e3f),
+            test_data_t("-4.5E-3", -4.5e-3f),
+            test_data_t("123", 123.f));
+
+        REQUIRE_NOTHROW(node = scalar_parser.parse_flow(lex_type, tag_type, test_data.first));
+        REQUIRE(node.is_float_number());
+        REQUIRE(node.get_value<float>() == test_data.second);
+    }
+}
+
 TEST_CASE("ScalarParser_FlowPlainScalar_string") {
     fkyaml::node node {};
     fkyaml::detail::scalar_parser<fkyaml::node> scalar_parser {0, 0};
@@ -95,7 +277,8 @@ TEST_CASE("ScalarParser_FlowPlainScalar_string") {
             test_data_t("foo \t\n \tbar", "foo bar"),
             test_data_t("foo\n\n \t\nbar", "foo\n\nbar"),
             test_data_t("\nfoo\n\n \t\nbar", " foo\n\nbar"),
-            test_data_t("foo\nbar\n", "foo bar "));
+            test_data_t("foo\nbar\n", "foo bar "),
+            test_data_t("foo        \t\t\t\nbar\n", "foo bar "));
 
         REQUIRE_NOTHROW(node = scalar_parser.parse_flow(lex_type, tag_type, test_data.first));
         REQUIRE(node.is_string());
@@ -195,6 +378,16 @@ TEST_CASE("ScalarParser_BlockLiteralScalar") {
     fkyaml::detail::lexical_token_t lex_type {fkyaml::detail::lexical_token_t::BLOCK_LITERAL_SCALAR};
     fkyaml::detail::tag_t tag_type {fkyaml::detail::tag_t::NONE};
     fkyaml::detail::block_scalar_header header {};
+
+    SECTION("empty block literal scalar token.") {
+        fkyaml::detail::str_view token = "";
+        header.chomp = fkyaml::detail::chomping_indicator_t::STRIP;
+        header.indent = 0;
+
+        REQUIRE_NOTHROW(node = scalar_parser.parse_block(lex_type, tag_type, token, header));
+        REQUIRE(node.is_string());
+        REQUIRE(node.get_value_ref<std::string&>() == "");
+    }
 
     SECTION("empty literal string scalar with strip chomping") {
         fkyaml::detail::str_view token = "  \n";
@@ -348,5 +541,176 @@ TEST_CASE("ScalarParser_BlockLiteralScalar") {
         REQUIRE_NOTHROW(node = scalar_parser.parse_block(lex_type, tag_type, token, header));
         REQUIRE(node.is_string());
         REQUIRE(node.get_value_ref<std::string&>() == "foo\n  bar\n\nbaz\n\n");
+    }
+}
+
+TEST_CASE("ScalarParser_BlockFoldedScalar") {
+    fkyaml::node node {};
+    fkyaml::detail::scalar_parser<fkyaml::node> scalar_parser {0, 0};
+    fkyaml::detail::lexical_token_t lex_type {fkyaml::detail::lexical_token_t::BLOCK_FOLDED_SCALAR};
+    fkyaml::detail::tag_t tag_type {fkyaml::detail::tag_t::NONE};
+    fkyaml::detail::block_scalar_header header {};
+
+    SECTION("empty block folded scalar token.") {
+        fkyaml::detail::str_view token = "";
+        header.chomp = fkyaml::detail::chomping_indicator_t::STRIP;
+        header.indent = 0;
+
+        REQUIRE_NOTHROW(node = scalar_parser.parse_block(lex_type, tag_type, token, header));
+        REQUIRE(node.is_string());
+        REQUIRE(node.get_value_ref<std::string&>() == "");
+    }
+
+    SECTION("empty folded string scalar with strip chomping") {
+        fkyaml::detail::str_view token = "  \n";
+
+        header.chomp = fkyaml::detail::chomping_indicator_t::STRIP;
+        header.indent = 3;
+
+        REQUIRE_NOTHROW(node = scalar_parser.parse_block(lex_type, tag_type, token, header));
+        REQUIRE(node.is_string());
+        REQUIRE(node.get_value_ref<std::string&>() == "");
+    }
+
+    SECTION("empty folded string scalar with clip chomping") {
+        fkyaml::detail::str_view token = "  \n";
+
+        header.chomp = fkyaml::detail::chomping_indicator_t::CLIP;
+        header.indent = 3;
+
+        REQUIRE_NOTHROW(node = scalar_parser.parse_block(lex_type, tag_type, token, header));
+        REQUIRE(node.is_string());
+        REQUIRE(node.get_value_ref<std::string&>() == "");
+    }
+
+    SECTION("empty folded string scalar with keep chomping") {
+        fkyaml::detail::str_view token = "  \n";
+
+        header.chomp = fkyaml::detail::chomping_indicator_t::KEEP;
+        header.indent = 3;
+
+        REQUIRE_NOTHROW(node = scalar_parser.parse_block(lex_type, tag_type, token, header));
+        REQUIRE(node.is_string());
+        REQUIRE(node.get_value_ref<std::string&>() == "\n");
+    }
+
+    SECTION("folded string scalar with the first line being more indented than the indicated level") {
+        fkyaml::detail::str_view token = "    foo\n"
+                                         "  bar\n";
+
+        header.chomp = fkyaml::detail::chomping_indicator_t::CLIP;
+        header.indent = 2;
+
+        REQUIRE_NOTHROW(node = scalar_parser.parse_block(lex_type, tag_type, token, header));
+        REQUIRE(node.is_string());
+        REQUIRE(node.get_value_ref<std::string&>() == "  foo\nbar\n");
+    }
+
+    SECTION("folded string scalar with the non-first line being more indented than the indicated level") {
+        fkyaml::detail::str_view token = "  foo\n"
+                                         "    bar\n";
+
+        header.chomp = fkyaml::detail::chomping_indicator_t::CLIP;
+        header.indent = 2;
+
+        REQUIRE_NOTHROW(node = scalar_parser.parse_block(lex_type, tag_type, token, header));
+        REQUIRE(node.is_string());
+        REQUIRE(node.get_value_ref<std::string&>() == "foo\n  bar\n");
+    }
+
+    SECTION("folded string scalar") {
+        fkyaml::detail::str_view token = "  foo\n"
+                                         "  \n"
+                                         "\n"
+                                         "  bar\n"
+                                         " \n";
+
+        header.chomp = fkyaml::detail::chomping_indicator_t::CLIP;
+        header.indent = 2;
+
+        REQUIRE_NOTHROW(node = scalar_parser.parse_block(lex_type, tag_type, token, header));
+        REQUIRE(node.is_string());
+        REQUIRE(node.get_value_ref<std::string&>() == "foo\n\nbar\n");
+    }
+
+    SECTION("folded string scalar with implicit indentation and strip chomping") {
+        fkyaml::detail::str_view token = "  foo\n"
+                                         "  bar\n"
+                                         " \n"
+                                         "\n";
+
+        header.chomp = fkyaml::detail::chomping_indicator_t::STRIP;
+        header.indent = 2;
+
+        REQUIRE_NOTHROW(node = scalar_parser.parse_block(lex_type, tag_type, token, header));
+        REQUIRE(node.is_string());
+        REQUIRE(node.get_value_ref<std::string&>() == "foo bar");
+    }
+
+    SECTION("folded string scalar with implicit indentation and clip chomping") {
+        fkyaml::detail::str_view token = "  foo\n"
+                                         "  bar\n"
+                                         "  \n"
+                                         "\n";
+
+        header.chomp = fkyaml::detail::chomping_indicator_t::CLIP;
+        header.indent = 2;
+
+        REQUIRE_NOTHROW(node = scalar_parser.parse_block(lex_type, tag_type, token, header));
+        REQUIRE(node.is_string());
+        REQUIRE(node.get_value_ref<std::string&>() == "foo bar\n");
+    }
+
+    SECTION("folded string scalar with implicit indentation and keep chomping") {
+        fkyaml::detail::str_view token = "  foo\n"
+                                         "  bar\n"
+                                         " \n"
+                                         "\n";
+
+        header.chomp = fkyaml::detail::chomping_indicator_t::KEEP;
+        header.indent = 2;
+
+        REQUIRE_NOTHROW(node = scalar_parser.parse_block(lex_type, tag_type, token, header));
+        REQUIRE(node.is_string());
+        REQUIRE(node.get_value_ref<std::string&>() == "foo bar\n\n");
+    }
+
+    SECTION("block folded scalar with no newline at the last content line and strip chomping.") {
+        fkyaml::detail::str_view token = "  foo\n"
+                                         "  bar\n"
+                                         "\n"
+                                         "  baz";
+        header.chomp = fkyaml::detail::chomping_indicator_t::STRIP;
+        header.indent = 2;
+
+        REQUIRE_NOTHROW(node = scalar_parser.parse_block(lex_type, tag_type, token, header));
+        REQUIRE(node.is_string());
+        REQUIRE(node.get_value_ref<std::string&>() == "foo bar\nbaz");
+    }
+
+    SECTION("block folded scalar with no newline at the last content line and clip chomping.") {
+        fkyaml::detail::str_view token = "  foo\n"
+                                         "  bar\n"
+                                         "\n"
+                                         "  baz";
+        header.chomp = fkyaml::detail::chomping_indicator_t::CLIP;
+        header.indent = 2;
+
+        REQUIRE_NOTHROW(node = scalar_parser.parse_block(lex_type, tag_type, token, header));
+        REQUIRE(node.is_string());
+        REQUIRE(node.get_value_ref<std::string&>() == "foo bar\nbaz");
+    }
+
+    SECTION("block folded scalar with no newline at the last more-indented content line.") {
+        fkyaml::detail::str_view token = "  foo\n"
+                                         "  bar\n"
+                                         "\n"
+                                         "    baz";
+        header.chomp = fkyaml::detail::chomping_indicator_t::STRIP;
+        header.indent = 2;
+
+        REQUIRE_NOTHROW(node = scalar_parser.parse_block(lex_type, tag_type, token, header));
+        REQUIRE(node.is_string());
+        REQUIRE(node.get_value_ref<std::string&>() == "foo bar\n  baz");
     }
 }

--- a/tool/benchmark/results/result_debug_citm_catalog_json.txt
+++ b/tool/benchmark/results/result_debug_citm_catalog_json.txt
@@ -1,4 +1,4 @@
-2024-09-22T12:25:20+09:00
+2024-10-13T02:04:56+09:00
 Running ./build_bm_debug/tool/benchmark/benchmarker
 Run on (16 X 3193.88 MHz CPU s)
 CPU Caches:
@@ -6,13 +6,13 @@ CPU Caches:
   L1 Instruction 32 KiB (x8)
   L2 Unified 512 KiB (x8)
   L3 Unified 16384 KiB (x1)
-Load Average: 0.30, 0.20, 0.17
+Load Average: 0.16, 0.30, 0.40
 ***WARNING*** Library was built as DEBUG. Timings may be affected.
 -------------------------------------------------------------------------------------
 Benchmark                           Time             CPU   Iterations UserCounters...
 -------------------------------------------------------------------------------------
-bm_fkyaml_parse              23303829 ns     23303823 ns           30 bytes_per_second=70.6833Mi/s items_per_second=42.9114/s
-bm_yamlcpp_parse            816478049 ns    816477500 ns            1 bytes_per_second=2.01743Mi/s items_per_second=1.22477/s
-bm_libfyaml_parse           116887627 ns    116889180 ns            5 bytes_per_second=14.0919Mi/s items_per_second=8.55511/s
-bm_rapidyaml_parse_inplace     338595 ns       338597 ns         2068 bytes_per_second=4.75074Gi/s items_per_second=2.95337k/s
-bm_rapidyaml_parse_arena     42533477 ns     42533631 ns           16 bytes_per_second=38.7268Mi/s items_per_second=23.5108/s
+bm_fkyaml_parse              23349021 ns     23347957 ns           30 bytes_per_second=70.5496Mi/s items_per_second=42.8303/s
+bm_yamlcpp_parse            831355289 ns    831372800 ns            1 bytes_per_second=1.98129Mi/s items_per_second=1.20283/s
+bm_libfyaml_parse           119048859 ns    119053880 ns            5 bytes_per_second=13.8357Mi/s items_per_second=8.39956/s
+bm_rapidyaml_parse_inplace      65126 ns        65125 ns         8378 bytes_per_second=24.7001Gi/s items_per_second=15.3552k/s
+bm_rapidyaml_parse_arena     44036503 ns     44038113 ns           16 bytes_per_second=37.4037Mi/s items_per_second=22.7076/s

--- a/tool/benchmark/results/result_debug_citm_catalog_yml.txt
+++ b/tool/benchmark/results/result_debug_citm_catalog_yml.txt
@@ -1,4 +1,4 @@
-2024-09-22T12:25:25+09:00
+2024-10-13T02:05:01+09:00
 Running ./build_bm_debug/tool/benchmark/benchmarker
 Run on (16 X 3193.88 MHz CPU s)
 CPU Caches:
@@ -6,13 +6,13 @@ CPU Caches:
   L1 Instruction 32 KiB (x8)
   L2 Unified 512 KiB (x8)
   L3 Unified 16384 KiB (x1)
-Load Average: 0.36, 0.21, 0.17
+Load Average: 0.23, 0.31, 0.40
 ***WARNING*** Library was built as DEBUG. Timings may be affected.
 -------------------------------------------------------------------------------------
 Benchmark                           Time             CPU   Iterations UserCounters...
 -------------------------------------------------------------------------------------
-bm_fkyaml_parse              22665404 ns     22665366 ns           32 bytes_per_second=30.1867Mi/s items_per_second=44.1202/s
-bm_yamlcpp_parse            866754333 ns    866758100 ns            1 bytes_per_second=808.316Ki/s items_per_second=1.15372/s
-bm_libfyaml_parse           110156634 ns    110156929 ns            7 bytes_per_second=6.21108Mi/s items_per_second=9.07796/s
-bm_rapidyaml_parse_inplace      22414 ns        22414 ns        31799 bytes_per_second=29.8103Gi/s items_per_second=44.6157k/s
-bm_rapidyaml_parse_arena     35693411 ns     35693555 ns           20 bytes_per_second=19.1685Mi/s items_per_second=28.0163/s
+bm_fkyaml_parse              22455707 ns     22457000 ns           30 bytes_per_second=30.4668Mi/s items_per_second=44.5295/s
+bm_yamlcpp_parse            848988826 ns    848900400 ns            1 bytes_per_second=825.32Ki/s items_per_second=1.17799/s
+bm_libfyaml_parse           112468150 ns    112466929 ns            7 bytes_per_second=6.08351Mi/s items_per_second=8.8915/s
+bm_rapidyaml_parse_inplace      20576 ns        20574 ns        34118 bytes_per_second=32.4757Gi/s items_per_second=48.6049k/s
+bm_rapidyaml_parse_arena     35946283 ns     35944910 ns           20 bytes_per_second=19.0345Mi/s items_per_second=27.8204/s

--- a/tool/benchmark/results/result_debug_ubuntu_yml.txt
+++ b/tool/benchmark/results/result_debug_ubuntu_yml.txt
@@ -1,4 +1,4 @@
-2024-09-22T12:25:16+09:00
+2024-10-13T02:04:52+09:00
 Running ./build_bm_debug/tool/benchmark/benchmarker
 Run on (16 X 3193.88 MHz CPU s)
 CPU Caches:
@@ -6,13 +6,13 @@ CPU Caches:
   L1 Instruction 32 KiB (x8)
   L2 Unified 512 KiB (x8)
   L3 Unified 16384 KiB (x1)
-Load Average: 0.30, 0.20, 0.17
+Load Average: 0.09, 0.28, 0.40
 ***WARNING*** Library was built as DEBUG. Timings may be affected.
 -------------------------------------------------------------------------------------
 Benchmark                           Time             CPU   Iterations UserCounters...
 -------------------------------------------------------------------------------------
-bm_fkyaml_parse                174850 ns       174852 ns         3991 bytes_per_second=48.0896Mi/s items_per_second=5.71913k/s
-bm_yamlcpp_parse              8001403 ns      8001507 ns           89 bytes_per_second=1.05087Mi/s items_per_second=124.976/s
-bm_libfyaml_parse             1002105 ns      1002095 ns          691 bytes_per_second=8.39097Mi/s items_per_second=997.909/s
-bm_rapidyaml_parse_inplace        913 ns          913 ns       772583 bytes_per_second=8.9962Gi/s items_per_second=1.09556M/s
-bm_rapidyaml_parse_arena       285457 ns       285459 ns         2452 bytes_per_second=29.4563Mi/s items_per_second=3.50313k/s
+bm_fkyaml_parse                165697 ns       165705 ns         4219 bytes_per_second=50.744Mi/s items_per_second=6.03481k/s
+bm_yamlcpp_parse              7938718 ns      7939041 ns           88 bytes_per_second=1.05914Mi/s items_per_second=125.96/s
+bm_libfyaml_parse             1025815 ns      1025825 ns          680 bytes_per_second=8.19686Mi/s items_per_second=974.825/s
+bm_rapidyaml_parse_inplace        959 ns          959 ns       717671 bytes_per_second=8.56577Gi/s items_per_second=1.04315M/s
+bm_rapidyaml_parse_arena       289903 ns       289915 ns         2444 bytes_per_second=29.0035Mi/s items_per_second=3.44929k/s

--- a/tool/benchmark/results/result_release_citm_catalog_json.txt
+++ b/tool/benchmark/results/result_release_citm_catalog_json.txt
@@ -1,4 +1,4 @@
-2024-09-22T12:14:55+09:00
+2024-10-13T01:55:12+09:00
 Running ./build_bm_release/tool/benchmark/benchmarker
 Run on (16 X 3193.88 MHz CPU s)
 CPU Caches:
@@ -6,12 +6,12 @@ CPU Caches:
   L1 Instruction 32 KiB (x8)
   L2 Unified 512 KiB (x8)
   L3 Unified 16384 KiB (x1)
-Load Average: 0.28, 0.23, 0.15
+Load Average: 0.38, 0.40, 0.44
 -------------------------------------------------------------------------------------
 Benchmark                           Time             CPU   Iterations UserCounters...
 -------------------------------------------------------------------------------------
-bm_fkyaml_parse              21801608 ns     21801655 ns           31 bytes_per_second=75.5534Mi/s items_per_second=45.8681/s
-bm_yamlcpp_parse            111770417 ns    111770867 ns            6 bytes_per_second=14.7372Mi/s items_per_second=8.94688/s
-bm_libfyaml_parse            31701073 ns     31701176 ns           25 bytes_per_second=51.9599Mi/s items_per_second=31.5446/s
-bm_rapidyaml_parse_inplace      97463 ns        97463 ns         7205 bytes_per_second=16.5046Gi/s items_per_second=10.2603k/s
-bm_rapidyaml_parse_arena     11288564 ns     11288585 ns           62 bytes_per_second=145.916Mi/s items_per_second=88.5851/s
+bm_fkyaml_parse              19846319 ns     19847303 ns           35 bytes_per_second=82.9931Mi/s items_per_second=50.3847/s
+bm_yamlcpp_parse            115684121 ns    115689950 ns            6 bytes_per_second=14.238Mi/s items_per_second=8.64379/s
+bm_libfyaml_parse            31415418 ns     31416483 ns           24 bytes_per_second=52.4308Mi/s items_per_second=31.8304/s
+bm_rapidyaml_parse_inplace      53018 ns        53020 ns        12756 bytes_per_second=30.339Gi/s items_per_second=18.8607k/s
+bm_rapidyaml_parse_arena     11307118 ns     11307543 ns           61 bytes_per_second=145.672Mi/s items_per_second=88.4365/s

--- a/tool/benchmark/results/result_release_citm_catalog_yml.txt
+++ b/tool/benchmark/results/result_release_citm_catalog_yml.txt
@@ -1,4 +1,4 @@
-2024-09-22T12:14:59+09:00
+2024-10-13T01:55:16+09:00
 Running ./build_bm_release/tool/benchmark/benchmarker
 Run on (16 X 3193.88 MHz CPU s)
 CPU Caches:
@@ -6,12 +6,12 @@ CPU Caches:
   L1 Instruction 32 KiB (x8)
   L2 Unified 512 KiB (x8)
   L3 Unified 16384 KiB (x1)
-Load Average: 0.34, 0.24, 0.15
+Load Average: 0.43, 0.41, 0.44
 -------------------------------------------------------------------------------------
 Benchmark                           Time             CPU   Iterations UserCounters...
 -------------------------------------------------------------------------------------
-bm_fkyaml_parse              20864500 ns     20864556 ns           34 bytes_per_second=32.7921Mi/s items_per_second=47.9282/s
-bm_yamlcpp_parse            110143678 ns    110145200 ns            6 bytes_per_second=6.21174Mi/s items_per_second=9.07892/s
-bm_libfyaml_parse            29383166 ns     29383492 ns           26 bytes_per_second=23.285Mi/s items_per_second=34.0327/s
-bm_rapidyaml_parse_inplace      22769 ns        22770 ns        28128 bytes_per_second=29.3442Gi/s items_per_second=43.918k/s
-bm_rapidyaml_parse_arena     10030665 ns     10030402 ns           65 bytes_per_second=68.212Mi/s items_per_second=99.6969/s
+bm_fkyaml_parse              19463284 ns     19463849 ns           37 bytes_per_second=35.152Mi/s items_per_second=51.3773/s
+bm_yamlcpp_parse            111843539 ns    111849533 ns            6 bytes_per_second=6.11709Mi/s items_per_second=8.94058/s
+bm_libfyaml_parse            29637484 ns     29638652 ns           25 bytes_per_second=23.0845Mi/s items_per_second=33.7397/s
+bm_rapidyaml_parse_inplace      21471 ns        21472 ns        29716 bytes_per_second=31.117Gi/s items_per_second=46.5713k/s
+bm_rapidyaml_parse_arena     10318869 ns     10318941 ns           66 bytes_per_second=66.3046Mi/s items_per_second=96.9092/s

--- a/tool/benchmark/results/result_release_ubuntu_yml.txt
+++ b/tool/benchmark/results/result_release_ubuntu_yml.txt
@@ -1,4 +1,4 @@
-2024-09-22T12:14:50+09:00
+2024-10-13T01:55:07+09:00
 Running ./build_bm_release/tool/benchmark/benchmarker
 Run on (16 X 3193.88 MHz CPU s)
 CPU Caches:
@@ -6,12 +6,12 @@ CPU Caches:
   L1 Instruction 32 KiB (x8)
   L2 Unified 512 KiB (x8)
   L3 Unified 16384 KiB (x1)
-Load Average: 0.13, 0.20, 0.14
+Load Average: 0.32, 0.38, 0.44
 -------------------------------------------------------------------------------------
 Benchmark                           Time             CPU   Iterations UserCounters...
 -------------------------------------------------------------------------------------
-bm_fkyaml_parse                166631 ns       166631 ns         4133 bytes_per_second=50.4621Mi/s items_per_second=6.00129k/s
-bm_yamlcpp_parse               969641 ns       969652 ns          736 bytes_per_second=8.67172Mi/s items_per_second=1.0313k/s
-bm_libfyaml_parse              235600 ns       235603 ns         3367 bytes_per_second=35.6895Mi/s items_per_second=4.24443k/s
-bm_rapidyaml_parse_inplace        420 ns          420 ns      1663248 bytes_per_second=19.5486Gi/s items_per_second=2.38064M/s
-bm_rapidyaml_parse_arena        59744 ns        59744 ns        11532 bytes_per_second=140.742Mi/s items_per_second=16.738k/s
+bm_fkyaml_parse                152489 ns       152496 ns         4506 bytes_per_second=55.1393Mi/s items_per_second=6.55753k/s
+bm_yamlcpp_parse               960175 ns       960191 ns          732 bytes_per_second=8.75716Mi/s items_per_second=1.04146k/s
+bm_libfyaml_parse              241862 ns       241871 ns         3140 bytes_per_second=34.7645Mi/s items_per_second=4.13443k/s
+bm_rapidyaml_parse_inplace        417 ns          417 ns      1656253 bytes_per_second=19.6806Gi/s items_per_second=2.39672M/s
+bm_rapidyaml_parse_arena        59956 ns        59958 ns        11651 bytes_per_second=140.24Mi/s items_per_second=16.6783k/s


### PR DESCRIPTION
In this PR, scalar parsing has been optimized by separating actual parsing of scalar contents from lexical analysis.  
That has significantly reduced unnecessarily complicated conditional branches and heap allocations for intermediate values.  
The performance of the whole deserialization process has therefore been increased by 5 Mi/s on average.  
|parsed YAML file|Before this PR|After this PR|
|---|---|---|
|ubuntu.yml|50.4621Mi/s|55.1393Mi/s|
|citm_catalog.json|75.5534Mi/s|82.9931Mi/s|
|citm_catalog.yml|32.7921Mi/s|35.152Mi/s|

---

## Pull Request Checklist

Read the [CONTRIBUTING.md](https://github.com/fktn-k/fkYAML/blob/develop/CONTRIBUTING.md) file for detailed information.  

- [x] Changes are described in the pull request or in a referenced [issue](https://github.com/fktn-k/fkYAML/issues).
- [x] The test suite compiles and runs without any error.
- [x] [The code coverage](https://coveralls.io/github/fktn-k/fkYAML) on your branch is 100%.
- [x] The documentation is updated if you added/changed a feature.

## Please don't

- The C++11 support varies between different **compilers** and versions. Please note the [list of supported compilers](https://github.com/fktn-k/fkYAML/blob/develop/README.md#supported-compilers). Some compilers like GCC 4.7 (and earlier), Clang 3.3 (and earlier), or Microsoft Visual Studio 13.0 and earlier are known not to work due to missing or incomplete C++11 support. Please refrain from proposing changes that work around these compiler's limitations with `#ifdef`s or other means.
- Please refrain from proposing changes that would **break [YAML](https://yaml.org/) specifications**. If you propose a conformant extension of YAML to be supported by the library, please motivate this extension.
- Please do not open pull requests that address **multiple issues**.
