### PR TITLE
Exclude detail::unreachable() from coverage target

### DIFF
--- a/include/fkYAML/detail/meta/stl_supplement.hpp
+++ b/include/fkYAML/detail/meta/stl_supplement.hpp
@@ -247,6 +247,9 @@ using std::remove_cvref_t;
 #endif
 
 /// @brief A wrapper function to call std::unreachable() (since C++23) or similar compiler specific extensions.
+/// @note This function is implemented only for better code optimization against dead code and thus excluded from
+/// coverage report.
+// LCOV_EXCL_START
 [[noreturn]] inline void unreachable() {
     // use compiler specific extensions if possible.
     // undefined behavior should be raised by an empty function with noreturn attribute.
@@ -259,6 +262,7 @@ using std::remove_cvref_t;
     __builtin_unreachable();
 #endif
 }
+// LCOV_EXCL_STOP
 
 FK_YAML_DETAIL_NAMESPACE_END
 

--- a/single_include/fkYAML/node.hpp
+++ b/single_include/fkYAML/node.hpp
@@ -563,6 +563,9 @@ using std::remove_cvref_t;
 #endif
 
 /// @brief A wrapper function to call std::unreachable() (since C++23) or similar compiler specific extensions.
+/// @note This function is implemented only for better code optimization against dead code and thus excluded from
+/// coverage report.
+// LCOV_EXCL_START
 [[noreturn]] inline void unreachable() {
     // use compiler specific extensions if possible.
     // undefined behavior should be raised by an empty function with noreturn attribute.
@@ -575,6 +578,7 @@ using std::remove_cvref_t;
     __builtin_unreachable();
 #endif
 }
+// LCOV_EXCL_STOP
 
 FK_YAML_DETAIL_NAMESPACE_END
 


### PR DESCRIPTION
This PR fixes unintended coverage loss due to no calls to the fkyaml::detail::unreachable() function.  
Since the function is intended not to be called in any expected way, I've just excluded it from the coverage targets.  

---

## Pull Request Checklist

Read the [CONTRIBUTING.md](https://github.com/fktn-k/fkYAML/blob/develop/CONTRIBUTING.md) file for detailed information.  

- [x] Changes are described in the pull request or in a referenced [issue](https://github.com/fktn-k/fkYAML/issues).
- [x] The test suite compiles and runs without any error.
- [x] [The code coverage](https://coveralls.io/github/fktn-k/fkYAML) on your branch is 100%.
- [x] The documentation is updated if you added/changed a feature.

## Please don't

- The C++11 support varies between different **compilers** and versions. Please note the [list of supported compilers](https://github.com/fktn-k/fkYAML/blob/develop/README.md#supported-compilers). Some compilers like GCC 4.7 (and earlier), Clang 3.3 (and earlier), or Microsoft Visual Studio 13.0 and earlier are known not to work due to missing or incomplete C++11 support. Please refrain from proposing changes that work around these compiler's limitations with `#ifdef`s or other means.
- Please refrain from proposing changes that would **break [YAML](https://yaml.org/) specifications**. If you propose a conformant extension of YAML to be supported by the library, please motivate this extension.
- Please do not open pull requests that address **multiple issues**.
