### PR TITLE
Emit error if an anchor is specified to an alias

### DIFF
--- a/include/fkYAML/detail/input/deserializer.hpp
+++ b/include/fkYAML/detail/input/deserializer.hpp
@@ -909,8 +909,13 @@ private:
                 m_flow_token_state = flow_token_state_t::NEEDS_VALUE_OR_SUFFIX;
                 break;
             case lexical_token_t::ALIAS_PREFIX: {
+                // An alias node must not specify any properties (tag, anchor).
+                // https://yaml.org/spec/1.2.2/#71-alias-nodes
                 if FK_YAML_UNLIKELY (m_needs_tag_impl) {
                     throw parse_error("Tag cannot be specified to an alias node", line, indent);
+                }
+                if FK_YAML_UNLIKELY (m_needs_anchor_impl) {
+                    throw parse_error("Anchor cannot be specified to an alias node.", line, indent);
                 }
 
                 std::string token_str = std::string(token.str.begin(), token.str.end());

--- a/single_include/fkYAML/node.hpp
+++ b/single_include/fkYAML/node.hpp
@@ -7878,8 +7878,13 @@ private:
                 m_flow_token_state = flow_token_state_t::NEEDS_VALUE_OR_SUFFIX;
                 break;
             case lexical_token_t::ALIAS_PREFIX: {
+                // An alias node must not specify any properties (tag, anchor).
+                // https://yaml.org/spec/1.2.2/#71-alias-nodes
                 if FK_YAML_UNLIKELY (m_needs_tag_impl) {
                     throw parse_error("Tag cannot be specified to an alias node", line, indent);
+                }
+                if FK_YAML_UNLIKELY (m_needs_anchor_impl) {
+                    throw parse_error("Anchor cannot be specified to an alias node.", line, indent);
                 }
 
                 std::string token_str = std::string(token.str.begin(), token.str.end());

--- a/test/unit_test/test_deserializer_class.cpp
+++ b/test/unit_test/test_deserializer_class.cpp
@@ -2880,6 +2880,11 @@ TEST_CASE("Deserializer_NodeProperties") {
         REQUIRE_THROWS_AS(deserializer.deserialize(fkyaml::detail::input_adapter(input)), fkyaml::parse_error);
     }
 
+    SECTION("alias node with anchor") {
+        std::string input = "&anchor foo: &anchor2 *anchor";
+        REQUIRE_THROWS_AS(deserializer.deserialize(fkyaml::detail::input_adapter(input)), fkyaml::parse_error);
+    }
+
     SECTION("parse anchored child block mapping as a block sequence entry") {
         std::string input = "values:\n"
                             "- &anchor !XXX\n"


### PR DESCRIPTION
As described in [the YAML specification (7.1. Alias Nodes)](https://yaml.org/spec/1.2.2/#71-alias-nodes), any properties (anchor and tag) must not be specified to an alias node.  
Although the library emits an error if a tag is specified to an alias node, it doesn't if an anchor is specified to an alias node.  
```yaml
&anchor foo: !!str *anchor # this is treated as an error.
---
&anchor foo: &anchor2 *anchor # this is not treated as an error, but it should be.
```

So, in this PR, the implementation has been fixed so the library would throws an parse_error if an anchor is specified to an alias node.  


---

## Pull Request Checklist

Read the [CONTRIBUTING.md](https://github.com/fktn-k/fkYAML/blob/develop/CONTRIBUTING.md) file for detailed information.  

- [x] Changes are described in the pull request or in a referenced [issue](https://github.com/fktn-k/fkYAML/issues).
- [x] The test suite compiles and runs without any error.
- [x] [The code coverage](https://coveralls.io/github/fktn-k/fkYAML) on your branch is 100%.
- [x] The documentation is updated if you added/changed a feature.

## Please don't

- The C++11 support varies between different **compilers** and versions. Please note the [list of supported compilers](https://github.com/fktn-k/fkYAML/blob/develop/README.md#supported-compilers). Some compilers like GCC 4.7 (and earlier), Clang 3.3 (and earlier), or Microsoft Visual Studio 13.0 and earlier are known not to work due to missing or incomplete C++11 support. Please refrain from proposing changes that work around these compiler's limitations with `#ifdef`s or other means.
- Please refrain from proposing changes that would **break [YAML](https://yaml.org/) specifications**. If you propose a conformant extension of YAML to be supported by the library, please motivate this extension.
- Please do not open pull requests that address **multiple issues**.
