### PR TITLE
Add more GCC & Clang versions to use in GitHub Actions workflows

### DIFF
--- a/.github/workflows/ubuntu.yml
+++ b/.github/workflows/ubuntu.yml
@@ -200,7 +200,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        compiler: [ "3.5", "3.6", "3.7", "3.8", "3.9", "4", "5", "6", "7", "8", "9", "10", "11", "12", "13", "14", "15", "16", "17", "18", latest ]
+        compiler: [ "3.4", "3.5", "3.6", "3.7", "3.8", "3.9", "4", "5", "6", "7", "8", "9", "10", "11", "12", "13", "14", "15", "16", "17", "18", "19" ]
         build_type: [ Debug, Release ]
     container: silkeh/clang:${{matrix.compiler}}
 

--- a/.github/workflows/ubuntu.yml
+++ b/.github/workflows/ubuntu.yml
@@ -270,6 +270,63 @@ jobs:
         cd ${{github.workspace}}/build
         ctest -C ${{matrix.build_type}} --output-on-failure -j ${{env.JOBS}}
 
+  ci_test_older_gcc_versions:
+    runs-on: ubuntu-22.04
+    strategy:
+      fail-fast: false
+      matrix:
+        build_type: [ Debug, Release ]
+        gcc_ver: [ '4.8', '5', '6' ]
+
+    steps:
+    - uses: actions/checkout@v4
+      with:
+        submodules: recursive
+
+    - name: add repository commonly needed to install GCC
+      run: |
+        sudo apt-get update
+        sudo add-apt-repository -y ppa:ubuntu-toolchain-r/test
+        sudo apt-get update
+
+    - name: add repository for GCC 4.8 or 5
+      run: |
+        sudo apt-key adv --keyserver keyserver.ubuntu.com --recv-keys 40976EAF437D05B5
+        sudo apt-key adv --keyserver keyserver.ubuntu.com --recv-keys 3B4FE6ACC0B21F32
+        sudo apt-get update
+
+        # for g++-4.8, g++-5
+        sudo apt-add-repository 'deb http://archive.ubuntu.com/ubuntu/ xenial main'
+        sudo apt-add-repository 'deb http://archive.ubuntu.com/ubuntu/ xenial universe'
+
+        sudo apt-get update
+      if: ${{ matrix.gcc_ver == '4.8' || matrix.gcc_ver == '5' }}
+
+    - name: add repository for GCC 6
+      run: |
+        sudo apt-key adv --keyserver keyserver.ubuntu.com --recv-keys 40976EAF437D05B5
+        sudo apt-key adv --keyserver keyserver.ubuntu.com --recv-keys 3B4FE6ACC0B21F32
+        sudo apt-get update
+
+        # for g++-6
+        sudo apt-add-repository 'deb http://archive.ubuntu.com/ubuntu/ bionic main'
+        sudo apt-add-repository 'deb http://archive.ubuntu.com/ubuntu/ bionic universe'
+
+        sudo apt-get update
+      if: ${{ matrix.gcc_ver == '6' }}
+
+    - name: install GCC
+      run: sudo apt-get install --no-install-recommends -y g++-${{matrix.gcc_ver}}
+
+    - name: Configure CMake
+      run: CXX=g++-${{matrix.gcc_ver}} cmake -B ${{github.workspace}}/build -DCMAKE_BUILD_TYPE=${{matrix.build_type}} -DFK_YAML_BUILD_TEST=ON
+
+    - name: Build & Test
+      run: |
+        cmake --build ${{github.workspace}}/build --config ${{matrix.build_type}} -j ${{env.JOBS}}
+        cd ${{github.workspace}}/build
+        ctest -C ${{matrix.build_type}} --output-on-failure -j ${{env.JOBS}}
+
   ci_test_icpx:
     runs-on: ubuntu-latest
     strategy:

--- a/README.md
+++ b/README.md
@@ -98,6 +98,7 @@ Currently, the following compilers are known to work and used in GitHub Actions 
 | AppleClang 15.0.0.15000100 | [macOS 14](https://github.com/actions/runner-images/blob/main/images/macos/macos-14-Readme.md)                 |
 | AppleClang 15.0.0.15000309 | [macOS 14](https://github.com/actions/runner-images/blob/main/images/macos/macos-14-Readme.md)                 |
 | AppleClang 16.0.0.16000026 | [macOS 15](https://github.com/actions/runner-images/blob/main/images/macos/macos-15-Readme.md)                 |
+| Clang 3.4.2                | [Ubuntu 22.04](https://github.com/actions/runner-images/blob/main/images/ubuntu/Ubuntu2204-Readme.md)          |
 | Clang 3.5.2                | [Ubuntu 22.04](https://github.com/actions/runner-images/blob/main/images/ubuntu/Ubuntu2204-Readme.md)          |
 | Clang 3.6.2                | [Ubuntu 22.04](https://github.com/actions/runner-images/blob/main/images/ubuntu/Ubuntu2204-Readme.md)          |
 | Clang 3.7.1                | [Ubuntu 22.04](https://github.com/actions/runner-images/blob/main/images/ubuntu/Ubuntu2204-Readme.md)          |
@@ -117,6 +118,10 @@ Currently, the following compilers are known to work and used in GitHub Actions 
 | Clang 16.0.6               | [Ubuntu 22.04](https://github.com/actions/runner-images/blob/main/images/ubuntu/Ubuntu2204-Readme.md)          |
 | Clang 17.0.6               | [Ubuntu 22.04](https://github.com/actions/runner-images/blob/main/images/ubuntu/Ubuntu2204-Readme.md)          |
 | Clang 18.1.6               | [Ubuntu 22.04](https://github.com/actions/runner-images/blob/main/images/ubuntu/Ubuntu2204-Readme.md)          |
+| Clang 19.1.4               | [Ubuntu 22.04](https://github.com/actions/runner-images/blob/main/images/ubuntu/Ubuntu2204-Readme.md)          |
+| GCC 4.8.5                  | [Ubuntu 22.04](https://github.com/actions/runner-images/blob/main/images/ubuntu/Ubuntu2204-Readme.md)          |
+| GCC 5.3.1                  | [Ubuntu 22.04](https://github.com/actions/runner-images/blob/main/images/ubuntu/Ubuntu2204-Readme.md)          |
+| GCC 6.4.0                  | [Ubuntu 22.04](https://github.com/actions/runner-images/blob/main/images/ubuntu/Ubuntu2204-Readme.md)          |
 | GCC 7.5.0                  | [Ubuntu 22.04](https://github.com/actions/runner-images/blob/main/images/ubuntu/Ubuntu2204-Readme.md)          |
 | GCC 8.5.0                  | [Ubuntu 22.04](https://github.com/actions/runner-images/blob/main/images/ubuntu/Ubuntu2204-Readme.md)          |
 | GCC 9.5.0                  | [Ubuntu 22.04](https://github.com/actions/runner-images/blob/main/images/ubuntu/Ubuntu2204-Readme.md)          |
@@ -124,7 +129,7 @@ Currently, the following compilers are known to work and used in GitHub Actions 
 | GCC 11.4.0                 | [Ubuntu 22.04](https://github.com/actions/runner-images/blob/main/images/ubuntu/Ubuntu2204-Readme.md)          |
 | GCC 12.3.0                 | [Ubuntu 22.04](https://github.com/actions/runner-images/blob/main/images/ubuntu/Ubuntu2204-Readme.md)          |
 | GCC 13.3.0                 | [Ubuntu 22.04](https://github.com/actions/runner-images/blob/main/images/ubuntu/Ubuntu2204-Readme.md)          |
-| GCC 14.1.0                 | [Ubuntu 22.04](https://github.com/actions/runner-images/blob/main/images/ubuntu/Ubuntu2204-Readme.md)          |
+| GCC 14.2.0                 | [Ubuntu 22.04](https://github.com/actions/runner-images/blob/main/images/ubuntu/Ubuntu2204-Readme.md)          |
 | IntelLLVM 2024.1.2         | [Ubuntu 22.04](https://github.com/actions/runner-images/blob/main/images/ubuntu/Ubuntu2204-Readme.md)          |
 | MinGW-64 8.1.0             | [Windows Server 2019](https://github.com/actions/runner-images/blob/main/images/windows/Windows2019-Readme.md) |
 | MinGW-64 12.2.0            | [Windows Server 2022](https://github.com/actions/runner-images/blob/main/images/windows/Windows2022-Readme.md) |

--- a/docs/mkdocs/docs/home/supported_compilers.md
+++ b/docs/mkdocs/docs/home/supported_compilers.md
@@ -12,6 +12,7 @@ Currently, the following compilers are known to work and used in GitHub Actions 
 | AppleClang 15.0.0.15000100 | [macOS 14](https://github.com/actions/runner-images/blob/main/images/macos/macos-14-Readme.md)                 |
 | AppleClang 15.0.0.15000309 | [macOS 14](https://github.com/actions/runner-images/blob/main/images/macos/macos-14-Readme.md)                 |
 | AppleClang 16.0.0.16000026 | [macOS 15](https://github.com/actions/runner-images/blob/main/images/macos/macos-15-Readme.md)                 |
+| Clang 3.4.2                | [Ubuntu 22.04](https://github.com/actions/runner-images/blob/main/images/ubuntu/Ubuntu2204-Readme.md)          |
 | Clang 3.5.2                | [Ubuntu 22.04](https://github.com/actions/runner-images/blob/main/images/ubuntu/Ubuntu2204-Readme.md)          |
 | Clang 3.6.2                | [Ubuntu 22.04](https://github.com/actions/runner-images/blob/main/images/ubuntu/Ubuntu2204-Readme.md)          |
 | Clang 3.7.1                | [Ubuntu 22.04](https://github.com/actions/runner-images/blob/main/images/ubuntu/Ubuntu2204-Readme.md)          |
@@ -31,6 +32,10 @@ Currently, the following compilers are known to work and used in GitHub Actions 
 | Clang 16.0.6               | [Ubuntu 22.04](https://github.com/actions/runner-images/blob/main/images/ubuntu/Ubuntu2204-Readme.md)          |
 | Clang 17.0.6               | [Ubuntu 22.04](https://github.com/actions/runner-images/blob/main/images/ubuntu/Ubuntu2204-Readme.md)          |
 | Clang 18.1.6               | [Ubuntu 22.04](https://github.com/actions/runner-images/blob/main/images/ubuntu/Ubuntu2204-Readme.md)          |
+| Clang 19.1.4               | [Ubuntu 22.04](https://github.com/actions/runner-images/blob/main/images/ubuntu/Ubuntu2204-Readme.md)          |
+| GCC 4.8.5                  | [Ubuntu 22.04](https://github.com/actions/runner-images/blob/main/images/ubuntu/Ubuntu2204-Readme.md)          |
+| GCC 5.3.1                  | [Ubuntu 22.04](https://github.com/actions/runner-images/blob/main/images/ubuntu/Ubuntu2204-Readme.md)          |
+| GCC 6.4.0                  | [Ubuntu 22.04](https://github.com/actions/runner-images/blob/main/images/ubuntu/Ubuntu2204-Readme.md)          |
 | GCC 7.5.0                  | [Ubuntu 22.04](https://github.com/actions/runner-images/blob/main/images/ubuntu/Ubuntu2204-Readme.md)          |
 | GCC 8.5.0                  | [Ubuntu 22.04](https://github.com/actions/runner-images/blob/main/images/ubuntu/Ubuntu2204-Readme.md)          |
 | GCC 9.5.0                  | [Ubuntu 22.04](https://github.com/actions/runner-images/blob/main/images/ubuntu/Ubuntu2204-Readme.md)          |
@@ -38,7 +43,7 @@ Currently, the following compilers are known to work and used in GitHub Actions 
 | GCC 11.4.0                 | [Ubuntu 22.04](https://github.com/actions/runner-images/blob/main/images/ubuntu/Ubuntu2204-Readme.md)          |
 | GCC 12.3.0                 | [Ubuntu 22.04](https://github.com/actions/runner-images/blob/main/images/ubuntu/Ubuntu2204-Readme.md)          |
 | GCC 13.3.0                 | [Ubuntu 22.04](https://github.com/actions/runner-images/blob/main/images/ubuntu/Ubuntu2204-Readme.md)          |
-| GCC 14.1.0                 | [Ubuntu 22.04](https://github.com/actions/runner-images/blob/main/images/ubuntu/Ubuntu2204-Readme.md)          |
+| GCC 14.2.0                 | [Ubuntu 22.04](https://github.com/actions/runner-images/blob/main/images/ubuntu/Ubuntu2204-Readme.md)          |
 | IntelLLVM 2024.1.2         | [Ubuntu 22.04](https://github.com/actions/runner-images/blob/main/images/ubuntu/Ubuntu2204-Readme.md)          |
 | MinGW-64 8.1.0             | [Windows Server 2019](https://github.com/actions/runner-images/blob/main/images/windows/Windows2019-Readme.md) |
 | MinGW-64 12.2.0            | [Windows Server 2022](https://github.com/actions/runner-images/blob/main/images/windows/Windows2022-Readme.md) |

--- a/include/fkYAML/detail/encodings/utf_encode_detector.hpp
+++ b/include/fkYAML/detail/encodings/utf_encode_detector.hpp
@@ -100,7 +100,8 @@ struct utf_encode_detector<ItrType, enable_if_t<is_iterator_of<ItrType, char>::v
             return utf_encode_t::UTF_8;
         }
 
-        std::array<uint8_t, 4> bytes {};
+        // the inner curly braces are necessary for older compilers
+        std::array<uint8_t, 4> bytes {{}};
         bytes.fill(0xFFu);
         for (int i = 0; i < 4 && begin + i != end; i++) {
             bytes[i] = static_cast<uint8_t>(begin[i]); // NOLINT(cppcoreguidelines-pro-bounds-constant-array-index)
@@ -182,7 +183,8 @@ struct utf_encode_detector<ItrType, enable_if_t<is_iterator_of<ItrType, char16_t
             return utf_encode_t::UTF_16BE;
         }
 
-        std::array<uint8_t, 4> bytes {};
+        // the inner curly braces are necessary for older compilers
+        std::array<uint8_t, 4> bytes {{}};
         bytes.fill(0xFFu);
         for (int i = 0; i < 2 && begin + i != end; i++) {
             // NOLINTBEGIN(cppcoreguidelines-pro-bounds-constant-array-index)
@@ -222,7 +224,8 @@ struct utf_encode_detector<ItrType, enable_if_t<is_iterator_of<ItrType, char32_t
             return utf_encode_t::UTF_32BE;
         }
 
-        std::array<uint8_t, 4> bytes {};
+        // the inner curly braces are necessary for older compilers
+        std::array<uint8_t, 4> bytes {{}};
         const char32_t elem = *begin;
         bytes[0] = static_cast<uint8_t>((elem & 0xFF000000u) >> 24);
         bytes[1] = static_cast<uint8_t>((elem & 0x00FF0000u) >> 16);
@@ -251,7 +254,8 @@ struct file_utf_encode_detector {
     /// @param p_file The input file handle.
     /// @return A detected encoding type.
     static utf_encode_t detect(std::FILE* p_file) noexcept {
-        std::array<uint8_t, 4> bytes {};
+        // the inner curly braces are necessary for older compilers
+        std::array<uint8_t, 4> bytes {{}};
         bytes.fill(0xFFu);
         for (int i = 0; i < 4; i++) {
             char byte = 0;
@@ -294,7 +298,8 @@ struct stream_utf_encode_detector {
     /// @param p_file The input file handle.
     /// @return A detected encoding type.
     static utf_encode_t detect(std::istream& is) noexcept {
-        std::array<uint8_t, 4> bytes {};
+        // the inner curly braces are necessary for older compilers
+        std::array<uint8_t, 4> bytes {{}};
         bytes.fill(0xFFu);
         for (int i = 0; i < 4; i++) {
             char ch = 0;

--- a/include/fkYAML/detail/encodings/yaml_escaper.hpp
+++ b/include/fkYAML/detail/encodings/yaml_escaper.hpp
@@ -333,7 +333,8 @@ private:
     }
 
     static void unescape_escaped_unicode(char32_t codepoint, std::string& buff) {
-        std::array<uint8_t, 4> encode_buff {};
+        // the inner curly braces are necessary to build with older compilers.
+        std::array<uint8_t, 4> encode_buff {{}};
         uint32_t encoded_size {0};
         utf8::from_utf32(codepoint, encode_buff, encoded_size);
         buff.append(reinterpret_cast<char*>(encode_buff.data()), encoded_size);

--- a/include/fkYAML/detail/input/lexical_analyzer.hpp
+++ b/include/fkYAML/detail/input/lexical_analyzer.hpp
@@ -813,7 +813,7 @@ private:
     void determine_plain_scalar_range(str_view& token) {
         const str_view sv {m_token_begin_itr, m_end_itr};
 
-        constexpr str_view filter = "\n :{}[],";
+        constexpr str_view filter {"\n :{}[],"};
         std::size_t pos = sv.find_first_of(filter);
         if FK_YAML_UNLIKELY (pos == str_view::npos) {
             token = sv;
@@ -831,7 +831,7 @@ private:
                     indent = get_current_indent_level(&sv[pos]);
                 }
 
-                constexpr str_view space_filter = " \t\n";
+                constexpr str_view space_filter {" \t\n"};
                 const std::size_t non_space_pos = sv.find_first_not_of(space_filter, pos);
                 const std::size_t last_newline_pos = sv.find_last_of('\n', non_space_pos);
                 FK_YAML_ASSERT(last_newline_pos != str_view::npos);
@@ -1112,7 +1112,7 @@ private:
     /// @param indent A variable to store the retrieved indent size.
     /// @return Block scalar header information converted from the header line.
     block_scalar_header convert_to_block_scalar_header(str_view line) {
-        constexpr str_view comment_prefix = " #";
+        constexpr str_view comment_prefix {" #"};
         const std::size_t comment_begin_pos = line.find(comment_prefix);
         if (comment_begin_pos != str_view::npos) {
             line = line.substr(0, comment_begin_pos);

--- a/include/fkYAML/detail/input/scalar_parser.hpp
+++ b/include/fkYAML/detail/input/scalar_parser.hpp
@@ -60,7 +60,7 @@ public:
     scalar_parser& operator=(const scalar_parser&) = default;
 
     scalar_parser(scalar_parser&&) noexcept = default;
-    scalar_parser& operator=(scalar_parser&&) noexcept = default;
+    scalar_parser& operator=(scalar_parser&&) noexcept(std::is_nothrow_move_assignable<std::string>::value) = default;
 
     /// @brief Parses a token into a flow scalar (either plain, single quoted or double quoted)
     /// @param lex_type Lexical token type for the scalar.
@@ -160,7 +160,7 @@ private:
             return token;
         }
 
-        constexpr str_view filter = "\'\n";
+        constexpr str_view filter {"\'\n"};
         std::size_t pos = token.find_first_of(filter);
         if (pos == str_view::npos) {
             return token;
@@ -204,7 +204,7 @@ private:
             return token;
         }
 
-        constexpr str_view filter = "\\\n";
+        constexpr str_view filter {"\\\n"};
         std::size_t pos = token.find_first_of(filter);
         if (pos == str_view::npos) {
             return token;
@@ -311,7 +311,7 @@ private:
         m_use_owned_buffer = true;
         m_buffer.reserve(token.size());
 
-        constexpr str_view white_space_filter = " \t";
+        constexpr str_view white_space_filter {" \t"};
 
         std::size_t cur_line_begin_pos = 0;
         bool has_newline_at_end = true;

--- a/include/fkYAML/detail/input/tag_resolver.hpp
+++ b/include/fkYAML/detail/input/tag_resolver.hpp
@@ -22,8 +22,8 @@
 
 FK_YAML_DETAIL_NAMESPACE_BEGIN
 
-static constexpr str_view default_primary_handle_prefix = "!";
-static constexpr str_view default_secondary_handle_prefix = "tag:yaml.org,2002:";
+static constexpr str_view default_primary_handle_prefix {"!"};
+static constexpr str_view default_secondary_handle_prefix {"tag:yaml.org,2002:"};
 
 template <typename BasicNodeType>
 class tag_resolver {

--- a/include/fkYAML/detail/node_property.hpp
+++ b/include/fkYAML/detail/node_property.hpp
@@ -17,9 +17,9 @@ FK_YAML_DETAIL_NAMESPACE_BEGIN
 
 struct node_property {
     /// The tag name property.
-    std::string tag;
+    std::string tag {}; // NOLINT(readability-redundant-member-init) necessary for older compilers
     /// The anchor name property.
-    std::string anchor;
+    std::string anchor {}; // NOLINT(readability-redundant-member-init) necessary for older compilers
 };
 
 FK_YAML_DETAIL_NAMESPACE_END

--- a/include/fkYAML/detail/str_view.hpp
+++ b/include/fkYAML/detail/str_view.hpp
@@ -88,8 +88,10 @@ public:
     template <
         typename CharPtrT,
         enable_if_t<
-            disjunction<std::is_same<CharPtrT, value_type*>, std::is_same<CharPtrT, const value_type*>>::value, int> =
-            0>
+            conjunction<
+                negation<std::is_array<CharPtrT>>, std::is_pointer<CharPtrT>,
+                disjunction<std::is_same<CharPtrT, value_type*>, std::is_same<CharPtrT, const value_type*>>>::value,
+            int> = 0>
     FK_YAML_CXX17_CONSTEXPR basic_str_view(CharPtrT p_str) noexcept
         : m_len(traits_type::length(p_str)),
           mp_str(p_str) {

--- a/test/unit_test/test_utf_encode_detector.cpp
+++ b/test/unit_test/test_utf_encode_detector.cpp
@@ -23,19 +23,19 @@
 #define ENABLE_C4996
 #endif
 
+struct test_data_t {
+    test_data_t(std::array<uint8_t, 4> input_, fkyaml::detail::utf_encode_t encode_type_, bool has_bom_)
+        : input(input_),
+          encode_type(encode_type_),
+          has_bom(has_bom_) {
+    }
+
+    std::array<uint8_t, 4> input {{}};
+    fkyaml::detail::utf_encode_t encode_type {fkyaml::detail::utf_encode_t::UTF_8};
+    bool has_bom {false};
+};
+
 TEST_CASE("UTFEncodeDetector_DetectEncodingType") {
-    struct test_data_t {
-        test_data_t(std::array<uint8_t, 4> input_, fkyaml::detail::utf_encode_t encode_type_, bool has_bom_)
-            : input(input_),
-              encode_type(encode_type_),
-              has_bom(has_bom_) {
-        }
-
-        std::array<uint8_t, 4> input {};
-        fkyaml::detail::utf_encode_t encode_type {fkyaml::detail::utf_encode_t::UTF_8};
-        bool has_bom {false};
-    };
-
     auto d = GENERATE(
         test_data_t {{{0xEFu, 0xBBu, 0xBFu, 0x80u}}, fkyaml::detail::utf_encode_t::UTF_8, true},
         test_data_t {{{0xEFu, 0, 0xBFu, 0x80u}}, fkyaml::detail::utf_encode_t::UTF_8, false},

--- a/test/unit_test/test_utf_encodings.cpp
+++ b/test/unit_test/test_utf_encodings.cpp
@@ -238,55 +238,56 @@ TEST_CASE("UTF8_Validate") {
     }
 }
 
+struct utf16_test_params {
+    std::array<char16_t, 2> utf16;
+    std::array<uint8_t, 4> utf8_bytes;
+    std::size_t consumed_size;
+    std::size_t encoded_size;
+};
+
 TEST_CASE("UTF8_FromUTF16") {
     SECTION("valid UTF-16 character(s)") {
-        struct test_params {
-            std::array<char16_t, 2> utf16;
-            std::array<uint8_t, 4> utf8_bytes;
-            std::size_t consumed_size;
-            std::size_t encoded_size;
-        };
         auto params = GENERATE(
-            test_params {{{char16_t(0x00u)}}, {{uint8_t(0x00u)}}, 1, 1},
-            test_params {{{char16_t(0x01u)}}, {{uint8_t(0x01u)}}, 1, 1},
-            test_params {{{char16_t(0x7Eu)}}, {{uint8_t(0x7Eu)}}, 1, 1},
-            test_params {{{char16_t(0x7Fu)}}, {{uint8_t(0x7Fu)}}, 1, 1},
-            test_params {{{char16_t(0x0080u)}}, {{uint8_t(0xC2u), uint8_t(0x80u)}}, 1, 2},
-            test_params {{{char16_t(0x0081u)}}, {{uint8_t(0xC2u), uint8_t(0x81u)}}, 1, 2},
-            test_params {{{char16_t(0x07FEu)}}, {{uint8_t(0xDFu), uint8_t(0xBEu)}}, 1, 2},
-            test_params {{{char16_t(0x07FFu)}}, {{uint8_t(0xDFu), uint8_t(0xBFu)}}, 1, 2},
-            test_params {{{char16_t(0x0800u)}}, {{uint8_t(0xE0u), uint8_t(0xA0u), uint8_t(0x80u)}}, 1, 3},
-            test_params {{{char16_t(0x0801u)}}, {{uint8_t(0xE0u), uint8_t(0xA0u), uint8_t(0x81u)}}, 1, 3},
-            test_params {{{char16_t(0xD7FEu)}}, {{uint8_t(0xEDu), uint8_t(0x9Fu), uint8_t(0xBEu)}}, 1, 3},
-            test_params {{{char16_t(0xD7FFu)}}, {{uint8_t(0xEDu), uint8_t(0x9Fu), uint8_t(0xBFu)}}, 1, 3},
-            test_params {{{char16_t(0xE000u)}}, {{uint8_t(0xEEu), uint8_t(0x80u), uint8_t(0x80u)}}, 1, 3},
-            test_params {{{char16_t(0xE001u)}}, {{uint8_t(0xEEu), uint8_t(0x80u), uint8_t(0x81u)}}, 1, 3},
-            test_params {
+            utf16_test_params {{{char16_t(0x00u)}}, {{uint8_t(0x00u)}}, 1, 1},
+            utf16_test_params {{{char16_t(0x01u)}}, {{uint8_t(0x01u)}}, 1, 1},
+            utf16_test_params {{{char16_t(0x7Eu)}}, {{uint8_t(0x7Eu)}}, 1, 1},
+            utf16_test_params {{{char16_t(0x7Fu)}}, {{uint8_t(0x7Fu)}}, 1, 1},
+            utf16_test_params {{{char16_t(0x0080u)}}, {{uint8_t(0xC2u), uint8_t(0x80u)}}, 1, 2},
+            utf16_test_params {{{char16_t(0x0081u)}}, {{uint8_t(0xC2u), uint8_t(0x81u)}}, 1, 2},
+            utf16_test_params {{{char16_t(0x07FEu)}}, {{uint8_t(0xDFu), uint8_t(0xBEu)}}, 1, 2},
+            utf16_test_params {{{char16_t(0x07FFu)}}, {{uint8_t(0xDFu), uint8_t(0xBFu)}}, 1, 2},
+            utf16_test_params {{{char16_t(0x0800u)}}, {{uint8_t(0xE0u), uint8_t(0xA0u), uint8_t(0x80u)}}, 1, 3},
+            utf16_test_params {{{char16_t(0x0801u)}}, {{uint8_t(0xE0u), uint8_t(0xA0u), uint8_t(0x81u)}}, 1, 3},
+            utf16_test_params {{{char16_t(0xD7FEu)}}, {{uint8_t(0xEDu), uint8_t(0x9Fu), uint8_t(0xBEu)}}, 1, 3},
+            utf16_test_params {{{char16_t(0xD7FFu)}}, {{uint8_t(0xEDu), uint8_t(0x9Fu), uint8_t(0xBFu)}}, 1, 3},
+            utf16_test_params {{{char16_t(0xE000u)}}, {{uint8_t(0xEEu), uint8_t(0x80u), uint8_t(0x80u)}}, 1, 3},
+            utf16_test_params {{{char16_t(0xE001u)}}, {{uint8_t(0xEEu), uint8_t(0x80u), uint8_t(0x81u)}}, 1, 3},
+            utf16_test_params {
                 {{char16_t(0xD800u), char16_t(0xDC00u)}},
                 {{uint8_t(0xF0u), uint8_t(0x90u), uint8_t(0x80u), uint8_t(0x80u)}},
                 2,
                 4},
-            test_params {
+            utf16_test_params {
                 {{char16_t(0xD801u), char16_t(0xDC00u)}},
                 {{uint8_t(0xF0u), uint8_t(0x90u), uint8_t(0x90u), uint8_t(0x80u)}},
                 2,
                 4},
-            test_params {
+            utf16_test_params {
                 {{char16_t(0xD800u), char16_t(0xDC01u)}},
                 {{uint8_t(0xF0u), uint8_t(0x90u), uint8_t(0x80u), uint8_t(0x81u)}},
                 2,
                 4},
-            test_params {
+            utf16_test_params {
                 {{char16_t(0xDBFEu), char16_t(0xDFFFu)}},
                 {{uint8_t(0xF4u), uint8_t(0x8Fu), uint8_t(0xAFu), uint8_t(0xBFu)}},
                 2,
                 4},
-            test_params {
+            utf16_test_params {
                 {{char16_t(0xDBFFu), char16_t(0xDFFEu)}},
                 {{uint8_t(0xF4u), uint8_t(0x8Fu), uint8_t(0xBFu), uint8_t(0xBEu)}},
                 2,
                 4},
-            test_params {
+            utf16_test_params {
                 {{char16_t(0xDBFFu), char16_t(0xDFFFu)}},
                 {{uint8_t(0xF4u), uint8_t(0x8Fu), uint8_t(0xBFu), uint8_t(0xBFu)}},
                 2,
@@ -319,29 +320,30 @@ TEST_CASE("UTF8_FromUTF16") {
     }
 }
 
+struct utf32_test_params {
+    char32_t utf32;
+    std::array<uint8_t, 4> utf8_bytes;
+    uint32_t size;
+};
+
 TEST_CASE("UTF8_FromUTF32") {
     SECTION("valid UTF-32 character") {
-        struct test_params {
-            char32_t utf32;
-            std::array<uint8_t, 4> utf8_bytes;
-            uint32_t size;
-        };
         auto params = GENERATE(
-            test_params {0x00u, {{uint8_t(0x00u)}}, 1},
-            test_params {0x01u, {{uint8_t(0x01u)}}, 1},
-            test_params {0x7Eu, {{uint8_t(0x7Eu)}}, 1},
-            test_params {0x7Fu, {{uint8_t(0x7Fu)}}, 1},
-            test_params {0x0080u, {{uint8_t(0xC2u), uint8_t(0x80u)}}, 2},
-            test_params {0x0081u, {{uint8_t(0xC2u), uint8_t(0x81u)}}, 2},
-            test_params {0x07FEu, {{uint8_t(0xDFu), uint8_t(0xBEu)}}, 2},
-            test_params {0x07FFu, {{uint8_t(0xDFu), uint8_t(0xBFu)}}, 2},
-            test_params {0x0800u, {{uint8_t(0xE0u), uint8_t(0xA0u), uint8_t(0x80u)}}, 3},
-            test_params {0x0801u, {{uint8_t(0xE0u), uint8_t(0xA0u), uint8_t(0x81u)}}, 3},
-            test_params {0xFFFFu, {{uint8_t(0xEFu), uint8_t(0xBFu), uint8_t(0xBFu)}}, 3},
-            test_params {0x010000u, {{uint8_t(0xF0u), uint8_t(0x90u), uint8_t(0x80u), uint8_t(0x80u)}}, 4},
-            test_params {0x010001u, {{uint8_t(0xF0u), uint8_t(0x90u), uint8_t(0x80u), uint8_t(0x81u)}}, 4},
-            test_params {0x10FFFEu, {{uint8_t(0xF4u), uint8_t(0x8Fu), uint8_t(0xBFu), uint8_t(0xBEu)}}, 4},
-            test_params {0x10FFFFu, {{uint8_t(0xF4u), uint8_t(0x8Fu), uint8_t(0xBFu), uint8_t(0xBFu)}}, 4});
+            utf32_test_params {0x00u, {{uint8_t(0x00u)}}, 1},
+            utf32_test_params {0x01u, {{uint8_t(0x01u)}}, 1},
+            utf32_test_params {0x7Eu, {{uint8_t(0x7Eu)}}, 1},
+            utf32_test_params {0x7Fu, {{uint8_t(0x7Fu)}}, 1},
+            utf32_test_params {0x0080u, {{uint8_t(0xC2u), uint8_t(0x80u)}}, 2},
+            utf32_test_params {0x0081u, {{uint8_t(0xC2u), uint8_t(0x81u)}}, 2},
+            utf32_test_params {0x07FEu, {{uint8_t(0xDFu), uint8_t(0xBEu)}}, 2},
+            utf32_test_params {0x07FFu, {{uint8_t(0xDFu), uint8_t(0xBFu)}}, 2},
+            utf32_test_params {0x0800u, {{uint8_t(0xE0u), uint8_t(0xA0u), uint8_t(0x80u)}}, 3},
+            utf32_test_params {0x0801u, {{uint8_t(0xE0u), uint8_t(0xA0u), uint8_t(0x81u)}}, 3},
+            utf32_test_params {0xFFFFu, {{uint8_t(0xEFu), uint8_t(0xBFu), uint8_t(0xBFu)}}, 3},
+            utf32_test_params {0x010000u, {{uint8_t(0xF0u), uint8_t(0x90u), uint8_t(0x80u), uint8_t(0x80u)}}, 4},
+            utf32_test_params {0x010001u, {{uint8_t(0xF0u), uint8_t(0x90u), uint8_t(0x80u), uint8_t(0x81u)}}, 4},
+            utf32_test_params {0x10FFFEu, {{uint8_t(0xF4u), uint8_t(0x8Fu), uint8_t(0xBFu), uint8_t(0xBEu)}}, 4},
+            utf32_test_params {0x10FFFFu, {{uint8_t(0xF4u), uint8_t(0x8Fu), uint8_t(0xBFu), uint8_t(0xBFu)}}, 4});
 
         std::array<uint8_t, 4> utf8_bytes;
         utf8_bytes.fill(0);


### PR DESCRIPTION
This PR adds more GCC & Clang versions to use in GitHub Actions workflows:
* GCC: 4.8, 5, 6
* Clang: 3.4, 19

Changes in the library implementations have been made to resolve warnings when compiled with the above older compilers.

---

## Pull Request Checklist

Read the [CONTRIBUTING.md](https://github.com/fktn-k/fkYAML/blob/develop/CONTRIBUTING.md) file for detailed information.  

- [x] Changes are described in the pull request or in a referenced [issue](https://github.com/fktn-k/fkYAML/issues).
- [x] The test suite compiles and runs without any error.
- [x] [The code coverage](https://coveralls.io/github/fktn-k/fkYAML) on your branch is 100%.
- [x] The documentation is updated if you added/changed a feature.

## Please don't

- The C++11 support varies between different **compilers** and versions. Please note the [list of supported compilers](https://github.com/fktn-k/fkYAML/blob/develop/README.md#supported-compilers). Some compilers like GCC 4.7 (and earlier), Clang 3.3 (and earlier), or Microsoft Visual Studio 13.0 and earlier are known not to work due to missing or incomplete C++11 support. Please refrain from proposing changes that work around these compiler's limitations with `#ifdef`s or other means.
- Please refrain from proposing changes that would **break [YAML](https://yaml.org/) specifications**. If you propose a conformant extension of YAML to be supported by the library, please motivate this extension.
- Please do not open pull requests that address **multiple issues**.
