### PR TITLE
Resolve the C4800 warning when compiled with MSVC

### DIFF
--- a/include/fkYAML/detail/encodings/uri_encoding.hpp
+++ b/include/fkYAML/detail/encodings/uri_encoding.hpp
@@ -115,7 +115,7 @@ private:
             return true;
         default:
             // alphabets and numbers are also allowed.
-            return std::isalnum(c);
+            return static_cast<bool>(std::isalnum(c));
         }
     }
 };

--- a/single_include/fkYAML/node.hpp
+++ b/single_include/fkYAML/node.hpp
@@ -1348,7 +1348,7 @@ private:
             return true;
         default:
             // alphabets and numbers are also allowed.
-            return std::isalnum(c);
+            return static_cast<bool>(std::isalnum(c));
         }
     }
 };

--- a/test/unit_test/CMakeLists.txt
+++ b/test/unit_test/CMakeLists.txt
@@ -111,6 +111,7 @@ target_compile_options(
       /W4 /WX /EHsc /utf-8 /permissive-
       /wd4709 # comma operator within array index expression
       /wd4996 # for testing deprecated functions
+      /w44800 # https://github.com/fktn-k/fkYAML/issues/429
       $<$<CONFIG:Debug>:/Z7>
       $<$<CONFIG:Release>:/Od>
     >


### PR DESCRIPTION
This PR fixes the [C4800](https://learn.microsoft.com/en-us/cpp/error-messages/compiler-warnings/compiler-warning-level-3-c4800?view=msvc-170) warnings when this library is compiled with a MSVC compiler as reported in the issue #429.  
The warnings are now resolved by `static_cast`ing the result of `std::isalnum()` as `bool`.  
Furthermore, the test suite is now built with the compile option `/w44800` to avoid a possible regression in the future (the C4800 warning is desabled by default and even with the compile option `/W4`).  

---

## Pull Request Checklist

Read the [CONTRIBUTING.md](https://github.com/fktn-k/fkYAML/blob/develop/CONTRIBUTING.md) file for detailed information.  

- [x] Changes are described in the pull request or in a referenced [issue](https://github.com/fktn-k/fkYAML/issues).
- [x] The test suite compiles and runs without any error.
- [x] [The code coverage](https://coveralls.io/github/fktn-k/fkYAML) on your branch is 100%.
- [x] The documentation is updated if you added/changed a feature.

## Please don't

- The C++11 support varies between different **compilers** and versions. Please note the [list of supported compilers](https://github.com/fktn-k/fkYAML/blob/develop/README.md#supported-compilers). Some compilers like GCC 4.7 (and earlier), Clang 3.3 (and earlier), or Microsoft Visual Studio 13.0 and earlier are known not to work due to missing or incomplete C++11 support. Please refrain from proposing changes that work around these compiler's limitations with `#ifdef`s or other means.
- Please refrain from proposing changes that would **break [YAML](https://yaml.org/) specifications**. If you propose a conformant extension of YAML to be supported by the library, please motivate this extension.
- Please do not open pull requests that address **multiple issues**.
