### PR TITLE
Support parsing multiline plain scalars

### DIFF
--- a/include/fkYAML/detail/input/lexical_analyzer.hpp
+++ b/include/fkYAML/detail/input/lexical_analyzer.hpp
@@ -799,7 +799,7 @@ private:
                         // If so, the indent value remains the current one.
                         // Otherwise, the indent value is changed based on the last ocurrence of the above 3.
                         // In any case, multiline plain scalar content must be indented more than the indent value.
-                        str_view line_content_part {line_begin_itr + indent, &sv[pos]};
+                        const str_view line_content_part {line_begin_itr + indent, &sv[pos]};
                         std::size_t key_seq_pos = line_content_part.find(": ");
                         if (key_seq_pos == str_view::npos) {
                             key_seq_pos = line_content_part.find(":\t");
@@ -808,11 +808,12 @@ private:
                         if (key_seq_pos == str_view::npos) {
                             constexpr char targets[] = "-?:";
                             FK_YAML_ASSERT(context - 1 < sizeof(targets));
+                            // NOLINTNEXTLINE(cppcoreguidelines-pro-bounds-constant-array-index)
+                            const char target_char = targets[context - 1];
 
                             // Find the position of the last ocuurence of "- ", "? " or ": ".
-                            str_view line_indent_part {line_begin_itr, indent};
-                            // NOLINTNEXTLINE(cppcoreguidelines-pro-bounds-constant-array-index)
-                            std::size_t block_seq_item_begin_pos = line_indent_part.find_last_of(targets[context - 1]);
+                            const str_view line_indent_part {line_begin_itr, indent};
+                            const std::size_t block_seq_item_begin_pos = line_indent_part.find_last_of(target_char);
                             FK_YAML_ASSERT(block_seq_item_begin_pos != str_view::npos);
                             indent = static_cast<uint32_t>(block_seq_item_begin_pos);
                         }
@@ -820,8 +821,8 @@ private:
                 }
 
                 constexpr str_view space_filter = " \t\n";
-                std::size_t non_space_pos = sv.find_first_not_of(space_filter, pos);
-                std::size_t last_newline_pos = sv.find_last_of('\n', non_space_pos);
+                const std::size_t non_space_pos = sv.find_first_not_of(space_filter, pos);
+                const std::size_t last_newline_pos = sv.find_last_of('\n', non_space_pos);
                 FK_YAML_ASSERT(last_newline_pos != str_view::npos);
 
                 if (non_space_pos == str_view::npos || non_space_pos - last_newline_pos - 1 <= indent) {

--- a/include/fkYAML/detail/input/lexical_analyzer.hpp
+++ b/include/fkYAML/detail/input/lexical_analyzer.hpp
@@ -811,6 +811,7 @@ private:
 
                             // Find the position of the last ocuurence of "- ", "? " or ": ".
                             str_view line_indent_part {line_begin_itr, indent};
+                            // NOLINTNEXTLINE(cppcoreguidelines-pro-bounds-constant-array-index)
                             std::size_t block_seq_item_begin_pos = line_indent_part.find_last_of(targets[context - 1]);
                             FK_YAML_ASSERT(block_seq_item_begin_pos != str_view::npos);
                             indent = static_cast<uint32_t>(block_seq_item_begin_pos);

--- a/include/fkYAML/detail/input/lexical_analyzer.hpp
+++ b/include/fkYAML/detail/input/lexical_analyzer.hpp
@@ -720,12 +720,113 @@ private:
         }
 
         bool ends_loop = false;
+        uint32_t indent = std::numeric_limits<uint32_t>::max();
         do {
             FK_YAML_ASSERT(pos < sv.size());
             switch (sv[pos]) {
-            case '\n':
-                ends_loop = true;
+            case '\n': {
+                if (indent == std::numeric_limits<uint32_t>::max()) {
+                    // get the beginning position of the current line.
+                    const char* cur_itr = m_token_begin_itr;
+                    const char* input_begin_itr = m_input_buffer.begin();
+                    while (cur_itr != input_begin_itr) {
+                        if (*cur_itr == '\n') {
+                            ++cur_itr;
+                            break;
+                        }
+                        --cur_itr;
+                    }
+
+                    const char* line_begin_itr = cur_itr;
+
+                    // get the indentation of the current line.
+                    indent = 0;
+                    bool indent_found = false;
+                    // 0: none, 1: block seq item, 2: explicit map key, 3: explicit map value
+                    uint32_t context = 0;
+                    while (cur_itr != m_token_begin_itr && !indent_found) {
+                        switch (*cur_itr) {
+                        case ' ':
+                        case '\t':
+                            ++indent;
+                            ++cur_itr;
+                            break;
+                        case '-':
+                            switch (*(cur_itr + 1)) {
+                            case ' ':
+                            case '\t':
+                                indent += 2;
+                                cur_itr += 2;
+                                context = 1;
+                                break;
+                            default:
+                                indent_found = true;
+                                break;
+                            }
+                            break;
+                        case '?':
+                            if (*(cur_itr + 1) == ' ') {
+                                indent += 2;
+                                cur_itr += 2;
+                                context = 2;
+                                break;
+                            }
+
+                            indent_found = true;
+                            break;
+                        case ':':
+                            switch (*(cur_itr + 1)) {
+                            case ' ':
+                            case '\t':
+                                indent += 2;
+                                cur_itr += 2;
+                                context = 3;
+                            }
+                            break;
+                        default:
+                            indent_found = true;
+                            break;
+                        }
+                    }
+
+                    // If "- ", "? " and/or ": " occur in the first line of this plain scalar content.
+                    if (context > 0) {
+                        // Check if the first line contains the key separator ": ".
+                        // If so, the indent value remains the current one.
+                        // Otherwise, the indent value is changed based on the last ocurrence of the above 3.
+                        // In any case, multiline plain scalar content must be indented more than the indent value.
+                        str_view line_content_part {line_begin_itr + indent, &sv[pos]};
+                        std::size_t key_seq_pos = line_content_part.find(": ");
+                        if (key_seq_pos == str_view::npos) {
+                            key_seq_pos = line_content_part.find(":\t");
+                        }
+
+                        if (key_seq_pos == str_view::npos) {
+                            constexpr char targets[] = "-?:";
+                            FK_YAML_ASSERT(context - 1 < sizeof(targets));
+
+                            // Find the position of the last ocuurence of "- ", "? " or ": ".
+                            str_view line_indent_part {line_begin_itr, indent};
+                            std::size_t block_seq_item_begin_pos = line_indent_part.find_last_of(targets[context - 1]);
+                            FK_YAML_ASSERT(block_seq_item_begin_pos != str_view::npos);
+                            indent = static_cast<uint32_t>(block_seq_item_begin_pos);
+                        }
+                    }
+                }
+
+                constexpr str_view space_filter = " \t\n";
+                std::size_t non_space_pos = sv.find_first_not_of(space_filter, pos);
+                std::size_t last_newline_pos = sv.find_last_of('\n', non_space_pos);
+                FK_YAML_ASSERT(last_newline_pos != str_view::npos);
+
+                if (non_space_pos == str_view::npos || non_space_pos - last_newline_pos - 1 <= indent) {
+                    ends_loop = true;
+                    break;
+                }
+
+                pos = non_space_pos;
                 break;
+            }
             case ' ':
                 if FK_YAML_UNLIKELY (pos == sv.size() - 1) {
                     // trim trailing space.

--- a/include/fkYAML/detail/input/lexical_analyzer.hpp
+++ b/include/fkYAML/detail/input/lexical_analyzer.hpp
@@ -781,6 +781,10 @@ private:
                                 indent += 2;
                                 cur_itr += 2;
                                 context = 3;
+                                break;
+                            default:
+                                indent_found = true;
+                                break;
                             }
                             break;
                         default:

--- a/include/fkYAML/detail/input/scalar_parser.hpp
+++ b/include/fkYAML/detail/input/scalar_parser.hpp
@@ -108,18 +108,50 @@ private:
     /// @return View into the parsed scalar contents.
     str_view parse_flow_scalar_token(lexical_token_t lex_type, str_view token) {
         switch (lex_type) {
+        case lexical_token_t::PLAIN_SCALAR:
+            token = parse_plain_scalar(token);
+            break;
         case lexical_token_t::SINGLE_QUOTED_SCALAR:
             token = parse_single_quoted_scalar(token);
             break;
         case lexical_token_t::DOUBLE_QUOTED_SCALAR:
             token = parse_double_quoted_scalar(token);
             break;
-        case lexical_token_t::PLAIN_SCALAR:
-        default:
-            break;
+        default:           // LCOV_EXCL_LINE
+            unreachable(); // LCOV_EXCL_LINE
         }
 
         return token;
+    }
+
+    /// @brief Parses plain scalar contents.
+    /// @param token Scalar contents.
+    /// @return View into the parsed scalar contents.
+    str_view parse_plain_scalar(str_view token) noexcept {
+        // plain scalars cannot be empty.
+        FK_YAML_ASSERT(!token.empty());
+
+        std::size_t newline_pos = token.find('\n');
+        if (newline_pos == str_view::npos) {
+            return token;
+        }
+
+        m_use_owned_buffer = true;
+
+        if (m_buffer.capacity() < token.size()) {
+            m_buffer.reserve(token.size());
+        }
+
+        do {
+            process_line_folding(token, newline_pos);
+            newline_pos = token.find('\n');
+        } while (newline_pos != str_view::npos);
+
+        if (!token.empty()) {
+            m_buffer.append(token.begin(), token.size());
+        }
+
+        return {m_buffer};
     }
 
     /// @brief Parses single quoted scalar contents.

--- a/include/fkYAML/detail/input/scalar_parser.hpp
+++ b/include/fkYAML/detail/input/scalar_parser.hpp
@@ -147,9 +147,7 @@ private:
             newline_pos = token.find('\n');
         } while (newline_pos != str_view::npos);
 
-        if (!token.empty()) {
-            m_buffer.append(token.begin(), token.size());
-        }
+        m_buffer.append(token.begin(), token.size());
 
         return {m_buffer};
     }

--- a/single_include/fkYAML/node.hpp
+++ b/single_include/fkYAML/node.hpp
@@ -3980,7 +3980,7 @@ private:
                         // If so, the indent value remains the current one.
                         // Otherwise, the indent value is changed based on the last ocurrence of the above 3.
                         // In any case, multiline plain scalar content must be indented more than the indent value.
-                        str_view line_content_part {line_begin_itr + indent, &sv[pos]};
+                        const str_view line_content_part {line_begin_itr + indent, &sv[pos]};
                         std::size_t key_seq_pos = line_content_part.find(": ");
                         if (key_seq_pos == str_view::npos) {
                             key_seq_pos = line_content_part.find(":\t");
@@ -3989,11 +3989,12 @@ private:
                         if (key_seq_pos == str_view::npos) {
                             constexpr char targets[] = "-?:";
                             FK_YAML_ASSERT(context - 1 < sizeof(targets));
+                            // NOLINTNEXTLINE(cppcoreguidelines-pro-bounds-constant-array-index)
+                            const char target_char = targets[context - 1];
 
                             // Find the position of the last ocuurence of "- ", "? " or ": ".
-                            str_view line_indent_part {line_begin_itr, indent};
-                            // NOLINTNEXTLINE(cppcoreguidelines-pro-bounds-constant-array-index)
-                            std::size_t block_seq_item_begin_pos = line_indent_part.find_last_of(targets[context - 1]);
+                            const str_view line_indent_part {line_begin_itr, indent};
+                            const std::size_t block_seq_item_begin_pos = line_indent_part.find_last_of(target_char);
                             FK_YAML_ASSERT(block_seq_item_begin_pos != str_view::npos);
                             indent = static_cast<uint32_t>(block_seq_item_begin_pos);
                         }
@@ -4001,8 +4002,8 @@ private:
                 }
 
                 constexpr str_view space_filter = " \t\n";
-                std::size_t non_space_pos = sv.find_first_not_of(space_filter, pos);
-                std::size_t last_newline_pos = sv.find_last_of('\n', non_space_pos);
+                const std::size_t non_space_pos = sv.find_first_not_of(space_filter, pos);
+                const std::size_t last_newline_pos = sv.find_last_of('\n', non_space_pos);
                 FK_YAML_ASSERT(last_newline_pos != str_view::npos);
 
                 if (non_space_pos == str_view::npos || non_space_pos - last_newline_pos - 1 <= indent) {

--- a/single_include/fkYAML/node.hpp
+++ b/single_include/fkYAML/node.hpp
@@ -3901,12 +3901,113 @@ private:
         }
 
         bool ends_loop = false;
+        uint32_t indent = std::numeric_limits<uint32_t>::max();
         do {
             FK_YAML_ASSERT(pos < sv.size());
             switch (sv[pos]) {
-            case '\n':
-                ends_loop = true;
+            case '\n': {
+                if (indent == std::numeric_limits<uint32_t>::max()) {
+                    // get the beginning position of the current line.
+                    const char* cur_itr = m_token_begin_itr;
+                    const char* input_begin_itr = m_input_buffer.begin();
+                    while (cur_itr != input_begin_itr) {
+                        if (*cur_itr == '\n') {
+                            ++cur_itr;
+                            break;
+                        }
+                        --cur_itr;
+                    }
+
+                    const char* line_begin_itr = cur_itr;
+
+                    // get the indentation of the current line.
+                    indent = 0;
+                    bool indent_found = false;
+                    // 0: none, 1: block seq item, 2: explicit map key, 3: explicit map value
+                    uint32_t context = 0;
+                    while (cur_itr != m_token_begin_itr && !indent_found) {
+                        switch (*cur_itr) {
+                        case ' ':
+                        case '\t':
+                            ++indent;
+                            ++cur_itr;
+                            break;
+                        case '-':
+                            switch (*(cur_itr + 1)) {
+                            case ' ':
+                            case '\t':
+                                indent += 2;
+                                cur_itr += 2;
+                                context = 1;
+                                break;
+                            default:
+                                indent_found = true;
+                                break;
+                            }
+                            break;
+                        case '?':
+                            if (*(cur_itr + 1) == ' ') {
+                                indent += 2;
+                                cur_itr += 2;
+                                context = 2;
+                                break;
+                            }
+
+                            indent_found = true;
+                            break;
+                        case ':':
+                            switch (*(cur_itr + 1)) {
+                            case ' ':
+                            case '\t':
+                                indent += 2;
+                                cur_itr += 2;
+                                context = 3;
+                            }
+                            break;
+                        default:
+                            indent_found = true;
+                            break;
+                        }
+                    }
+
+                    // If "- ", "? " and/or ": " occur in the first line of this plain scalar content.
+                    if (context > 0) {
+                        // Check if the first line contains the key separator ": ".
+                        // If so, the indent value remains the current one.
+                        // Otherwise, the indent value is changed based on the last ocurrence of the above 3.
+                        // In any case, multiline plain scalar content must be indented more than the indent value.
+                        str_view line_content_part {line_begin_itr + indent, &sv[pos]};
+                        std::size_t key_seq_pos = line_content_part.find(": ");
+                        if (key_seq_pos == str_view::npos) {
+                            key_seq_pos = line_content_part.find(":\t");
+                        }
+
+                        if (key_seq_pos == str_view::npos) {
+                            constexpr char targets[] = "-?:";
+                            FK_YAML_ASSERT(context - 1 < sizeof(targets));
+
+                            // Find the position of the last ocuurence of "- ", "? " or ": ".
+                            str_view line_indent_part {line_begin_itr, indent};
+                            std::size_t block_seq_item_begin_pos = line_indent_part.find_last_of(targets[context - 1]);
+                            FK_YAML_ASSERT(block_seq_item_begin_pos != str_view::npos);
+                            indent = static_cast<uint32_t>(block_seq_item_begin_pos);
+                        }
+                    }
+                }
+
+                constexpr str_view space_filter = " \t\n";
+                std::size_t non_space_pos = sv.find_first_not_of(space_filter, pos);
+                std::size_t last_newline_pos = sv.find_last_of('\n', non_space_pos);
+                FK_YAML_ASSERT(last_newline_pos != str_view::npos);
+
+                if (non_space_pos == str_view::npos || non_space_pos - last_newline_pos - 1 <= indent) {
+                    ends_loop = true;
+                    break;
+                }
+
+                pos = non_space_pos;
                 break;
+            }
             case ' ':
                 if FK_YAML_UNLIKELY (pos == sv.size() - 1) {
                     // trim trailing space.

--- a/single_include/fkYAML/node.hpp
+++ b/single_include/fkYAML/node.hpp
@@ -3962,6 +3962,10 @@ private:
                                 indent += 2;
                                 cur_itr += 2;
                                 context = 3;
+                                break;
+                            default:
+                                indent_found = true;
+                                break;
                             }
                             break;
                         default:
@@ -6051,18 +6055,48 @@ private:
     /// @return View into the parsed scalar contents.
     str_view parse_flow_scalar_token(lexical_token_t lex_type, str_view token) {
         switch (lex_type) {
+        case lexical_token_t::PLAIN_SCALAR:
+            token = parse_plain_scalar(token);
+            break;
         case lexical_token_t::SINGLE_QUOTED_SCALAR:
             token = parse_single_quoted_scalar(token);
             break;
         case lexical_token_t::DOUBLE_QUOTED_SCALAR:
             token = parse_double_quoted_scalar(token);
             break;
-        case lexical_token_t::PLAIN_SCALAR:
-        default:
-            break;
+        default:           // LCOV_EXCL_LINE
+            unreachable(); // LCOV_EXCL_LINE
         }
 
         return token;
+    }
+
+    /// @brief Parses plain scalar contents.
+    /// @param token Scalar contents.
+    /// @return View into the parsed scalar contents.
+    str_view parse_plain_scalar(str_view token) noexcept {
+        // plain scalars cannot be empty.
+        FK_YAML_ASSERT(!token.empty());
+
+        std::size_t newline_pos = token.find('\n');
+        if (newline_pos == str_view::npos) {
+            return token;
+        }
+
+        m_use_owned_buffer = true;
+
+        if (m_buffer.capacity() < token.size()) {
+            m_buffer.reserve(token.size());
+        }
+
+        do {
+            process_line_folding(token, newline_pos);
+            newline_pos = token.find('\n');
+        } while (newline_pos != str_view::npos);
+
+        m_buffer.append(token.begin(), token.size());
+
+        return {m_buffer};
     }
 
     /// @brief Parses single quoted scalar contents.

--- a/single_include/fkYAML/node.hpp
+++ b/single_include/fkYAML/node.hpp
@@ -3992,6 +3992,7 @@ private:
 
                             // Find the position of the last ocuurence of "- ", "? " or ": ".
                             str_view line_indent_part {line_begin_itr, indent};
+                            // NOLINTNEXTLINE(cppcoreguidelines-pro-bounds-constant-array-index)
                             std::size_t block_seq_item_begin_pos = line_indent_part.find_last_of(targets[context - 1]);
                             FK_YAML_ASSERT(block_seq_item_begin_pos != str_view::npos);
                             indent = static_cast<uint32_t>(block_seq_item_begin_pos);

--- a/test/unit_test/test_lexical_analyzer_class.cpp
+++ b/test/unit_test/test_lexical_analyzer_class.cpp
@@ -412,6 +412,32 @@ TEST_CASE("LexicalAnalyzer_PlainScalar") {
         REQUIRE(token.str.end() == input.end() - 1);
     }
 
+    SECTION("multiline as an implicit mapping value") {
+        fkyaml::detail::str_view input = "  foo: foo\n"
+                                         "   bar\n"
+                                         "     baz\n"
+                                         "  qux";
+        fkyaml::detail::lexical_analyzer lexer(input);
+
+        REQUIRE_NOTHROW(token = lexer.get_next_token());
+        REQUIRE(token.type == fkyaml::detail::lexical_token_t::PLAIN_SCALAR);
+        REQUIRE(token.str.begin() == input.begin() + 2);
+        REQUIRE(token.str.end() == input.begin() + 5);
+
+        REQUIRE_NOTHROW(token = lexer.get_next_token());
+        REQUIRE(token.type == fkyaml::detail::lexical_token_t::KEY_SEPARATOR);
+
+        REQUIRE_NOTHROW(token = lexer.get_next_token());
+        REQUIRE(token.type == fkyaml::detail::lexical_token_t::PLAIN_SCALAR);
+        REQUIRE(token.str.begin() == input.begin() + 7);
+        REQUIRE(token.str.end() == input.end() - 6);
+
+        REQUIRE_NOTHROW(token = lexer.get_next_token());
+        REQUIRE(token.type == fkyaml::detail::lexical_token_t::PLAIN_SCALAR);
+        REQUIRE(token.str.begin() == input.end() - 3);
+        REQUIRE(token.str.end() == input.end());
+    }
+
     SECTION("multiline as a block sequence item") {
         fkyaml::detail::str_view input = "  - foo\n"
                                          "   bar\n"
@@ -424,6 +450,34 @@ TEST_CASE("LexicalAnalyzer_PlainScalar") {
         REQUIRE_NOTHROW(token = lexer.get_next_token());
         REQUIRE(token.type == fkyaml::detail::lexical_token_t::PLAIN_SCALAR);
         REQUIRE(token.str.begin() == input.begin() + 4);
+        REQUIRE(token.str.end() == input.end());
+    }
+
+    SECTION("multiline as a block sequence item and an implicit mapping value") {
+        fkyaml::detail::str_view input = "  - -foo: bar\n"
+                                         "     baz\n"
+                                         "   baz";
+        fkyaml::detail::lexical_analyzer lexer(input);
+
+        REQUIRE_NOTHROW(token = lexer.get_next_token());
+        REQUIRE(token.type == fkyaml::detail::lexical_token_t::SEQUENCE_BLOCK_PREFIX);
+
+        REQUIRE_NOTHROW(token = lexer.get_next_token());
+        REQUIRE(token.type == fkyaml::detail::lexical_token_t::PLAIN_SCALAR);
+        REQUIRE(token.str.begin() == input.begin() + 4);
+        REQUIRE(token.str.end() == input.begin() + 8);
+
+        REQUIRE_NOTHROW(token = lexer.get_next_token());
+        REQUIRE(token.type == fkyaml::detail::lexical_token_t::KEY_SEPARATOR);
+
+        REQUIRE_NOTHROW(token = lexer.get_next_token());
+        REQUIRE(token.type == fkyaml::detail::lexical_token_t::PLAIN_SCALAR);
+        REQUIRE(token.str.begin() == input.begin() + 10);
+        REQUIRE(token.str.end() == input.end() - 7);
+
+        REQUIRE_NOTHROW(token = lexer.get_next_token());
+        REQUIRE(token.type == fkyaml::detail::lexical_token_t::PLAIN_SCALAR);
+        REQUIRE(token.str.begin() == input.end() - 3);
         REQUIRE(token.str.end() == input.end());
     }
 
@@ -442,6 +496,34 @@ TEST_CASE("LexicalAnalyzer_PlainScalar") {
         REQUIRE(token.str.end() == input.end());
     }
 
+    SECTION("multiline as an explicit mapping key and an implicit mapping value") {
+        fkyaml::detail::str_view input = "  ? ?foo: bar\n"
+                                         "     baz\n"
+                                         "   baz";
+        fkyaml::detail::lexical_analyzer lexer(input);
+
+        REQUIRE_NOTHROW(token = lexer.get_next_token());
+        REQUIRE(token.type == fkyaml::detail::lexical_token_t::EXPLICIT_KEY_PREFIX);
+
+        REQUIRE_NOTHROW(token = lexer.get_next_token());
+        REQUIRE(token.type == fkyaml::detail::lexical_token_t::PLAIN_SCALAR);
+        REQUIRE(token.str.begin() == input.begin() + 4);
+        REQUIRE(token.str.end() == input.begin() + 8);
+
+        REQUIRE_NOTHROW(token = lexer.get_next_token());
+        REQUIRE(token.type == fkyaml::detail::lexical_token_t::KEY_SEPARATOR);
+
+        REQUIRE_NOTHROW(token = lexer.get_next_token());
+        REQUIRE(token.type == fkyaml::detail::lexical_token_t::PLAIN_SCALAR);
+        REQUIRE(token.str.begin() == input.begin() + 10);
+        REQUIRE(token.str.end() == input.end() - 7);
+
+        REQUIRE_NOTHROW(token = lexer.get_next_token());
+        REQUIRE(token.type == fkyaml::detail::lexical_token_t::PLAIN_SCALAR);
+        REQUIRE(token.str.begin() == input.end() - 3);
+        REQUIRE(token.str.end() == input.end());
+    }
+
     SECTION("multiline as an explicit mapping value") {
         fkyaml::detail::str_view input = "  : foo\n"
                                          "   bar\n"
@@ -454,6 +536,34 @@ TEST_CASE("LexicalAnalyzer_PlainScalar") {
         REQUIRE_NOTHROW(token = lexer.get_next_token());
         REQUIRE(token.type == fkyaml::detail::lexical_token_t::PLAIN_SCALAR);
         REQUIRE(token.str.begin() == input.begin() + 4);
+        REQUIRE(token.str.end() == input.end());
+    }
+
+    SECTION("multiline as an explicit mapping value and an implicit mapping value") {
+        fkyaml::detail::str_view input = "  : :foo: bar\n"
+                                         "     bar\n"
+                                         "   baz";
+        fkyaml::detail::lexical_analyzer lexer(input);
+
+        REQUIRE_NOTHROW(token = lexer.get_next_token());
+        REQUIRE(token.type == fkyaml::detail::lexical_token_t::KEY_SEPARATOR);
+
+        REQUIRE_NOTHROW(token = lexer.get_next_token());
+        REQUIRE(token.type == fkyaml::detail::lexical_token_t::PLAIN_SCALAR);
+        REQUIRE(token.str.begin() == input.begin() + 4);
+        REQUIRE(token.str.end() == input.begin() + 8);
+
+        REQUIRE_NOTHROW(token = lexer.get_next_token());
+        REQUIRE(token.type == fkyaml::detail::lexical_token_t::KEY_SEPARATOR);
+
+        REQUIRE_NOTHROW(token = lexer.get_next_token());
+        REQUIRE(token.type == fkyaml::detail::lexical_token_t::PLAIN_SCALAR);
+        REQUIRE(token.str.begin() == input.begin() + 10);
+        REQUIRE(token.str.end() == input.end() - 7);
+
+        REQUIRE_NOTHROW(token = lexer.get_next_token());
+        REQUIRE(token.type == fkyaml::detail::lexical_token_t::PLAIN_SCALAR);
+        REQUIRE(token.str.begin() == input.end() - 3);
         REQUIRE(token.str.end() == input.end());
     }
 

--- a/test/unit_test/test_scalar_parser_class.cpp
+++ b/test/unit_test/test_scalar_parser_class.cpp
@@ -260,6 +260,20 @@ TEST_CASE("ScalarParser_FlowPlainScalar_string") {
         REQUIRE(node.get_value_ref<std::string&>() == token);
     }
 
+    SECTION("plain: multiline contents") {
+        fkyaml::detail::lexical_token_t lex_type {fkyaml::detail::lexical_token_t::PLAIN_SCALAR};
+        using test_data_t = std::pair<fkyaml::detail::str_view, std::string>;
+        auto test_data = GENERATE(
+            test_data_t("foo\nbar", "foo bar"),
+            test_data_t("foo\n \tbar", "foo bar"),
+            test_data_t("foo\n\n \t\n bar", "foo\n\nbar"),
+            test_data_t("foo\n        \t\t\t\n bar", "foo\nbar"));
+
+        REQUIRE_NOTHROW(node = scalar_parser.parse_flow(lex_type, tag_type, test_data.first));
+        REQUIRE(node.is_string());
+        REQUIRE(node.get_value_ref<std::string&>() == test_data.second);
+    }
+
     SECTION("single quoted: single line contents") {
         fkyaml::detail::lexical_token_t lex_type {fkyaml::detail::lexical_token_t::SINGLE_QUOTED_SCALAR};
         using test_data_t = std::pair<fkyaml::detail::str_view, std::string>;


### PR DESCRIPTION
In this PR, parsing multiline plain (unquoted) scalars has been implemented, which was described as a restriction in the PR #344  
> **The flow line folding for plain scalars is not yet supported** since the deserialization feature is not yet ready for that feature. It will, however, surely be supported in the future. Until the feature gets ready, please make such a scalar be either single or double quoted.

Before this PR, multiline plain scalars seemed to be parsed with no error but the parse result was just incorrect since its data structure was different from the expected one. (I know this was terrible in debugging...)  
The library can now successfully parses such scalars and the result has its correct data structure.  
We can simply pass this YAML
```yaml
key: this line
  is a multiline
  plain scalar.
```

to the `fkyaml::node::deserialize()` function, and the function then interprets the input as if the following YAML is passed.
```yaml
key: this line is a multiline plain scalar.
```

Note that, although multiline scalars (either plain or single/double quoted) cannot be used as an implicit mapping key as stated in [the YAML specification (7.3. Flow Scalar Styles)](https://yaml.org/spec/1.2.2/#73-flow-scalar-styles), the library currently allows for such an invalid syntax like this:
```yaml
this implicit
  multiline
  scalar: should not be allowed
```

This will be fixed in another PR for sure.  

---

## Pull Request Checklist

Read the [CONTRIBUTING.md](https://github.com/fktn-k/fkYAML/blob/develop/CONTRIBUTING.md) file for detailed information.  

- [x] Changes are described in the pull request or in a referenced [issue](https://github.com/fktn-k/fkYAML/issues).
- [x] The test suite compiles and runs without any error.
- [x] [The code coverage](https://coveralls.io/github/fktn-k/fkYAML) on your branch is 100%.
- [x] The documentation is updated if you added/changed a feature.

## Please don't

- The C++11 support varies between different **compilers** and versions. Please note the [list of supported compilers](https://github.com/fktn-k/fkYAML/blob/develop/README.md#supported-compilers). Some compilers like GCC 4.7 (and earlier), Clang 3.3 (and earlier), or Microsoft Visual Studio 13.0 and earlier are known not to work due to missing or incomplete C++11 support. Please refrain from proposing changes that work around these compiler's limitations with `#ifdef`s or other means.
- Please refrain from proposing changes that would **break [YAML](https://yaml.org/) specifications**. If you propose a conformant extension of YAML to be supported by the library, please motivate this extension.
- Please do not open pull requests that address **multiple issues**.
