### PR TITLE
Fix wrong parse result from single scalar document

### DIFF
--- a/include/fkYAML/detail/input/deserializer.hpp
+++ b/include/fkYAML/detail/input/deserializer.hpp
@@ -203,17 +203,58 @@ private:
                 lexer.get_lines_processed(), lexer.get_last_token_begin_pos(), context_state_t::FLOW_MAPPING, &root);
             token = lexer.get_next_token();
             break;
-        default: {
+        case lexical_token_t::EXPLICIT_KEY_PREFIX: {
+            // If the explicit key prefix (? ) is detected here, the root node of current document must be a mapping.
+            // Also, tag and anchor if any are associated to the root mapping node.
+            // No get_next_token() call here to handle the token event in the deserialize_node() function.
             root = basic_node_type::mapping();
             apply_directive_set(root);
-            if (found_props && line < lexer.get_lines_processed()) {
-                // If node properties and a followed node are on the different line, the properties belong to the root
-                // node.
-                apply_node_properties(root);
-            }
+            apply_node_properties(root);
             parse_context context(
                 lexer.get_lines_processed(), lexer.get_last_token_begin_pos(), context_state_t::BLOCK_MAPPING, &root);
             m_context_stack.emplace_back(std::move(context));
+            break;
+        }
+        case lexical_token_t::BLOCK_LITERAL_SCALAR:
+        case lexical_token_t::BLOCK_FOLDED_SCALAR:
+            // If a block scalar token is detected here, current document contains single scalar.
+            // Do nothing here since the token is handled in the deserialize_node() function.
+            break;
+        case lexical_token_t::PLAIN_SCALAR:
+        case lexical_token_t::SINGLE_QUOTED_SCALAR:
+        case lexical_token_t::DOUBLE_QUOTED_SCALAR:
+        case lexical_token_t::ALIAS_PREFIX:
+            // Defer handling the above token events until the next call on the deserialize_scalar() function since the
+            // meaning depends on subsequent events.
+            if (found_props && line < lexer.get_lines_processed()) {
+                // If node properties and a followed node are on the different line, the properties belong to the root
+                // node.
+                if (m_needs_anchor_impl) {
+                    m_root_anchor_name = std::move(m_anchor_name);
+                    m_needs_anchor_impl = false;
+                    m_anchor_name.clear();
+                }
+
+                if (m_needs_tag_impl) {
+                    m_root_tag_name = std::move(m_tag_name);
+                    m_needs_tag_impl = false;
+                    m_tag_name.clear();
+                }
+            }
+            break;
+        default: {
+            // root = basic_node_type::mapping();
+            // apply_directive_set(root);
+            // if (found_props && line < lexer.get_lines_processed()) {
+            //     // If node properties and a followed node are on the different line, the properties belong to the
+            //     root
+            //     // node.
+            //     apply_node_properties(root);
+            // }
+            // parse_context context(
+            //     lexer.get_lines_processed(), lexer.get_last_token_begin_pos(), context_state_t::BLOCK_MAPPING,
+            //     &root);
+            // m_context_stack.emplace_back(std::move(context));
             break;
         }
         }
@@ -1092,6 +1133,12 @@ private:
 
         // a scalar node
         *mp_current_node = std::move(node_value);
+
+        if (m_context_stack.empty()) {
+            // single scalar document
+            return;
+        }
+
         if (m_flow_context_depth > 0 || m_context_stack.back().state != context_state_t::BLOCK_MAPPING_EXPLICIT_KEY) {
             m_context_stack.pop_back();
             mp_current_node = m_context_stack.back().p_node;
@@ -1137,24 +1184,41 @@ private:
             }
 
             if (mp_current_node->is_scalar()) {
-                parse_context& cur_context = m_context_stack.back();
-                switch (cur_context.state) {
-                case context_state_t::BLOCK_MAPPING_EXPLICIT_KEY:
-                case context_state_t::BLOCK_MAPPING_EXPLICIT_VALUE:
+                if (m_context_stack.empty()) {
                     m_context_stack.emplace_back(line, indent, context_state_t::BLOCK_MAPPING, mp_current_node);
-                    break;
-                default:
-                    if FK_YAML_UNLIKELY (cur_context.line == line) {
-                        throw parse_error("Multiple mapping keys are specified on the same line.", line, indent);
-                    }
-                    cur_context.line = line;
-                    cur_context.indent = indent;
-                    cur_context.state = context_state_t::BLOCK_MAPPING;
-                    break;
-                }
+                    *mp_current_node = basic_node_type::mapping();
+                    apply_directive_set(*mp_current_node);
 
-                *mp_current_node = basic_node_type::mapping();
-                apply_directive_set(*mp_current_node);
+                    // apply node properties if any to the root mapping node.
+                    if (!m_root_anchor_name.empty()) {
+                        mp_current_node->add_anchor_name(std::move(m_root_anchor_name));
+                        m_root_anchor_name.clear();
+                    }
+                    if (!m_root_tag_name.empty()) {
+                        mp_current_node->add_tag_name(std::move(m_root_tag_name));
+                        m_root_tag_name.clear();
+                    }
+                }
+                else {
+                    parse_context& cur_context = m_context_stack.back();
+                    switch (cur_context.state) {
+                    case context_state_t::BLOCK_MAPPING_EXPLICIT_KEY:
+                    case context_state_t::BLOCK_MAPPING_EXPLICIT_VALUE:
+                        m_context_stack.emplace_back(line, indent, context_state_t::BLOCK_MAPPING, mp_current_node);
+                        break;
+                    default:
+                        if FK_YAML_UNLIKELY (cur_context.line == line) {
+                            throw parse_error("Multiple mapping keys are specified on the same line.", line, indent);
+                        }
+                        cur_context.line = line;
+                        cur_context.indent = indent;
+                        cur_context.state = context_state_t::BLOCK_MAPPING;
+                        break;
+                    }
+
+                    *mp_current_node = basic_node_type::mapping();
+                    apply_directive_set(*mp_current_node);
+                }
             }
             add_new_key(std::move(node), line, indent);
         }
@@ -1213,6 +1277,10 @@ private:
     std::string m_anchor_name {};
     /// The last tag name.
     std::string m_tag_name {};
+    /// The root YAML anchor name. (maybe empty and unused)
+    std::string m_root_anchor_name {};
+    /// The root tag name. (maybe empty and unused)
+    std::string m_root_tag_name {};
 };
 
 FK_YAML_DETAIL_NAMESPACE_END

--- a/include/fkYAML/detail/input/deserializer.hpp
+++ b/include/fkYAML/detail/input/deserializer.hpp
@@ -242,21 +242,9 @@ private:
                 }
             }
             break;
-        default: {
-            // root = basic_node_type::mapping();
-            // apply_directive_set(root);
-            // if (found_props && line < lexer.get_lines_processed()) {
-            //     // If node properties and a followed node are on the different line, the properties belong to the
-            //     root
-            //     // node.
-            //     apply_node_properties(root);
-            // }
-            // parse_context context(
-            //     lexer.get_lines_processed(), lexer.get_last_token_begin_pos(), context_state_t::BLOCK_MAPPING,
-            //     &root);
-            // m_context_stack.emplace_back(std::move(context));
+        default:
+            // Do nothing since current document has no contents.
             break;
-        }
         }
 
         mp_current_node = &root;
@@ -1133,19 +1121,20 @@ private:
 
         // a scalar node
         *mp_current_node = std::move(node_value);
+        if FK_YAML_LIKELY (!m_context_stack.empty()) {
+            if (m_flow_context_depth > 0 ||
+                m_context_stack.back().state != context_state_t::BLOCK_MAPPING_EXPLICIT_KEY) {
+                m_context_stack.pop_back();
+                mp_current_node = m_context_stack.back().p_node;
 
-        if (m_context_stack.empty()) {
-            // single scalar document
-            return;
-        }
-
-        if (m_flow_context_depth > 0 || m_context_stack.back().state != context_state_t::BLOCK_MAPPING_EXPLICIT_KEY) {
-            m_context_stack.pop_back();
-            mp_current_node = m_context_stack.back().p_node;
-
-            if (m_flow_context_depth > 0) {
-                m_flow_token_state = flow_token_state_t::NEEDS_SEPARATOR_OR_SUFFIX;
+                if (m_flow_context_depth > 0) {
+                    m_flow_token_state = flow_token_state_t::NEEDS_SEPARATOR_OR_SUFFIX;
+                }
             }
+        }
+        else {
+            // single scalar document.
+            return;
         }
     }
 
@@ -1184,22 +1173,7 @@ private:
             }
 
             if (mp_current_node->is_scalar()) {
-                if (m_context_stack.empty()) {
-                    m_context_stack.emplace_back(line, indent, context_state_t::BLOCK_MAPPING, mp_current_node);
-                    *mp_current_node = basic_node_type::mapping();
-                    apply_directive_set(*mp_current_node);
-
-                    // apply node properties if any to the root mapping node.
-                    if (!m_root_anchor_name.empty()) {
-                        mp_current_node->add_anchor_name(std::move(m_root_anchor_name));
-                        m_root_anchor_name.clear();
-                    }
-                    if (!m_root_tag_name.empty()) {
-                        mp_current_node->add_tag_name(std::move(m_root_tag_name));
-                        m_root_tag_name.clear();
-                    }
-                }
-                else {
+                if FK_YAML_LIKELY (!m_context_stack.empty()) {
                     parse_context& cur_context = m_context_stack.back();
                     switch (cur_context.state) {
                     case context_state_t::BLOCK_MAPPING_EXPLICIT_KEY:
@@ -1218,6 +1192,23 @@ private:
 
                     *mp_current_node = basic_node_type::mapping();
                     apply_directive_set(*mp_current_node);
+                }
+                else {
+                    // root mapping node
+
+                    m_context_stack.emplace_back(line, indent, context_state_t::BLOCK_MAPPING, mp_current_node);
+                    *mp_current_node = basic_node_type::mapping();
+                    apply_directive_set(*mp_current_node);
+
+                    // apply node properties if any to the root mapping node.
+                    if (!m_root_anchor_name.empty()) {
+                        mp_current_node->add_anchor_name(std::move(m_root_anchor_name));
+                        m_root_anchor_name.clear();
+                    }
+                    if (!m_root_tag_name.empty()) {
+                        mp_current_node->add_tag_name(std::move(m_root_tag_name));
+                        m_root_tag_name.clear();
+                    }
                 }
             }
             add_new_key(std::move(node), line, indent);

--- a/single_include/fkYAML/node.hpp
+++ b/single_include/fkYAML/node.hpp
@@ -6726,17 +6726,58 @@ private:
                 lexer.get_lines_processed(), lexer.get_last_token_begin_pos(), context_state_t::FLOW_MAPPING, &root);
             token = lexer.get_next_token();
             break;
-        default: {
+        case lexical_token_t::EXPLICIT_KEY_PREFIX: {
+            // If the explicit key prefix (? ) is detected here, the root node of current document must be a mapping.
+            // Also, tag and anchor if any are associated to the root mapping node.
+            // No get_next_token() call here to handle the token event in the deserialize_node() function.
             root = basic_node_type::mapping();
             apply_directive_set(root);
-            if (found_props && line < lexer.get_lines_processed()) {
-                // If node properties and a followed node are on the different line, the properties belong to the root
-                // node.
-                apply_node_properties(root);
-            }
+            apply_node_properties(root);
             parse_context context(
                 lexer.get_lines_processed(), lexer.get_last_token_begin_pos(), context_state_t::BLOCK_MAPPING, &root);
             m_context_stack.emplace_back(std::move(context));
+            break;
+        }
+        case lexical_token_t::BLOCK_LITERAL_SCALAR:
+        case lexical_token_t::BLOCK_FOLDED_SCALAR:
+            // If a block scalar token is detected here, current document contains single scalar.
+            // Do nothing here since the token is handled in the deserialize_node() function.
+            break;
+        case lexical_token_t::PLAIN_SCALAR:
+        case lexical_token_t::SINGLE_QUOTED_SCALAR:
+        case lexical_token_t::DOUBLE_QUOTED_SCALAR:
+        case lexical_token_t::ALIAS_PREFIX:
+            // Defer handling the above token events until the next call on the deserialize_scalar() function since the
+            // meaning depends on subsequent events.
+            if (found_props && line < lexer.get_lines_processed()) {
+                // If node properties and a followed node are on the different line, the properties belong to the root
+                // node.
+                if (m_needs_anchor_impl) {
+                    m_root_anchor_name = std::move(m_anchor_name);
+                    m_needs_anchor_impl = false;
+                    m_anchor_name.clear();
+                }
+
+                if (m_needs_tag_impl) {
+                    m_root_tag_name = std::move(m_tag_name);
+                    m_needs_tag_impl = false;
+                    m_tag_name.clear();
+                }
+            }
+            break;
+        default: {
+            // root = basic_node_type::mapping();
+            // apply_directive_set(root);
+            // if (found_props && line < lexer.get_lines_processed()) {
+            //     // If node properties and a followed node are on the different line, the properties belong to the
+            //     root
+            //     // node.
+            //     apply_node_properties(root);
+            // }
+            // parse_context context(
+            //     lexer.get_lines_processed(), lexer.get_last_token_begin_pos(), context_state_t::BLOCK_MAPPING,
+            //     &root);
+            // m_context_stack.emplace_back(std::move(context));
             break;
         }
         }
@@ -7615,6 +7656,12 @@ private:
 
         // a scalar node
         *mp_current_node = std::move(node_value);
+
+        if (m_context_stack.empty()) {
+            // single scalar document
+            return;
+        }
+
         if (m_flow_context_depth > 0 || m_context_stack.back().state != context_state_t::BLOCK_MAPPING_EXPLICIT_KEY) {
             m_context_stack.pop_back();
             mp_current_node = m_context_stack.back().p_node;
@@ -7660,24 +7707,41 @@ private:
             }
 
             if (mp_current_node->is_scalar()) {
-                parse_context& cur_context = m_context_stack.back();
-                switch (cur_context.state) {
-                case context_state_t::BLOCK_MAPPING_EXPLICIT_KEY:
-                case context_state_t::BLOCK_MAPPING_EXPLICIT_VALUE:
+                if (m_context_stack.empty()) {
                     m_context_stack.emplace_back(line, indent, context_state_t::BLOCK_MAPPING, mp_current_node);
-                    break;
-                default:
-                    if FK_YAML_UNLIKELY (cur_context.line == line) {
-                        throw parse_error("Multiple mapping keys are specified on the same line.", line, indent);
-                    }
-                    cur_context.line = line;
-                    cur_context.indent = indent;
-                    cur_context.state = context_state_t::BLOCK_MAPPING;
-                    break;
-                }
+                    *mp_current_node = basic_node_type::mapping();
+                    apply_directive_set(*mp_current_node);
 
-                *mp_current_node = basic_node_type::mapping();
-                apply_directive_set(*mp_current_node);
+                    // apply node properties if any to the root mapping node.
+                    if (!m_root_anchor_name.empty()) {
+                        mp_current_node->add_anchor_name(std::move(m_root_anchor_name));
+                        m_root_anchor_name.clear();
+                    }
+                    if (!m_root_tag_name.empty()) {
+                        mp_current_node->add_tag_name(std::move(m_root_tag_name));
+                        m_root_tag_name.clear();
+                    }
+                }
+                else {
+                    parse_context& cur_context = m_context_stack.back();
+                    switch (cur_context.state) {
+                    case context_state_t::BLOCK_MAPPING_EXPLICIT_KEY:
+                    case context_state_t::BLOCK_MAPPING_EXPLICIT_VALUE:
+                        m_context_stack.emplace_back(line, indent, context_state_t::BLOCK_MAPPING, mp_current_node);
+                        break;
+                    default:
+                        if FK_YAML_UNLIKELY (cur_context.line == line) {
+                            throw parse_error("Multiple mapping keys are specified on the same line.", line, indent);
+                        }
+                        cur_context.line = line;
+                        cur_context.indent = indent;
+                        cur_context.state = context_state_t::BLOCK_MAPPING;
+                        break;
+                    }
+
+                    *mp_current_node = basic_node_type::mapping();
+                    apply_directive_set(*mp_current_node);
+                }
             }
             add_new_key(std::move(node), line, indent);
         }
@@ -7736,6 +7800,10 @@ private:
     std::string m_anchor_name {};
     /// The last tag name.
     std::string m_tag_name {};
+    /// The root YAML anchor name. (maybe empty and unused)
+    std::string m_root_anchor_name {};
+    /// The root tag name. (maybe empty and unused)
+    std::string m_root_tag_name {};
 };
 
 FK_YAML_DETAIL_NAMESPACE_END

--- a/test/unit_test/test_deserializer_class.cpp
+++ b/test/unit_test/test_deserializer_class.cpp
@@ -15,8 +15,7 @@ TEST_CASE("Deserializer_EmptyInput") {
     fkyaml::node root;
 
     REQUIRE_NOTHROW(root = deserializer.deserialize(fkyaml::detail::input_adapter(" ")));
-    REQUIRE(root.is_mapping());
-    REQUIRE(root.empty());
+    REQUIRE(root.is_null());
 }
 
 TEST_CASE("Deserializer_KeySeparator") {
@@ -98,6 +97,12 @@ TEST_CASE("Deserializer_BooleanValue") {
         REQUIRE_NOTHROW(root = deserializer.deserialize(fkyaml::detail::input_adapter("test:\n  - False")));
         REQUIRE(root["test"][0].get_value<bool>() == false);
     }
+
+    SECTION("root scalar") {
+        REQUIRE_NOTHROW(root = deserializer.deserialize(fkyaml::detail::input_adapter("true")));
+        REQUIRE(root.is_boolean());
+        REQUIRE(root.get_value<bool>() == true);
+    }
 }
 
 TEST_CASE("Deserializer_IntegerKey") {
@@ -124,6 +129,12 @@ TEST_CASE("Deserializer_IntegerKey") {
         REQUIRE_NOTHROW(root = deserializer.deserialize(fkyaml::detail::input_adapter("test:\n  - 123")));
         REQUIRE(root["test"][0].get_value<int>() == 123);
     }
+
+    SECTION("root scalar") {
+        REQUIRE_NOTHROW(root = deserializer.deserialize(fkyaml::detail::input_adapter("123")));
+        REQUIRE(root.is_integer());
+        REQUIRE(root.get_value<int>() == 123);
+    }
 }
 
 TEST_CASE("Deserializer_FloatingPointNumberKey") {
@@ -149,6 +160,12 @@ TEST_CASE("Deserializer_FloatingPointNumberKey") {
     SECTION("sequence value.") {
         REQUIRE_NOTHROW(root = deserializer.deserialize(fkyaml::detail::input_adapter("test:\n  - 1.23e-5")));
         REQUIRE(root["test"][0].get_value<double>() == 1.23e-5);
+    }
+
+    SECTION("root scalar") {
+        REQUIRE_NOTHROW(root = deserializer.deserialize(fkyaml::detail::input_adapter("3.14")));
+        REQUIRE(root.is_float_number());
+        REQUIRE(root.get_value<double>() == 3.14);
     }
 }
 
@@ -206,6 +223,17 @@ TEST_CASE("Deserializer_BlockLiteralScalar") {
         REQUIRE(val_node.is_string());
         REQUIRE(val_node.get_value_ref<std::string&>() == "map value");
     }
+
+    SECTION("root scalar") {
+        std::string input = "--- |\n"
+                            "  first sentence.\n"
+                            "  second sentence.\n"
+                            "  last sentence.\n";
+
+        REQUIRE_NOTHROW(root = deserializer.deserialize(fkyaml::detail::input_adapter(input)));
+        REQUIRE(root.is_string());
+        REQUIRE(root.get_value_ref<std::string&>() == "first sentence.\nsecond sentence.\nlast sentence.\n");
+    }
 }
 
 TEST_CASE("Deserializer_BlockFoldedScalar") {
@@ -261,6 +289,17 @@ TEST_CASE("Deserializer_BlockFoldedScalar") {
         fkyaml::node& val_node = root["first sentence. second sentence. last sentence.\n"];
         REQUIRE(val_node.is_string());
         REQUIRE(val_node.get_value_ref<std::string&>() == "map value");
+    }
+
+    SECTION("root scalar") {
+        std::string input = "--- >\n"
+                            "  first sentence.\n"
+                            "  second sentence.\n"
+                            "  last sentence.\n";
+
+        REQUIRE_NOTHROW(root = deserializer.deserialize(fkyaml::detail::input_adapter(input)));
+        REQUIRE(root.is_string());
+        REQUIRE(root.get_value_ref<std::string&>() == "first sentence. second sentence. last sentence.\n");
     }
 }
 
@@ -2189,8 +2228,7 @@ TEST_CASE("Deserializer_InvalidDirective") {
     fkyaml::node root;
 
     REQUIRE_NOTHROW(root = deserializer.deserialize(fkyaml::detail::input_adapter("%INVALID foo bar")));
-    REQUIRE(root.is_mapping());
-    REQUIRE(root.empty());
+    REQUIRE(root.is_null());
 }
 
 TEST_CASE("Deserializer_Anchor") {


### PR DESCRIPTION
This PR fixes wrong parse results from YAML documents which contains only one scalar (either flow or block) as described in the issue #406.  
The root cause was that the current parser overestimates the root node is a mapping if the first node is a scalar.  
So, the overestimation is corrected by determining the root node type based on the lexical token type, and some test cases are added to validate the chages.  

---

## Pull Request Checklist

Read the [CONTRIBUTING.md](https://github.com/fktn-k/fkYAML/blob/develop/CONTRIBUTING.md) file for detailed information.  

- [x] Changes are described in the pull request or in a referenced [issue](https://github.com/fktn-k/fkYAML/issues).
- [x] The test suite compiles and runs without any error.
- [x] [The code coverage](https://coveralls.io/github/fktn-k/fkYAML) on your branch is 100%.
- [x] The documentation is updated if you added/changed a feature.

## Please don't

- The C++11 support varies between different **compilers** and versions. Please note the [list of supported compilers](https://github.com/fktn-k/fkYAML/blob/develop/README.md#supported-compilers). Some compilers like GCC 4.7 (and earlier), Clang 3.3 (and earlier), or Microsoft Visual Studio 13.0 and earlier are known not to work due to missing or incomplete C++11 support. Please refrain from proposing changes that work around these compiler's limitations with `#ifdef`s or other means.
- Please refrain from proposing changes that would **break [YAML](https://yaml.org/) specifications**. If you propose a conformant extension of YAML to be supported by the library, please motivate this extension.
- Please do not open pull requests that address **multiple issues**.
