### PR TITLE
Support more STL types in from_node

### DIFF
--- a/docs/examples/ex_basic_node_get_value.cpp
+++ b/docs/examples/ex_basic_node_get_value.cpp
@@ -10,7 +10,38 @@
 #include <fkYAML/node.hpp>
 
 int main() {
-    // create a YAML node.
+    // create sequence nodes.
+    fkyaml::node seq = {true, false};
+    fkyaml::node seq2 = {123, 3.14, "foo"};
+
+    // get the node values
+    // to std::vector
+    auto bool_vec = seq.get_value<std::vector<bool>>();
+    for (auto b : bool_vec) {
+        std::cout << std::boolalpha << b << " ";
+    }
+    std::cout << "\n\n";
+    // to std::tuple
+    auto tpl = seq2.get_value<std::tuple<int, float, std::string>>();
+    std::cout << std::get<0>(tpl) << " ";
+    std::cout << std::get<1>(tpl) << " ";
+    std::cout << std::get<2>(tpl) << "\n\n";
+
+    // create a mapping node.
+    fkyaml::node map = {
+        {0, "foo"},
+        {1, "bar"},
+        {2, "baz"},
+    };
+    // get the node values
+    // to std::unordered_map
+    auto umap = map.get_value<std::unordered_map<uint32_t, std::string>>();
+    for (auto& p : umap) {
+        std::cout << p.first << " : " << p.second << std::endl;
+    }
+    std::cout << std::endl;
+
+    // create scalar nodes.
     fkyaml::node n = 1.23;
     fkyaml::node n2 = "foo";
 

--- a/docs/examples/ex_basic_node_get_value.output
+++ b/docs/examples/ex_basic_node_get_value.output
@@ -1,3 +1,11 @@
+true false 
+
+123 3.14 foo
+
+2 : baz
+1 : bar
+0 : foo
+
 1.23
 foo
 true

--- a/docs/mkdocs/docs/api/basic_node/get_value.md
+++ b/docs/mkdocs/docs/api/basic_node/get_value.md
@@ -3,37 +3,82 @@
 # <small>fkyaml::basic_node::</small>get_value
 
 ```cpp
-template <
-    typename T, typename ValueType = detail::remove_cvref_t<T>,
-    detail::enable_if_t<
-        detail::conjunction<
-            std::is_default_constructible<ValueType>, detail::has_from_node<basic_node, ValueType>>::value,
-        int> = 0>
+template <typename T, typename ValueType = detail::remove_cvref_t<T>>
 T get_value() const noexcept(
-    noexcept(ConverterType<ValueType>::from_node(std::declval<const basic_node&>(), std::declval<ValueType&>())));
+    noexcept(ConverterType<ValueType>::from_node(std::declval<const basic_node&>(), std::declval<ValueType&>()))); // (1)
+
+template <typename BasicNodeType>
+BasicNodeType get_value() const; // (2)
 ```
 
-Explicit type conversion between the internally stored YAML node value and a compatible value which is [copy-constructible](https://en.cppreference.com/w/cpp/named_req/CopyConstructible) and [default-constructible](https://en.cppreference.com/w/cpp/named_req/DefaultConstructible).  
-The conversion relies on the [`node_value_converter`](../node_value_converter/index.md)::[`from_node`](../node_value_converter/from_node.md).  
-This API makes a copy of the value.  
-If the copying costs a lot, or if you need an address of the original value, then you should call [`get_value_ref`](get_value_ref.md) instead.  
+This function converts a [fkyaml::basic_node](./index.md) to either  
 
-If the YAML node value is a null, boolean, integer or floating point, this function internally executes type conversion according to the following rules which all depend on the template paramter type `T`:
-* If the YAML node value is a **null** (node_type::NULL_OBJECT), the value can be converted to:
-    * `false` (boolean)
-    * `0` (integer)
-    * `0.0` (floating point)
-* If the YAML node value is a **boolean** (node_type::BOOLEAN), the value can be converted to:
-    * `1 /*true*/` or `0 /*false*/` (integer)
-    * `1.0 /*true*/` or `0.0 /*false*/` (floating point)
-* If the YAML node value is a **integer** (node_type::INTEGER), the value can be converted to:
-    * `true /*non-0*/` or `false /*0*/` (boolean)
-    * `static_cast`ed floating point value (floating point)
-* If the YAML node value is a **floating point** (node_type::FLOAT), the value can be converted to:
-    * `true /*non-0*/` or `false /*0*/` (boolean)
-    * `static_cast`ed integer value (integer)
+1. a compatible value ([copy-constructible](https://en.cppreference.com/w/cpp/named_req/CopyConstructible) and [default-constructible](https://en.cppreference.com/w/cpp/named_req/DefaultConstructible))  
+   The function is equivalent to executing  
+   ```cpp
+   ValueType ret;
+   ConverterType<ValueType>::from_node(*this, ret);
+   return ret;
+   ```
+   This library implements conversions from a node to a number of STL container types and scalar types. (see the notes down below)
+2. a [fkyaml::basic_node](./index.md) object  
+   The function is equivalent to executing  
+   ```cpp
+   return *this; // Copy-constructs a new basic_node object.
+   ```
 
-Note that those scalar type cannot be converted to a sequence, mapping, string scalar and throws a [`type_error`](../exception/type_error.md).
+Actual conversions rely on the [`node_value_converter`](../node_value_converter/index.md)::[`from_node`](../node_value_converter/from_node.md) function.  
+This API makes a copy of the value, and if the copying costs too much, or if you need an address of the original value, then you should call [`get_value_ref`](get_value_ref.md) instead.  
+
+???+ Note "Convert from a Sequence Node"
+
+    This library implements conversions from a sequence node to a number of STL container types whose element type is not a key-value pair. The implementation can be used for custom container types, but they need to have both `iterator` member type and `insert()` member function. The test suite confirms successful conversions to the following types.
+    
+    * std::vector, std::deque, std::list *(sequence containers)*
+    * std::set, std::multiset *(associative containers for keys)*
+    * std::unordered_set, std::unordered_multiset *(unordered associative containers for keys)*
+
+    And you can also convert to these types which do not have `insert()` member function though.
+
+    * std::array, std::valarray *(sequence containers)*
+    * std::stack, std::queue, std::priority_queue *(sequence container adapters)*
+    * std::pair, std::tuple
+
+    Note that the above types cannot be converted from a non-sequence node, which results in throwing a [type_error](../exception/type_error.md).
+
+???+ Note "Convert from a Mapping Node"
+
+    This library implements conversions from a mapping node to STL container types whose element type is a key-value pair. The implementation can be used for custom container types, but they need to have `key_type`, `mapped_type` and `value_type` member types and `emplace()` member function. The test suite confirms successful conversions to the following types.
+
+    * std::map, std::multimap *(associative containers for key-value pairs)*
+    * std::unordered_map, std::unordered_multi_map *(unordered associative containers for key-value pairs)*
+
+???+ Note "Convert from a Null or Numeric Scalar Node"
+
+    If the YAML node value is a null, boolean, integer or floating point, this function internally executes type conversion according to the following rules which all depend on the template paramter type `T`:
+
+    * If the YAML node value is a **null** (node_type::NULL_OBJECT), the value can be converted to:
+        * `false` (boolean)
+        * `0` (integer)
+        * `0.0` (floating point)
+    * If the YAML node value is a **boolean** (node_type::BOOLEAN), the value can be converted to:
+        * `1 /*true*/` or `0 /*false*/` (integer)
+        * `1.0 /*true*/` or `0.0 /*false*/` (floating point)
+    * If the YAML node value is a **integer** (node_type::INTEGER), the value can be converted to:
+        * `true /*non-0*/` or `false /*0*/` (boolean)
+        * `static_cast`ed floating point value (floating point)
+    * If the YAML node value is a **floating point** (node_type::FLOAT), the value can be converted to:
+        * `true /*non-0*/` or `false /*0*/` (boolean)
+        * `static_cast`ed integer value (integer)
+
+    Note that those scalar type cannot be converted to a sequence, mapping, string scalar, which results in throwing a [`type_error`](../exception/type_error.md).
+
+???+ Note "Convert from a String Scalar Node"
+
+    String scalar nodes can be converted to STL container types which can be constructible from `const fkyaml::basic_node::string_type&` (`const std::string&` by default). The test suite confirms successful conversions to the following types.
+
+    * std::string
+    * std::string_view (from C++17)
 
 ## **Template Parameters**
 
@@ -45,9 +90,12 @@ Note that those scalar type cannot be converted to a sequence, mapping, string s
     This is, by default, a type of [std::remove_cvref_t<T>](https://en.cppreference.com/w/cpp/types/remove_cvref).  
     If fkYAML is compiled with C++11, C++14 or C++17, fkYAML uses its own implementation.  
 
+***BasicNodeType***
+:   A basic_node template instance type.  
+
 ## **Return Value**
 
-A compatible native data value converted from the basic_node object.
+A compatible native data value converted from the [basic_node](./index.md) object.
 
 ???+ Example
 

--- a/include/fkYAML/detail/conversions/from_node.hpp
+++ b/include/fkYAML/detail/conversions/from_node.hpp
@@ -167,8 +167,9 @@ inline auto from_node(const BasicNodeType& n, SeqContainerAdapter& ca)
     }
 
     for (const auto& elem : n) {
-        // container adapter classes commonly have emplace function.
-        ca.emplace(elem.template get_value<typename SeqContainerAdapter::value_type>());
+        // container adapter classes commonly have push function.
+        // emplace function cannot be used in case SeqContainerAdapter::container_type is std::vector<bool> in C++11.
+        ca.push(elem.template get_value<typename SeqContainerAdapter::value_type>());
     }
 }
 

--- a/include/fkYAML/detail/conversions/from_node.hpp
+++ b/include/fkYAML/detail/conversions/from_node.hpp
@@ -9,11 +9,11 @@
 #ifndef FK_YAML_DETAIL_CONVERSIONS_FROM_NODE_HPP
 #define FK_YAML_DETAIL_CONVERSIONS_FROM_NODE_HPP
 
+#include <array>
 #include <cmath>
 #include <limits>
-#include <map>
 #include <utility>
-#include <vector>
+#include <valarray>
 
 #include <fkYAML/detail/macros/version_macros.hpp>
 #include <fkYAML/detail/meta/node_traits.hpp>
@@ -22,65 +22,157 @@
 #include <fkYAML/detail/types/node_t.hpp>
 #include <fkYAML/exception.hpp>
 
+#ifdef FK_YAML_HAS_CXX_17
+#include <optional>
+#endif
+
 FK_YAML_DETAIL_NAMESPACE_BEGIN
 
 ///////////////////
 //   from_node   //
 ///////////////////
 
-/// @brief from_node function for BasicNodeType::sequence_type objects.
+// utility type traits and functors
+
+/// @brief Utility traits type alias to detect constructible associative container types from a mapping node, e.g.,
+/// std::map or std::unordered_map.
+/// @tparam T A target type for detection.
+template <typename T>
+using is_constructible_mapping_type =
+    conjunction<detect::has_key_type<T>, detect::has_mapped_type<T>, detect::has_value_type<T>>;
+
+/// @brief Utility traits type alias to detect constructible container types from a sequence node, e.g., std::vector or
+/// std::list.
 /// @tparam BasicNodeType A basic_node template instance type.
+/// @tparam T A target type for detection.
+template <typename BasicNodeType, typename T>
+using is_constructible_sequence_type = conjunction<
+    negation<is_basic_node<T>>, detect::has_iterator<T>, detect::is_iterator_traits<typename T::iterator>,
+    detect::has_begin_end<T>, negation<std::is_same<T, typename BasicNodeType::mapping_type>>,
+    negation<is_constructible_mapping_type<T>>>;
+
+/// @brief Utility traits type alias to detect a sequence container adapter type, e.g., std::stack or std::queue.
+/// @tparam T A target type for detection.
+template <typename T>
+using is_sequence_container_adapter = conjunction<
+    negation<is_basic_node<T>>, detect::has_container_type<T>, detect::has_value_type<T>,
+    negation<detect::has_key_type<T>>>;
+
+/// @brief Helper struct for reserve() member function call switch for types which do not have reserve function.
+/// @tparam ContainerType A container type.
+template <typename ContainerType, typename = void>
+struct call_reserve_if_available {
+    /// @brief Do nothing since ContainerType does not have reserve function.
+    /// @param
+    /// @param
+    static void call(ContainerType& /*unused*/, typename ContainerType::size_type /*unused*/) {
+    }
+};
+
+/// @brief Helper struct for reserve() member function call switch for types which have reserve function.
+/// @tparam ContainerType A container type.
+template <typename ContainerType>
+struct call_reserve_if_available<ContainerType, enable_if_t<detect::has_reserve<ContainerType>::value>> {
+    /// @brief Call reserve function on the ContainerType object with a given size.
+    /// @param c A container object.
+    /// @param n A size to reserve.
+    static void call(ContainerType& c, typename ContainerType::size_type n) {
+        c.reserve(n);
+    }
+};
+
+// from_node() implementations
+
+/// @brief from_node function for std::array objects whose element type must be a basic_node template instance type or a
+/// compatible type. This function is necessary since insert function is not implemented for std::array.
+/// @tparam BasicNodeType A basic_node template instance type.
+/// @tparam T Element type of std::array.
+/// @tparam N Size of std::array.
 /// @param n A basic_node object.
-/// @param s A sequence node value object.
-template <typename BasicNodeType, enable_if_t<is_basic_node<BasicNodeType>::value, int> = 0>
-inline void from_node(const BasicNodeType& n, typename BasicNodeType::sequence_type& s) {
+/// @param arr A std::array object.
+template <typename BasicNodeType, typename T, std::size_t N>
+inline auto from_node(const BasicNodeType& n, std::array<T, N>& arr) -> decltype(n.template get_value<T>(), void()) {
     if FK_YAML_UNLIKELY (!n.is_sequence()) {
         throw type_error("The target node value type is not sequence type.", n.get_type());
     }
-    s = n.template get_value_ref<const typename BasicNodeType::sequence_type&>();
+
+    std::size_t count = std::min(n.size(), N);
+    for (std::size_t i = 0; i < count; i++) {
+        arr.at(i) = n.at(i).template get_value<T>();
+    }
 }
 
-/// @brief from_node function for objects of the std::vector of compatible types.
+/// @brief from_node function for std::valarray objects whose element type must be a basic_node template instance type
+/// or a compatible type. This function is necessary since insert function is not implemented for std::valarray.
 /// @tparam BasicNodeType A basic_node template instance type.
-/// @tparam CompatibleValueType A compatible type for BasicNodeType.
+/// @tparam T Element type of std::valarray.
 /// @param n A basic_node object.
-/// @param s A vector of compatible type objects.
+/// @param va A std::valarray object.
+template <typename BasicNodeType, typename T>
+inline auto from_node(const BasicNodeType& n, std::valarray<T>& va) -> decltype(n.template get_value<T>(), void()) {
+    if FK_YAML_UNLIKELY (!n.is_sequence()) {
+        throw type_error("The target node value type is not sequence type.", n.get_type());
+    }
+
+    std::size_t count = n.size();
+    va.resize(count);
+    for (std::size_t i = 0; i < count; i++) {
+        va[i] = n.at(i).template get_value<T>();
+    }
+}
+
+/// @brief from_node function for container objects of only keys or values, e.g., std::vector or std::set, whose element
+/// type must be a basic_node template instance type or a compatible type.
+/// @tparam BasicNodeType A basic_node template instance type.
+/// @tparam CompatSeqType A container type.
+/// @param n A basic_node object.
+/// @param s A container object.
 template <
-    typename BasicNodeType, typename CompatibleValueType,
+    typename BasicNodeType, typename CompatSeqType,
     enable_if_t<
         conjunction<
-            is_basic_node<BasicNodeType>, negation<is_basic_node<CompatibleValueType>>,
-            has_from_node<BasicNodeType, CompatibleValueType>,
-            negation<std::is_same<std::vector<CompatibleValueType>, typename BasicNodeType::sequence_type>>>::value,
+            is_basic_node<BasicNodeType>, is_constructible_sequence_type<BasicNodeType, CompatSeqType>,
+            negation<std::is_constructible<typename BasicNodeType::string_type, CompatSeqType>>>::value,
         int> = 0>
-inline void from_node(const BasicNodeType& n, std::vector<CompatibleValueType>& s) {
+inline auto from_node(const BasicNodeType& n, CompatSeqType& s)
+    -> decltype(n.template get_value<typename CompatSeqType::value_type>(), void()) {
     if FK_YAML_UNLIKELY (!n.is_sequence()) {
         throw type_error("The target node value is not sequence type.", n.get_type());
     }
 
-    s.reserve(n.size());
+    // call reserve function first if it's available (like std::vector).
+    call_reserve_if_available<CompatSeqType>::call(s, n.size());
+
+    // transform a sequence node into a destination type object by calling insert function.
+    using std::end;
+    std::transform(n.begin(), n.end(), std::inserter(s, end(s)), [](const BasicNodeType& elem) {
+        return elem.template get_value<typename CompatSeqType::value_type>();
+    });
+}
+
+/// @brief from_node function for sequence container adapter objects, e.g., std::stack or std::queue, whose element type
+/// must be either a basic_node template instance type or a compatible type.
+/// @tparam BasicNodeType A basic_node template instance type.
+/// @tparam SeqContainerAdapter A sequence container adapter type.
+/// @param n A node object.
+/// @param ca A sequence container adapter object.
+template <
+    typename BasicNodeType, typename SeqContainerAdapter,
+    enable_if_t<
+        conjunction<is_basic_node<BasicNodeType>, is_sequence_container_adapter<SeqContainerAdapter>>::value, int> = 0>
+inline auto from_node(const BasicNodeType& n, SeqContainerAdapter& ca)
+    -> decltype(n.template get_value<typename SeqContainerAdapter::value_type>(), ca.emplace(std::declval<typename SeqContainerAdapter::value_type>()), void()) {
+    if FK_YAML_UNLIKELY (!n.is_sequence()) {
+        throw type_error("The target node value is not sequence type.", n.get_type());
+    }
 
     for (const auto& elem : n) {
-        s.emplace_back(elem.template get_value<CompatibleValueType>());
+        // container adapter classes commonly have emplace function.
+        ca.emplace(elem.template get_value<typename SeqContainerAdapter::value_type>());
     }
 }
 
-/// @brief from_node function for BasicNodeType::mapping_type objects.
-/// @tparam BasicNodeType A basic_node template instance type.
-/// @param n A basic_node object.
-/// @param m A mapping node value object.
-template <typename BasicNodeType, enable_if_t<is_basic_node<BasicNodeType>::value, int> = 0>
-inline void from_node(const BasicNodeType& n, typename BasicNodeType::mapping_type& m) {
-    if FK_YAML_UNLIKELY (!n.is_mapping()) {
-        throw type_error("The target node value type is not mapping type.", n.get_type());
-    }
-
-    for (auto pair : n.template get_value_ref<const typename BasicNodeType::mapping_type&>()) {
-        m.emplace(pair.first, pair.second);
-    }
-}
-
-/// @brief from node function for mappings whose key and value are of both compatible types.
+/// @brief from_node function for mappings whose key and value are of both compatible types.
 /// @tparam BasicNodeType A basic_node template instance type.
 /// @tparam CompatibleKeyType Mapping key type compatible with BasicNodeType.
 /// @tparam CompatibleValueType Mapping value type compatible with BasicNodeType.
@@ -88,23 +180,23 @@ inline void from_node(const BasicNodeType& n, typename BasicNodeType::mapping_ty
 /// @tparam Allocator Allocator type for destination mapping object.
 /// @param n A node object.
 /// @param m Mapping container object to store converted key/value objects.
-template <
-    typename BasicNodeType, typename CompatibleKeyType, typename CompatibleValueType, typename Compare,
-    typename Allocator,
-    enable_if_t<
-        conjunction<
-            is_basic_node<BasicNodeType>, negation<is_basic_node<CompatibleKeyType>>,
-            negation<is_basic_node<CompatibleValueType>>, has_from_node<BasicNodeType, CompatibleKeyType>,
-            has_from_node<BasicNodeType, CompatibleValueType>>::value,
-        int> = 0>
-inline void from_node(const BasicNodeType& n, std::map<CompatibleKeyType, CompatibleValueType, Compare, Allocator>& m) {
+template <typename BasicNodeType, typename CompatMapType, enable_if_t<is_constructible_mapping_type<CompatMapType>::value, int> = 0>
+inline auto from_node(const BasicNodeType& n, CompatMapType& m)
+    -> decltype(
+        std::declval<const BasicNodeType&>().template get_value<typename CompatMapType::key_type>(),
+        std::declval<const BasicNodeType&>().template get_value<typename CompatMapType::mapped_type>(),
+        m.emplace(std::declval<typename CompatMapType::key_type>(), std::declval<typename CompatMapType::mapped_type>()),
+        void()) {
     if FK_YAML_UNLIKELY (!n.is_mapping()) {
         throw type_error("The target node value type is not mapping type.", n.get_type());
     }
 
-    for (auto pair : n.template get_value_ref<const typename BasicNodeType::mapping_type&>()) {
+    call_reserve_if_available<CompatMapType>::call(m, n.size());
+
+    for (const auto& pair : n.template get_value_ref<const typename BasicNodeType::mapping_type&>()) {
         m.emplace(
-            pair.first.template get_value<CompatibleKeyType>(), pair.second.template get_value<CompatibleValueType>());
+            pair.first.template get_value<typename CompatMapType::key_type>(),
+            pair.second.template get_value<typename CompatMapType::mapped_type>());
     }
 }
 
@@ -371,6 +463,74 @@ inline void from_node(const BasicNodeType& n, CompatibleStringType& s) {
     }
     s = n.template get_value_ref<const typename BasicNodeType::string_type&>();
 }
+
+/// @brief from_node function for std::pair objects whose element types must be either a basic_node template instance
+/// type or a compatible type.
+/// @tparam BasicNodeType A basic_node template instance type.
+/// @tparam T The first type of the std::pair.
+/// @tparam U The second type of the std::pair.
+/// @param n A basic_node object.
+/// @param p A std::pair object.
+template <typename BasicNodeType, typename T, typename U, enable_if_t<is_basic_node<BasicNodeType>::value, int> = 0>
+inline auto from_node(const BasicNodeType& n, std::pair<T, U>& p)
+    -> decltype(std::declval<const BasicNodeType&>().template get_value<T>(), std::declval<const BasicNodeType&>().template get_value<U>(), void()) {
+    if FK_YAML_UNLIKELY (!n.is_sequence()) {
+        throw type_error("The target node value type is not sequence type.", n.get_type());
+    }
+
+    p = {n.at(0).template get_value<T>(), n.at(1).template get_value<U>()};
+}
+
+/// @brief concrete implementation of from_node function for std::tuple objects.
+/// @tparam BasicNodeType A basic_node template instance type.
+/// @tparam ...Types The value types of std::tuple.
+/// @tparam ...Idx Index sequence values for std::tuples value types.
+/// @param n A basic_node object
+/// @param _ Index sequence values (unused).
+/// @return A std::tuple object converted from the sequence node values.
+template <typename BasicNodeType, typename... Types, std::size_t... Idx>
+inline std::tuple<Types...> from_node_tuple_impl(const BasicNodeType& n, index_sequence<Idx...> /*unused*/) {
+    return std::make_tuple(n.at(Idx).template get_value<Types>()...);
+}
+
+/// @brief from_node function for std::tuple objects whose value types must all be either a basic_node template instance
+/// type or a compatible type
+/// @tparam BasicNodeType A basic_node template instance type.
+/// @tparam ...Types Value types of std::tuple.
+/// @param n A basic_node object.
+/// @param t A std::tuple object.
+template <typename BasicNodeType, typename... Types, enable_if_t<is_basic_node<BasicNodeType>::value, int> = 0>
+inline void from_node(const BasicNodeType& n, std::tuple<Types...>& t) {
+    if FK_YAML_UNLIKELY (!n.is_sequence()) {
+        throw type_error("The target node value type is not sequence type.", n.get_type());
+    }
+
+    // Types... must be explicitly specified; the retun type would otherwise be std::tuple with no value types.
+    t = from_node_tuple_impl<BasicNodeType, Types...>(n, index_sequence_for<Types...> {});
+}
+
+#ifdef FK_YAML_HAS_CXX_17
+
+/// @brief from_node function for std::optional objects whose value type must be either a basic_node template instance
+/// type or a compatible type.
+/// @tparam BasicNodeType A basic_node template instance type.
+/// @tparam T A value type of the std::optional.
+/// @param n A basic_node object.
+/// @param o A std::optional object.
+template <typename BasicNodeType, typename T, enable_if_t<is_basic_node<BasicNodeType>::value, int> = 0>
+inline auto from_node(const BasicNodeType& n, std::optional<T>& o) -> decltype(n.template get_value<T>(), void()) {
+    try {
+        o.emplace(n.template get_value<T>());
+    }
+    catch (const std::exception& /*unused*/) {
+        // Any exception derived from std::exception is interpreted as a conversion failure in some way
+        // since user-defined from_node function may throw a different object from a fkyaml::type_error.
+        // and std::exception is usually the base class of user-defined exception types.
+        o = std::nullopt;
+    }
+}
+
+#endif // defined(FK_YAML_HAS_CXX_17)
 
 /// @brief A function object to call from_node functions.
 /// @note User-defined specialization is available by providing implementation **OUTSIDE** fkyaml namespace.

--- a/include/fkYAML/detail/macros/cpp_config_macros.hpp
+++ b/include/fkYAML/detail/macros/cpp_config_macros.hpp
@@ -88,6 +88,19 @@
 #define FK_YAML_HAS_CPP_ATTRIBUTE(attr) (0)
 #endif
 
+#ifdef __has_feature
+#define FK_YAML_HAS_FEATURE(feat) __has_feature(feat)
+#else
+#define FK_YAML_HAS_FEATURE(feat) (0)
+#endif
+
+// switch usage of the no_sanitize attribute only when Clang sanitizer is active.
+#if defined(__clang__) && FK_YAML_HAS_FEATURE(address_sanitizer)
+#define FK_YAML_NO_SANITIZE(...) __attribute__((no_sanitize(__VA_ARGS__)))
+#else
+#define FK_YAML_NO_SANITIZE(...)
+#endif
+
 #if FK_YAML_HAS_INCLUDE(<version>)
 // <version> is available since C++20
 #include <version>

--- a/include/fkYAML/detail/meta/detect.hpp
+++ b/include/fkYAML/detail/meta/detect.hpp
@@ -9,6 +9,7 @@
 #ifndef FK_YAML_DETAIL_META_DETECT_HPP
 #define FK_YAML_DETAIL_META_DETECT_HPP
 
+#include <iterator>
 #include <type_traits>
 
 #include <fkYAML/detail/macros/version_macros.hpp>
@@ -70,6 +71,122 @@ using detected_t = typename detector_impl::detector<nonesuch, void, Op, Args...>
 /// @tparam Args Argument types passed to desired operation.
 template <typename Expected, template <typename...> class Op, typename... Args>
 using is_detected_exact = std::is_same<Expected, detected_t<Op, Args...>>;
+
+/// @brief namespace for member type detections of aliases and functions.
+namespace detect {
+
+/// @brief The type which represents `iterator` member type.
+/// @tparam T A target type.
+template <typename T>
+using iterator_t = typename T::iterator;
+
+/// @brief The type which represents `key_type` member type.
+/// @tparam T A target type.
+template <typename T>
+using key_type_t = typename T::key_type;
+
+/// @brief The type which represents `mapped_type` member type.
+/// @tparam T A target type.
+template <typename T>
+using mapped_type_t = typename T::mapped_type;
+
+/// @brief The type which represents `value_type` member type.
+/// @tparam T A target type.
+template <typename T>
+using value_type_t = typename T::value_type;
+
+/// @brief The type which represents `difference_type` member type.
+/// @tparam T A target type.
+template <typename T>
+using difference_type_t = typename T::difference_type;
+
+/// @brief The type which represents `pointer` member type.
+/// @tparam T A target type.
+template <typename T>
+using pointer_t = typename T::pointer;
+
+/// @brief The type which represents `reference` member type.
+/// @tparam T A target type.
+template <typename T>
+using reference_t = typename T::reference;
+
+/// @brief The type which represents `iterator_category` member type.
+/// @tparam T A target type.
+template <typename T>
+using iterator_category_t = typename T::iterator_category;
+
+/// @brief The type which represents `container_type` member type.
+/// @tparam T A target type.
+template <typename T>
+using container_type_t = typename T::container_type;
+
+/// @brief The type which represents emplace member function.
+/// @tparam T A target type.
+template <typename T, typename... Args>
+using emplace_fn_t = decltype(std::declval<T>().emplace(std::declval<Args>()...));
+
+/// @brief The type which represents reserve member function.
+/// @tparam T A target type.
+template <typename T>
+using reserve_fn_t = decltype(std::declval<T>().reserve(std::declval<typename T::size_type>()));
+
+/// @brief Type traits to check if T has `iterator` member type.
+/// @tparam T A target type.
+template <typename T>
+using has_iterator = is_detected<iterator_t, T>;
+
+/// @brief Type traits to check if T has `key_type` member type.
+/// @tparam T A target type.
+template <typename T>
+using has_key_type = is_detected<key_type_t, T>;
+
+/// @brief Type traits to check if T has `mapped_type` member type.
+/// @tparam T A target type.
+template <typename T>
+using has_mapped_type = is_detected<mapped_type_t, T>;
+
+/// @brief Type traits to check if T has `value_type` member type.
+/// @tparam T A target type.
+template <typename T>
+using has_value_type = is_detected<value_type_t, T>;
+
+/// @brief Type traits to check if T is a std::iterator_traits like type.
+/// @tparam T A target type.
+template <typename T>
+struct is_iterator_traits : conjunction<
+                                is_detected<difference_type_t, T>, has_value_type<T>, is_detected<pointer_t, T>,
+                                is_detected<reference_t, T>, is_detected<iterator_category_t, T>> {};
+
+/// @brief Type traits to check if T has `container_type` member type.
+/// @tparam T A target type.
+template <typename T>
+using has_container_type = is_detected<container_type_t, T>;
+
+/// @brief Type traits to check if T has emplace member function.
+/// @tparam T A target type.
+template <typename T, typename... Args>
+using has_emplace = is_detected<emplace_fn_t, T, Args...>;
+
+/// @brief Type traits to check if T has reserve member function.
+/// @tparam T A target type.
+template <typename T>
+using has_reserve = is_detected<reserve_fn_t, T>;
+
+// fallback to these STL functions.
+using std::begin;
+using std::end;
+
+/// @brief Type traits to check if begin/end functions can be called on a T object.
+/// @tparam T A target type.
+template <typename T, typename = void>
+struct has_begin_end : std::false_type {};
+
+/// @brief Type traits to check if begin/end functions can be called on a T object.
+/// @tparam T A target type.
+template <typename T>
+struct has_begin_end<T, void_t<decltype(begin(std::declval<T>()), end(std::declval<T>()))>> : std::true_type {};
+
+} // namespace detect
 
 FK_YAML_DETAIL_NAMESPACE_END
 

--- a/include/fkYAML/detail/meta/stl_supplement.hpp
+++ b/include/fkYAML/detail/meta/stl_supplement.hpp
@@ -14,6 +14,10 @@
 
 #include <fkYAML/detail/macros/version_macros.hpp>
 
+#ifdef FK_YAML_HAS_CXX_14
+#include <utility>
+#endif
+
 FK_YAML_DETAIL_NAMESPACE_BEGIN
 
 /////////////////////////////////////////////////////////////////////////////////////////////////////////
@@ -70,16 +74,80 @@ using remove_pointer_t = typename std::remove_pointer<T>::type;
 template <typename T>
 using remove_reference_t = typename std::remove_reference<T>::type;
 
+template <typename T, T... I>
+struct integer_sequence {
+    using value_type = T;
+    static constexpr std::size_t size() noexcept {
+        return sizeof...(I);
+    }
+};
+
+#if !FK_YAML_HAS_BUILTIN(__make_integer_seq) && !FK_YAML_HAS_BUILTIN(__integer_pack)
+
+namespace make_int_seq_impl {
+
+template <typename IntSeq0, typename IntSeq1>
+struct merger;
+
+template <typename T, T... Ints0, T... Ints1>
+struct merger<integer_sequence<T, Ints0...>, integer_sequence<T, Ints1...>> {
+    using type = integer_sequence<T, Ints0..., (sizeof...(Ints0) + Ints1)...>;
+};
+
+template <typename T, std::size_t Num>
+struct generator {
+    using type =
+        typename merger<typename generator<T, Num / 2>::type, typename generator<T, Num - Num / 2>::type>::type;
+};
+
+template <typename T>
+struct generator<T, 0> {
+    using type = integer_sequence<T>;
+};
+
+template <typename T>
+struct generator<T, 1> {
+    using type = integer_sequence<T, 0>;
+};
+
+} // namespace make_int_seq_impl
+
+#endif
+
+template <typename T, T Num>
+using make_integer_sequence
+#if FK_YAML_HAS_BUILTIN(__make_integer_seq)
+    = __make_integer_seq<integer_sequence, T, Num>;
+#elif FK_YAML_HAS_BUILTIN(__integer_pack)
+    = integer_sequence<T, __integer_pack(Num)...>;
 #else
+    = make_int_seq_impl::generator<T, Num>::type;
+#endif
+
+template <std::size_t... Idx>
+using index_sequence = integer_sequence<std::size_t, Idx...>;
+
+template <std::size_t Num>
+using make_index_sequence = make_integer_sequence<std::size_t, Num>;
+
+template <typename... Types>
+using index_sequence_for = make_index_sequence<sizeof...(Types)>;
+
+#else // !defined(FK_YAML_HAS_CXX_14)
 
 using std::add_pointer_t;
 using std::enable_if_t;
+using std::index_sequence;
+using std::index_sequence_for;
+using std::integer_sequence;
 using std::is_null_pointer;
+using std::make_index_sequence;
+using std::make_integer_sequence;
 using std::remove_cv_t;
 using std::remove_pointer_t;
 using std::remove_reference_t;
 
-#endif
+#endif // !defined(FK_YAML_HAS_CXX_14)
 
 #ifndef FK_YAML_HAS_CXX_17
 
@@ -149,7 +217,7 @@ struct make_void {
 template <typename... Types>
 using void_t = typename make_void<Types...>::type;
 
-#else
+#else // !defined(FK_YAML_HAS_CXX_17)
 
 using std::bool_constant;
 using std::conjunction;
@@ -157,7 +225,7 @@ using std::disjunction;
 using std::negation;
 using std::void_t;
 
-#endif
+#endif // !defined(FK_YAML_HAS_CXX_17)
 
 #ifndef FK_YAML_HAS_CXX_20
 

--- a/include/fkYAML/detail/meta/stl_supplement.hpp
+++ b/include/fkYAML/detail/meta/stl_supplement.hpp
@@ -117,11 +117,15 @@ struct generator<T, 1> {
 template <typename T, T Num>
 using make_integer_sequence
 #if FK_YAML_HAS_BUILTIN(__make_integer_seq)
+    // clang defines built-in __make_integer_seq to generate an integer sequence.
     = __make_integer_seq<integer_sequence, T, Num>;
 #elif FK_YAML_HAS_BUILTIN(__integer_pack)
+    // GCC or other compilers may implement built-in __integer_pack to generate an
+    // integer sequence.
     = integer_sequence<T, __integer_pack(Num)...>;
 #else
-    = make_int_seq_impl::generator<T, Num>::type;
+    // fallback to the library implementation of make_integer_sequence.
+    = typename make_int_seq_impl::generator<T, Num>::type;
 #endif
 
 template <std::size_t... Idx>

--- a/include/fkYAML/node.hpp
+++ b/include/fkYAML/node.hpp
@@ -1792,8 +1792,8 @@ struct hash<fkyaml::basic_node<
         case fkyaml::node_type::STRING:
             hash_combine(seed, std::hash<string_type>()(n.template get_value<string_type>()));
             return seed;
-        default:
-            return 0;
+        default:      // LCOV_EXCL_LINE
+            return 0; // LCOV_EXCL_LINE
         }
     }
 

--- a/include/fkYAML/node.hpp
+++ b/include/fkYAML/node.hpp
@@ -1484,7 +1484,8 @@ private:
 
     template <
         typename ValueType, detail::enable_if_t<detail::negation<detail::is_basic_node<ValueType>>::value, int> = 0>
-    void get_value_impl(ValueType& v) const noexcept(noexcept(ConverterType<ValueType, void>::from_node(*this, v))) {
+    void get_value_impl(ValueType& v) const
+        noexcept(noexcept(ConverterType<ValueType, void>::from_node(std::declval<const basic_node&>(), v))) {
         ConverterType<ValueType, void>::from_node(*this, v);
     }
 
@@ -1745,6 +1746,7 @@ template <
     template <typename, typename...> class SequenceType, template <typename, typename, typename...> class MappingType,
     typename BooleanType, typename IntegerType, typename FloatNumberType, typename StringType,
     template <typename, typename = void> class ConverterType>
+// NOLINTNEXTLINE(cert-dcl58-cpp)
 struct hash<fkyaml::basic_node<
     SequenceType, MappingType, BooleanType, IntegerType, FloatNumberType, StringType, ConverterType>> {
     using node_t = fkyaml::basic_node<
@@ -1799,8 +1801,9 @@ struct hash<fkyaml::basic_node<
 
 private:
     // taken from boost::hash_combine
+    FK_YAML_NO_SANITIZE("unsigned-shift-base", "unsigned-integer-overflow")
     static void hash_combine(std::size_t& seed, std::size_t v) {
-        seed ^= v + 0x9e3779b9 + (seed << 6) + (seed >> 2);
+        seed ^= v + 0x9e3779b9 + (seed << 6u) + (seed >> 2u);
     }
 };
 

--- a/single_include/fkYAML/node.hpp
+++ b/single_include/fkYAML/node.hpp
@@ -13384,8 +13384,8 @@ struct hash<fkyaml::basic_node<
         case fkyaml::node_type::STRING:
             hash_combine(seed, std::hash<string_type>()(n.template get_value<string_type>()));
             return seed;
-        default:
-            return 0;
+        default:      // LCOV_EXCL_LINE
+            return 0; // LCOV_EXCL_LINE
         }
     }
 

--- a/test/unit_test/test_node_class.cpp
+++ b/test/unit_test/test_node_class.cpp
@@ -2616,6 +2616,17 @@ TEST_CASE("Node_GetValue") {
             REQUIRE(umap_compat.at("test") == 123);
             REQUIRE(umap_compat.find("foo") != umap_compat.end());
             REQUIRE(umap_compat.at("foo") == -456);
+
+            fkyaml::node various_type_nodes = {
+                {nullptr, nullptr},
+                {true, nullptr},
+                {123, nullptr},
+                {3.14, nullptr},
+                {"foo", nullptr},
+                {{{"foo", "bar"}}, nullptr},
+                {{"foo", "bar"}, nullptr},
+            };
+            auto umap = various_type_nodes.get_value<std::unordered_map<fkyaml::node, std::nullptr_t>>();
         }
 
         SECTION("mapping value (std::unordered_multimap)") {
@@ -2646,6 +2657,14 @@ TEST_CASE("Node_GetValue") {
 
         SECTION("non-mapping values") {
             REQUIRE_THROWS_AS(node.get_value<fkyaml::node::sequence_type>(), fkyaml::type_error);
+            using array_t = std::array<int, 2>;
+            REQUIRE_THROWS_AS(node.get_value<array_t>(), fkyaml::type_error);
+            REQUIRE_THROWS_AS(node.get_value<std::valarray<double>>(), fkyaml::type_error);
+            REQUIRE_THROWS_AS(node.get_value<std::stack<int>>(), fkyaml::type_error);
+            using pair_t = std::pair<bool, int>;
+            REQUIRE_THROWS_AS(node.get_value<pair_t>(), fkyaml::type_error);
+            using tuple_t = std::tuple<bool, int, float>;
+            REQUIRE_THROWS_AS(node.get_value<tuple_t>(), fkyaml::type_error);
             REQUIRE_THROWS_AS(node.get_value<std::nullptr_t>(), fkyaml::type_error);
             REQUIRE_THROWS_AS(node.get_value<fkyaml::node::boolean_type>(), fkyaml::type_error);
             REQUIRE_THROWS_AS(node.get_value<fkyaml::node::integer_type>(), fkyaml::type_error);

--- a/test/unit_test/test_node_class.cpp
+++ b/test/unit_test/test_node_class.cpp
@@ -8,9 +8,16 @@
 
 #include <cmath>
 #include <cfloat>
+#include <deque>
 #include <fstream>
-#include <sstream>
+#include <list>
 #include <map>
+#include <queue>
+#include <set>
+#include <sstream>
+#include <stack>
+#include <unordered_map>
+#include <unordered_set>
 
 #include <catch2/catch.hpp>
 
@@ -2369,15 +2376,170 @@ struct string_wrap {
 TEST_CASE("Node_GetValue") {
 
     SECTION("sequence") {
-        fkyaml::node node(fkyaml::node::sequence_type {fkyaml::node(true), fkyaml::node(false)});
+        fkyaml::node node {true, false};
 
-        SECTION("sequence value") {
-            auto seq = node.get_value<fkyaml::node::sequence_type>();
-            REQUIRE(seq.size() == 2);
-            REQUIRE(seq[0].is_boolean());
-            REQUIRE(seq[0].get_value<bool>() == true);
-            REQUIRE(seq[1].is_boolean());
-            REQUIRE(seq[1].get_value<bool>() == false);
+        SECTION("sequence value (std::vector)") {
+            auto vector_node = node.get_value<std::vector<fkyaml::node>>();
+            REQUIRE(vector_node.size() == 2);
+            REQUIRE(vector_node[0].is_boolean());
+            REQUIRE(vector_node[0].get_value<bool>() == true);
+            REQUIRE(vector_node[1].is_boolean());
+            REQUIRE(vector_node[1].get_value<bool>() == false);
+
+            auto vector_bool = node.get_value<std::vector<bool>>();
+            REQUIRE(vector_bool.size() == 2);
+            REQUIRE(vector_bool[0] == true);
+            REQUIRE(vector_bool[1] == false);
+        }
+
+        SECTION("sequence value (std::array)") {
+            auto array_node = node.get_value<std::array<fkyaml::node, 2>>();
+            REQUIRE(array_node[0].is_boolean());
+            REQUIRE(array_node[0].get_value<bool>() == true);
+            REQUIRE(array_node[1].is_boolean());
+            REQUIRE(array_node[1].get_value<bool>() == false);
+
+            auto array_bool = node.get_value<std::array<bool, 2>>();
+            REQUIRE(array_bool[0] == true);
+            REQUIRE(array_bool[1] == false);
+        }
+
+        SECTION("sequence value (std::valarray)") {
+            auto valarray_node = node.get_value<std::valarray<fkyaml::node>>();
+            REQUIRE(valarray_node[0].is_boolean());
+            REQUIRE(valarray_node[0].get_value<bool>() == true);
+            REQUIRE(valarray_node[1].is_boolean());
+            REQUIRE(valarray_node[1].get_value<bool>() == false);
+
+            auto valarray_bool = node.get_value<std::valarray<bool>>();
+            REQUIRE(valarray_bool[0] == true);
+            REQUIRE(valarray_bool[1] == false);
+        }
+
+        SECTION("sequence value (std::deque)") {
+            auto deque_node = node.get_value<std::deque<fkyaml::node>>();
+            REQUIRE(deque_node.size() == 2);
+            REQUIRE(deque_node[0].is_boolean());
+            REQUIRE(deque_node[0].get_value<bool>() == true);
+            REQUIRE(deque_node[1].is_boolean());
+            REQUIRE(deque_node[1].get_value<bool>() == false);
+
+            auto deque_bool = node.get_value<std::deque<bool>>();
+            REQUIRE(deque_bool.size() == 2);
+            REQUIRE(deque_bool[0] == true);
+            REQUIRE(deque_bool[1] == false);
+        }
+
+        SECTION("sequence value (std::list)") {
+            auto list_node = node.get_value<std::list<fkyaml::node>>();
+            REQUIRE(list_node.size() == 2);
+            auto list_node_itr = list_node.begin();
+            REQUIRE(list_node_itr->is_boolean());
+            REQUIRE(list_node_itr->get_value<bool>() == true);
+            list_node_itr++;
+            REQUIRE(list_node_itr->is_boolean());
+            REQUIRE(list_node_itr->get_value<bool>() == false);
+
+            auto list_bool = node.get_value<std::list<bool>>();
+            REQUIRE(list_bool.size() == 2);
+            REQUIRE(*list_bool.begin() == true);
+            REQUIRE(*(std::next(list_bool.begin())) == false);
+        }
+
+        SECTION("sequence value (std::set)") {
+            auto set_node = node.get_value<std::set<fkyaml::node>>();
+            REQUIRE(set_node.size() == 2);
+            REQUIRE(set_node.find(fkyaml::node(true)) != set_node.end());
+            REQUIRE(set_node.find(fkyaml::node(false)) != set_node.end());
+
+            auto set_bool = node.get_value<std::set<bool>>();
+            REQUIRE(set_bool.size() == 2);
+            REQUIRE(set_bool.find(true) != set_bool.end());
+            REQUIRE(set_bool.find(false) != set_bool.end());
+        }
+
+        SECTION("sequence value (std::multiset)") {
+            auto mset_node = node.get_value<std::multiset<fkyaml::node>>();
+            REQUIRE(mset_node.size() == 2);
+            REQUIRE(mset_node.find(fkyaml::node(true)) != mset_node.end());
+            REQUIRE(mset_node.find(fkyaml::node(false)) != mset_node.end());
+
+            auto mset_bool = node.get_value<std::multiset<fkyaml::node>>();
+            REQUIRE(mset_bool.size() == 2);
+            REQUIRE(mset_bool.find(true) != mset_bool.end());
+            REQUIRE(mset_bool.find(false) != mset_bool.end());
+        }
+
+        SECTION("sequence value (std::unordered_set)") {
+            auto uset_node = node.get_value<std::unordered_set<fkyaml::node>>();
+            REQUIRE(uset_node.size() == 2);
+            REQUIRE(uset_node.find(fkyaml::node(true)) != uset_node.end());
+            REQUIRE(uset_node.find(fkyaml::node(false)) != uset_node.end());
+
+            auto uset_bool = node.get_value<std::unordered_set<bool>>();
+            REQUIRE(uset_bool.size() == 2);
+            REQUIRE(uset_bool.find(true) != uset_bool.end());
+            REQUIRE(uset_bool.find(false) != uset_bool.end());
+        }
+
+        SECTION("sequence value (std::unordered_set)") {
+            auto umset_node = node.get_value<std::unordered_multiset<fkyaml::node>>();
+            REQUIRE(umset_node.size() == 2);
+            REQUIRE(umset_node.find(fkyaml::node(true)) != umset_node.end());
+            REQUIRE(umset_node.find(fkyaml::node(false)) != umset_node.end());
+
+            auto umset_bool = node.get_value<std::unordered_multiset<bool>>();
+            REQUIRE(umset_bool.size() == 2);
+            REQUIRE(umset_bool.find(true) != umset_bool.end());
+            REQUIRE(umset_bool.find(false) != umset_bool.end());
+        }
+
+        SECTION("sequence value (std::stack)") {
+            auto stack_node = node.get_value<std::stack<fkyaml::node>>();
+            REQUIRE(stack_node.size() == 2);
+            REQUIRE(stack_node.top().is_boolean());
+            REQUIRE(stack_node.top().get_value<bool>() == false);
+            stack_node.pop();
+            REQUIRE(stack_node.top().is_boolean());
+            REQUIRE(stack_node.top().get_value<bool>() == true);
+
+            auto stack_bool = node.get_value<std::stack<bool>>();
+            REQUIRE(stack_bool.size() == 2);
+            REQUIRE(stack_bool.top() == false);
+            stack_bool.pop();
+            REQUIRE(stack_bool.top() == true);
+        }
+
+        SECTION("sequence value (std::queue)") {
+            auto queue_node = node.get_value<std::queue<fkyaml::node>>();
+            REQUIRE(queue_node.size() == 2);
+            REQUIRE(queue_node.front().is_boolean());
+            REQUIRE(queue_node.front().get_value<bool>() == true);
+            queue_node.pop();
+            REQUIRE(queue_node.front().is_boolean());
+            REQUIRE(queue_node.front().get_value<bool>() == false);
+
+            auto queue_bool = node.get_value<std::queue<bool>>();
+            REQUIRE(queue_bool.size() == 2);
+            REQUIRE(queue_bool.front() == true);
+            queue_bool.pop();
+            REQUIRE(queue_bool.front() == false);
+        }
+
+        SECTION("sequence value (std::queue)") {
+            auto pqueue_node = node.get_value<std::priority_queue<fkyaml::node>>();
+            REQUIRE(pqueue_node.size() == 2);
+            REQUIRE(pqueue_node.top().is_boolean());
+            REQUIRE(pqueue_node.top().get_value<bool>() == true);
+            pqueue_node.pop();
+            REQUIRE(pqueue_node.top().is_boolean());
+            REQUIRE(pqueue_node.top().get_value<bool>() == false);
+
+            auto pqueue_bool = node.get_value<std::priority_queue<bool>>();
+            REQUIRE(pqueue_bool.size() == 2);
+            REQUIRE(pqueue_bool.top() == true);
+            pqueue_bool.pop();
+            REQUIRE(pqueue_bool.top() == false);
         }
 
         SECTION("non-sequence value") {
@@ -2392,17 +2554,94 @@ TEST_CASE("Node_GetValue") {
     }
 
     SECTION("mapping") {
-        fkyaml::node node(fkyaml::node::mapping_type {{"test", fkyaml::node(3.14)}, {"foo", fkyaml::node("bar")}});
+        fkyaml::node node {{"test", 123}, {"foo", -456}};
 
-        SECTION("mapping value") {
-            auto map = node.get_value<fkyaml::node::mapping_type>();
-            REQUIRE(map.size() == 2);
-            REQUIRE(map.find("test") != map.end());
-            REQUIRE(map.at("test").is_float_number());
-            REQUIRE(map.at("test").get_value<double>() == 3.14);
-            REQUIRE(map.find("foo") != map.end());
-            REQUIRE(map.at("foo").is_string());
-            REQUIRE(map.at("foo").get_value_ref<std::string&>() == "bar");
+        SECTION("mapping value (std::map)") {
+            auto map_node = node.get_value<std::map<fkyaml::node, fkyaml::node>>();
+            REQUIRE(map_node.size() == 2);
+            REQUIRE(map_node.find("test") != map_node.end());
+            REQUIRE(map_node.at("test").is_integer());
+            REQUIRE(map_node.at("test").get_value<int>() == 123);
+            REQUIRE(map_node.find("foo") != map_node.end());
+            REQUIRE(map_node.at("foo").is_integer());
+            REQUIRE(map_node.at("foo").get_value<int>() == -456);
+
+            auto map_compat = node.get_value<std::map<std::string, int>>();
+            REQUIRE(map_compat.size() == 2);
+            REQUIRE(map_compat.find("test") != map_compat.end());
+            REQUIRE(map_compat.at("test") == 123);
+            REQUIRE(map_compat.find("foo") != map_compat.end());
+            REQUIRE(map_compat.at("foo") == -456);
+        }
+
+        SECTION("mapping value (std::multimap)") {
+            auto mmap_node = node.get_value<std::multimap<fkyaml::node, fkyaml::node>>();
+            REQUIRE(mmap_node.size() == 2);
+            REQUIRE(mmap_node.find("test") != mmap_node.end());
+            auto mmap_node_test_range = mmap_node.equal_range("test");
+            REQUIRE(std::distance(mmap_node_test_range.first, mmap_node_test_range.second) == 1);
+            REQUIRE(mmap_node_test_range.first->second.is_integer());
+            REQUIRE(mmap_node_test_range.first->second.get_value<int>() == 123);
+            REQUIRE(mmap_node.find("foo") != mmap_node.end());
+            auto mmap_node_foo_range = mmap_node.equal_range("foo");
+            REQUIRE(std::distance(mmap_node_test_range.first, mmap_node_test_range.second) == 1);
+            REQUIRE(mmap_node_foo_range.first->second.is_integer());
+            REQUIRE(mmap_node_foo_range.first->second.get_value<int>() == -456);
+
+            auto mmap_compat = node.get_value<std::multimap<std::string, int>>();
+            REQUIRE(mmap_compat.size() == 2);
+            REQUIRE(mmap_compat.find("test") != mmap_compat.end());
+            auto mmap_compat_test_range = mmap_compat.equal_range("test");
+            REQUIRE(std::distance(mmap_compat_test_range.first, mmap_compat_test_range.second) == 1);
+            REQUIRE(mmap_compat_test_range.first->second == 123);
+            REQUIRE(mmap_compat.find("foo") != mmap_compat.end());
+            auto mmap_compat_foo_range = mmap_compat.equal_range("foo");
+            REQUIRE(std::distance(mmap_compat_test_range.first, mmap_compat_test_range.second) == 1);
+            REQUIRE(mmap_compat_foo_range.first->second == -456);
+        }
+
+        SECTION("mapping value (std::unordered_map)") {
+            auto umap_node = node.get_value<std::unordered_map<fkyaml::node, fkyaml::node>>();
+            REQUIRE(umap_node.size() == 2);
+            REQUIRE(umap_node.find("test") != umap_node.end());
+            REQUIRE(umap_node.at("test").is_integer());
+            REQUIRE(umap_node.at("test").get_value<int>() == 123);
+            REQUIRE(umap_node.find("foo") != umap_node.end());
+            REQUIRE(umap_node.at("foo").is_integer());
+            REQUIRE(umap_node.at("foo").get_value<int>() == -456);
+
+            auto umap_compat = node.get_value<std::unordered_map<std::string, int>>();
+            REQUIRE(umap_compat.size() == 2);
+            REQUIRE(umap_compat.find("test") != umap_compat.end());
+            REQUIRE(umap_compat.at("test") == 123);
+            REQUIRE(umap_compat.find("foo") != umap_compat.end());
+            REQUIRE(umap_compat.at("foo") == -456);
+        }
+
+        SECTION("mapping value (std::unordered_multimap)") {
+            auto ummap_node = node.get_value<std::unordered_multimap<fkyaml::node, fkyaml::node>>();
+            REQUIRE(ummap_node.size() == 2);
+            REQUIRE(ummap_node.find("test") != ummap_node.end());
+            auto ummap_node_test_range = ummap_node.equal_range("test");
+            REQUIRE(std::distance(ummap_node_test_range.first, ummap_node_test_range.second) == 1);
+            REQUIRE(ummap_node_test_range.first->second.is_integer());
+            REQUIRE(ummap_node_test_range.first->second.get_value<int>() == 123);
+            REQUIRE(ummap_node.find("foo") != ummap_node.end());
+            auto ummap_node_foo_range = ummap_node.equal_range("foo");
+            REQUIRE(std::distance(ummap_node_test_range.first, ummap_node_test_range.second) == 1);
+            REQUIRE(ummap_node_foo_range.first->second.is_integer());
+            REQUIRE(ummap_node_foo_range.first->second.get_value<int>() == -456);
+
+            auto ummap_compat = node.get_value<std::unordered_multimap<std::string, int>>();
+            REQUIRE(ummap_compat.size() == 2);
+            REQUIRE(ummap_compat.find("test") != ummap_compat.end());
+            auto ummap_compat_test_range = ummap_compat.equal_range("test");
+            REQUIRE(std::distance(ummap_compat_test_range.first, ummap_compat_test_range.second) == 1);
+            REQUIRE(ummap_compat_test_range.first->second == 123);
+            REQUIRE(ummap_compat.find("foo") != ummap_compat.end());
+            auto ummap_compat_foo_range = ummap_compat.equal_range("foo");
+            REQUIRE(std::distance(ummap_compat_test_range.first, ummap_compat_test_range.second) == 1);
+            REQUIRE(ummap_compat_foo_range.first->second == -456);
         }
 
         SECTION("non-mapping values") {
@@ -2628,20 +2867,26 @@ TEST_CASE("Node_GetValue") {
     SECTION("string node value") {
         fkyaml::node node("test");
 
-        SECTION("string value") {
-            auto str = node.get_value<fkyaml::node::string_type>();
+        SECTION("string value (std::string)") {
+            auto str = node.get_value<std::string>();
             REQUIRE(str.size() == 4);
             REQUIRE(str == "test");
         }
 
-        SECTION("compatible string value") {
+        SECTION("string value (string_wrap)") {
             auto str_wrap = node.get_value<string_wrap>();
             REQUIRE(str_wrap.str.size() == 4);
             REQUIRE(str_wrap.str == "test");
         }
 
+        SECTION("string value (fkyaml::detail::str_view)") {
+            auto str_view = node.get_value<fkyaml::detail::str_view>();
+            REQUIRE(str_view.size() == 4);
+            REQUIRE(str_view == "test");
+        }
+
 #ifdef FK_YAML_HAS_CXX_17
-        SECTION("string view") {
+        SECTION("string value (std::string_view)") {
             auto str_view = node.get_value<std::string_view>();
             REQUIRE(str_view.size() == 4);
             REQUIRE(str_view == "test");
@@ -2657,6 +2902,51 @@ TEST_CASE("Node_GetValue") {
             REQUIRE_THROWS_AS(node.get_value<fkyaml::node::float_number_type>(), fkyaml::type_error);
         }
     }
+
+    SECTION("std::pair") {
+        fkyaml::node n {123, "test"};
+
+        auto pair_node = n.get_value<std::pair<fkyaml::node, fkyaml::node>>();
+        REQUIRE(pair_node.first.is_integer());
+        REQUIRE(pair_node.first.get_value<int>() == 123);
+        REQUIRE(pair_node.second.is_string());
+        REQUIRE(pair_node.second.get_value<std::string>() == "test");
+
+        auto pair_val = n.get_value<std::pair<int, std::string>>();
+        REQUIRE(pair_val.first == 123);
+        REQUIRE(pair_val.second == "test");
+    }
+
+    SECTION("std::tuple") {
+        fkyaml::node n {123, "test", true};
+
+        auto tuple_node = n.get_value<std::tuple<fkyaml::node, fkyaml::node, fkyaml::node>>();
+        REQUIRE(std::get<0>(tuple_node).is_integer());
+        REQUIRE(std::get<0>(tuple_node).get_value<int>() == 123);
+        REQUIRE(std::get<1>(tuple_node).is_string());
+        REQUIRE(std::get<1>(tuple_node).get_value<std::string>() == "test");
+        REQUIRE(std::get<2>(tuple_node).is_boolean());
+        REQUIRE(std::get<2>(tuple_node).get_value<bool>() == true);
+
+        auto tuple_val = n.get_value<std::tuple<int, std::string, bool>>();
+        REQUIRE(std::get<0>(tuple_val) == 123);
+        REQUIRE(std::get<1>(tuple_val) == "test");
+        REQUIRE(std::get<2>(tuple_val) == true);
+    }
+
+#ifdef FK_YAML_HAS_CXX_17
+    SECTION("std::optional") {
+        fkyaml::node n {true, false};
+        auto opt_vec = n.get_value<std::optional<std::vector<bool>>>();
+        REQUIRE(opt_vec.has_value());
+        REQUIRE(opt_vec.value().size() == 2);
+        REQUIRE(opt_vec.value().at(0) == true);
+        REQUIRE(opt_vec.value().at(1) == false);
+
+        auto opt_bool = n.get_value<std::optional<bool>>();
+        REQUIRE_FALSE(opt_bool.has_value());
+    }
+#endif
 }
 
 //


### PR DESCRIPTION
This PR added support of much more STL container types in `basic_node::get_value()` API.  
For details, please visit [the documentation](https://fktn-k.github.io/fkYAML/api/basic_node/get_value/) for the API.  
Moreover, the API now accepts basic_node template instance types as its return type to allow conversions to container types whose element type is a basic_node template instance type, e.g., `std::array<fkyaml::node, 3>` or `std::unordered_map<fkyaml::node, fkyaml::node>`.  
When this library is compiled with C++17 or greater, `std::optional` can be the return type which holds some converted value on success or `std::nullopt` otherwise.  
Types which were convertible from nodes should still be convertible in the same way.

---

## Pull Request Checklist

Read the [CONTRIBUTING.md](https://github.com/fktn-k/fkYAML/blob/develop/CONTRIBUTING.md) file for detailed information.  

- [x] Changes are described in the pull request or in a referenced [issue](https://github.com/fktn-k/fkYAML/issues).
- [x] The test suite compiles and runs without any error.
- [x] [The code coverage](https://coveralls.io/github/fktn-k/fkYAML) on your branch is 100%.
- [x] The documentation is updated if you added/changed a feature.

## Please don't

- The C++11 support varies between different **compilers** and versions. Please note the [list of supported compilers](https://github.com/fktn-k/fkYAML/blob/develop/README.md#supported-compilers). Some compilers like GCC 4.7 (and earlier), Clang 3.3 (and earlier), or Microsoft Visual Studio 13.0 and earlier are known not to work due to missing or incomplete C++11 support. Please refrain from proposing changes that work around these compiler's limitations with `#ifdef`s or other means.
- Please refrain from proposing changes that would **break [YAML](https://yaml.org/) specifications**. If you propose a conformant extension of YAML to be supported by the library, please motivate this extension.
- Please do not open pull requests that address **multiple issues**.
