### PR TITLE
Fixed bugs in parsing block scalars

### DIFF
--- a/include/fkYAML/detail/input/block_scalar_header.hpp
+++ b/include/fkYAML/detail/input/block_scalar_header.hpp
@@ -26,7 +26,7 @@ enum class chomping_indicator_t : std::uint8_t {
 struct block_scalar_header {
     /// Chomping indicator type.
     chomping_indicator_t chomp {chomping_indicator_t::CLIP};
-    /// Indentation for block scalar contents.
+    /// Content indentation level of a block scalar.
     uint32_t indent {0};
 };
 

--- a/include/fkYAML/detail/input/lexical_analyzer.hpp
+++ b/include/fkYAML/detail/input/lexical_analyzer.hpp
@@ -976,6 +976,18 @@ private:
             FK_YAML_ASSERT(last_newline_pos < cur_line_content_begin_pos);
             cur_indent = static_cast<uint32_t>(cur_line_content_begin_pos - last_newline_pos - 1);
             if (cur_indent < content_indent && sv[cur_line_content_begin_pos] != '\n') {
+                if FK_YAML_UNLIKELY (cur_indent > base_indent) {
+                    // This path assumes an input like the following:
+                    // ```yaml
+                    // foo: |
+                    //   text
+                    //  invalid # this line is less indented than the content indent level (2)
+                    //          # but more indented than the base indent level (0)
+                    // ```
+                    // In such cases, the less indented line cannot be the start of the next token.
+                    emit_error("A content line of the block scalar is less indented.");
+                }
+
                 // Interpret less indented non-space characters as the start of the next token.
                 break;
             }

--- a/include/fkYAML/detail/input/lexical_analyzer.hpp
+++ b/include/fkYAML/detail/input/lexical_analyzer.hpp
@@ -978,7 +978,7 @@ private:
             last_newline_pos = sv.size();
         }
 
-        uint32_t content_indent = base_indent + indicated_indent;
+        const uint32_t content_indent = base_indent + indicated_indent;
         while (last_newline_pos < sv.size()) {
             std::size_t cur_line_end_pos = sv.find('\n', last_newline_pos + 1);
             if (cur_line_end_pos == str_view::npos) {

--- a/include/fkYAML/detail/input/lexical_analyzer.hpp
+++ b/include/fkYAML/detail/input/lexical_analyzer.hpp
@@ -221,16 +221,22 @@ public:
         case '>': {
             const str_view sv {m_token_begin_itr, m_end_itr};
             const std::size_t header_end_pos = sv.find('\n');
-
-            FK_YAML_ASSERT(!sv.empty());
-            token.type = (sv[0] == '|') ? lexical_token_t::BLOCK_LITERAL_SCALAR : lexical_token_t::BLOCK_FOLDED_SCALAR;
-
             FK_YAML_ASSERT(header_end_pos != str_view::npos);
+            const uint32_t base_indent = get_current_indent_level(&sv[header_end_pos]);
+
+            if (*m_token_begin_itr == '|') {
+                token.type = lexical_token_t::BLOCK_LITERAL_SCALAR;
+            }
+            else {
+                token.type = lexical_token_t::BLOCK_FOLDED_SCALAR;
+            }
+
             const str_view header_line = sv.substr(1, header_end_pos - 1);
             m_block_scalar_header = convert_to_block_scalar_header(header_line);
 
             m_token_begin_itr = sv.begin() + (header_end_pos + 1);
-            scan_block_style_string_token(m_block_scalar_header.indent, token.str);
+            m_block_scalar_header.indent =
+                determine_block_scalar_content_range(base_indent, m_block_scalar_header.indent, token.str);
 
             return token;
         }
@@ -299,6 +305,102 @@ public:
     }
 
 private:
+    uint32_t get_current_indent_level(const char* p_line_end) {
+        // get the beginning position of the current line.
+        const char* cur_itr = p_line_end - 1;
+        const char* input_begin_itr = m_input_buffer.begin();
+        while (cur_itr != input_begin_itr) {
+            if (*cur_itr == '\n') {
+                ++cur_itr;
+                break;
+            }
+            --cur_itr;
+        }
+
+        const char* line_begin_itr = cur_itr;
+
+        // get the indentation of the current line.
+        uint32_t indent = 0;
+        bool indent_found = false;
+        // 0: none, 1: block seq item, 2: explicit map key, 3: explicit map value
+        uint32_t context = 0;
+        while (cur_itr != p_line_end && !indent_found) {
+            switch (*cur_itr) {
+            case ' ':
+                ++indent;
+                ++cur_itr;
+                break;
+            case '-':
+                switch (*(cur_itr + 1)) {
+                case ' ':
+                case '\t':
+                    indent += 2;
+                    cur_itr += 2;
+                    context = 1;
+                    break;
+                default:
+                    indent_found = true;
+                    break;
+                }
+                break;
+            case '?':
+                if (*(cur_itr + 1) == ' ') {
+                    indent += 2;
+                    cur_itr += 2;
+                    context = 2;
+                    break;
+                }
+
+                indent_found = true;
+                break;
+            case ':':
+                switch (*(cur_itr + 1)) {
+                case ' ':
+                case '\t':
+                    indent += 2;
+                    cur_itr += 2;
+                    context = 3;
+                    break;
+                default:
+                    indent_found = true;
+                    break;
+                }
+                break;
+            default:
+                indent_found = true;
+                break;
+            }
+        }
+
+        // If "- ", "? " and/or ": " occur in the first line of this plain scalar content.
+        if (context > 0) {
+            // Check if the first line contains the key separator ": ".
+            // If so, the indent value remains the current one.
+            // Otherwise, the indent value is changed based on the last ocurrence of the above 3.
+            // In any case, multiline plain scalar content must be indented more than the indent value.
+            const str_view line_content_part {line_begin_itr + indent, p_line_end};
+            std::size_t key_sep_pos = line_content_part.find(": ");
+            if (key_sep_pos == str_view::npos) {
+                key_sep_pos = line_content_part.find(":\t");
+            }
+
+            if (key_sep_pos == str_view::npos) {
+                constexpr char targets[] = "-?:";
+                FK_YAML_ASSERT(context - 1 < sizeof(targets));
+                // NOLINTNEXTLINE(cppcoreguidelines-pro-bounds-constant-array-index)
+                const char target_char = targets[context - 1];
+
+                // Find the position of the last ocuurence of "- ", "? " or ": ".
+                const str_view line_indent_part {line_begin_itr, indent};
+                const std::size_t block_seq_item_begin_pos = line_indent_part.find_last_of(target_char);
+                FK_YAML_ASSERT(block_seq_item_begin_pos != str_view::npos);
+                indent = static_cast<uint32_t>(block_seq_item_begin_pos);
+            }
+        }
+
+        return indent;
+    }
+
     /// @brief Skip until a newline code or a null character is found.
     void scan_comment() {
         FK_YAML_ASSERT(*m_cur_itr == '#');
@@ -726,98 +828,7 @@ private:
             switch (sv[pos]) {
             case '\n': {
                 if (indent == std::numeric_limits<uint32_t>::max()) {
-                    // get the beginning position of the current line.
-                    const char* cur_itr = m_token_begin_itr;
-                    const char* input_begin_itr = m_input_buffer.begin();
-                    while (cur_itr != input_begin_itr) {
-                        if (*cur_itr == '\n') {
-                            ++cur_itr;
-                            break;
-                        }
-                        --cur_itr;
-                    }
-
-                    const char* line_begin_itr = cur_itr;
-
-                    // get the indentation of the current line.
-                    indent = 0;
-                    bool indent_found = false;
-                    // 0: none, 1: block seq item, 2: explicit map key, 3: explicit map value
-                    uint32_t context = 0;
-                    while (cur_itr != m_token_begin_itr && !indent_found) {
-                        switch (*cur_itr) {
-                        case ' ':
-                        case '\t':
-                            ++indent;
-                            ++cur_itr;
-                            break;
-                        case '-':
-                            switch (*(cur_itr + 1)) {
-                            case ' ':
-                            case '\t':
-                                indent += 2;
-                                cur_itr += 2;
-                                context = 1;
-                                break;
-                            default:
-                                indent_found = true;
-                                break;
-                            }
-                            break;
-                        case '?':
-                            if (*(cur_itr + 1) == ' ') {
-                                indent += 2;
-                                cur_itr += 2;
-                                context = 2;
-                                break;
-                            }
-
-                            indent_found = true;
-                            break;
-                        case ':':
-                            switch (*(cur_itr + 1)) {
-                            case ' ':
-                            case '\t':
-                                indent += 2;
-                                cur_itr += 2;
-                                context = 3;
-                                break;
-                            default:
-                                indent_found = true;
-                                break;
-                            }
-                            break;
-                        default:
-                            indent_found = true;
-                            break;
-                        }
-                    }
-
-                    // If "- ", "? " and/or ": " occur in the first line of this plain scalar content.
-                    if (context > 0) {
-                        // Check if the first line contains the key separator ": ".
-                        // If so, the indent value remains the current one.
-                        // Otherwise, the indent value is changed based on the last ocurrence of the above 3.
-                        // In any case, multiline plain scalar content must be indented more than the indent value.
-                        const str_view line_content_part {line_begin_itr + indent, &sv[pos]};
-                        std::size_t key_seq_pos = line_content_part.find(": ");
-                        if (key_seq_pos == str_view::npos) {
-                            key_seq_pos = line_content_part.find(":\t");
-                        }
-
-                        if (key_seq_pos == str_view::npos) {
-                            constexpr char targets[] = "-?:";
-                            FK_YAML_ASSERT(context - 1 < sizeof(targets));
-                            // NOLINTNEXTLINE(cppcoreguidelines-pro-bounds-constant-array-index)
-                            const char target_char = targets[context - 1];
-
-                            // Find the position of the last ocuurence of "- ", "? " or ": ".
-                            const str_view line_indent_part {line_begin_itr, indent};
-                            const std::size_t block_seq_item_begin_pos = line_indent_part.find_last_of(target_char);
-                            FK_YAML_ASSERT(block_seq_item_begin_pos != str_view::npos);
-                            indent = static_cast<uint32_t>(block_seq_item_begin_pos);
-                        }
-                    }
+                    indent = get_current_indent_level(&sv[pos]);
                 }
 
                 constexpr str_view space_filter = " \t\n";
@@ -903,49 +914,45 @@ private:
     }
 
     /// @brief Scan a block style string token either in the literal or folded style.
-    /// @param style The style of the given token, either literal or folded.
-    /// @param chomp The chomping indicator type of the given token, either strip, keep or clip.
-    /// @param indent The indent size specified for the given token.
-    void scan_block_style_string_token(uint32_t& indent, str_view& token) {
+    /// @param base_indent The base indent level of the block scalar.
+    /// @param indicated_indent The indicated indent level in the block scalar header. 0 means it's not indicated.
+    /// @param token Storage for the scanned block scalar range.
+    /// @return The content indentation level of the block scalar.
+    uint32_t determine_block_scalar_content_range(uint32_t base_indent, uint32_t indicated_indent, str_view& token) {
         const str_view sv {m_token_begin_itr, m_end_itr};
 
         // Handle leading all-space lines.
         constexpr str_view space_filter = " \t\n";
         const std::size_t first_non_space_pos = sv.find_first_not_of(space_filter);
         if (first_non_space_pos == str_view::npos) {
-            // empty block scalar with no subsequent tokens.
-            indent = static_cast<uint32_t>(sv.size());
-            token = sv;
-
             // Without the following iterator update, lexer cannot reach the end of input buffer and causes infinite
             // loops from the next loop. (https://github.com/fktn-k/fkYAML/pull/410)
             m_cur_itr = m_end_itr;
-            return;
+
+            // empty block scalar with no subsequent tokens.
+            token = sv;
+            return static_cast<uint32_t>(sv.size());
         }
 
         // get indentation of the first non-space character.
         std::size_t last_newline_pos = sv.substr(0, first_non_space_pos).find_last_of('\n');
+        uint32_t cur_indent = 0;
+
+        // get indentation level of the first non-empty line.
         if (last_newline_pos == str_view::npos) {
             // first_non_space_pos in on the first line.
-            const auto cur_indent = static_cast<uint32_t>(first_non_space_pos);
-            if (indent == 0) {
-                indent = cur_indent;
-            }
-            else if FK_YAML_UNLIKELY (cur_indent < indent) {
-                emit_error("A block style scalar is less indented than the indicated level.");
-            }
+            cur_indent = static_cast<uint32_t>(first_non_space_pos);
         }
         else {
             FK_YAML_ASSERT(last_newline_pos < first_non_space_pos);
-            const auto cur_indent = static_cast<uint32_t>(first_non_space_pos - last_newline_pos - 1);
+            cur_indent = static_cast<uint32_t>(first_non_space_pos - last_newline_pos - 1);
+        }
 
-            // TODO: preserve and compare the last indentation with `cur_indent`
-            if (indent == 0) {
-                indent = cur_indent;
-            }
-            else if FK_YAML_UNLIKELY (cur_indent < indent) {
-                emit_error("A block style scalar is less indented than the indicated level.");
-            }
+        if (indicated_indent == 0) {
+            indicated_indent = cur_indent - base_indent;
+        }
+        else if FK_YAML_UNLIKELY (cur_indent < base_indent + indicated_indent) {
+            emit_error("The first non-empty line in the block scalar is less indented.");
         }
 
         last_newline_pos = sv.find('\n', first_non_space_pos + 1);
@@ -953,6 +960,7 @@ private:
             last_newline_pos = sv.size();
         }
 
+        uint32_t content_indent = base_indent + indicated_indent;
         while (last_newline_pos < sv.size()) {
             std::size_t cur_line_end_pos = sv.find('\n', last_newline_pos + 1);
             if (cur_line_end_pos == str_view::npos) {
@@ -966,8 +974,8 @@ private:
             }
 
             FK_YAML_ASSERT(last_newline_pos < cur_line_content_begin_pos);
-            const auto cur_indent = static_cast<uint32_t>(cur_line_content_begin_pos - last_newline_pos - 1);
-            if (cur_indent < indent && sv[cur_line_content_begin_pos] != '\n') {
+            cur_indent = static_cast<uint32_t>(cur_line_content_begin_pos - last_newline_pos - 1);
+            if (cur_indent < content_indent && sv[cur_line_content_begin_pos] != '\n') {
                 // Interpret less indented non-space characters as the start of the next token.
                 break;
             }
@@ -982,6 +990,8 @@ private:
 
         token = sv.substr(0, last_newline_pos);
         m_cur_itr = token.end();
+
+        return content_indent;
     }
 
     /// @brief Handle unescaped control characters.

--- a/include/fkYAML/detail/input/scalar_parser.hpp
+++ b/include/fkYAML/detail/input/scalar_parser.hpp
@@ -311,6 +311,8 @@ private:
         m_use_owned_buffer = true;
         m_buffer.reserve(token.size());
 
+        constexpr str_view white_space_filter = " \t";
+
         std::size_t cur_line_begin_pos = 0;
         bool has_newline_at_end = true;
         bool can_be_folded = false;
@@ -323,14 +325,21 @@ private:
 
             const std::size_t line_size = cur_line_end_pos - cur_line_begin_pos;
             const str_view line = token.substr(cur_line_begin_pos, line_size);
+            const bool is_empty = line.find_first_not_of(white_space_filter) == str_view::npos;
 
             if (line.size() <= header.indent) {
-                // empty or less-indented lines are turned into a newline
+                // A less-indented line is turned into a newline.
                 m_buffer.push_back('\n');
                 can_be_folded = false;
             }
+            else if (is_empty) {
+                // more-indented empty lines are not folded.
+                m_buffer.push_back('\n');
+                m_buffer.append(line.begin() + header.indent, line.end());
+                m_buffer.push_back('\n');
+            }
             else {
-                const std::size_t non_space_pos = line.find_first_not_of(' ');
+                const std::size_t non_space_pos = line.find_first_not_of(white_space_filter);
                 const bool is_more_indented = (non_space_pos != str_view::npos) && (non_space_pos > header.indent);
 
                 if (can_be_folded) {

--- a/single_include/fkYAML/node.hpp
+++ b/single_include/fkYAML/node.hpp
@@ -4159,7 +4159,7 @@ private:
             last_newline_pos = sv.size();
         }
 
-        uint32_t content_indent = base_indent + indicated_indent;
+        const uint32_t content_indent = base_indent + indicated_indent;
         while (last_newline_pos < sv.size()) {
             std::size_t cur_line_end_pos = sv.find('\n', last_newline_pos + 1);
             if (cur_line_end_pos == str_view::npos) {

--- a/single_include/fkYAML/node.hpp
+++ b/single_include/fkYAML/node.hpp
@@ -2061,7 +2061,7 @@ enum class chomping_indicator_t : std::uint8_t {
 struct block_scalar_header {
     /// Chomping indicator type.
     chomping_indicator_t chomp {chomping_indicator_t::CLIP};
-    /// Indentation for block scalar contents.
+    /// Content indentation level of a block scalar.
     uint32_t indent {0};
 };
 
@@ -3402,16 +3402,22 @@ public:
         case '>': {
             const str_view sv {m_token_begin_itr, m_end_itr};
             const std::size_t header_end_pos = sv.find('\n');
-
-            FK_YAML_ASSERT(!sv.empty());
-            token.type = (sv[0] == '|') ? lexical_token_t::BLOCK_LITERAL_SCALAR : lexical_token_t::BLOCK_FOLDED_SCALAR;
-
             FK_YAML_ASSERT(header_end_pos != str_view::npos);
+            const uint32_t base_indent = get_current_indent_level(&sv[header_end_pos]);
+
+            if (*m_token_begin_itr == '|') {
+                token.type = lexical_token_t::BLOCK_LITERAL_SCALAR;
+            }
+            else {
+                token.type = lexical_token_t::BLOCK_FOLDED_SCALAR;
+            }
+
             const str_view header_line = sv.substr(1, header_end_pos - 1);
             m_block_scalar_header = convert_to_block_scalar_header(header_line);
 
             m_token_begin_itr = sv.begin() + (header_end_pos + 1);
-            scan_block_style_string_token(m_block_scalar_header.indent, token.str);
+            m_block_scalar_header.indent =
+                determine_block_scalar_content_range(base_indent, m_block_scalar_header.indent, token.str);
 
             return token;
         }
@@ -3480,6 +3486,102 @@ public:
     }
 
 private:
+    uint32_t get_current_indent_level(const char* p_line_end) {
+        // get the beginning position of the current line.
+        const char* cur_itr = p_line_end - 1;
+        const char* input_begin_itr = m_input_buffer.begin();
+        while (cur_itr != input_begin_itr) {
+            if (*cur_itr == '\n') {
+                ++cur_itr;
+                break;
+            }
+            --cur_itr;
+        }
+
+        const char* line_begin_itr = cur_itr;
+
+        // get the indentation of the current line.
+        uint32_t indent = 0;
+        bool indent_found = false;
+        // 0: none, 1: block seq item, 2: explicit map key, 3: explicit map value
+        uint32_t context = 0;
+        while (cur_itr != p_line_end && !indent_found) {
+            switch (*cur_itr) {
+            case ' ':
+                ++indent;
+                ++cur_itr;
+                break;
+            case '-':
+                switch (*(cur_itr + 1)) {
+                case ' ':
+                case '\t':
+                    indent += 2;
+                    cur_itr += 2;
+                    context = 1;
+                    break;
+                default:
+                    indent_found = true;
+                    break;
+                }
+                break;
+            case '?':
+                if (*(cur_itr + 1) == ' ') {
+                    indent += 2;
+                    cur_itr += 2;
+                    context = 2;
+                    break;
+                }
+
+                indent_found = true;
+                break;
+            case ':':
+                switch (*(cur_itr + 1)) {
+                case ' ':
+                case '\t':
+                    indent += 2;
+                    cur_itr += 2;
+                    context = 3;
+                    break;
+                default:
+                    indent_found = true;
+                    break;
+                }
+                break;
+            default:
+                indent_found = true;
+                break;
+            }
+        }
+
+        // If "- ", "? " and/or ": " occur in the first line of this plain scalar content.
+        if (context > 0) {
+            // Check if the first line contains the key separator ": ".
+            // If so, the indent value remains the current one.
+            // Otherwise, the indent value is changed based on the last ocurrence of the above 3.
+            // In any case, multiline plain scalar content must be indented more than the indent value.
+            const str_view line_content_part {line_begin_itr + indent, p_line_end};
+            std::size_t key_sep_pos = line_content_part.find(": ");
+            if (key_sep_pos == str_view::npos) {
+                key_sep_pos = line_content_part.find(":\t");
+            }
+
+            if (key_sep_pos == str_view::npos) {
+                constexpr char targets[] = "-?:";
+                FK_YAML_ASSERT(context - 1 < sizeof(targets));
+                // NOLINTNEXTLINE(cppcoreguidelines-pro-bounds-constant-array-index)
+                const char target_char = targets[context - 1];
+
+                // Find the position of the last ocuurence of "- ", "? " or ": ".
+                const str_view line_indent_part {line_begin_itr, indent};
+                const std::size_t block_seq_item_begin_pos = line_indent_part.find_last_of(target_char);
+                FK_YAML_ASSERT(block_seq_item_begin_pos != str_view::npos);
+                indent = static_cast<uint32_t>(block_seq_item_begin_pos);
+            }
+        }
+
+        return indent;
+    }
+
     /// @brief Skip until a newline code or a null character is found.
     void scan_comment() {
         FK_YAML_ASSERT(*m_cur_itr == '#');
@@ -3907,98 +4009,7 @@ private:
             switch (sv[pos]) {
             case '\n': {
                 if (indent == std::numeric_limits<uint32_t>::max()) {
-                    // get the beginning position of the current line.
-                    const char* cur_itr = m_token_begin_itr;
-                    const char* input_begin_itr = m_input_buffer.begin();
-                    while (cur_itr != input_begin_itr) {
-                        if (*cur_itr == '\n') {
-                            ++cur_itr;
-                            break;
-                        }
-                        --cur_itr;
-                    }
-
-                    const char* line_begin_itr = cur_itr;
-
-                    // get the indentation of the current line.
-                    indent = 0;
-                    bool indent_found = false;
-                    // 0: none, 1: block seq item, 2: explicit map key, 3: explicit map value
-                    uint32_t context = 0;
-                    while (cur_itr != m_token_begin_itr && !indent_found) {
-                        switch (*cur_itr) {
-                        case ' ':
-                        case '\t':
-                            ++indent;
-                            ++cur_itr;
-                            break;
-                        case '-':
-                            switch (*(cur_itr + 1)) {
-                            case ' ':
-                            case '\t':
-                                indent += 2;
-                                cur_itr += 2;
-                                context = 1;
-                                break;
-                            default:
-                                indent_found = true;
-                                break;
-                            }
-                            break;
-                        case '?':
-                            if (*(cur_itr + 1) == ' ') {
-                                indent += 2;
-                                cur_itr += 2;
-                                context = 2;
-                                break;
-                            }
-
-                            indent_found = true;
-                            break;
-                        case ':':
-                            switch (*(cur_itr + 1)) {
-                            case ' ':
-                            case '\t':
-                                indent += 2;
-                                cur_itr += 2;
-                                context = 3;
-                                break;
-                            default:
-                                indent_found = true;
-                                break;
-                            }
-                            break;
-                        default:
-                            indent_found = true;
-                            break;
-                        }
-                    }
-
-                    // If "- ", "? " and/or ": " occur in the first line of this plain scalar content.
-                    if (context > 0) {
-                        // Check if the first line contains the key separator ": ".
-                        // If so, the indent value remains the current one.
-                        // Otherwise, the indent value is changed based on the last ocurrence of the above 3.
-                        // In any case, multiline plain scalar content must be indented more than the indent value.
-                        const str_view line_content_part {line_begin_itr + indent, &sv[pos]};
-                        std::size_t key_seq_pos = line_content_part.find(": ");
-                        if (key_seq_pos == str_view::npos) {
-                            key_seq_pos = line_content_part.find(":\t");
-                        }
-
-                        if (key_seq_pos == str_view::npos) {
-                            constexpr char targets[] = "-?:";
-                            FK_YAML_ASSERT(context - 1 < sizeof(targets));
-                            // NOLINTNEXTLINE(cppcoreguidelines-pro-bounds-constant-array-index)
-                            const char target_char = targets[context - 1];
-
-                            // Find the position of the last ocuurence of "- ", "? " or ": ".
-                            const str_view line_indent_part {line_begin_itr, indent};
-                            const std::size_t block_seq_item_begin_pos = line_indent_part.find_last_of(target_char);
-                            FK_YAML_ASSERT(block_seq_item_begin_pos != str_view::npos);
-                            indent = static_cast<uint32_t>(block_seq_item_begin_pos);
-                        }
-                    }
+                    indent = get_current_indent_level(&sv[pos]);
                 }
 
                 constexpr str_view space_filter = " \t\n";
@@ -4084,49 +4095,45 @@ private:
     }
 
     /// @brief Scan a block style string token either in the literal or folded style.
-    /// @param style The style of the given token, either literal or folded.
-    /// @param chomp The chomping indicator type of the given token, either strip, keep or clip.
-    /// @param indent The indent size specified for the given token.
-    void scan_block_style_string_token(uint32_t& indent, str_view& token) {
+    /// @param base_indent The base indent level of the block scalar.
+    /// @param indicated_indent The indicated indent level in the block scalar header. 0 means it's not indicated.
+    /// @param token Storage for the scanned block scalar range.
+    /// @return The content indentation level of the block scalar.
+    uint32_t determine_block_scalar_content_range(uint32_t base_indent, uint32_t indicated_indent, str_view& token) {
         const str_view sv {m_token_begin_itr, m_end_itr};
 
         // Handle leading all-space lines.
         constexpr str_view space_filter = " \t\n";
         const std::size_t first_non_space_pos = sv.find_first_not_of(space_filter);
         if (first_non_space_pos == str_view::npos) {
-            // empty block scalar with no subsequent tokens.
-            indent = static_cast<uint32_t>(sv.size());
-            token = sv;
-
             // Without the following iterator update, lexer cannot reach the end of input buffer and causes infinite
             // loops from the next loop. (https://github.com/fktn-k/fkYAML/pull/410)
             m_cur_itr = m_end_itr;
-            return;
+
+            // empty block scalar with no subsequent tokens.
+            token = sv;
+            return static_cast<uint32_t>(sv.size());
         }
 
         // get indentation of the first non-space character.
         std::size_t last_newline_pos = sv.substr(0, first_non_space_pos).find_last_of('\n');
+        uint32_t cur_indent = 0;
+
+        // get indentation level of the first non-empty line.
         if (last_newline_pos == str_view::npos) {
             // first_non_space_pos in on the first line.
-            const auto cur_indent = static_cast<uint32_t>(first_non_space_pos);
-            if (indent == 0) {
-                indent = cur_indent;
-            }
-            else if FK_YAML_UNLIKELY (cur_indent < indent) {
-                emit_error("A block style scalar is less indented than the indicated level.");
-            }
+            cur_indent = static_cast<uint32_t>(first_non_space_pos);
         }
         else {
             FK_YAML_ASSERT(last_newline_pos < first_non_space_pos);
-            const auto cur_indent = static_cast<uint32_t>(first_non_space_pos - last_newline_pos - 1);
+            cur_indent = static_cast<uint32_t>(first_non_space_pos - last_newline_pos - 1);
+        }
 
-            // TODO: preserve and compare the last indentation with `cur_indent`
-            if (indent == 0) {
-                indent = cur_indent;
-            }
-            else if FK_YAML_UNLIKELY (cur_indent < indent) {
-                emit_error("A block style scalar is less indented than the indicated level.");
-            }
+        if (indicated_indent == 0) {
+            indicated_indent = cur_indent - base_indent;
+        }
+        else if FK_YAML_UNLIKELY (cur_indent < base_indent + indicated_indent) {
+            emit_error("The first non-empty line in the block scalar is less indented.");
         }
 
         last_newline_pos = sv.find('\n', first_non_space_pos + 1);
@@ -4134,6 +4141,7 @@ private:
             last_newline_pos = sv.size();
         }
 
+        uint32_t content_indent = base_indent + indicated_indent;
         while (last_newline_pos < sv.size()) {
             std::size_t cur_line_end_pos = sv.find('\n', last_newline_pos + 1);
             if (cur_line_end_pos == str_view::npos) {
@@ -4147,8 +4155,8 @@ private:
             }
 
             FK_YAML_ASSERT(last_newline_pos < cur_line_content_begin_pos);
-            const auto cur_indent = static_cast<uint32_t>(cur_line_content_begin_pos - last_newline_pos - 1);
-            if (cur_indent < indent && sv[cur_line_content_begin_pos] != '\n') {
+            cur_indent = static_cast<uint32_t>(cur_line_content_begin_pos - last_newline_pos - 1);
+            if (cur_indent < content_indent && sv[cur_line_content_begin_pos] != '\n') {
                 // Interpret less indented non-space characters as the start of the next token.
                 break;
             }
@@ -4163,6 +4171,8 @@ private:
 
         token = sv.substr(0, last_newline_pos);
         m_cur_itr = token.end();
+
+        return content_indent;
     }
 
     /// @brief Handle unescaped control characters.

--- a/single_include/fkYAML/node.hpp
+++ b/single_include/fkYAML/node.hpp
@@ -4103,40 +4103,58 @@ private:
         const str_view sv {m_token_begin_itr, m_end_itr};
 
         // Handle leading all-space lines.
-        constexpr str_view space_filter = " \t\n";
-        const std::size_t first_non_space_pos = sv.find_first_not_of(space_filter);
-        if (first_non_space_pos == str_view::npos) {
+        uint32_t cur_indent = 0;
+        uint32_t max_leading_indent = 0;
+        const char* cur_itr = m_token_begin_itr;
+        for (bool stop_increment = false; cur_itr != m_end_itr; ++cur_itr) {
+            const char c = *cur_itr;
+            if (c == ' ') {
+                if (!stop_increment) {
+                    ++cur_indent;
+                }
+                continue;
+            }
+            if (c == '\n') {
+                max_leading_indent = std::max(cur_indent, max_leading_indent);
+                cur_indent = 0;
+                stop_increment = false;
+                continue;
+            }
+            if (c == '\t') {
+                // Tabs are not counted as an indent character but still part of an empty line.
+                // See https://yaml.org/spec/1.2.2/#rule-s-indent and https://yaml.org/spec/1.2.2/#64-empty-lines.
+                stop_increment = true;
+                continue;
+            }
+            break;
+        }
+
+        // all the block scalar contents are empty lines, and no subsequent token exists.
+        if FK_YAML_UNLIKELY (cur_itr == m_end_itr) {
             // Without the following iterator update, lexer cannot reach the end of input buffer and causes infinite
             // loops from the next loop. (https://github.com/fktn-k/fkYAML/pull/410)
             m_cur_itr = m_end_itr;
 
-            // empty block scalar with no subsequent tokens.
             token = sv;
-            return static_cast<uint32_t>(sv.size());
+            // If there's no non-empty line, the content indentation level is equal to the number of spaces on the
+            // longest line. https://yaml.org/spec/1.2.2/#8111-block-indentation-indicator
+            return indicated_indent == 0 ? std::max(cur_indent, max_leading_indent) : base_indent + indicated_indent;
         }
 
-        // get indentation of the first non-space character.
-        std::size_t last_newline_pos = sv.substr(0, first_non_space_pos).find_last_of('\n');
-        uint32_t cur_indent = 0;
-
-        // get indentation level of the first non-empty line.
-        if (last_newline_pos == str_view::npos) {
-            // first_non_space_pos in on the first line.
-            cur_indent = static_cast<uint32_t>(first_non_space_pos);
-        }
-        else {
-            FK_YAML_ASSERT(last_newline_pos < first_non_space_pos);
-            cur_indent = static_cast<uint32_t>(first_non_space_pos - last_newline_pos - 1);
+        // Any leading empty line must not contain more spaces than the first non-empty line.
+        if FK_YAML_UNLIKELY (cur_indent < max_leading_indent) {
+            emit_error("Any leading empty line must not be more indented than the first non-empty line.");
         }
 
         if (indicated_indent == 0) {
+            FK_YAML_ASSERT(base_indent < cur_indent);
             indicated_indent = cur_indent - base_indent;
         }
         else if FK_YAML_UNLIKELY (cur_indent < base_indent + indicated_indent) {
             emit_error("The first non-empty line in the block scalar is less indented.");
         }
 
-        last_newline_pos = sv.find('\n', first_non_space_pos + 1);
+        std::size_t last_newline_pos = sv.find('\n', cur_itr - m_token_begin_itr + 1);
         if (last_newline_pos == str_view::npos) {
             last_newline_pos = sv.size();
         }

--- a/single_include/fkYAML/node.hpp
+++ b/single_include/fkYAML/node.hpp
@@ -4157,6 +4157,18 @@ private:
             FK_YAML_ASSERT(last_newline_pos < cur_line_content_begin_pos);
             cur_indent = static_cast<uint32_t>(cur_line_content_begin_pos - last_newline_pos - 1);
             if (cur_indent < content_indent && sv[cur_line_content_begin_pos] != '\n') {
+                if FK_YAML_UNLIKELY (cur_indent > base_indent) {
+                    // This path assumes an input like the following:
+                    // ```yaml
+                    // foo: |
+                    //   text
+                    //  invalid # this line is less indented than the content indent level (2)
+                    //          # but more indented than the base indent level (0)
+                    // ```
+                    // In such cases, the less indented line cannot be the start of the next token.
+                    emit_error("A content line of the block scalar is less indented.");
+                }
+
                 // Interpret less indented non-space characters as the start of the next token.
                 break;
             }

--- a/test/unit_test/test_lexical_analyzer_class.cpp
+++ b/test/unit_test/test_lexical_analyzer_class.cpp
@@ -906,14 +906,14 @@ TEST_CASE("LexicalAnalyzer_LiteralStringScalar") {
 
     SECTION("a leading empty line contains a tab") {
         const char input[] = "|\n"
-                             "  \t\n"
+                             "  \t \n"
                              "  foo";
         fkyaml::detail::lexical_analyzer lexer(input);
 
         REQUIRE_NOTHROW(token = lexer.get_next_token());
         REQUIRE(token.type == fkyaml::detail::lexical_token_t::BLOCK_LITERAL_SCALAR);
         REQUIRE(token.str.begin() == &input[2]);
-        REQUIRE(token.str.end() == &input[0] + 11);
+        REQUIRE(token.str.end() == &input[0] + 12);
         REQUIRE(lexer.get_block_scalar_header().chomp == fkyaml::detail::chomping_indicator_t::CLIP);
         REQUIRE(lexer.get_block_scalar_header().indent == 2);
 
@@ -1243,14 +1243,14 @@ TEST_CASE("LexicalAnalyzer_FoldedString") {
 
     SECTION("a leading empty line contains a tab") {
         const char input[] = ">\n"
-                             "  \t\n"
+                             "  \t \n"
                              "  foo";
         fkyaml::detail::lexical_analyzer lexer(input);
 
         REQUIRE_NOTHROW(token = lexer.get_next_token());
         REQUIRE(token.type == fkyaml::detail::lexical_token_t::BLOCK_FOLDED_SCALAR);
         REQUIRE(token.str.begin() == &input[2]);
-        REQUIRE(token.str.end() == &input[0] + 11);
+        REQUIRE(token.str.end() == &input[0] + 12);
         REQUIRE(lexer.get_block_scalar_header().chomp == fkyaml::detail::chomping_indicator_t::CLIP);
         REQUIRE(lexer.get_block_scalar_header().indent == 2);
 

--- a/test/unit_test/test_lexical_analyzer_class.cpp
+++ b/test/unit_test/test_lexical_analyzer_class.cpp
@@ -895,6 +895,15 @@ TEST_CASE("LexicalAnalyzer_LiteralStringScalar") {
         REQUIRE_THROWS_AS(lexer.get_next_token(), fkyaml::parse_error);
     }
 
+    SECTION("a following content line is less indented") {
+        const char input[] = "|\n"
+                             "  foo\n"
+                             " bar";
+
+        fkyaml::detail::lexical_analyzer lexer(input);
+        REQUIRE_THROWS_AS(lexer.get_next_token(), fkyaml::parse_error);
+    }
+
     SECTION("less indented literal string scalar") {
         const char input[] = "|2\n"
                              " foo";
@@ -1192,6 +1201,15 @@ TEST_CASE("LexicalAnalyzer_FoldedString") {
     SECTION("folded string scalar with 0 indent level") {
         const char input[] = "|0\n"
                              "foo";
+
+        fkyaml::detail::lexical_analyzer lexer(input);
+        REQUIRE_THROWS_AS(lexer.get_next_token(), fkyaml::parse_error);
+    }
+
+    SECTION("a following content line is less indented") {
+        const char input[] = ">\n"
+                             "  foo\n"
+                             " bar";
 
         fkyaml::detail::lexical_analyzer lexer(input);
         REQUIRE_THROWS_AS(lexer.get_next_token(), fkyaml::parse_error);

--- a/test/unit_test/test_scalar_parser_class.cpp
+++ b/test/unit_test/test_scalar_parser_class.cpp
@@ -417,7 +417,7 @@ TEST_CASE("ScalarParser_BlockLiteralScalar") {
     SECTION("empty literal string scalar with strip chomping") {
         fkyaml::detail::str_view token = "  \n";
         header.chomp = fkyaml::detail::chomping_indicator_t::STRIP;
-        header.indent = 3;
+        header.indent = 2;
 
         REQUIRE_NOTHROW(node = scalar_parser.parse_block(lex_type, tag_type, token, header));
         REQUIRE(node.is_string());
@@ -427,7 +427,7 @@ TEST_CASE("ScalarParser_BlockLiteralScalar") {
     SECTION("empty literal string scalar with clip chomping") {
         fkyaml::detail::str_view token = "  \n";
         header.chomp = fkyaml::detail::chomping_indicator_t::CLIP;
-        header.indent = 3;
+        header.indent = 2;
 
         REQUIRE_NOTHROW(node = scalar_parser.parse_block(lex_type, tag_type, token, header));
         REQUIRE(node.is_string());
@@ -437,11 +437,22 @@ TEST_CASE("ScalarParser_BlockLiteralScalar") {
     SECTION("empty literal string scalar with keep chomping") {
         fkyaml::detail::str_view token = "  \n";
         header.chomp = fkyaml::detail::chomping_indicator_t::KEEP;
-        header.indent = 3;
+        header.indent = 2;
 
         REQUIRE_NOTHROW(node = scalar_parser.parse_block(lex_type, tag_type, token, header));
         REQUIRE(node.is_string());
         REQUIRE(node.get_value_ref<std::string&>() == "\n");
+    }
+
+    SECTION("a leading empty line contains a tab") {
+        fkyaml::detail::str_view token = "  \t \n"
+                                         "  foo";
+        header.chomp = fkyaml::detail::chomping_indicator_t::CLIP;
+        header.indent = 2;
+
+        REQUIRE_NOTHROW(node = scalar_parser.parse_block(lex_type, tag_type, token, header));
+        REQUIRE(node.is_string());
+        REQUIRE(node.get_value_ref<std::string&>() == "\t \nfoo");
     }
 
     SECTION("literal scalar with the first line being more indented than the indicated level") {
@@ -617,6 +628,17 @@ TEST_CASE("ScalarParser_BlockFoldedScalar") {
         REQUIRE_NOTHROW(node = scalar_parser.parse_block(lex_type, tag_type, token, header));
         REQUIRE(node.is_string());
         REQUIRE(node.get_value_ref<std::string&>() == "\n");
+    }
+
+    SECTION("a leading empty line contains a tab") {
+        fkyaml::detail::str_view token = "  \t \n"
+                                         "  foo";
+        header.chomp = fkyaml::detail::chomping_indicator_t::CLIP;
+        header.indent = 2;
+
+        REQUIRE_NOTHROW(node = scalar_parser.parse_block(lex_type, tag_type, token, header));
+        REQUIRE(node.is_string());
+        REQUIRE(node.get_value_ref<std::string&>() == "\n\t \nfoo");
     }
 
     SECTION("folded string scalar with the first line being more indented than the indicated level") {


### PR DESCRIPTION
In this PR, several bugs in parsing block literal/folded scalars (due to wrong implementations) have been fixed.
1. A leading empty line which is more indented than the first non-empty line  
   ```yaml
   foo: |
      # this leading line contains 3 spaces as indentation
     foo # 2 spaces as indentation
   ```
   
   * Before: no error was emitted
   * After: `parse_error` is thrown
2. A non-empty line which is less indented than the content indentation level  
   but more indented than the base indentation level  
   ```yaml
   foo: |
     text
    invalid # this line is less indented than the content indentation level (2)
            # but more indented than the base indentation level (0)
   ```
   
   * Before: no error was emitted
   * After: `parse_error` is thrown
3. A more-indented empty line in block folded scalar contents  
   ```yaml
   foo: >
          # 2 spaces(indent) + 1 tab(content) + 1 space(content)
     bar
   ```
   * Before: parsed as `foo: "\t  bar"`
   * After: parsed as `\n\t \nbar`

Furthermore, although the current implementation treats half-width spaces and tabs as indentation characters, only half-width spaces should be treated as the indentation character as the YAML specification defines [here](https://yaml.org/spec/1.2.2/#rule-s-indent).  
So, in this PR, detecting an indentation level has been fixed to search only for half-width spaces in parsing block scalars.

---

## Pull Request Checklist

Read the [CONTRIBUTING.md](https://github.com/fktn-k/fkYAML/blob/develop/CONTRIBUTING.md) file for detailed information.  

- [x] Changes are described in the pull request or in a referenced [issue](https://github.com/fktn-k/fkYAML/issues).
- [x] The test suite compiles and runs without any error.
- [x] [The code coverage](https://coveralls.io/github/fktn-k/fkYAML) on your branch is 100%.
- [x] The documentation is updated if you added/changed a feature.

## Please don't

- The C++11 support varies between different **compilers** and versions. Please note the [list of supported compilers](https://github.com/fktn-k/fkYAML/blob/develop/README.md#supported-compilers). Some compilers like GCC 4.7 (and earlier), Clang 3.3 (and earlier), or Microsoft Visual Studio 13.0 and earlier are known not to work due to missing or incomplete C++11 support. Please refrain from proposing changes that work around these compiler's limitations with `#ifdef`s or other means.
- Please refrain from proposing changes that would **break [YAML](https://yaml.org/) specifications**. If you propose a conformant extension of YAML to be supported by the library, please motivate this extension.
- Please do not open pull requests that address **multiple issues**.
