### PR TITLE
Disable -Wdeprecated-literal-operator warnings

### DIFF
--- a/include/fkYAML/node.hpp
+++ b/include/fkYAML/node.hpp
@@ -1677,6 +1677,13 @@ inline namespace literals {
 /// @brief namespace for user-defined literals for YAML node objects.
 inline namespace yaml_literals {
 
+// Whitespace before the literal operator identifier is deprecated in C++23 or better but required in C++11.
+// Ignore the warning as a workaround. https://github.com/fktn-k/fkYAML/pull/417
+#if defined(__clang__)
+#pragma clang diagnostic push
+#pragma clang diagnostic ignored "-Wdeprecated"
+#endif
+
 /// @brief The user-defined string literal which deserializes a `char` array into a `node` object.
 /// @param s An input `char` array.
 /// @param n The size of `s`.
@@ -1712,6 +1719,11 @@ inline fkyaml::node operator"" _yaml(const char32_t* s, std::size_t n) {
 inline fkyaml::node operator"" _yaml(const char8_t* s, std::size_t n) {
     return fkyaml::node::deserialize((const char8_t*)s, (const char8_t*)s + n);
 }
+
+#if defined(__clang__)
+#pragma clang diagnostic pop
+#endif
+
 #endif
 
 } // namespace yaml_literals

--- a/single_include/fkYAML/node.hpp
+++ b/single_include/fkYAML/node.hpp
@@ -12809,6 +12809,13 @@ inline namespace literals {
 /// @brief namespace for user-defined literals for YAML node objects.
 inline namespace yaml_literals {
 
+// Whitespace before the literal operator identifier is deprecated in C++23 or better but required in C++11.
+// Ignore the warning as a workaround. https://github.com/fktn-k/fkYAML/pull/417
+#if defined(__clang__)
+#pragma clang diagnostic push
+#pragma clang diagnostic ignored "-Wdeprecated"
+#endif
+
 /// @brief The user-defined string literal which deserializes a `char` array into a `node` object.
 /// @param s An input `char` array.
 /// @param n The size of `s`.
@@ -12844,6 +12851,11 @@ inline fkyaml::node operator"" _yaml(const char32_t* s, std::size_t n) {
 inline fkyaml::node operator"" _yaml(const char8_t* s, std::size_t n) {
     return fkyaml::node::deserialize((const char8_t*)s, (const char8_t*)s + n);
 }
+
+#if defined(__clang__)
+#pragma clang diagnostic pop
+#endif
+
 #endif
 
 } // namespace yaml_literals

--- a/test/unit_test/CMakeLists.txt
+++ b/test/unit_test/CMakeLists.txt
@@ -116,18 +116,18 @@ target_compile_options(
     >
     # GNU
     $<$<CXX_COMPILER_ID:GNU>:
-      -Wall -Wextra -Werror -pedantic -Wpedantic --all-warnings --extra-warnings
+      -Wall -Wextra -Werror -pedantic -Wpedantic -Wdeprecated --all-warnings --extra-warnings
       -Wno-deprecated-declarations # for testing deprecated functions
       -Wno-self-move # necessary to build the detail::iterator class test
     >
     # Clang
     $<$<CXX_COMPILER_ID:Clang>:
-      -Wall -Wextra -Werror -pedantic
+      -Wall -Wextra -Werror -pedantic -Wdeprecated
       -Wno-c++98-compat -Wno-c++98-compat-pedantic
       -Wno-deprecated-declarations # for testing deprecated functions
     >
     $<$<CXX_COMPILER_ID:AppleClang>:
-      -Wall -Wextra -Werror -pedantic
+      -Wall -Wextra -Werror -pedantic -Wdeprecated
       -Wno-deprecated-declarations # for testing deprecated functions
     >
     # IntelLLVM


### PR DESCRIPTION
Newer versions of Clang (including AppleClang) compilers emits the `-Wdeprecated-literal-operator` warning against the definitions of literal operators `fkyaml::literals::yaml_literals::operator "" _yaml()` since a space before the suffix `_yaml` is deprecated from C++23.  
Even if the active C++ standard is not C++23, however, compiling this library with the `-Wdeprecated` compile option causes the warning.  
So, as a workaround, the `-Wdeprecated-literal-operator` warning is disabled while declaring `_yaml` literal operators.  

---

## Pull Request Checklist

Read the [CONTRIBUTING.md](https://github.com/fktn-k/fkYAML/blob/develop/CONTRIBUTING.md) file for detailed information.  

- [x] Changes are described in the pull request or in a referenced [issue](https://github.com/fktn-k/fkYAML/issues).
- [x] The test suite compiles and runs without any error.
- [x] [The code coverage](https://coveralls.io/github/fktn-k/fkYAML) on your branch is 100%.
- [x] The documentation is updated if you added/changed a feature.

## Please don't

- The C++11 support varies between different **compilers** and versions. Please note the [list of supported compilers](https://github.com/fktn-k/fkYAML/blob/develop/README.md#supported-compilers). Some compilers like GCC 4.7 (and earlier), Clang 3.3 (and earlier), or Microsoft Visual Studio 13.0 and earlier are known not to work due to missing or incomplete C++11 support. Please refrain from proposing changes that work around these compiler's limitations with `#ifdef`s or other means.
- Please refrain from proposing changes that would **break [YAML](https://yaml.org/) specifications**. If you propose a conformant extension of YAML to be supported by the library, please motivate this extension.
- Please do not open pull requests that address **multiple issues**.
