### PR TITLE
Fix parsing input which begins with a newline & indentation

### DIFF
--- a/docs/examples/CMakeLists.txt
+++ b/docs/examples/CMakeLists.txt
@@ -3,15 +3,26 @@
 #############################
 
 add_library(example_common_config INTERFACE)
-target_include_directories(
-  example_common_config
-  INTERFACE
-    ${CMAKE_CURRENT_BINARY_DIR}/include
-)
 target_link_libraries(
   example_common_config
   INTERFACE
     ${FK_YAML_TARGET_NAME}
+)
+target_compile_options(
+  example_common_config
+  INTERFACE
+    # MSVC
+    $<$<CXX_COMPILER_ID:MSVC>:
+      /wd4996 # examples contain deprecated APIs.
+    >
+    # GNU
+    $<$<CXX_COMPILER_ID:GNU>:
+      -Wno-deprecated-declarations # examples contain deprecated APIs.
+    >
+    # Clang
+    $<$<CXX_COMPILER_ID:Clang>:
+      -Wno-deprecated-declarations #examples contain deprecated APIs.
+    >
 )
 
 ###############################
@@ -23,13 +34,14 @@ foreach(TUT_SRC_FILE ${TUT_SRC_FILES})
   file(RELATIVE_PATH REL_TUT_SRC_FILE ${CMAKE_CURRENT_SOURCE_DIR} ${TUT_SRC_FILE})
   string(REPLACE ".cpp" "" TUT_SRC_FILE_BASE ${REL_TUT_SRC_FILE})
   add_executable(${TUT_SRC_FILE_BASE} ${TUT_SRC_FILE})
-  target_link_libraries(${TUT_SRC_FILE_BASE} ${FK_YAML_TARGET_NAME})
+  target_link_libraries(${TUT_SRC_FILE_BASE} example_common_config)
 
   add_custom_command(
     TARGET ${TUT_SRC_FILE_BASE}
     POST_BUILD
     COMMAND ${CMAKE_COMMAND} -E copy_if_different ${CMAKE_CURRENT_SOURCE_DIR}/example.yaml $<TARGET_FILE_DIR:${TUT_SRC_FILE_BASE}>
     COMMAND $<TARGET_FILE:${TUT_SRC_FILE_BASE}> > ${CMAKE_CURRENT_SOURCE_DIR}/${TUT_SRC_FILE_BASE}.output
+    WORKING_DIRECTORY $<TARGET_FILE_DIR:${TUT_SRC_FILE_BASE}>
   )
 endforeach()
 
@@ -44,7 +56,7 @@ foreach(EX_SRC_FILE ${EX_SRC_FILES})
   file(RELATIVE_PATH REL_EX_SRC_FILE ${CMAKE_CURRENT_SOURCE_DIR} ${EX_SRC_FILE})
   string(REPLACE ".cpp" "" EX_SRC_FILE_BASE ${REL_EX_SRC_FILE})
   add_executable(${EX_SRC_FILE_BASE} ${EX_SRC_FILE})
-  target_link_libraries(${EX_SRC_FILE_BASE} ${FK_YAML_TARGET_NAME})
+  target_link_libraries(${EX_SRC_FILE_BASE} example_common_config)
 
   add_custom_command(
     TARGET ${EX_SRC_FILE_BASE}
@@ -52,5 +64,6 @@ foreach(EX_SRC_FILE ${EX_SRC_FILES})
     COMMAND ${CMAKE_COMMAND} -E copy_if_different ${CMAKE_CURRENT_SOURCE_DIR}/input.yaml $<TARGET_FILE_DIR:${EX_SRC_FILE_BASE}>
     COMMAND ${CMAKE_COMMAND} -E copy_if_different ${CMAKE_CURRENT_SOURCE_DIR}/input_multi.yaml $<TARGET_FILE_DIR:${EX_SRC_FILE_BASE}>
     COMMAND $<TARGET_FILE:${EX_SRC_FILE_BASE}> > ${CMAKE_CURRENT_SOURCE_DIR}/${EX_SRC_FILE_BASE}.output
+    WORKING_DIRECTORY $<TARGET_FILE_DIR:${EX_SRC_FILE_BASE}>
   )
 endforeach()

--- a/docs/examples/ex_basic_node_empty.cpp
+++ b/docs/examples/ex_basic_node_empty.cpp
@@ -28,7 +28,7 @@ int main() {
             std::cout << std::boolalpha << n.empty() << std::endl;
         }
         catch (const fkyaml::exception& e) {
-            std::cout << "The node does not have a container nor string value." << std::endl;
+            std::cout << e.what() << std::endl;
         }
     }
 

--- a/docs/examples/ex_basic_node_empty.output
+++ b/docs/examples/ex_basic_node_empty.output
@@ -1,8 +1,8 @@
 true
 false
 false
-The node does not have a container nor string value.
-The node does not have a container nor string value.
-The node does not have a container nor string value.
-The node does not have a container nor string value.
+type_error: The target node is not of a container type. type=NULL_OBJECT
+type_error: The target node is not of a container type. type=BOOLEAN
+type_error: The target node is not of a container type. type=INTEGER
+type_error: The target node is not of a container type. type=FLOAT
 false

--- a/docs/examples/ex_basic_node_get_value.cpp
+++ b/docs/examples/ex_basic_node_get_value.cpp
@@ -7,6 +7,10 @@
 // SPDX-License-Identifier: MIT
 
 #include <iostream>
+#include <string>
+#include <tuple>
+#include <unordered_map>
+#include <vector>
 #include <fkYAML/node.hpp>
 
 int main() {

--- a/docs/examples/ex_basic_node_size.cpp
+++ b/docs/examples/ex_basic_node_size.cpp
@@ -21,7 +21,7 @@ int main() {
             std::cout << n.size() << std::endl;
         }
         catch (const fkyaml::exception& e) {
-            std::cout << "The node does not have a container nor string value." << std::endl;
+            std::cout << e.what() << std::endl;
         }
     }
 

--- a/docs/examples/ex_basic_node_size.output
+++ b/docs/examples/ex_basic_node_size.output
@@ -1,7 +1,7 @@
 3
 3
-The node does not have a container nor string value.
-The node does not have a container nor string value.
-The node does not have a container nor string value.
-The node does not have a container nor string value.
+type_error: The target node is not of a container type. type=NULL_OBJECT
+type_error: The target node is not of a container type. type=BOOLEAN
+type_error: The target node is not of a container type. type=INTEGER
+type_error: The target node is not of a container type. type=FLOAT
 3

--- a/include/fkYAML/detail/input/lexical_analyzer.hpp
+++ b/include/fkYAML/detail/input/lexical_analyzer.hpp
@@ -307,17 +307,15 @@ public:
 private:
     uint32_t get_current_indent_level(const char* p_line_end) {
         // get the beginning position of the current line.
-        const char* cur_itr = p_line_end - 1;
-        const char* input_begin_itr = m_input_buffer.begin();
-        while (cur_itr != input_begin_itr) {
-            if (*cur_itr == '\n') {
-                ++cur_itr;
-                break;
-            }
-            --cur_itr;
+        std::size_t line_begin_pos = str_view(m_input_buffer.begin(), p_line_end - 1).find_last_of('\n');
+        if (line_begin_pos == str_view::npos) {
+            line_begin_pos = 0;
         }
-
-        const char* line_begin_itr = cur_itr;
+        else {
+            ++line_begin_pos;
+        }
+        const char* p_line_begin = m_input_buffer.begin() + line_begin_pos;
+        const char* cur_itr = p_line_begin;
 
         // get the indentation of the current line.
         uint32_t indent = 0;
@@ -378,7 +376,7 @@ private:
             // If so, the indent value remains the current one.
             // Otherwise, the indent value is changed based on the last ocurrence of the above 3.
             // In any case, multiline plain scalar content must be indented more than the indent value.
-            const str_view line_content_part {line_begin_itr + indent, p_line_end};
+            const str_view line_content_part {p_line_begin + indent, p_line_end};
             std::size_t key_sep_pos = line_content_part.find(": ");
             if (key_sep_pos == str_view::npos) {
                 key_sep_pos = line_content_part.find(":\t");
@@ -391,7 +389,7 @@ private:
                 const char target_char = targets[context - 1];
 
                 // Find the position of the last ocuurence of "- ", "? " or ": ".
-                const str_view line_indent_part {line_begin_itr, indent};
+                const str_view line_indent_part {p_line_begin, indent};
                 const std::size_t block_seq_item_begin_pos = line_indent_part.find_last_of(target_char);
                 FK_YAML_ASSERT(block_seq_item_begin_pos != str_view::npos);
                 indent = static_cast<uint32_t>(block_seq_item_begin_pos);

--- a/single_include/fkYAML/node.hpp
+++ b/single_include/fkYAML/node.hpp
@@ -3490,17 +3490,15 @@ public:
 private:
     uint32_t get_current_indent_level(const char* p_line_end) {
         // get the beginning position of the current line.
-        const char* cur_itr = p_line_end - 1;
-        const char* input_begin_itr = m_input_buffer.begin();
-        while (cur_itr != input_begin_itr) {
-            if (*cur_itr == '\n') {
-                ++cur_itr;
-                break;
-            }
-            --cur_itr;
+        std::size_t line_begin_pos = str_view(m_input_buffer.begin(), p_line_end - 1).find_last_of('\n');
+        if (line_begin_pos == str_view::npos) {
+            line_begin_pos = 0;
         }
-
-        const char* line_begin_itr = cur_itr;
+        else {
+            ++line_begin_pos;
+        }
+        const char* p_line_begin = m_input_buffer.begin() + line_begin_pos;
+        const char* cur_itr = p_line_begin;
 
         // get the indentation of the current line.
         uint32_t indent = 0;
@@ -3561,7 +3559,7 @@ private:
             // If so, the indent value remains the current one.
             // Otherwise, the indent value is changed based on the last ocurrence of the above 3.
             // In any case, multiline plain scalar content must be indented more than the indent value.
-            const str_view line_content_part {line_begin_itr + indent, p_line_end};
+            const str_view line_content_part {p_line_begin + indent, p_line_end};
             std::size_t key_sep_pos = line_content_part.find(": ");
             if (key_sep_pos == str_view::npos) {
                 key_sep_pos = line_content_part.find(":\t");
@@ -3574,7 +3572,7 @@ private:
                 const char target_char = targets[context - 1];
 
                 // Find the position of the last ocuurence of "- ", "? " or ": ".
-                const str_view line_indent_part {line_begin_itr, indent};
+                const str_view line_indent_part {p_line_begin, indent};
                 const std::size_t block_seq_item_begin_pos = line_indent_part.find_last_of(target_char);
                 FK_YAML_ASSERT(block_seq_item_begin_pos != str_view::npos);
                 indent = static_cast<uint32_t>(block_seq_item_begin_pos);

--- a/test/unit_test/test_deserializer_class.cpp
+++ b/test/unit_test/test_deserializer_class.cpp
@@ -732,6 +732,33 @@ TEST_CASE("Deserializer_BlockMapping") {
         REQUIRE(pi_node.get_value<double>() == 3.14);
     }
 
+    // regression test for https://github.com/fktn-k/fkYAML/pull/437
+    SECTION("indented block mapping beginning with a newline") {
+        std::string input = R"(
+    foo: true
+    bar: 123
+    baz: 3.14)";
+
+        REQUIRE_NOTHROW(root = deserializer.deserialize(fkyaml::detail::input_adapter(input)));
+        REQUIRE(root.is_mapping());
+        REQUIRE(root.size() == 3);
+        REQUIRE(root.contains("foo"));
+        REQUIRE(root.contains("bar"));
+        REQUIRE(root.contains("baz"));
+
+        fkyaml::node& foo_node = root["foo"];
+        REQUIRE(foo_node.is_boolean());
+        REQUIRE(foo_node.get_value<bool>() == true);
+
+        fkyaml::node& bar_node = root["bar"];
+        REQUIRE(bar_node.is_integer());
+        REQUIRE(bar_node.get_value<int>() == 123);
+
+        fkyaml::node& baz_node = root["baz"];
+        REQUIRE(baz_node.is_float_number());
+        REQUIRE(baz_node.get_value<double>() == 3.14);
+    };
+
     SECTION("nested block mapping") {
         std::string input = "test:\n"
                             "  bool: true\n"


### PR DESCRIPTION
This PR fixes parse error in building example files for basic_node::deserialize() function.  
The root cause was that #432 introduced a bug in parsing an input which
* begins with a newline and
* contains a plain scalar as a mapping value with indentation on the second line

The above two conditions caused invalid indentation detections.  
This bug can be reproduced by running this cpp file:  

```cpp
#include <fkYAML/node.hpp>
int main() {
    std::string input = R"(
    foo: true
    bar: 123
    baz: 3.14
    )";
    return 0;
}
```

The above snipet now runs as expected by fixing detection of indentation during deserialization.  

Moreover, some minor fixes have been made to resolve warnings during example builds.  

---

## Pull Request Checklist

Read the [CONTRIBUTING.md](https://github.com/fktn-k/fkYAML/blob/develop/CONTRIBUTING.md) file for detailed information.  

- [x] Changes are described in the pull request or in a referenced [issue](https://github.com/fktn-k/fkYAML/issues).
- [x] The test suite compiles and runs without any error.
- [x] [The code coverage](https://coveralls.io/github/fktn-k/fkYAML) on your branch is 100%.
- [x] The documentation is updated if you added/changed a feature.

## Please don't

- The C++11 support varies between different **compilers** and versions. Please note the [list of supported compilers](https://github.com/fktn-k/fkYAML/blob/develop/README.md#supported-compilers). Some compilers like GCC 4.7 (and earlier), Clang 3.3 (and earlier), or Microsoft Visual Studio 13.0 and earlier are known not to work due to missing or incomplete C++11 support. Please refrain from proposing changes that work around these compiler's limitations with `#ifdef`s or other means.
- Please refrain from proposing changes that would **break [YAML](https://yaml.org/) specifications**. If you propose a conformant extension of YAML to be supported by the library, please motivate this extension.
- Please do not open pull requests that address **multiple issues**.
