### PR TITLE
Fix duplicate include error if clang-tidy helper file already exists

### DIFF
--- a/tool/clang_tidy/CMakeLists.txt
+++ b/tool/clang_tidy/CMakeLists.txt
@@ -17,6 +17,9 @@ message(STATUS "Found clang-tidy. version: ${CLANG_TIDY_VERSION} path: ${CLANG_T
 ####################################
 
 set(HELPER_FILE_PATH "${CMAKE_CURRENT_BINARY_DIR}/clang_tidy_helper.cpp")
+# clear the contents written previously to the file.
+file(WRITE ${HELPER_FILE_PATH} "")
+
 file(GLOB_RECURSE SRC_FILES ${PROJECT_SOURCE_DIR}/include/fkYAML/*.hpp)
 foreach(SRC_FILE ${SRC_FILES})
   file(RELATIVE_PATH REL_SRC_FILE "${PROJECT_SOURCE_DIR}/include" ${SRC_FILE})


### PR DESCRIPTION
The current utility tool for clang-tidy just appends `#include` lines without checking the existence of its resulting helper file. That causes a number of errors like this:

```bash
/home/fktn/github/fkYAML/build_clang_tidy/tool/clang_tidy/clang_tidy_helper.cpp:48:1: error: duplicate include [readability-duplicate-include,-warnings-as-errors]
   47 | int main() { return 0; }
      |
   48 | #include <fkYAML/detail/assert.hpp> // NOLINT(misc-include-cleaner)
```

The tool now clears the file contents first by overwriting it with an empty string so the resulting file always have one `#include` directive for each library header file.  

---

## Pull Request Checklist

Read the [CONTRIBUTING.md](https://github.com/fktn-k/fkYAML/blob/develop/CONTRIBUTING.md) file for detailed information.  

- [x] Changes are described in the pull request or in a referenced [issue](https://github.com/fktn-k/fkYAML/issues).
- [x] The test suite compiles and runs without any error.
- [x] [The code coverage](https://coveralls.io/github/fktn-k/fkYAML) on your branch is 100%.
- [x] The documentation is updated if you added/changed a feature.

## Please don't

- The C++11 support varies between different **compilers** and versions. Please note the [list of supported compilers](https://github.com/fktn-k/fkYAML/blob/develop/README.md#supported-compilers). Some compilers like GCC 4.7 (and earlier), Clang 3.3 (and earlier), or Microsoft Visual Studio 13.0 and earlier are known not to work due to missing or incomplete C++11 support. Please refrain from proposing changes that work around these compiler's limitations with `#ifdef`s or other means.
- Please refrain from proposing changes that would **break [YAML](https://yaml.org/) specifications**. If you propose a conformant extension of YAML to be supported by the library, please motivate this extension.
- Please do not open pull requests that address **multiple issues**.
