### PR TITLE
Clarify type restriction of get_value() & get_value_ref() APIs

### DIFF
--- a/docs/mkdocs/docs/api/basic_node/get_value.md
+++ b/docs/mkdocs/docs/api/basic_node/get_value.md
@@ -20,7 +20,8 @@ This function converts a [fkyaml::basic_node](./index.md) to either
    ConverterType<ValueType>::from_node(*this, ret);
    return ret;
    ```
-   This library implements conversions from a node to a number of STL container types and scalar types. (see the notes down below)
+   This library implements conversions from a node to a number of STL container types and scalar types. (see the notes down below)  
+   Note that ValueType cannot be either a reference, pointer or C-style array type except `std::nullptr_t`.  
 2. a [fkyaml::basic_node](./index.md) object  
    The function is equivalent to executing  
    ```cpp

--- a/docs/mkdocs/docs/api/basic_node/get_value_ref.md
+++ b/docs/mkdocs/docs/api/basic_node/get_value_ref.md
@@ -23,8 +23,7 @@ This API makes no copies.
 
 ***ReferenceType***
 :   reference type to the target YAML node value.  
-    This must be a reference to [`sequence_type`](sequence_type.md), [`mapping_type`](mapping_type.md), [`boolean_type`](boolean_type.md), [`integer_type`](integer_type.md), [`float_number_type`](float_number_type.md) or [`string_type`](string_type.md).  
-    The above restriction is enforced by a static assertion.
+    This must be a (const) reference type to [`sequence_type`](sequence_type.md), [`mapping_type`](mapping_type.md), [`boolean_type`](boolean_type.md), [`integer_type`](integer_type.md), [`float_number_type`](float_number_type.md) or [`string_type`](string_type.md).  
 
 ## **Return Value**
 

--- a/include/fkYAML/node.hpp
+++ b/include/fkYAML/node.hpp
@@ -1305,15 +1305,22 @@ public:
 
     /// @brief Get the node value object converted into a given type.
     /// @note This function requires T objects to be default constructible.
-    /// @tparam T A compatible value type which might be cv-qualified or a reference type.
-    /// @tparam ValueType A compatible value type, without cv-qualifiers and reference by default.
+    /// @tparam T A compatible value type which might be cv-qualified.
+    /// @tparam ValueType A compatible value type with cv-qualifiers removed by default.
     /// @return A compatible native data value converted from the basic_node object.
     /// @sa https://fktn-k.github.io/fkYAML/api/basic_node/get_value/
     template <
-        typename T, typename ValueType = detail::remove_cvref_t<T>,
+        typename T, typename ValueType = detail::remove_cv_t<T>,
         detail::enable_if_t<std::is_default_constructible<ValueType>::value, int> = 0>
     T get_value() const noexcept(
         noexcept(std::declval<const basic_node>().template get_value_impl<ValueType>(std::declval<ValueType&>()))) {
+        // emit a compile error if T is either a reference, pointer or C-style array type.
+        static_assert(
+            !std::is_reference<T>::value,
+            "get_value() cannot be called with reference types. you might want to call get_value_ref().");
+        static_assert(!std::is_pointer<T>::value, "get_value() cannot be called with pointer types.");
+        static_assert(!std::is_array<T>::value, "get_value() cannot be called with C-style array types.");
+
         auto ret = ValueType();
         if (has_anchor_name()) {
             auto itr = mp_meta->anchor_table.equal_range(m_prop.anchor).first;

--- a/test/unit_test/test_node_class.cpp
+++ b/test/unit_test/test_node_class.cpp
@@ -2373,6 +2373,9 @@ struct string_wrap {
     std::string str;
 };
 
+template <typename T, typename U>
+using get_fn_t = decltype(std::declval<T>().template get<U>());
+
 TEST_CASE("Node_GetValue") {
 
     SECTION("sequence") {
@@ -2966,6 +2969,12 @@ TEST_CASE("Node_GetValue") {
         REQUIRE_FALSE(opt_bool.has_value());
     }
 #endif
+
+    SECTION("unsupported types") {
+        STATIC_REQUIRE_FALSE(fkyaml::detail::is_detected<get_fn_t, const fkyaml::node&, int*>::value);
+        STATIC_REQUIRE_FALSE(fkyaml::detail::is_detected<get_fn_t, const fkyaml::node&, int[]>::value);
+        STATIC_REQUIRE_FALSE(fkyaml::detail::is_detected<get_fn_t, const fkyaml::node&, int&>::value);
+    }
 }
 
 //


### PR DESCRIPTION
Although get_value() calls with a reference, pointer, or C-style array type are not supported, but actual attempts of such calls emit user-unfriendly compile error messages.  
So, in this PR, `static_assert`s have been added to detect those types and emit an error message which clearly states they are unsupported.  
The documentation pages for get_value() and get_value_ref() APIs have also been updated to clarify type restrictions.  

---

## Pull Request Checklist

Read the [CONTRIBUTING.md](https://github.com/fktn-k/fkYAML/blob/develop/CONTRIBUTING.md) file for detailed information.  

- [x] Changes are described in the pull request or in a referenced [issue](https://github.com/fktn-k/fkYAML/issues).
- [x] The test suite compiles and runs without any error.
- [x] [The code coverage](https://coveralls.io/github/fktn-k/fkYAML) on your branch is 100%.
- [x] The documentation is updated if you added/changed a feature.

## Please don't

- The C++11 support varies between different **compilers** and versions. Please note the [list of supported compilers](https://github.com/fktn-k/fkYAML/blob/develop/README.md#supported-compilers). Some compilers like GCC 4.7 (and earlier), Clang 3.3 (and earlier), or Microsoft Visual Studio 13.0 and earlier are known not to work due to missing or incomplete C++11 support. Please refrain from proposing changes that work around these compiler's limitations with `#ifdef`s or other means.
- Please refrain from proposing changes that would **break [YAML](https://yaml.org/) specifications**. If you propose a conformant extension of YAML to be supported by the library, please motivate this extension.
- Please do not open pull requests that address **multiple issues**.
