### PR TITLE
Stop throwing parse_error on string-to-int/float conversion failures if not forced with tag

### DIFF
--- a/include/fkYAML/detail/input/scalar_parser.hpp
+++ b/include/fkYAML/detail/input/scalar_parser.hpp
@@ -75,7 +75,7 @@ public:
 
         token = parse_flow_scalar_token(lex_type, token);
         const node_type value_type = decide_value_type(lex_type, tag_type, token);
-        return create_scalar_node(value_type, token);
+        return create_scalar_node(value_type, tag_type, token);
     }
 
     /// @brief Parses a token into a block scalar (either literal or folded)
@@ -98,7 +98,7 @@ public:
         }
 
         const node_type value_type = decide_value_type(lex_type, tag_type, token);
-        return create_scalar_node(value_type, token);
+        return create_scalar_node(value_type, tag_type, token);
     }
 
 private:
@@ -470,18 +470,16 @@ private:
     /// @param type Scalar value type.
     /// @param token Scalar contents.
     /// @return A YAML scalar object.
-    basic_node_type create_scalar_node(node_type type, str_view token) {
-        basic_node_type node {};
-
-        switch (type) {
+    basic_node_type create_scalar_node(node_type val_type, tag_t tag_type, str_view token) {
+        switch (val_type) {
         case node_type::NULL_OBJECT: {
             std::nullptr_t null = nullptr;
             const bool converted = detail::aton(token.begin(), token.end(), null);
             if FK_YAML_UNLIKELY (!converted) {
                 throw parse_error("Failed to convert a scalar to a null.", m_line, m_indent);
             }
-            // The above `node` variable is already null, so no instance creation is needed.
-            break;
+            // The default basic_node object is a null scalar node.
+            return basic_node_type {};
         }
         case node_type::BOOLEAN: {
             auto boolean = static_cast<boolean_type>(false);
@@ -489,41 +487,45 @@ private:
             if FK_YAML_UNLIKELY (!converted) {
                 throw parse_error("Failed to convert a scalar to a boolean.", m_line, m_indent);
             }
-            node = basic_node_type(boolean);
-            break;
+            return basic_node_type(boolean);
         }
         case node_type::INTEGER: {
             integer_type integer = 0;
             const bool converted = detail::atoi(token.begin(), token.end(), integer);
-            if FK_YAML_UNLIKELY (!converted) {
+            if FK_YAML_LIKELY (converted) {
+                return basic_node_type(integer);
+            }
+            if FK_YAML_UNLIKELY (tag_type == tag_t::INTEGER) {
                 throw parse_error("Failed to convert a scalar to an integer.", m_line, m_indent);
             }
-            node = basic_node_type(integer);
-            break;
+
+            // conversion error from a scalar which is not tagged with !!int is recovered by treating it as a string
+            // scalar. See https://github.com/fktn-k/fkYAML/issues/428.
+            return basic_node_type(string_type(token.begin(), token.end()));
         }
         case node_type::FLOAT: {
             float_number_type float_val = 0;
             const bool converted = detail::atof(token.begin(), token.end(), float_val);
-            if FK_YAML_UNLIKELY (!converted) {
+            if FK_YAML_LIKELY (converted) {
+                return basic_node_type(float_val);
+            }
+            if FK_YAML_UNLIKELY (tag_type == tag_t::FLOATING_NUMBER) {
                 throw parse_error("Failed to convert a scalar to a floating point value", m_line, m_indent);
             }
-            node = basic_node_type(float_val);
-            break;
+
+            // conversion error from a scalar which is not tagged with !!float is recovered by treating it as a string
+            // scalar. See https://github.com/fktn-k/fkYAML/issues/428.
+            return basic_node_type(string_type(token.begin(), token.end()));
         }
         case node_type::STRING:
-            if (m_use_owned_buffer) {
-                node = basic_node_type(std::move(m_buffer));
-                m_use_owned_buffer = false;
+            if (!m_use_owned_buffer) {
+                return basic_node_type(string_type(token.begin(), token.end()));
             }
-            else {
-                node = basic_node_type(std::string(token.begin(), token.end()));
-            }
-            break;
+            m_use_owned_buffer = false;
+            return basic_node_type(std::move(m_buffer));
         default:                   // LCOV_EXCL_LINE
             detail::unreachable(); // LCOV_EXCL_LINE
         }
-
-        return node;
     }
 
     /// Current line

--- a/test/unit_test/test_scalar_parser_class.cpp
+++ b/test/unit_test/test_scalar_parser_class.cpp
@@ -204,7 +204,7 @@ TEST_CASE("ScalarParser_FlowPlainScalar_string") {
     fkyaml::detail::scalar_parser<fkyaml::node> scalar_parser {0, 0};
     fkyaml::detail::tag_t tag_type {fkyaml::detail::tag_t::NONE};
 
-    SECTION("plain: normal contents") {
+    SECTION("plain: single line contents") {
         fkyaml::detail::lexical_token_t lex_type {fkyaml::detail::lexical_token_t::PLAIN_SCALAR};
 
         auto token = GENERATE(
@@ -249,7 +249,11 @@ TEST_CASE("ScalarParser_FlowPlainScalar_string") {
             fkyaml::detail::str_view("-.INF_VALUE"),
             fkyaml::detail::str_view(".nanValue"),
             fkyaml::detail::str_view(".NaNValue"),
-            fkyaml::detail::str_view(".NAN_VALUE"));
+            fkyaml::detail::str_view(".NAN_VALUE"),
+            // fkyaml::node::integer_type(=int64_t) cannot express this value.
+            fkyaml::detail::str_view("0xFFFFFFFFFFFFFFFF0"),
+            // fkyaml::node::float_number_type(=double) cannot express this value.
+            fkyaml::detail::str_view("6E-578"));
 
         REQUIRE_NOTHROW(node = scalar_parser.parse_flow(lex_type, tag_type, token));
         REQUIRE(node.is_string());


### PR DESCRIPTION
This PR has fixed the issue reported in #428, that is, conversion failure from a string to either an integer or a floating point value throws a `parse_error` exception.  
The error should be recovered by treating the source scalar as a string scalar instead if the scalar is not tagged with `!!int`, `!!float` or the equivalents.  
Note that conversion to null and boolean scalars are not considered as recoverable since their presentations are restricted to literals defined in the YAML spec, e.g., `null`, `true` or `False`.  

---

## Pull Request Checklist

Read the [CONTRIBUTING.md](https://github.com/fktn-k/fkYAML/blob/develop/CONTRIBUTING.md) file for detailed information.  

- [x] Changes are described in the pull request or in a referenced [issue](https://github.com/fktn-k/fkYAML/issues).
- [x] The test suite compiles and runs without any error.
- [x] [The code coverage](https://coveralls.io/github/fktn-k/fkYAML) on your branch is 100%.
- [x] The documentation is updated if you added/changed a feature.

## Please don't

- The C++11 support varies between different **compilers** and versions. Please note the [list of supported compilers](https://github.com/fktn-k/fkYAML/blob/develop/README.md#supported-compilers). Some compilers like GCC 4.7 (and earlier), Clang 3.3 (and earlier), or Microsoft Visual Studio 13.0 and earlier are known not to work due to missing or incomplete C++11 support. Please refrain from proposing changes that work around these compiler's limitations with `#ifdef`s or other means.
- Please refrain from proposing changes that would **break [YAML](https://yaml.org/) specifications**. If you propose a conformant extension of YAML to be supported by the library, please motivate this extension.
- Please do not open pull requests that address **multiple issues**.
