### PR TITLE
Make node iterators compatible with different value type const-ness

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -21,7 +21,7 @@ TARGET_VERSION_FULL := $(TARGET_MAJOR_VERSION).$(TARGET_MINOR_VERSION).$(TARGET_
 VERSION_MACRO_FILE := include/fkYAML/detail/macros/version_macros.hpp
 
 # system
-JOBS = $(($(shell grep cpu.cores /proc/cpuinfo | sort -u | sed 's/[^0-9]//g') + 1))
+JOBS = $(($(shell grep cpu.cores /proc/cpuinfo | sort -u | sed 's/[^0-9]//g') - 1))
 
 ###############################################
 #   documentation of the Makefile's targets   #

--- a/docs/mkdocs/docs/api/basic_node/begin.md
+++ b/docs/mkdocs/docs/api/basic_node/begin.md
@@ -1,20 +1,21 @@
 <small>Defined in header [`<fkYAML/node.hpp>`](https://github.com/fktn-k/fkYAML/blob/develop/include/fkYAML/node.hpp)</small>
 
-# <small>fkyaml::basic_node::</small>begin
+# <small>fkyaml::basic_node::</small>begin, <small>fkyaml::basic_node::</small>cbegin
 
 ```cpp
 iterator begin();
 const_iterator begin() const;
+const_iterator cbegin() const;
 ```
 
-Returns an iterator to the first element of a container node value.  
-Throws a [`fkyaml::exception`](../exception/index.md) if a basic_node does not have a sequence nor mapping value.  
+Returns an iterator to the first element of a container node.  
+Throws a [`fkyaml::type_error`](../exception/type_error.md) if a basic_node is neither a sequence nor mapping node.  
 
 ![Image from https://en.cppreference.com/w/cpp/iterator/begin](../../img/range-begin-end.svg)
 
 ### **Return Value**
 
-An iterator to the first element of a container node value (either sequence or mapping).
+An iterator to the first element of a container node.
 
 ???+ Example
 
@@ -33,4 +34,5 @@ An iterator to the first element of a container node value (either sequence or m
 * [node](node.md)
 * [iterator](iterator.md)  
 * [const_iterator](const_iterator.md)
-* [end](end.md)
+* [end, cend](end.md)
+* [operator<<](insertion_operator.md)

--- a/docs/mkdocs/docs/api/basic_node/end.md
+++ b/docs/mkdocs/docs/api/basic_node/end.md
@@ -1,20 +1,21 @@
 <small>Defined in header [`<fkYAML/node.hpp>`](https://github.com/fktn-k/fkYAML/blob/develop/include/fkYAML/node.hpp)</small>
 
-# <small>fkyaml::basic_node::</small>end
+# <small>fkyaml::basic_node::</small>end, <small>fkyaml::basic_node::</small>cend
 
 ```cpp
 iterator end();
 const_iterator end() const;
+const_iterator cend() const;
 ```
 
-Returns an iterator to the past-the-last element of a container node value.  
-Throws a [`fkyaml::exception`](../exception/index.md) if a basic_node does not have a sequence nor mapping value.  
+Returns an iterator to the past-the-last element of a container node.  
+Throws a [`fkyaml::type_error`](../exception/type_error.md) if a basic_node is neither a sequence nor mapping node.  
 
 ![Image from https://en.cppreference.com/w/cpp/iterator/end](../../img/range-begin-end.svg)
 
 ### **Return Value**
 
-An iterator to the past-the-last element of a container node value (either sequence or mapping).
+An iterator to the past-the-last element of a container node.
 
 ???+ Example
 
@@ -33,5 +34,5 @@ An iterator to the past-the-last element of a container node value (either seque
 * [node](node.md)
 * [iterator](iterator.md)  
 * [const_iterator](const_iterator.md)
-* [begin](begin.md)
+* [begin, cbegin](begin.md)
 * [operator<<](insertion_operator.md)

--- a/docs/mkdocs/docs/api/basic_node/index.md
+++ b/docs/mkdocs/docs/api/basic_node/index.md
@@ -34,17 +34,33 @@ This class provides features to handle YAML nodes.
 
 ## Member Types
 
+### Node Value Types
+| Name                                      | Description                                            |
+| ----------------------------------------- | ------------------------------------------------------ |
+| [sequence_type](sequence_type.md)         | The type used to store sequence node value containers. |
+| [mapping_type](mapping_type.md)           | The type used to store mapping node value containers.  |
+| [boolean_type](boolean_type.md)           | The type used to store boolean node values.            |
+| [integer_type](integer_type.md)           | The type used to store integer node values.            |
+| [float_number_type](float_number_type.md) | The type used to store float number node values.       |
+| [string_type](string_type.md)             | The type used to store string node values.             |
+
+### Container Types
+| Name                                | Description                                                                                               |
+| ----------------------------------- | --------------------------------------------------------------------------------------------------------- |
+| value_type                          | `basic_node`                                                                                              |
+| reference                           | `basic_node&`                                                                                             |
+| const_reference                     | `const basic_node&`                                                                                       |
+| pointer                             | `basic_node*`                                                                                             |
+| const_pointer                       | `const basic_node*`                                                                                       |
+| size_type                           | [`std::size_t`](https://en.cppreference.com/w/cpp/types/size_t)                                           |
+| difference_type                     | [`std::ptrdiff_t`](https://en.cppreference.com/w/cpp/types/ptrdiff_t)                                     |
+| [iterator](iterator.md)             | [LegacyBidirectionalIterator](https://en.cppreference.com/w/cpp/named_req/BidirectionalIterator)          |
+| [const_iterator](const_iterator.md) | constant [LegacyBidirectionalIterator](https://en.cppreference.com/w/cpp/named_req/BidirectionalIterator) |
+
+### Miscellaneous
 | Name                                            | Description                                                         |
 | ----------------------------------------------- | ------------------------------------------------------------------- |
-| [sequence_type](sequence_type.md)               | The type used to store sequence node value containers.              |
-| [mapping_type](mapping_type.md)                 | The type used to store mapping node value containers.               |
-| [boolean_type](boolean_type.md)                 | The type used to store boolean node values.                         |
-| [integer_type](integer_type.md)                 | The type used to store integer node values.                         |
-| [float_number_type](float_number_type.md)       | The type used to store float number node values.                    |
-| [string_type](string_type.md)                   | The type used to store string node values.                          |
 | [value_converter_type](value_converter_type.md) | The type used to convert between node and native data.              |
-| [iterator](iterator.md)                         | The type for non-constant iterators.                                |
-| [const_iterator](const_iterator.md)             | The type for constant iterators.                                    |
 | [node_t](node_t.md)                             | **(DEPRECATED)** The type used to store the internal value type.    |
 | [yaml_version_t](yaml_version_t.md)             | **(DEPRECATED)** The type used to store the enable version of YAML. |
 

--- a/docs/mkdocs/mkdocs.yml
+++ b/docs/mkdocs/mkdocs.yml
@@ -107,6 +107,8 @@ nav:
           - at: api/basic_node/at.md
           - begin: api/basic_node/begin.md
           - boolean_type: api/basic_node/boolean_type.md
+          - cbegin: api/basic_node/begin.md
+          - cend: api/basic_node/end.md
           - const_iterator: api/basic_node/const_iterator.md
           - contains: api/basic_node/contains.md
           - deserialize: api/basic_node/deserialize.md

--- a/include/fkYAML/detail/iterator.hpp
+++ b/include/fkYAML/detail/iterator.hpp
@@ -23,15 +23,15 @@ FK_YAML_DETAIL_NAMESPACE_BEGIN
 template <typename ValueType>
 struct iterator_traits {
     /// A type of iterated elements.
-    using value_type = ValueType;
+    using value_type = typename ValueType::value_type;
     /// A type to represent difference between iterators.
-    using difference_type = std::ptrdiff_t;
+    using difference_type = typename ValueType::difference_type;
     /// A type to represent iterator sizes.
-    using size_type = std::size_t;
+    using size_type = typename ValueType::size_type;
     /// A type of an element pointer.
-    using pointer = value_type*;
+    using pointer = typename ValueType::pointer;
     /// A type of reference to an element.
-    using reference = value_type&;
+    using reference = typename ValueType::reference;
 };
 
 /// @brief A specialization of @ref iterator_traits for constant value types.
@@ -39,15 +39,15 @@ struct iterator_traits {
 template <typename ValueType>
 struct iterator_traits<const ValueType> {
     /// A type of iterated elements.
-    using value_type = ValueType;
+    using value_type = typename ValueType::value_type;
     /// A type to represent difference between iterators.
-    using difference_type = std::ptrdiff_t;
+    using difference_type = typename ValueType::difference_type;
     /// A type to represent iterator sizes.
-    using size_type = std::size_t;
+    using size_type = typename ValueType::size_type;
     /// A type of a constant element pointer.
-    using pointer = const value_type*;
+    using pointer = typename ValueType::const_pointer;
     /// A type of constant reference to an element.
-    using reference = const value_type&;
+    using reference = typename ValueType::const_reference;
 };
 
 /// @brief Definitions of iterator types for iterators internally held.

--- a/include/fkYAML/detail/iterator.hpp
+++ b/include/fkYAML/detail/iterator.hpp
@@ -62,33 +62,30 @@ template <typename ValueType>
 class iterator {
 public:
     /// A type for iterator traits of instantiated @Iterator template class.
-    using ItrTraitsType = iterator_traits<ValueType>;
+    using iterator_traits_type = iterator_traits<ValueType>;
 
     /// A type for iterator category tag.
     using iterator_category = std::bidirectional_iterator_tag;
     /// A type of iterated element.
-    using value_type = typename ItrTraitsType::value_type;
+    using value_type = typename iterator_traits_type::value_type;
     /// A type to represent differences between iterators.
-    using difference_type = typename ItrTraitsType::difference_type;
+    using difference_type = typename iterator_traits_type::difference_type;
     /// A type to represent container sizes.
-    using size_type = typename ItrTraitsType::size_type;
+    using size_type = typename iterator_traits_type::size_type;
     /// A type of an element pointer.
-    using pointer = typename ItrTraitsType::pointer;
+    using pointer = typename iterator_traits_type::pointer;
     /// A type of reference to an element.
-    using reference = typename ItrTraitsType::reference;
+    using reference = typename iterator_traits_type::reference;
 
 private:
-    /// A type of non-const version of iterated elements.
-    using NonConstValueType = typename std::remove_const<ValueType>::type;
-
-    static_assert(is_basic_node<NonConstValueType>::value, "Iterator only accepts basic_node<...>");
+    static_assert(is_basic_node<value_type>::value, "iterator class only accepts a basic_node as its value type.");
 
     /// @brief The actual storage for iterators internally held in @ref Iterator.
     struct iterator_holder {
         /// A sequence iterator object.
-        typename NonConstValueType::sequence_type::iterator sequence_iterator {};
+        typename value_type::sequence_type::iterator sequence_iterator {};
         /// A mapping iterator object.
-        typename NonConstValueType::mapping_type::iterator mapping_iterator {};
+        typename value_type::mapping_type::iterator mapping_iterator {};
     };
 
 public:
@@ -357,9 +354,9 @@ public:
         return m_inner_iterator_type;
     }
 
-    /// @brief Get the key string of the YAML mapping node for the current iterator.
-    /// @return const std::string& The key string of the YAML mapping node for the current iterator.
-    const typename ValueType::mapping_type::key_type& key() const {
+    /// @brief Get the mapping key node of the current iterator.
+    /// @return The mapping key node of the current iterator.
+    const typename value_type::mapping_type::key_type& key() const {
         if FK_YAML_UNLIKELY (m_inner_iterator_type == iterator_t::SEQUENCE) {
             throw fkyaml::exception("Cannot retrieve key from non-mapping iterators.");
         }
@@ -367,8 +364,8 @@ public:
         return m_iterator_holder.mapping_iterator->first;
     }
 
-    /// @brief Get the reference of the YAML node for the current iterator.
-    /// @return reference A reference to the YAML node for the current iterator.
+    /// @brief Get reference to the YAML node of the current iterator.
+    /// @return Reference to the YAML node of the current iterator.
     reference value() noexcept {
         return operator*();
     }

--- a/include/fkYAML/detail/iterator.hpp
+++ b/include/fkYAML/detail/iterator.hpp
@@ -18,12 +18,6 @@
 
 FK_YAML_DETAIL_NAMESPACE_BEGIN
 
-/// @brief A tag which tells Iterator will contain sequence value iterator.
-struct sequence_iterator_tag {};
-
-/// @brief A tag which tells Iterator will contain mapping value iterator.
-struct mapping_iterator_tag {};
-
 /// @brief The template definitions of type information used in @ref Iterator class
 /// @tparam ValueType The type of iterated elements.
 template <typename ValueType>
@@ -100,13 +94,13 @@ private:
 public:
     /// @brief Construct a new iterator object with sequence iterator object.
     /// @param[in] itr An sequence iterator object.
-    iterator(sequence_iterator_tag /* unused */, const typename ValueType::sequence_type::iterator& itr) noexcept {
+    iterator(const typename ValueType::sequence_type::iterator& itr) noexcept {
         m_iterator_holder.sequence_iterator = itr;
     }
 
     /// @brief Construct a new iterator object with mapping iterator object.
     /// @param[in] itr An mapping iterator object.
-    iterator(mapping_iterator_tag /* unused */, const typename ValueType::mapping_type::iterator& itr) noexcept
+    iterator(const typename ValueType::mapping_type::iterator& itr) noexcept
         : m_inner_iterator_type(iterator_t::MAPPING) {
         m_iterator_holder.mapping_iterator = itr;
     }

--- a/include/fkYAML/node.hpp
+++ b/include/fkYAML/node.hpp
@@ -1411,9 +1411,9 @@ public:
         swap(m_prop.anchor, rhs.m_prop.anchor);
     }
 
-    /// @brief Returns the first iterator of basic_node values of container types (sequence or mapping) from a non-const
-    /// basic_node object. Throws exception if the basic_node value is not of container types.
-    /// @return An iterator to the first element of a YAML node value (either sequence or mapping).
+    /// @brief Returns an iterator to the first element of a container node (sequence or mapping).
+    /// @throw `type_error` if this basic_node is neither a sequence nor mapping node.
+    /// @return An iterator to the first element of a container node.
     /// @sa https://fktn-k.github.io/fkYAML/api/basic_node/begin/
     iterator begin() {
         switch (get_node_attrs() & detail::node_attr_mask::value) {
@@ -1432,9 +1432,9 @@ public:
         }
     }
 
-    /// @brief Returns the first iterator of basic_node values of container types (sequence or mapping) from a const
-    /// basic_node object. Throws exception if the basic_node value is not of container types.
-    /// @return A constant iterator to the first element of a YAML node value (either sequence or mapping).
+    /// @brief Returns a const iterator to the first element of a container node (sequence or mapping).
+    /// @throw `type_error` if this basic_node is neither a sequence nor mapping node.
+    /// @return A const iterator to the first element of a container node.
     /// @sa https://fktn-k.github.io/fkYAML/api/basic_node/begin/
     const_iterator begin() const {
         switch (get_node_attrs() & detail::node_attr_mask::value) {
@@ -1453,9 +1453,17 @@ public:
         }
     }
 
-    /// @brief Returns the last iterator of basic_node values of container types (sequence or mapping) from a non-const
-    /// basic_node object. Throws exception if the basic_node value is not of container types.
-    /// @return An iterator to the past-the end element of a YAML node value (either sequence or mapping).
+    /// @brief Returns a const iterator to the first element of a container node (sequence or mapping).
+    /// @throw `type_error` if this basic_node is neither a sequence nor mapping node.
+    /// @return A const iterator to the first element of a container node.
+    /// @sa https://fktn-k.github.io/fkYAML/api/basic_node/cbegin/
+    const_iterator cbegin() const {
+        return begin();
+    }
+
+    /// @brief Returns an iterator to the past-the-last element of a container node (sequence or mapping).
+    /// @throw `type_error` if the basic_node value is not of container types.
+    /// @return An iterator to the past-the-last element of a container node.
     /// @sa https://fktn-k.github.io/fkYAML/api/basic_node/end/
     iterator end() {
         switch (get_node_attrs() & detail::node_attr_mask::value) {
@@ -1474,9 +1482,9 @@ public:
         }
     }
 
-    /// @brief Returns the last iterator of basic_node values of container types (sequence or mapping) from a const
-    /// basic_node object. Throws exception if the basic_node value is not of container types.
-    /// @return A constant iterator to the past-the end element of a YAML node value (either sequence or mapping).
+    /// @brief Returns a const iterator to the past-the-last element of a container node (sequence or mapping).
+    /// @throw `type_error` if this basic_node is neither a sequence nor mapping node.
+    /// @return A const iterator to the past-the-last element of a container node.
     /// @sa https://fktn-k.github.io/fkYAML/api/basic_node/end/
     const_iterator end() const {
         switch (get_node_attrs() & detail::node_attr_mask::value) {
@@ -1493,6 +1501,14 @@ public:
         default:
             throw fkyaml::type_error("The target node is neither of sequence nor mapping types.", get_type());
         }
+    }
+
+    /// @brief Returns a const iterator to the past-the-last element of a container node (sequence or mapping).
+    /// @throw `type_error` if this basic_node is neither a sequence nor mapping node.
+    /// @return A const iterator to the past-the-last element of a container node.
+    /// @sa https://fktn-k.github.io/fkYAML/api/basic_node/cend/
+    const_iterator cend() const {
+        return end();
     }
 
 private:

--- a/include/fkYAML/node.hpp
+++ b/include/fkYAML/node.hpp
@@ -1392,12 +1392,12 @@ public:
         case detail::node_attr_bits::seq_bit: {
             const node_value* p_node_value = get_node_value_ptr();
             FK_YAML_ASSERT(p_node_value->p_sequence != nullptr);
-            return {detail::sequence_iterator_tag(), p_node_value->p_sequence->begin()};
+            return {p_node_value->p_sequence->begin()};
         }
         case detail::node_attr_bits::map_bit: {
             const node_value* p_node_value = get_node_value_ptr();
             FK_YAML_ASSERT(p_node_value->p_mapping != nullptr);
-            return {detail::mapping_iterator_tag(), p_node_value->p_mapping->begin()};
+            return {p_node_value->p_mapping->begin()};
         }
         default:
             throw fkyaml::type_error("The target node is neither of sequence nor mapping types.", get_type());
@@ -1413,12 +1413,12 @@ public:
         case detail::node_attr_bits::seq_bit: {
             const node_value* p_node_value = get_node_value_ptr();
             FK_YAML_ASSERT(p_node_value->p_sequence != nullptr);
-            return {detail::sequence_iterator_tag(), p_node_value->p_sequence->begin()};
+            return {p_node_value->p_sequence->begin()};
         }
         case detail::node_attr_bits::map_bit: {
             const node_value* p_node_value = get_node_value_ptr();
             FK_YAML_ASSERT(p_node_value->p_mapping != nullptr);
-            return {detail::mapping_iterator_tag(), p_node_value->p_mapping->begin()};
+            return {p_node_value->p_mapping->begin()};
         }
         default:
             throw fkyaml::type_error("The target node is neither of sequence nor mapping types.", get_type());
@@ -1434,12 +1434,12 @@ public:
         case detail::node_attr_bits::seq_bit: {
             const node_value* p_node_value = get_node_value_ptr();
             FK_YAML_ASSERT(p_node_value->p_sequence != nullptr);
-            return {detail::sequence_iterator_tag(), p_node_value->p_sequence->end()};
+            return {p_node_value->p_sequence->end()};
         }
         case detail::node_attr_bits::map_bit: {
             const node_value* p_node_value = get_node_value_ptr();
             FK_YAML_ASSERT(p_node_value->p_mapping != nullptr);
-            return {detail::mapping_iterator_tag(), p_node_value->p_mapping->end()};
+            return {p_node_value->p_mapping->end()};
         }
         default:
             throw fkyaml::type_error("The target node is neither of sequence nor mapping types.", get_type());
@@ -1455,12 +1455,12 @@ public:
         case detail::node_attr_bits::seq_bit: {
             const node_value* p_node_value = get_node_value_ptr();
             FK_YAML_ASSERT(p_node_value->p_sequence != nullptr);
-            return {detail::sequence_iterator_tag(), p_node_value->p_sequence->end()};
+            return {p_node_value->p_sequence->end()};
         }
         case detail::node_attr_bits::map_bit: {
             const node_value* p_node_value = get_node_value_ptr();
             FK_YAML_ASSERT(p_node_value->p_mapping != nullptr);
-            return {detail::mapping_iterator_tag(), p_node_value->p_mapping->end()};
+            return {p_node_value->p_mapping->end()};
         }
         default:
             throw fkyaml::type_error("The target node is neither of sequence nor mapping types.", get_type());

--- a/include/fkYAML/node.hpp
+++ b/include/fkYAML/node.hpp
@@ -49,14 +49,6 @@ template <
     template <typename, typename = void> class ConverterType>
 class basic_node {
 public:
-    /// @brief A type for iterators of basic_node containers.
-    /// @sa https://fktn-k.github.io/fkYAML/api/basic_node/iterator/
-    using iterator = fkyaml::detail::iterator<basic_node>;
-
-    /// @brief A type for constant iterators of basic_node containers.
-    /// @sa https://fktn-k.github.io/fkYAML/api/basic_node/const_iterator/
-    using const_iterator = fkyaml::detail::iterator<const basic_node>;
-
     /// @brief A type for sequence basic_node values.
     /// @sa https://fktn-k.github.io/fkYAML/api/basic_node/sequence_type/
     using sequence_type = SequenceType<basic_node, std::allocator<basic_node>>;
@@ -81,6 +73,42 @@ public:
     /// @brief A type for string basic_node values.
     /// @sa https://fktn-k.github.io/fkYAML/api/basic_node/string_type/
     using string_type = StringType;
+
+    /// @brief A type of elements in a basic_node container.
+    /// @sa https://fktn-k.github.io/fkYAML/api/basic_node/#container-types
+    using value_type = basic_node;
+
+    /// @brief A type of reference to a basic_node element.
+    /// @sa https://fktn-k.github.io/fkYAML/api/basic_node/#container-types
+    using reference = value_type&;
+
+    /// @brief A type of constant reference to a basic_node element.
+    /// @sa https://fktn-k.github.io/fkYAML/api/basic_node/#container-types
+    using const_reference = const value_type&;
+
+    /// @brief A type of a pointer to a basic_node element.
+    /// @sa https://fktn-k.github.io/fkYAML/api/basic_node/#container-types
+    using pointer = value_type*;
+
+    /// @brief A type of a constant pointer to a basic_node element.
+    /// @sa https://fktn-k.github.io/fkYAML/api/basic_node/#container-types
+    using const_pointer = const value_type*;
+
+    /// @brief A type to represent basic_node container sizes.
+    /// @sa https://fktn-k.github.io/fkYAML/api/basic_node/#container-types
+    using size_type = std::size_t;
+
+    /// @brief A type to represent differences between basic_node iterators.
+    /// @sa https://fktn-k.github.io/fkYAML/api/basic_node/#container-types
+    using difference_type = std::ptrdiff_t;
+
+    /// @brief A type for iterators of basic_node containers.
+    /// @sa https://fktn-k.github.io/fkYAML/api/basic_node/iterator/
+    using iterator = fkyaml::detail::iterator<basic_node>;
+
+    /// @brief A type for constant iterators of basic_node containers.
+    /// @sa https://fktn-k.github.io/fkYAML/api/basic_node/const_iterator/
+    using const_iterator = fkyaml::detail::iterator<const basic_node>;
 
     /// @brief A helper alias to determine converter type for the given target native data type.
     /// @sa https://fktn-k.github.io/fkYAML/api/basic_node/value_converter_type/

--- a/single_include/fkYAML/node.hpp
+++ b/single_include/fkYAML/node.hpp
@@ -9814,128 +9814,99 @@ enum class iterator_t : std::uint8_t {
     MAPPING,  //!< mapping iterator type.
 };
 
+/// @brief The actual storage for iterators internally held in iterator.
+template <typename BasicNodeType>
+struct iterator_holder {
+    static_assert(
+        is_basic_node<BasicNodeType>::value,
+        "iterator_holder class only accepts a basic_node as its template parameter.");
+
+    /// A sequence iterator object.
+    typename BasicNodeType::sequence_type::iterator sequence_iterator {};
+    /// A mapping iterator object.
+    typename BasicNodeType::mapping_type::iterator mapping_iterator {};
+};
+
 /// @brief A class which holds iterators either of sequence or mapping type
 /// @tparam ValueType The type of iterated elements.
 template <typename ValueType>
 class iterator {
+    /// @brief The iterator type with ValueType of different const-ness.
+    using other_iterator_type = typename std::conditional<
+        std::is_const<ValueType>::value, iterator<typename std::remove_const<ValueType>::type>,
+        iterator<const ValueType>>::type;
+
+    friend other_iterator_type;
+
 public:
     /// A type for iterator traits of instantiated @Iterator template class.
-    using ItrTraitsType = iterator_traits<ValueType>;
+    using iterator_traits_type = iterator_traits<ValueType>;
 
     /// A type for iterator category tag.
     using iterator_category = std::bidirectional_iterator_tag;
     /// A type of iterated element.
-    using value_type = typename ItrTraitsType::value_type;
+    using value_type = typename iterator_traits_type::value_type;
     /// A type to represent differences between iterators.
-    using difference_type = typename ItrTraitsType::difference_type;
+    using difference_type = typename iterator_traits_type::difference_type;
     /// A type to represent container sizes.
-    using size_type = typename ItrTraitsType::size_type;
+    using size_type = typename iterator_traits_type::size_type;
     /// A type of an element pointer.
-    using pointer = typename ItrTraitsType::pointer;
+    using pointer = typename iterator_traits_type::pointer;
     /// A type of reference to an element.
-    using reference = typename ItrTraitsType::reference;
+    using reference = typename iterator_traits_type::reference;
 
-private:
-    /// A type of non-const version of iterated elements.
-    using NonConstValueType = typename std::remove_const<ValueType>::type;
+    static_assert(is_basic_node<value_type>::value, "iterator class only accepts a basic_node as its value type.");
 
-    static_assert(is_basic_node<NonConstValueType>::value, "Iterator only accepts basic_node<...>");
-
-    /// @brief The actual storage for iterators internally held in @ref Iterator.
-    struct iterator_holder {
-        /// A sequence iterator object.
-        typename NonConstValueType::sequence_type::iterator sequence_iterator {};
-        /// A mapping iterator object.
-        typename NonConstValueType::mapping_type::iterator mapping_iterator {};
-    };
-
-public:
     /// @brief Construct a new iterator object with sequence iterator object.
     /// @param[in] itr An sequence iterator object.
-    iterator(const typename ValueType::sequence_type::iterator& itr) noexcept {
+    iterator(const typename value_type::sequence_type::iterator& itr) noexcept {
         m_iterator_holder.sequence_iterator = itr;
     }
 
     /// @brief Construct a new iterator object with mapping iterator object.
     /// @param[in] itr An mapping iterator object.
-    iterator(const typename ValueType::mapping_type::iterator& itr) noexcept
+    iterator(const typename value_type::mapping_type::iterator& itr) noexcept
         : m_inner_iterator_type(iterator_t::MAPPING) {
         m_iterator_holder.mapping_iterator = itr;
     }
 
-    /// @brief Copy constructor of the iterator class.
-    /// @param other An iterator object to be copied with.
-    iterator(const iterator& other) noexcept
-        : m_inner_iterator_type(other.m_inner_iterator_type) {
-        switch (m_inner_iterator_type) {
-        case iterator_t::SEQUENCE:
-            m_iterator_holder.sequence_iterator = other.m_iterator_holder.sequence_iterator;
-            break;
-        case iterator_t::MAPPING:
-            m_iterator_holder.mapping_iterator = other.m_iterator_holder.mapping_iterator;
-            break;
-        }
+    /// @brief Copy constructs an iterator.
+    iterator(const iterator&) = default;
+
+    /// @brief Copy constructs an iterator from another iterator with different const-ness in ValueType.
+    /// @note This copy constructor is not defined if ValueType is not const to avoid const removal from ValueType.
+    /// @tparam OtherIterator The iterator type to copy from.
+    /// @param other An iterator to copy from with different const-ness in ValueType.
+    template <
+        typename OtherIterator,
+        enable_if_t<
+            conjunction<std::is_same<OtherIterator, other_iterator_type>, std::is_const<ValueType>>::value, int> = 0>
+    iterator(const OtherIterator& other) noexcept
+        : m_inner_iterator_type(other.m_inner_iterator_type),
+          m_iterator_holder(other.m_iterator_holder) {
     }
 
-    /// @brief Move constructor of the iterator class.
-    /// @param other An iterator object to be moved from.
-    iterator(iterator&& other) noexcept
-        : m_inner_iterator_type(other.m_inner_iterator_type) {
-        switch (m_inner_iterator_type) {
-        case iterator_t::SEQUENCE:
-            m_iterator_holder.sequence_iterator = std::move(other.m_iterator_holder.sequence_iterator);
-            break;
-        case iterator_t::MAPPING:
-            m_iterator_holder.mapping_iterator = std::move(other.m_iterator_holder.mapping_iterator);
-            break;
-        }
+    /// @brief A copy assignment operator of the iterator class.
+    iterator& operator=(const iterator&) = default;
+
+    template <
+        typename OtherIterator,
+        enable_if_t<
+            conjunction<std::is_same<OtherIterator, other_iterator_type>, std::is_const<ValueType>>::value, int> = 0>
+    iterator& operator=(const OtherIterator& other) noexcept {
+        m_inner_iterator_type = other.m_inner_iterator_type;
+        m_iterator_holder = other.m_iterator_holder;
+        return *this;
     }
+
+    /// @brief Move constructs an iterator.
+    iterator(iterator&&) = default;
+
+    /// @brief A move assignment operator of the iterator class.
+    iterator& operator=(iterator&&) = default;
 
     /// @brief Destroys an iterator.
     ~iterator() = default;
-
-public:
-    /// @brief A copy assignment operator of the iterator class.
-    /// @param rhs An iterator object to be copied with.
-    /// @return iterator& Reference to this iterator object.
-    iterator& operator=(const iterator& rhs) noexcept {
-        if FK_YAML_UNLIKELY (&rhs == this) {
-            return *this;
-        }
-
-        m_inner_iterator_type = rhs.m_inner_iterator_type;
-        switch (m_inner_iterator_type) {
-        case iterator_t::SEQUENCE:
-            m_iterator_holder.sequence_iterator = rhs.m_iterator_holder.sequence_iterator;
-            break;
-        case iterator_t::MAPPING:
-            m_iterator_holder.mapping_iterator = rhs.m_iterator_holder.mapping_iterator;
-            break;
-        }
-
-        return *this;
-    }
-
-    /// @brief A move assignment operator of the iterator class.
-    /// @param rhs An iterator object to be moved from.
-    /// @return iterator& Reference to this iterator object.
-    iterator& operator=(iterator&& rhs) noexcept {
-        if FK_YAML_UNLIKELY (&rhs == this) {
-            return *this;
-        }
-
-        m_inner_iterator_type = rhs.m_inner_iterator_type;
-        switch (m_inner_iterator_type) {
-        case iterator_t::SEQUENCE:
-            m_iterator_holder.sequence_iterator = std::move(rhs.m_iterator_holder.sequence_iterator);
-            break;
-        case iterator_t::MAPPING:
-            m_iterator_holder.mapping_iterator = std::move(rhs.m_iterator_holder.mapping_iterator);
-            break;
-        }
-
-        return *this;
-    }
 
     /// @brief An arrow operator of the iterator class.
     /// @return pointer A pointer to the BasicNodeType object internally referenced by the actual iterator object.
@@ -10047,7 +10018,11 @@ public:
     /// @param rhs An iterator object to be compared with this iterator object.
     /// @return true  This iterator object is equal to the other.
     /// @return false This iterator object is not equal to the other.
-    bool operator==(const iterator& rhs) const {
+    template <
+        typename Iterator,
+        enable_if_t<
+            disjunction<std::is_same<Iterator, iterator>, std::is_same<Iterator, other_iterator_type>>::value, int> = 0>
+    bool operator==(const Iterator& rhs) const {
         if FK_YAML_UNLIKELY (m_inner_iterator_type != rhs.m_inner_iterator_type) {
             throw fkyaml::exception("Cannot compare iterators of different container types.");
         }
@@ -10064,7 +10039,11 @@ public:
     /// @param rhs An iterator object to be compared with this iterator object.
     /// @return true  This iterator object is not equal to the other.
     /// @return false This iterator object is equal to the other.
-    bool operator!=(const iterator& rhs) const {
+    template <
+        typename Iterator,
+        enable_if_t<
+            disjunction<std::is_same<Iterator, iterator>, std::is_same<Iterator, other_iterator_type>>::value, int> = 0>
+    bool operator!=(const Iterator& rhs) const {
         return !operator==(rhs);
     }
 
@@ -10072,7 +10051,11 @@ public:
     /// @param rhs An iterator object to be compared with this iterator object.
     /// @return true  This iterator object is less than the other.
     /// @return false This iterator object is not less than the other.
-    bool operator<(const iterator& rhs) const {
+    template <
+        typename Iterator,
+        enable_if_t<
+            disjunction<std::is_same<Iterator, iterator>, std::is_same<Iterator, other_iterator_type>>::value, int> = 0>
+    bool operator<(const Iterator& rhs) const {
         if FK_YAML_UNLIKELY (m_inner_iterator_type != rhs.m_inner_iterator_type) {
             throw fkyaml::exception("Cannot compare iterators of different container types.");
         }
@@ -10088,7 +10071,11 @@ public:
     ///  @param rhs An iterator object to be compared with this iterator object.
     ///  @return true  This iterator object is either less than or equal to the other.
     ///  @return false This iterator object is neither less than nor equal to the other.
-    bool operator<=(const iterator& rhs) const {
+    template <
+        typename Iterator,
+        enable_if_t<
+            disjunction<std::is_same<Iterator, iterator>, std::is_same<Iterator, other_iterator_type>>::value, int> = 0>
+    bool operator<=(const Iterator& rhs) const {
         return !rhs.operator<(*this);
     }
 
@@ -10096,7 +10083,11 @@ public:
     /// @param rhs An iterator object to be compared with this iterator object.
     /// @return true  This iterator object is greater than the other.
     /// @return false This iterator object is not greater than the other.
-    bool operator>(const iterator& rhs) const {
+    template <
+        typename Iterator,
+        enable_if_t<
+            disjunction<std::is_same<Iterator, iterator>, std::is_same<Iterator, other_iterator_type>>::value, int> = 0>
+    bool operator>(const Iterator& rhs) const {
         return !operator<=(rhs);
     }
 
@@ -10104,7 +10095,11 @@ public:
     /// @param rhs An iterator object to be compared with this iterator object.
     /// @return true  This iterator object is either greater than or equal to the other.
     /// @return false This iterator object is neither greater than nor equal to the other.
-    bool operator>=(const iterator& rhs) const {
+    template <
+        typename Iterator,
+        enable_if_t<
+            disjunction<std::is_same<Iterator, iterator>, std::is_same<Iterator, other_iterator_type>>::value, int> = 0>
+    bool operator>=(const Iterator& rhs) const {
         return !operator<(rhs);
     }
 
@@ -10115,9 +10110,9 @@ public:
         return m_inner_iterator_type;
     }
 
-    /// @brief Get the key string of the YAML mapping node for the current iterator.
-    /// @return const std::string& The key string of the YAML mapping node for the current iterator.
-    const typename ValueType::mapping_type::key_type& key() const {
+    /// @brief Get the mapping key node of the current iterator.
+    /// @return The mapping key node of the current iterator.
+    const typename value_type::mapping_type::key_type& key() const {
         if FK_YAML_UNLIKELY (m_inner_iterator_type == iterator_t::SEQUENCE) {
             throw fkyaml::exception("Cannot retrieve key from non-mapping iterators.");
         }
@@ -10125,8 +10120,8 @@ public:
         return m_iterator_holder.mapping_iterator->first;
     }
 
-    /// @brief Get the reference of the YAML node for the current iterator.
-    /// @return reference A reference to the YAML node for the current iterator.
+    /// @brief Get reference to the YAML node of the current iterator.
+    /// @return Reference to the YAML node of the current iterator.
     reference value() noexcept {
         return operator*();
     }
@@ -10135,7 +10130,7 @@ private:
     /// A type of the internally-held iterator.
     iterator_t m_inner_iterator_type {iterator_t::SEQUENCE};
     /// A holder of actual iterators.
-    mutable iterator_holder m_iterator_holder {};
+    iterator_holder<value_type> m_iterator_holder {};
 };
 
 FK_YAML_DETAIL_NAMESPACE_END

--- a/single_include/fkYAML/node.hpp
+++ b/single_include/fkYAML/node.hpp
@@ -9776,12 +9776,6 @@ FK_YAML_DETAIL_NAMESPACE_END
 
 FK_YAML_DETAIL_NAMESPACE_BEGIN
 
-/// @brief A tag which tells Iterator will contain sequence value iterator.
-struct sequence_iterator_tag {};
-
-/// @brief A tag which tells Iterator will contain mapping value iterator.
-struct mapping_iterator_tag {};
-
 /// @brief The template definitions of type information used in @ref Iterator class
 /// @tparam ValueType The type of iterated elements.
 template <typename ValueType>
@@ -9858,13 +9852,13 @@ private:
 public:
     /// @brief Construct a new iterator object with sequence iterator object.
     /// @param[in] itr An sequence iterator object.
-    iterator(sequence_iterator_tag /* unused */, const typename ValueType::sequence_type::iterator& itr) noexcept {
+    iterator(const typename ValueType::sequence_type::iterator& itr) noexcept {
         m_iterator_holder.sequence_iterator = itr;
     }
 
     /// @brief Construct a new iterator object with mapping iterator object.
     /// @param[in] itr An mapping iterator object.
-    iterator(mapping_iterator_tag /* unused */, const typename ValueType::mapping_type::iterator& itr) noexcept
+    iterator(const typename ValueType::mapping_type::iterator& itr) noexcept
         : m_inner_iterator_type(iterator_t::MAPPING) {
         m_iterator_holder.mapping_iterator = itr;
     }
@@ -13285,12 +13279,12 @@ public:
         case detail::node_attr_bits::seq_bit: {
             const node_value* p_node_value = get_node_value_ptr();
             FK_YAML_ASSERT(p_node_value->p_sequence != nullptr);
-            return {detail::sequence_iterator_tag(), p_node_value->p_sequence->begin()};
+            return {p_node_value->p_sequence->begin()};
         }
         case detail::node_attr_bits::map_bit: {
             const node_value* p_node_value = get_node_value_ptr();
             FK_YAML_ASSERT(p_node_value->p_mapping != nullptr);
-            return {detail::mapping_iterator_tag(), p_node_value->p_mapping->begin()};
+            return {p_node_value->p_mapping->begin()};
         }
         default:
             throw fkyaml::type_error("The target node is neither of sequence nor mapping types.", get_type());
@@ -13306,12 +13300,12 @@ public:
         case detail::node_attr_bits::seq_bit: {
             const node_value* p_node_value = get_node_value_ptr();
             FK_YAML_ASSERT(p_node_value->p_sequence != nullptr);
-            return {detail::sequence_iterator_tag(), p_node_value->p_sequence->begin()};
+            return {p_node_value->p_sequence->begin()};
         }
         case detail::node_attr_bits::map_bit: {
             const node_value* p_node_value = get_node_value_ptr();
             FK_YAML_ASSERT(p_node_value->p_mapping != nullptr);
-            return {detail::mapping_iterator_tag(), p_node_value->p_mapping->begin()};
+            return {p_node_value->p_mapping->begin()};
         }
         default:
             throw fkyaml::type_error("The target node is neither of sequence nor mapping types.", get_type());
@@ -13327,12 +13321,12 @@ public:
         case detail::node_attr_bits::seq_bit: {
             const node_value* p_node_value = get_node_value_ptr();
             FK_YAML_ASSERT(p_node_value->p_sequence != nullptr);
-            return {detail::sequence_iterator_tag(), p_node_value->p_sequence->end()};
+            return {p_node_value->p_sequence->end()};
         }
         case detail::node_attr_bits::map_bit: {
             const node_value* p_node_value = get_node_value_ptr();
             FK_YAML_ASSERT(p_node_value->p_mapping != nullptr);
-            return {detail::mapping_iterator_tag(), p_node_value->p_mapping->end()};
+            return {p_node_value->p_mapping->end()};
         }
         default:
             throw fkyaml::type_error("The target node is neither of sequence nor mapping types.", get_type());
@@ -13348,12 +13342,12 @@ public:
         case detail::node_attr_bits::seq_bit: {
             const node_value* p_node_value = get_node_value_ptr();
             FK_YAML_ASSERT(p_node_value->p_sequence != nullptr);
-            return {detail::sequence_iterator_tag(), p_node_value->p_sequence->end()};
+            return {p_node_value->p_sequence->end()};
         }
         case detail::node_attr_bits::map_bit: {
             const node_value* p_node_value = get_node_value_ptr();
             FK_YAML_ASSERT(p_node_value->p_mapping != nullptr);
-            return {detail::mapping_iterator_tag(), p_node_value->p_mapping->end()};
+            return {p_node_value->p_mapping->end()};
         }
         default:
             throw fkyaml::type_error("The target node is neither of sequence nor mapping types.", get_type());

--- a/single_include/fkYAML/node.hpp
+++ b/single_include/fkYAML/node.hpp
@@ -9781,15 +9781,15 @@ FK_YAML_DETAIL_NAMESPACE_BEGIN
 template <typename ValueType>
 struct iterator_traits {
     /// A type of iterated elements.
-    using value_type = ValueType;
+    using value_type = typename ValueType::value_type;
     /// A type to represent difference between iterators.
-    using difference_type = std::ptrdiff_t;
+    using difference_type = typename ValueType::difference_type;
     /// A type to represent iterator sizes.
-    using size_type = std::size_t;
+    using size_type = typename ValueType::size_type;
     /// A type of an element pointer.
-    using pointer = value_type*;
+    using pointer = typename ValueType::pointer;
     /// A type of reference to an element.
-    using reference = value_type&;
+    using reference = typename ValueType::reference;
 };
 
 /// @brief A specialization of @ref iterator_traits for constant value types.
@@ -9797,15 +9797,15 @@ struct iterator_traits {
 template <typename ValueType>
 struct iterator_traits<const ValueType> {
     /// A type of iterated elements.
-    using value_type = ValueType;
+    using value_type = typename ValueType::value_type;
     /// A type to represent difference between iterators.
-    using difference_type = std::ptrdiff_t;
+    using difference_type = typename ValueType::difference_type;
     /// A type to represent iterator sizes.
-    using size_type = std::size_t;
+    using size_type = typename ValueType::size_type;
     /// A type of a constant element pointer.
-    using pointer = const value_type*;
+    using pointer = typename ValueType::const_pointer;
     /// A type of constant reference to an element.
-    using reference = const value_type&;
+    using reference = typename ValueType::const_reference;
 };
 
 /// @brief Definitions of iterator types for iterators internally held.
@@ -11936,14 +11936,6 @@ template <
     template <typename, typename = void> class ConverterType>
 class basic_node {
 public:
-    /// @brief A type for iterators of basic_node containers.
-    /// @sa https://fktn-k.github.io/fkYAML/api/basic_node/iterator/
-    using iterator = fkyaml::detail::iterator<basic_node>;
-
-    /// @brief A type for constant iterators of basic_node containers.
-    /// @sa https://fktn-k.github.io/fkYAML/api/basic_node/const_iterator/
-    using const_iterator = fkyaml::detail::iterator<const basic_node>;
-
     /// @brief A type for sequence basic_node values.
     /// @sa https://fktn-k.github.io/fkYAML/api/basic_node/sequence_type/
     using sequence_type = SequenceType<basic_node, std::allocator<basic_node>>;
@@ -11968,6 +11960,42 @@ public:
     /// @brief A type for string basic_node values.
     /// @sa https://fktn-k.github.io/fkYAML/api/basic_node/string_type/
     using string_type = StringType;
+
+    /// @brief A type of elements in a basic_node container.
+    /// @sa https://fktn-k.github.io/fkYAML/api/basic_node/#container-types
+    using value_type = basic_node;
+
+    /// @brief A type of reference to a basic_node element.
+    /// @sa https://fktn-k.github.io/fkYAML/api/basic_node/#container-types
+    using reference = value_type&;
+
+    /// @brief A type of constant reference to a basic_node element.
+    /// @sa https://fktn-k.github.io/fkYAML/api/basic_node/#container-types
+    using const_reference = const value_type&;
+
+    /// @brief A type of a pointer to a basic_node element.
+    /// @sa https://fktn-k.github.io/fkYAML/api/basic_node/#container-types
+    using pointer = value_type*;
+
+    /// @brief A type of a constant pointer to a basic_node element.
+    /// @sa https://fktn-k.github.io/fkYAML/api/basic_node/#container-types
+    using const_pointer = const value_type*;
+
+    /// @brief A type to represent basic_node container sizes.
+    /// @sa https://fktn-k.github.io/fkYAML/api/basic_node/#container-types
+    using size_type = std::size_t;
+
+    /// @brief A type to represent differences between basic_node iterators.
+    /// @sa https://fktn-k.github.io/fkYAML/api/basic_node/#container-types
+    using difference_type = std::ptrdiff_t;
+
+    /// @brief A type for iterators of basic_node containers.
+    /// @sa https://fktn-k.github.io/fkYAML/api/basic_node/iterator/
+    using iterator = fkyaml::detail::iterator<basic_node>;
+
+    /// @brief A type for constant iterators of basic_node containers.
+    /// @sa https://fktn-k.github.io/fkYAML/api/basic_node/const_iterator/
+    using const_iterator = fkyaml::detail::iterator<const basic_node>;
 
     /// @brief A helper alias to determine converter type for the given target native data type.
     /// @sa https://fktn-k.github.io/fkYAML/api/basic_node/value_converter_type/

--- a/single_include/fkYAML/node.hpp
+++ b/single_include/fkYAML/node.hpp
@@ -13293,9 +13293,9 @@ public:
         swap(m_prop.anchor, rhs.m_prop.anchor);
     }
 
-    /// @brief Returns the first iterator of basic_node values of container types (sequence or mapping) from a non-const
-    /// basic_node object. Throws exception if the basic_node value is not of container types.
-    /// @return An iterator to the first element of a YAML node value (either sequence or mapping).
+    /// @brief Returns an iterator to the first element of a container node (sequence or mapping).
+    /// @throw `type_error` if this basic_node is neither a sequence nor mapping node.
+    /// @return An iterator to the first element of a container node.
     /// @sa https://fktn-k.github.io/fkYAML/api/basic_node/begin/
     iterator begin() {
         switch (get_node_attrs() & detail::node_attr_mask::value) {
@@ -13314,9 +13314,9 @@ public:
         }
     }
 
-    /// @brief Returns the first iterator of basic_node values of container types (sequence or mapping) from a const
-    /// basic_node object. Throws exception if the basic_node value is not of container types.
-    /// @return A constant iterator to the first element of a YAML node value (either sequence or mapping).
+    /// @brief Returns a const iterator to the first element of a container node (sequence or mapping).
+    /// @throw `type_error` if this basic_node is neither a sequence nor mapping node.
+    /// @return A const iterator to the first element of a container node.
     /// @sa https://fktn-k.github.io/fkYAML/api/basic_node/begin/
     const_iterator begin() const {
         switch (get_node_attrs() & detail::node_attr_mask::value) {
@@ -13335,9 +13335,17 @@ public:
         }
     }
 
-    /// @brief Returns the last iterator of basic_node values of container types (sequence or mapping) from a non-const
-    /// basic_node object. Throws exception if the basic_node value is not of container types.
-    /// @return An iterator to the past-the end element of a YAML node value (either sequence or mapping).
+    /// @brief Returns a const iterator to the first element of a container node (sequence or mapping).
+    /// @throw `type_error` if this basic_node is neither a sequence nor mapping node.
+    /// @return A const iterator to the first element of a container node.
+    /// @sa https://fktn-k.github.io/fkYAML/api/basic_node/cbegin/
+    const_iterator cbegin() const {
+        return begin();
+    }
+
+    /// @brief Returns an iterator to the past-the-last element of a container node (sequence or mapping).
+    /// @throw `type_error` if the basic_node value is not of container types.
+    /// @return An iterator to the past-the-last element of a container node.
     /// @sa https://fktn-k.github.io/fkYAML/api/basic_node/end/
     iterator end() {
         switch (get_node_attrs() & detail::node_attr_mask::value) {
@@ -13356,9 +13364,9 @@ public:
         }
     }
 
-    /// @brief Returns the last iterator of basic_node values of container types (sequence or mapping) from a const
-    /// basic_node object. Throws exception if the basic_node value is not of container types.
-    /// @return A constant iterator to the past-the end element of a YAML node value (either sequence or mapping).
+    /// @brief Returns a const iterator to the past-the-last element of a container node (sequence or mapping).
+    /// @throw `type_error` if this basic_node is neither a sequence nor mapping node.
+    /// @return A const iterator to the past-the-last element of a container node.
     /// @sa https://fktn-k.github.io/fkYAML/api/basic_node/end/
     const_iterator end() const {
         switch (get_node_attrs() & detail::node_attr_mask::value) {
@@ -13375,6 +13383,14 @@ public:
         default:
             throw fkyaml::type_error("The target node is neither of sequence nor mapping types.", get_type());
         }
+    }
+
+    /// @brief Returns a const iterator to the past-the-last element of a container node (sequence or mapping).
+    /// @throw `type_error` if this basic_node is neither a sequence nor mapping node.
+    /// @return A const iterator to the past-the-last element of a container node.
+    /// @sa https://fktn-k.github.io/fkYAML/api/basic_node/cend/
+    const_iterator cend() const {
+        return end();
     }
 
 private:

--- a/test/unit_test/test_iterator_class.cpp
+++ b/test/unit_test/test_iterator_class.cpp
@@ -12,13 +12,13 @@
 
 TEST_CASE("Iterator_SequenceCtor") {
     fkyaml::node sequence = fkyaml::node::sequence();
-    fkyaml::detail::iterator<fkyaml::node> iterator(sequence.get_value_ref<fkyaml::node::sequence_type&>().begin());
+    fkyaml::detail::iterator<fkyaml::node> iterator(sequence.begin());
     REQUIRE(iterator.type() == fkyaml::detail::iterator_t::SEQUENCE);
 }
 
 TEST_CASE("Iterator_MappingCtor") {
     fkyaml::node mapping = fkyaml::node::mapping();
-    fkyaml::detail::iterator<fkyaml::node> iterator(mapping.get_value_ref<fkyaml::node::mapping_type&>().begin());
+    fkyaml::detail::iterator<fkyaml::node> iterator(mapping.begin());
     REQUIRE(iterator.type() == fkyaml::detail::iterator_t::MAPPING);
 }
 
@@ -39,9 +39,17 @@ TEST_CASE("Iterator_MappingCopyCtor") {
     REQUIRE(iterator.value().is_null());
 }
 
+TEST_CASE("Iterator_CtorDifferentConstness") {
+    fkyaml::node seq = {nullptr, 123};
+    fkyaml::detail::iterator<const fkyaml::node> const_itr = seq.begin();
+
+    REQUIRE(const_itr.type() == fkyaml::detail::iterator_t::SEQUENCE);
+    REQUIRE(const_itr->is_null());
+}
+
 TEST_CASE("Iterator_SequenceMoveCtor") {
     fkyaml::node sequence = {"test"};
-    fkyaml::detail::iterator<fkyaml::node> moved(sequence.get_value_ref<fkyaml::node::sequence_type&>().begin());
+    fkyaml::detail::iterator<fkyaml::node> moved(sequence.begin());
     fkyaml::detail::iterator<fkyaml::node> iterator(std::move(moved));
     REQUIRE(iterator.type() == fkyaml::detail::iterator_t::SEQUENCE);
     REQUIRE(iterator->is_string());
@@ -50,7 +58,7 @@ TEST_CASE("Iterator_SequenceMoveCtor") {
 
 TEST_CASE("Iterator_MappingMoveCtor") {
     fkyaml::node mapping = fkyaml::node::mapping({{"test", fkyaml::node()}});
-    fkyaml::detail::iterator<fkyaml::node> moved(mapping.get_value_ref<fkyaml::node::mapping_type&>().begin());
+    fkyaml::detail::iterator<fkyaml::node> moved(mapping.begin());
     fkyaml::detail::iterator<fkyaml::node> iterator(std::move(moved));
     REQUIRE(iterator.type() == fkyaml::detail::iterator_t::MAPPING);
     REQUIRE(iterator.key().get_value_ref<const std::string&>() == "test");
@@ -60,7 +68,7 @@ TEST_CASE("Iterator_MappingMoveCtor") {
 TEST_CASE("Iterator_AssignmentOperator") {
     SECTION("self assignment.") {
         fkyaml::node sequence = fkyaml::node::sequence({fkyaml::node()});
-        fkyaml::detail::iterator<fkyaml::node> iterator(sequence.get_value_ref<fkyaml::node::sequence_type&>().begin());
+        fkyaml::detail::iterator<fkyaml::node> iterator(sequence.begin());
 
         SECTION("lvalue iterator") {
             iterator = *&iterator;
@@ -80,7 +88,7 @@ TEST_CASE("Iterator_AssignmentOperator") {
         fkyaml::detail::iterator<fkyaml::node> copied_itr(
             copied_seq.get_value_ref<fkyaml::node::sequence_type&>().begin());
         fkyaml::node sequence = {false};
-        fkyaml::detail::iterator<fkyaml::node> iterator(sequence.get_value_ref<fkyaml::node::sequence_type&>().begin());
+        fkyaml::detail::iterator<fkyaml::node> iterator(sequence.begin());
 
         SECTION("lvalue iterator") {
             iterator = copied_itr;
@@ -120,6 +128,17 @@ TEST_CASE("Iterator_AssignmentOperator") {
             REQUIRE(iterator.value().get_value_ref<fkyaml::node::string_type&>().compare("test") == 0);
         }
     }
+
+    SECTION("different const-ness") {
+        fkyaml::node seq = {nullptr, 123};
+        const fkyaml::node const_seq = {true, 3.14};
+        fkyaml::detail::iterator<const fkyaml::node> const_itr = const_seq.begin();
+
+        const_itr = seq.begin();
+
+        REQUIRE(const_itr.type() == fkyaml::detail::iterator_t::SEQUENCE);
+        REQUIRE(const_itr->is_null());
+    }
 }
 
 TEST_CASE("Iterator_ArrowOperator") {
@@ -153,7 +172,7 @@ TEST_CASE("Iterator_DereferenceOperator") {
 TEST_CASE("Iterator_CompoundAssignmentOperatorBySum") {
     SECTION("sequence iterator") {
         fkyaml::node sequence = {false, true};
-        fkyaml::detail::iterator<fkyaml::node> iterator(sequence.get_value_ref<fkyaml::node::sequence_type&>().begin());
+        fkyaml::detail::iterator<fkyaml::node> iterator(sequence.begin());
         iterator += 1;
         REQUIRE(iterator->is_boolean());
         REQUIRE(iterator->get_value<fkyaml::node::boolean_type>() == true);
@@ -161,7 +180,7 @@ TEST_CASE("Iterator_CompoundAssignmentOperatorBySum") {
 
     SECTION("mapping iterator") {
         fkyaml::node mapping = {{"test0", false}, {"test1", true}};
-        fkyaml::detail::iterator<fkyaml::node> iterator(mapping.get_value_ref<fkyaml::node::mapping_type&>().begin());
+        fkyaml::detail::iterator<fkyaml::node> iterator(mapping.begin());
         iterator += 1;
         REQUIRE(iterator.key().get_value_ref<const std::string&>() == "test1");
         REQUIRE(iterator.value().is_boolean());
@@ -172,7 +191,7 @@ TEST_CASE("Iterator_CompoundAssignmentOperatorBySum") {
 TEST_CASE("Iterator_PlusOperator") {
     SECTION("sequence iterator") {
         fkyaml::node sequence = {false, true};
-        fkyaml::detail::iterator<fkyaml::node> iterator(sequence.get_value_ref<fkyaml::node::sequence_type&>().begin());
+        fkyaml::detail::iterator<fkyaml::node> iterator(sequence.begin());
         fkyaml::detail::iterator<fkyaml::node> after_plus_itr = iterator + 1;
         REQUIRE(after_plus_itr->is_boolean());
         REQUIRE(after_plus_itr->get_value<fkyaml::node::boolean_type>() == true);
@@ -180,7 +199,7 @@ TEST_CASE("Iterator_PlusOperator") {
 
     SECTION("mapping iterator") {
         fkyaml::node mapping = {{"test0", false}, {"test1", true}};
-        fkyaml::detail::iterator<fkyaml::node> iterator(mapping.get_value_ref<fkyaml::node::mapping_type&>().begin());
+        fkyaml::detail::iterator<fkyaml::node> iterator(mapping.begin());
         fkyaml::detail::iterator<fkyaml::node> after_plus_itr = iterator + 1;
         REQUIRE(after_plus_itr.key().get_value_ref<const std::string&>() == "test1");
         REQUIRE(after_plus_itr.value().is_boolean());
@@ -191,7 +210,7 @@ TEST_CASE("Iterator_PlusOperator") {
 TEST_CASE("Iterator_PreIncrementOperator") {
     SECTION("sequence iterator") {
         fkyaml::node sequence = {false, true};
-        fkyaml::detail::iterator<fkyaml::node> iterator(sequence.get_value_ref<fkyaml::node::sequence_type&>().begin());
+        fkyaml::detail::iterator<fkyaml::node> iterator(sequence.begin());
         ++iterator;
         REQUIRE(iterator->is_boolean());
         REQUIRE(iterator->get_value<fkyaml::node::boolean_type>() == true);
@@ -199,7 +218,7 @@ TEST_CASE("Iterator_PreIncrementOperator") {
 
     SECTION("mapping iterator") {
         fkyaml::node mapping = {{"test0", false}, {"test1", true}};
-        fkyaml::detail::iterator<fkyaml::node> iterator(mapping.get_value_ref<fkyaml::node::mapping_type&>().begin());
+        fkyaml::detail::iterator<fkyaml::node> iterator(mapping.begin());
         ++iterator;
         REQUIRE(iterator.key().get_value_ref<const std::string&>() == "test1");
         REQUIRE(iterator.value().is_boolean());
@@ -210,7 +229,7 @@ TEST_CASE("Iterator_PreIncrementOperator") {
 TEST_CASE("Iterator_PostIncrementOperator") {
     SECTION("sequence iterator") {
         fkyaml::node sequence = {false, true};
-        fkyaml::detail::iterator<fkyaml::node> iterator(sequence.get_value_ref<fkyaml::node::sequence_type&>().begin());
+        fkyaml::detail::iterator<fkyaml::node> iterator(sequence.begin());
         iterator++;
         REQUIRE(iterator->is_boolean());
         REQUIRE(iterator->get_value<fkyaml::node::boolean_type>() == true);
@@ -218,7 +237,7 @@ TEST_CASE("Iterator_PostIncrementOperator") {
 
     SECTION("mapping iterator") {
         fkyaml::node mapping = {{"test0", false}, {"test1", true}};
-        fkyaml::detail::iterator<fkyaml::node> iterator(mapping.get_value_ref<fkyaml::node::mapping_type&>().begin());
+        fkyaml::detail::iterator<fkyaml::node> iterator(mapping.begin());
         iterator++;
         REQUIRE(iterator.key().get_value_ref<const std::string&>() == "test1");
         REQUIRE(iterator.value().is_boolean());
@@ -229,7 +248,7 @@ TEST_CASE("Iterator_PostIncrementOperator") {
 TEST_CASE("Iterator_CompoundAssignmentOperatorByDifference") {
     SECTION("sequence iterator") {
         fkyaml::node sequence = {false, true};
-        fkyaml::detail::iterator<fkyaml::node> iterator(sequence.get_value_ref<fkyaml::node::sequence_type&>().end());
+        fkyaml::detail::iterator<fkyaml::node> iterator(sequence.end());
         iterator -= 1;
         REQUIRE(iterator->is_boolean());
         REQUIRE(iterator->get_value<fkyaml::node::boolean_type>() == true);
@@ -237,7 +256,7 @@ TEST_CASE("Iterator_CompoundAssignmentOperatorByDifference") {
 
     SECTION("mapping iterator") {
         fkyaml::node mapping = {{"test0", false}, {"test1", true}};
-        fkyaml::detail::iterator<fkyaml::node> iterator(mapping.get_value_ref<fkyaml::node::mapping_type&>().end());
+        fkyaml::detail::iterator<fkyaml::node> iterator(mapping.end());
         iterator -= 1;
         REQUIRE(iterator.key().get_value_ref<const std::string&>() == "test1");
         REQUIRE(iterator.value().is_boolean());
@@ -248,7 +267,7 @@ TEST_CASE("Iterator_CompoundAssignmentOperatorByDifference") {
 TEST_CASE("Iterator_MinusOperator") {
     SECTION("sequence iterator") {
         fkyaml::node sequence = {false, true};
-        fkyaml::detail::iterator<fkyaml::node> iterator(sequence.get_value_ref<fkyaml::node::sequence_type&>().end());
+        fkyaml::detail::iterator<fkyaml::node> iterator(sequence.end());
         fkyaml::detail::iterator<fkyaml::node> after_minus_itr = iterator - 1;
         REQUIRE(after_minus_itr->is_boolean());
         REQUIRE(after_minus_itr->get_value<fkyaml::node::boolean_type>() == true);
@@ -256,7 +275,7 @@ TEST_CASE("Iterator_MinusOperator") {
 
     SECTION("mapping iterator.") {
         fkyaml::node mapping = {{"test0", false}, {"test1", true}};
-        fkyaml::detail::iterator<fkyaml::node> iterator(mapping.get_value_ref<fkyaml::node::mapping_type&>().end());
+        fkyaml::detail::iterator<fkyaml::node> iterator(mapping.end());
         fkyaml::detail::iterator<fkyaml::node> after_minus_itr = iterator - 1;
         REQUIRE(after_minus_itr.key().get_value_ref<const std::string&>() == "test1");
         REQUIRE(after_minus_itr.value().is_boolean());
@@ -267,7 +286,7 @@ TEST_CASE("Iterator_MinusOperator") {
 TEST_CASE("Iterator_PreDecrementOperator") {
     SECTION("sequence iterator") {
         fkyaml::node sequence = {false, true};
-        fkyaml::detail::iterator<fkyaml::node> iterator(sequence.get_value_ref<fkyaml::node::sequence_type&>().end());
+        fkyaml::detail::iterator<fkyaml::node> iterator(sequence.end());
         --iterator;
         REQUIRE(iterator->is_boolean());
         REQUIRE(iterator->get_value<fkyaml::node::boolean_type>() == true);
@@ -275,7 +294,7 @@ TEST_CASE("Iterator_PreDecrementOperator") {
 
     SECTION("mapping iterator") {
         fkyaml::node mapping = {{"test0", false}, {"test1", true}};
-        fkyaml::detail::iterator<fkyaml::node> iterator(mapping.get_value_ref<fkyaml::node::mapping_type&>().end());
+        fkyaml::detail::iterator<fkyaml::node> iterator(mapping.end());
         --iterator;
         REQUIRE(iterator.key().get_value_ref<const std::string&>() == "test1");
         REQUIRE(iterator.value().is_boolean());
@@ -286,7 +305,7 @@ TEST_CASE("Iterator_PreDecrementOperator") {
 TEST_CASE("Iterator_PostDecrementOperator") {
     SECTION("sequence iterator") {
         fkyaml::node sequence = {false, true};
-        fkyaml::detail::iterator<fkyaml::node> iterator(sequence.get_value_ref<fkyaml::node::sequence_type&>().end());
+        fkyaml::detail::iterator<fkyaml::node> iterator(sequence.end());
         iterator--;
         REQUIRE(iterator->is_boolean());
         REQUIRE(iterator->get_value<fkyaml::node::boolean_type>() == true);
@@ -294,7 +313,7 @@ TEST_CASE("Iterator_PostDecrementOperator") {
 
     SECTION("mapping iterator") {
         fkyaml::node mapping = {{"test0", false}, {"test1", true}};
-        fkyaml::detail::iterator<fkyaml::node> iterator(mapping.get_value_ref<fkyaml::node::mapping_type&>().end());
+        fkyaml::detail::iterator<fkyaml::node> iterator(mapping.end());
         iterator--;
         REQUIRE(iterator.key().get_value_ref<const std::string&>() == "test1");
         REQUIRE(iterator.value().is_boolean());
@@ -305,23 +324,35 @@ TEST_CASE("Iterator_PostDecrementOperator") {
 TEST_CASE("Iterator_EqualToOperator") {
     SECTION("sequence iterator") {
         fkyaml::node sequence = {false, true};
-        fkyaml::detail::iterator<fkyaml::node> lhs(sequence.get_value_ref<fkyaml::node::sequence_type&>().begin());
-        fkyaml::detail::iterator<fkyaml::node> rhs(sequence.get_value_ref<fkyaml::node::sequence_type&>().begin());
-        REQUIRE(lhs == rhs);
+        fkyaml::detail::iterator<fkyaml::node> itr(sequence.begin());
+        fkyaml::detail::iterator<fkyaml::node> itr2(sequence.begin());
+        fkyaml::detail::iterator<const fkyaml::node> const_itr(sequence.begin());
+        fkyaml::detail::iterator<const fkyaml::node> const_itr2(sequence.begin());
+
+        REQUIRE(itr == itr2);
+        REQUIRE(const_itr == const_itr2);
+        REQUIRE(itr == const_itr);
+        REQUIRE(const_itr == itr);
     }
 
     SECTION("mapping iterator") {
         fkyaml::node mapping = {{"test0", false}, {"test1", true}};
-        fkyaml::detail::iterator<fkyaml::node> lhs(mapping.get_value_ref<fkyaml::node::mapping_type&>().begin());
-        fkyaml::detail::iterator<fkyaml::node> rhs(mapping.get_value_ref<fkyaml::node::mapping_type&>().begin());
-        REQUIRE(lhs == rhs);
+        fkyaml::detail::iterator<fkyaml::node> itr(mapping.begin());
+        fkyaml::detail::iterator<fkyaml::node> itr2(mapping.begin());
+        fkyaml::detail::iterator<const fkyaml::node> const_itr(mapping.begin());
+        fkyaml::detail::iterator<const fkyaml::node> const_itr2(mapping.begin());
+
+        REQUIRE(itr == itr2);
+        REQUIRE(const_itr == const_itr2);
+        REQUIRE(itr == const_itr);
+        REQUIRE(const_itr == itr);
     }
 
     SECTION("equality check between different type iterators") {
         fkyaml::node sequence = {false, true};
-        fkyaml::detail::iterator<fkyaml::node> lhs(sequence.get_value_ref<fkyaml::node::sequence_type&>().begin());
+        fkyaml::detail::iterator<fkyaml::node> lhs(sequence.begin());
         fkyaml::node mapping = {{"test0", false}, {"test1", true}};
-        fkyaml::detail::iterator<fkyaml::node> rhs(mapping.get_value_ref<fkyaml::node::mapping_type&>().begin());
+        fkyaml::detail::iterator<fkyaml::node> rhs(mapping.begin());
         REQUIRE_THROWS_AS(lhs == rhs, fkyaml::exception);
     }
 }
@@ -329,51 +360,71 @@ TEST_CASE("Iterator_EqualToOperator") {
 TEST_CASE("Iterator_NotEqualToOperator") {
     SECTION("sequence iterator.") {
         fkyaml::node sequence = {false, true};
-        fkyaml::detail::iterator<fkyaml::node> lhs(sequence.get_value_ref<fkyaml::node::sequence_type&>().begin());
-        fkyaml::detail::iterator<fkyaml::node> rhs(sequence.get_value_ref<fkyaml::node::sequence_type&>().begin());
-        ++rhs;
+        fkyaml::detail::iterator<fkyaml::node> lhs(sequence.begin());
+        fkyaml::detail::iterator<fkyaml::node> rhs(sequence.begin() + 1);
+        fkyaml::detail::iterator<const fkyaml::node> const_lhs(sequence.begin());
+        fkyaml::detail::iterator<const fkyaml::node> const_rhs(sequence.begin() + 1);
+
         REQUIRE(lhs != rhs);
+        REQUIRE(const_lhs != const_rhs);
+        REQUIRE(lhs != const_rhs);
+        REQUIRE(const_lhs != rhs);
     }
 
     SECTION("mapping iterator") {
         fkyaml::node mapping = {{"test0", false}, {"test1", true}};
-        fkyaml::detail::iterator<fkyaml::node> lhs(mapping.get_value_ref<fkyaml::node::mapping_type&>().begin());
-        fkyaml::detail::iterator<fkyaml::node> rhs(mapping.get_value_ref<fkyaml::node::mapping_type&>().begin());
-        ++rhs;
+        fkyaml::detail::iterator<fkyaml::node> lhs(mapping.begin());
+        fkyaml::detail::iterator<fkyaml::node> rhs(mapping.begin() + 1);
+        fkyaml::detail::iterator<const fkyaml::node> const_lhs(mapping.begin());
+        fkyaml::detail::iterator<const fkyaml::node> const_rhs(mapping.begin() + 1);
+
         REQUIRE(lhs != rhs);
+        REQUIRE(const_lhs != const_rhs);
+        REQUIRE(lhs != const_rhs);
+        REQUIRE(const_lhs != rhs);
     }
 
     SECTION("equality check between different type iterators") {
         fkyaml::node sequence = {false, true};
-        fkyaml::detail::iterator<fkyaml::node> lhs(sequence.get_value_ref<fkyaml::node::sequence_type&>().begin());
+        fkyaml::detail::iterator<fkyaml::node> lhs(sequence.begin());
         fkyaml::node mapping = {{"test0", false}, {"test1", true}};
-        fkyaml::detail::iterator<fkyaml::node> rhs(mapping.get_value_ref<fkyaml::node::mapping_type&>().begin());
-        REQUIRE_THROWS_AS(lhs == rhs, fkyaml::exception);
+        fkyaml::detail::iterator<fkyaml::node> rhs(mapping.begin());
+        REQUIRE_THROWS_AS(lhs != rhs, fkyaml::exception);
     }
 }
 
 TEST_CASE("Iterator_LessThanOperator") {
     SECTION("sequence iterator") {
         fkyaml::node sequence = {false, true};
-        fkyaml::detail::iterator<fkyaml::node> lhs(sequence.get_value_ref<fkyaml::node::sequence_type&>().begin());
-        fkyaml::detail::iterator<fkyaml::node> rhs(sequence.get_value_ref<fkyaml::node::sequence_type&>().begin());
+        fkyaml::detail::iterator<fkyaml::node> lhs(sequence.begin());
+        fkyaml::detail::iterator<fkyaml::node> rhs(sequence.begin());
+        fkyaml::detail::iterator<const fkyaml::node> const_lhs(sequence.begin());
+        fkyaml::detail::iterator<const fkyaml::node> const_rhs(sequence.begin());
+
         REQUIRE_FALSE(lhs < rhs);
+        REQUIRE_FALSE(const_lhs < const_rhs);
+        REQUIRE_FALSE(lhs < const_rhs);
+        REQUIRE_FALSE(const_lhs < rhs);
         ++rhs;
+        ++const_rhs;
         REQUIRE(lhs < rhs);
+        REQUIRE(const_lhs < const_rhs);
+        REQUIRE(lhs < const_rhs);
+        REQUIRE(const_lhs < rhs);
     }
 
     SECTION("mapping iterator") {
         fkyaml::node mapping = {{"test0", false}, {"test1", true}};
-        fkyaml::detail::iterator<fkyaml::node> lhs(mapping.get_value_ref<fkyaml::node::mapping_type&>().begin());
-        fkyaml::detail::iterator<fkyaml::node> rhs(mapping.get_value_ref<fkyaml::node::mapping_type&>().begin());
+        fkyaml::detail::iterator<fkyaml::node> lhs(mapping.begin());
+        fkyaml::detail::iterator<fkyaml::node> rhs(mapping.begin());
         REQUIRE_THROWS_AS(lhs < rhs, fkyaml::exception);
     }
 
     SECTION("less-than check between different type iterators") {
         fkyaml::node sequence = {false, true};
-        fkyaml::detail::iterator<fkyaml::node> lhs(sequence.get_value_ref<fkyaml::node::sequence_type&>().begin());
+        fkyaml::detail::iterator<fkyaml::node> lhs(sequence.begin());
         fkyaml::node mapping = {{"test0", false}, {"test1", true}};
-        fkyaml::detail::iterator<fkyaml::node> rhs(mapping.get_value_ref<fkyaml::node::mapping_type&>().begin());
+        fkyaml::detail::iterator<fkyaml::node> rhs(mapping.begin());
         REQUIRE_THROWS_AS(lhs < rhs, fkyaml::exception);
     }
 }
@@ -381,28 +432,41 @@ TEST_CASE("Iterator_LessThanOperator") {
 TEST_CASE("Iterator_LessThanOrEqualToOperator") {
     SECTION("sequence iterator") {
         fkyaml::node sequence = {false, true};
-        fkyaml::detail::iterator<fkyaml::node> lhs(sequence.get_value_ref<fkyaml::node::sequence_type&>().begin());
-        fkyaml::detail::iterator<fkyaml::node> rhs(sequence.get_value_ref<fkyaml::node::sequence_type&>().begin());
-        ++lhs;
+        fkyaml::detail::iterator<fkyaml::node> lhs(sequence.begin() + 1);
+        fkyaml::detail::iterator<fkyaml::node> rhs(sequence.begin());
+        fkyaml::detail::iterator<const fkyaml::node> const_lhs(sequence.begin() + 1);
+        fkyaml::detail::iterator<const fkyaml::node> const_rhs(sequence.begin());
+
         REQUIRE_FALSE(lhs <= rhs);
+        REQUIRE_FALSE(const_lhs <= const_rhs);
+        REQUIRE_FALSE(lhs <= const_rhs);
+        REQUIRE_FALSE(const_lhs <= rhs);
         --lhs;
+        --const_lhs;
         REQUIRE(lhs <= rhs);
+        REQUIRE(const_lhs <= const_rhs);
+        REQUIRE(lhs <= const_rhs);
+        REQUIRE(const_lhs <= rhs);
         ++rhs;
-        REQUIRE(lhs < rhs);
+        ++const_rhs;
+        REQUIRE(lhs <= rhs);
+        REQUIRE(const_lhs <= const_rhs);
+        REQUIRE(lhs <= const_rhs);
+        REQUIRE(const_lhs <= rhs);
     }
 
     SECTION("mapping iterator") {
         fkyaml::node mapping = {{"test0", false}, {"test1", true}};
-        fkyaml::detail::iterator<fkyaml::node> lhs(mapping.get_value_ref<fkyaml::node::mapping_type&>().begin());
-        fkyaml::detail::iterator<fkyaml::node> rhs(mapping.get_value_ref<fkyaml::node::mapping_type&>().begin());
+        fkyaml::detail::iterator<fkyaml::node> lhs(mapping.begin());
+        fkyaml::detail::iterator<fkyaml::node> rhs(mapping.begin());
         REQUIRE_THROWS_AS(lhs <= rhs, fkyaml::exception);
     }
 
     SECTION("less-than-or-equal-to check between different type iterators") {
         fkyaml::node sequence = {false, true};
-        fkyaml::detail::iterator<fkyaml::node> lhs(sequence.get_value_ref<fkyaml::node::sequence_type&>().begin());
+        fkyaml::detail::iterator<fkyaml::node> lhs(sequence.begin());
         fkyaml::node mapping = {{"test0", false}, {"test1", true}};
-        fkyaml::detail::iterator<fkyaml::node> rhs(mapping.get_value_ref<fkyaml::node::mapping_type&>().begin());
+        fkyaml::detail::iterator<fkyaml::node> rhs(mapping.begin());
         REQUIRE_THROWS_AS(lhs <= rhs, fkyaml::exception);
     }
 }
@@ -410,25 +474,35 @@ TEST_CASE("Iterator_LessThanOrEqualToOperator") {
 TEST_CASE("Iterator_GreaterThanOperator") {
     SECTION("sequence iterator") {
         fkyaml::node sequence = {false, true};
-        fkyaml::detail::iterator<fkyaml::node> lhs(sequence.get_value_ref<fkyaml::node::sequence_type&>().begin());
-        fkyaml::detail::iterator<fkyaml::node> rhs(sequence.get_value_ref<fkyaml::node::sequence_type&>().begin());
+        fkyaml::detail::iterator<fkyaml::node> lhs(sequence.begin());
+        fkyaml::detail::iterator<fkyaml::node> rhs(sequence.begin());
+        fkyaml::detail::iterator<const fkyaml::node> const_lhs(sequence.begin());
+        fkyaml::detail::iterator<const fkyaml::node> const_rhs(sequence.begin());
+
         REQUIRE_FALSE(lhs > rhs);
+        REQUIRE_FALSE(const_lhs > const_rhs);
+        REQUIRE_FALSE(lhs > const_rhs);
+        REQUIRE_FALSE(const_lhs > rhs);
         ++lhs;
+        ++const_lhs;
         REQUIRE(lhs > rhs);
+        REQUIRE(const_lhs > const_rhs);
+        REQUIRE(lhs > const_rhs);
+        REQUIRE(const_lhs > rhs);
     }
 
     SECTION("mapping iterator") {
         fkyaml::node mapping = {{"test0", false}, {"test1", true}};
-        fkyaml::detail::iterator<fkyaml::node> lhs(mapping.get_value_ref<fkyaml::node::mapping_type&>().begin());
-        fkyaml::detail::iterator<fkyaml::node> rhs(mapping.get_value_ref<fkyaml::node::mapping_type&>().begin());
+        fkyaml::detail::iterator<fkyaml::node> lhs(mapping.begin());
+        fkyaml::detail::iterator<fkyaml::node> rhs(mapping.begin());
         REQUIRE_THROWS_AS(lhs > rhs, fkyaml::exception);
     }
 
     SECTION("greater-than check between different type iterators") {
         fkyaml::node sequence = {false, true};
-        fkyaml::detail::iterator<fkyaml::node> lhs(sequence.get_value_ref<fkyaml::node::sequence_type&>().begin());
+        fkyaml::detail::iterator<fkyaml::node> lhs(sequence.begin());
         fkyaml::node mapping = {{"test0", false}, {"test1", true}};
-        fkyaml::detail::iterator<fkyaml::node> rhs(mapping.get_value_ref<fkyaml::node::mapping_type&>().begin());
+        fkyaml::detail::iterator<fkyaml::node> rhs(mapping.begin());
         REQUIRE_THROWS_AS(lhs > rhs, fkyaml::exception);
     }
 }
@@ -436,28 +510,41 @@ TEST_CASE("Iterator_GreaterThanOperator") {
 TEST_CASE("Iterator_GreaterThanOrEqualToOperator") {
     SECTION("sequence iterator") {
         fkyaml::node sequence = {false, true};
-        fkyaml::detail::iterator<fkyaml::node> lhs(sequence.get_value_ref<fkyaml::node::sequence_type&>().begin());
-        fkyaml::detail::iterator<fkyaml::node> rhs(sequence.get_value_ref<fkyaml::node::sequence_type&>().begin());
-        ++rhs;
+        fkyaml::detail::iterator<fkyaml::node> lhs(sequence.begin());
+        fkyaml::detail::iterator<fkyaml::node> rhs(sequence.begin() + 1);
+        fkyaml::detail::iterator<const fkyaml::node> const_lhs(sequence.begin());
+        fkyaml::detail::iterator<const fkyaml::node> const_rhs(sequence.begin() + 1);
+
         REQUIRE_FALSE(lhs >= rhs);
+        REQUIRE_FALSE(const_lhs >= const_rhs);
+        REQUIRE_FALSE(lhs >= const_rhs);
+        REQUIRE_FALSE(const_lhs >= rhs);
         --rhs;
+        --const_rhs;
         REQUIRE(lhs >= rhs);
+        REQUIRE(const_lhs >= const_rhs);
+        REQUIRE(lhs >= const_rhs);
+        REQUIRE(const_lhs >= rhs);
         ++lhs;
+        ++const_lhs;
         REQUIRE(lhs >= rhs);
+        REQUIRE(const_lhs >= const_rhs);
+        REQUIRE(lhs >= const_rhs);
+        REQUIRE(const_lhs >= rhs);
     }
 
     SECTION("mapping iterator") {
         fkyaml::node mapping = {{"test0", false}, {"test1", true}};
-        fkyaml::detail::iterator<fkyaml::node> lhs(mapping.get_value_ref<fkyaml::node::mapping_type&>().begin());
-        fkyaml::detail::iterator<fkyaml::node> rhs(mapping.get_value_ref<fkyaml::node::mapping_type&>().begin());
+        fkyaml::detail::iterator<fkyaml::node> lhs(mapping.begin());
+        fkyaml::detail::iterator<fkyaml::node> rhs(mapping.begin());
         REQUIRE_THROWS_AS(lhs >= rhs, fkyaml::exception);
     }
 
     SECTION("greater-than-or-equal-to check between different type iterators") {
         fkyaml::node sequence = {false, true};
-        fkyaml::detail::iterator<fkyaml::node> lhs(sequence.get_value_ref<fkyaml::node::sequence_type&>().begin());
+        fkyaml::detail::iterator<fkyaml::node> lhs(sequence.begin());
         fkyaml::node mapping = {{"test0", false}, {"test1", true}};
-        fkyaml::detail::iterator<fkyaml::node> rhs(mapping.get_value_ref<fkyaml::node::mapping_type&>().begin());
+        fkyaml::detail::iterator<fkyaml::node> rhs(mapping.begin());
         REQUIRE_THROWS_AS(lhs >= rhs, fkyaml::exception);
     }
 }
@@ -465,13 +552,13 @@ TEST_CASE("Iterator_GreaterThanOrEqualToOperator") {
 TEST_CASE("Iterator_TypeGetter") {
     SECTION("sequence iterator") {
         fkyaml::node sequence = {false, true};
-        fkyaml::detail::iterator<fkyaml::node> iterator(sequence.get_value_ref<fkyaml::node::sequence_type&>().begin());
+        fkyaml::detail::iterator<fkyaml::node> iterator(sequence.begin());
         REQUIRE(iterator.type() == fkyaml::detail::iterator_t::SEQUENCE);
     }
 
     SECTION("mapping iterator") {
         fkyaml::node mapping = {{"test0", false}, {"test1", true}};
-        fkyaml::detail::iterator<fkyaml::node> iterator(mapping.get_value_ref<fkyaml::node::mapping_type&>().begin());
+        fkyaml::detail::iterator<fkyaml::node> iterator(mapping.begin());
         REQUIRE(iterator.type() == fkyaml::detail::iterator_t::MAPPING);
     }
 }
@@ -479,13 +566,13 @@ TEST_CASE("Iterator_TypeGetter") {
 TEST_CASE("Iterator_KeyGetter") {
     SECTION("sequence iterator") {
         fkyaml::node sequence = {false, true};
-        fkyaml::detail::iterator<fkyaml::node> iterator(sequence.get_value_ref<fkyaml::node::sequence_type&>().begin());
+        fkyaml::detail::iterator<fkyaml::node> iterator(sequence.begin());
         REQUIRE_THROWS_AS(iterator.key(), fkyaml::exception);
     }
 
     SECTION("mapping iterator") {
         fkyaml::node mapping = {{"test0", false}, {"test1", true}};
-        fkyaml::detail::iterator<fkyaml::node> iterator(mapping.get_value_ref<fkyaml::node::mapping_type&>().begin());
+        fkyaml::detail::iterator<fkyaml::node> iterator(mapping.begin());
         REQUIRE_NOTHROW(iterator.key());
         REQUIRE(iterator.key().get_value_ref<const std::string&>() == "test0");
     }
@@ -494,14 +581,14 @@ TEST_CASE("Iterator_KeyGetter") {
 TEST_CASE("Iterator_ValueGetter") {
     SECTION("sequence iterator") {
         fkyaml::node sequence = {false, true};
-        fkyaml::detail::iterator<fkyaml::node> iterator(sequence.get_value_ref<fkyaml::node::sequence_type&>().begin());
+        fkyaml::detail::iterator<fkyaml::node> iterator(sequence.begin());
         REQUIRE(iterator.value().is_boolean());
         REQUIRE(iterator.value().get_value<fkyaml::node::boolean_type>() == false);
     }
 
     SECTION("mapping iterator") {
         fkyaml::node mapping = {{"test0", false}, {"test1", true}};
-        fkyaml::detail::iterator<fkyaml::node> iterator(mapping.get_value_ref<fkyaml::node::mapping_type&>().begin());
+        fkyaml::detail::iterator<fkyaml::node> iterator(mapping.begin());
         REQUIRE(iterator.value().is_boolean());
         REQUIRE(iterator.value().get_value<fkyaml::node::boolean_type>() == false);
     }

--- a/test/unit_test/test_iterator_class.cpp
+++ b/test/unit_test/test_iterator_class.cpp
@@ -12,22 +12,19 @@
 
 TEST_CASE("Iterator_SequenceCtor") {
     fkyaml::node sequence = fkyaml::node::sequence();
-    fkyaml::detail::iterator<fkyaml::node> iterator(
-        fkyaml::detail::sequence_iterator_tag {}, sequence.get_value_ref<fkyaml::node::sequence_type&>().begin());
+    fkyaml::detail::iterator<fkyaml::node> iterator(sequence.get_value_ref<fkyaml::node::sequence_type&>().begin());
     REQUIRE(iterator.type() == fkyaml::detail::iterator_t::SEQUENCE);
 }
 
 TEST_CASE("Iterator_MappingCtor") {
     fkyaml::node mapping = fkyaml::node::mapping();
-    fkyaml::detail::iterator<fkyaml::node> iterator(
-        fkyaml::detail::mapping_iterator_tag {}, mapping.get_value_ref<fkyaml::node::mapping_type&>().begin());
+    fkyaml::detail::iterator<fkyaml::node> iterator(mapping.get_value_ref<fkyaml::node::mapping_type&>().begin());
     REQUIRE(iterator.type() == fkyaml::detail::iterator_t::MAPPING);
 }
 
 TEST_CASE("Iterator_SequenceCopyCtor") {
     fkyaml::node sequence = fkyaml::node::sequence({fkyaml::node()});
-    fkyaml::detail::iterator<fkyaml::node> copied(
-        fkyaml::detail::sequence_iterator_tag {}, sequence.get_value_ref<fkyaml::node::sequence_type&>().begin());
+    fkyaml::detail::iterator<fkyaml::node> copied(sequence.get_value_ref<fkyaml::node::sequence_type&>().begin());
     fkyaml::detail::iterator<fkyaml::node> iterator(copied);
     REQUIRE(iterator.type() == fkyaml::detail::iterator_t::SEQUENCE);
     REQUIRE(iterator->is_null());
@@ -35,8 +32,7 @@ TEST_CASE("Iterator_SequenceCopyCtor") {
 
 TEST_CASE("Iterator_MappingCopyCtor") {
     fkyaml::node mapping = fkyaml::node::mapping({{"test", fkyaml::node()}});
-    fkyaml::detail::iterator<fkyaml::node> copied(
-        fkyaml::detail::mapping_iterator_tag {}, mapping.get_value_ref<fkyaml::node::mapping_type&>().begin());
+    fkyaml::detail::iterator<fkyaml::node> copied(mapping.get_value_ref<fkyaml::node::mapping_type&>().begin());
     fkyaml::detail::iterator<fkyaml::node> iterator(copied);
     REQUIRE(iterator.type() == fkyaml::detail::iterator_t::MAPPING);
     REQUIRE(iterator.key().get_value_ref<const std::string&>() == "test");
@@ -45,8 +41,7 @@ TEST_CASE("Iterator_MappingCopyCtor") {
 
 TEST_CASE("Iterator_SequenceMoveCtor") {
     fkyaml::node sequence = {"test"};
-    fkyaml::detail::iterator<fkyaml::node> moved(
-        fkyaml::detail::sequence_iterator_tag {}, sequence.get_value_ref<fkyaml::node::sequence_type&>().begin());
+    fkyaml::detail::iterator<fkyaml::node> moved(sequence.get_value_ref<fkyaml::node::sequence_type&>().begin());
     fkyaml::detail::iterator<fkyaml::node> iterator(std::move(moved));
     REQUIRE(iterator.type() == fkyaml::detail::iterator_t::SEQUENCE);
     REQUIRE(iterator->is_string());
@@ -55,8 +50,7 @@ TEST_CASE("Iterator_SequenceMoveCtor") {
 
 TEST_CASE("Iterator_MappingMoveCtor") {
     fkyaml::node mapping = fkyaml::node::mapping({{"test", fkyaml::node()}});
-    fkyaml::detail::iterator<fkyaml::node> moved(
-        fkyaml::detail::mapping_iterator_tag {}, mapping.get_value_ref<fkyaml::node::mapping_type&>().begin());
+    fkyaml::detail::iterator<fkyaml::node> moved(mapping.get_value_ref<fkyaml::node::mapping_type&>().begin());
     fkyaml::detail::iterator<fkyaml::node> iterator(std::move(moved));
     REQUIRE(iterator.type() == fkyaml::detail::iterator_t::MAPPING);
     REQUIRE(iterator.key().get_value_ref<const std::string&>() == "test");
@@ -66,8 +60,7 @@ TEST_CASE("Iterator_MappingMoveCtor") {
 TEST_CASE("Iterator_AssignmentOperator") {
     SECTION("self assignment.") {
         fkyaml::node sequence = fkyaml::node::sequence({fkyaml::node()});
-        fkyaml::detail::iterator<fkyaml::node> iterator(
-            fkyaml::detail::sequence_iterator_tag {}, sequence.get_value_ref<fkyaml::node::sequence_type&>().begin());
+        fkyaml::detail::iterator<fkyaml::node> iterator(sequence.get_value_ref<fkyaml::node::sequence_type&>().begin());
 
         SECTION("lvalue iterator") {
             iterator = *&iterator;
@@ -85,10 +78,9 @@ TEST_CASE("Iterator_AssignmentOperator") {
     SECTION("sequence iterators") {
         fkyaml::node copied_seq = {"test"};
         fkyaml::detail::iterator<fkyaml::node> copied_itr(
-            fkyaml::detail::sequence_iterator_tag {}, copied_seq.get_value_ref<fkyaml::node::sequence_type&>().begin());
+            copied_seq.get_value_ref<fkyaml::node::sequence_type&>().begin());
         fkyaml::node sequence = {false};
-        fkyaml::detail::iterator<fkyaml::node> iterator(
-            fkyaml::detail::sequence_iterator_tag {}, sequence.get_value_ref<fkyaml::node::sequence_type&>().begin());
+        fkyaml::detail::iterator<fkyaml::node> iterator(sequence.get_value_ref<fkyaml::node::sequence_type&>().begin());
 
         SECTION("lvalue iterator") {
             iterator = copied_itr;
@@ -108,10 +100,9 @@ TEST_CASE("Iterator_AssignmentOperator") {
     SECTION("mapping iterators") {
         fkyaml::node copied_map = {{"key", "test"}};
         fkyaml::detail::iterator<fkyaml::node> copied_itr(
-            fkyaml::detail::mapping_iterator_tag {}, copied_map.get_value_ref<fkyaml::node::mapping_type&>().begin());
+            copied_map.get_value_ref<fkyaml::node::mapping_type&>().begin());
         fkyaml::node map = {{"foo", false}};
-        fkyaml::detail::iterator<fkyaml::node> iterator(
-            fkyaml::detail::mapping_iterator_tag {}, map.get_value_ref<fkyaml::node::mapping_type&>().begin());
+        fkyaml::detail::iterator<fkyaml::node> iterator(map.get_value_ref<fkyaml::node::mapping_type&>().begin());
 
         SECTION("lvalue iterator") {
             iterator = copied_itr;
@@ -134,15 +125,13 @@ TEST_CASE("Iterator_AssignmentOperator") {
 TEST_CASE("Iterator_ArrowOperator") {
     SECTION("sequence iterator") {
         fkyaml::node seq = {"test"};
-        fkyaml::detail::iterator<fkyaml::node> iterator(
-            fkyaml::detail::sequence_iterator_tag {}, seq.get_value_ref<fkyaml::node::sequence_type&>().begin());
+        fkyaml::detail::iterator<fkyaml::node> iterator(seq.get_value_ref<fkyaml::node::sequence_type&>().begin());
         REQUIRE(iterator.operator->() == &(seq.get_value_ref<fkyaml::node::sequence_type&>().operator[](0)));
     }
 
     SECTION("mapping iterator") {
         fkyaml::node map = {{"key", "test"}};
-        fkyaml::detail::iterator<fkyaml::node> iterator(
-            fkyaml::detail::mapping_iterator_tag {}, map.get_value_ref<fkyaml::node::mapping_type&>().begin());
+        fkyaml::detail::iterator<fkyaml::node> iterator(map.get_value_ref<fkyaml::node::mapping_type&>().begin());
         REQUIRE(iterator.operator->() == &(map.get_value_ref<fkyaml::node::mapping_type&>().operator[]("key")));
     }
 }
@@ -150,15 +139,13 @@ TEST_CASE("Iterator_ArrowOperator") {
 TEST_CASE("Iterator_DereferenceOperator") {
     SECTION("sequence iterator") {
         fkyaml::node seq = {"test"};
-        fkyaml::detail::iterator<fkyaml::node> iterator(
-            fkyaml::detail::sequence_iterator_tag {}, seq.get_value_ref<fkyaml::node::sequence_type&>().begin());
+        fkyaml::detail::iterator<fkyaml::node> iterator(seq.get_value_ref<fkyaml::node::sequence_type&>().begin());
         REQUIRE(&(iterator.operator*()) == &(seq.get_value_ref<fkyaml::node::sequence_type&>().operator[](0)));
     }
 
     SECTION("mapping iterator") {
         fkyaml::node map = fkyaml::node::mapping({{"key", "test"}});
-        fkyaml::detail::iterator<fkyaml::node> iterator(
-            fkyaml::detail::mapping_iterator_tag {}, map.get_value_ref<fkyaml::node::mapping_type&>().begin());
+        fkyaml::detail::iterator<fkyaml::node> iterator(map.get_value_ref<fkyaml::node::mapping_type&>().begin());
         REQUIRE(&(iterator.operator*()) == &(map.get_value_ref<fkyaml::node::mapping_type&>().operator[]("key")));
     }
 }
@@ -166,8 +153,7 @@ TEST_CASE("Iterator_DereferenceOperator") {
 TEST_CASE("Iterator_CompoundAssignmentOperatorBySum") {
     SECTION("sequence iterator") {
         fkyaml::node sequence = {false, true};
-        fkyaml::detail::iterator<fkyaml::node> iterator(
-            fkyaml::detail::sequence_iterator_tag {}, sequence.get_value_ref<fkyaml::node::sequence_type&>().begin());
+        fkyaml::detail::iterator<fkyaml::node> iterator(sequence.get_value_ref<fkyaml::node::sequence_type&>().begin());
         iterator += 1;
         REQUIRE(iterator->is_boolean());
         REQUIRE(iterator->get_value<fkyaml::node::boolean_type>() == true);
@@ -175,8 +161,7 @@ TEST_CASE("Iterator_CompoundAssignmentOperatorBySum") {
 
     SECTION("mapping iterator") {
         fkyaml::node mapping = {{"test0", false}, {"test1", true}};
-        fkyaml::detail::iterator<fkyaml::node> iterator(
-            fkyaml::detail::mapping_iterator_tag {}, mapping.get_value_ref<fkyaml::node::mapping_type&>().begin());
+        fkyaml::detail::iterator<fkyaml::node> iterator(mapping.get_value_ref<fkyaml::node::mapping_type&>().begin());
         iterator += 1;
         REQUIRE(iterator.key().get_value_ref<const std::string&>() == "test1");
         REQUIRE(iterator.value().is_boolean());
@@ -187,8 +172,7 @@ TEST_CASE("Iterator_CompoundAssignmentOperatorBySum") {
 TEST_CASE("Iterator_PlusOperator") {
     SECTION("sequence iterator") {
         fkyaml::node sequence = {false, true};
-        fkyaml::detail::iterator<fkyaml::node> iterator(
-            fkyaml::detail::sequence_iterator_tag {}, sequence.get_value_ref<fkyaml::node::sequence_type&>().begin());
+        fkyaml::detail::iterator<fkyaml::node> iterator(sequence.get_value_ref<fkyaml::node::sequence_type&>().begin());
         fkyaml::detail::iterator<fkyaml::node> after_plus_itr = iterator + 1;
         REQUIRE(after_plus_itr->is_boolean());
         REQUIRE(after_plus_itr->get_value<fkyaml::node::boolean_type>() == true);
@@ -196,8 +180,7 @@ TEST_CASE("Iterator_PlusOperator") {
 
     SECTION("mapping iterator") {
         fkyaml::node mapping = {{"test0", false}, {"test1", true}};
-        fkyaml::detail::iterator<fkyaml::node> iterator(
-            fkyaml::detail::mapping_iterator_tag {}, mapping.get_value_ref<fkyaml::node::mapping_type&>().begin());
+        fkyaml::detail::iterator<fkyaml::node> iterator(mapping.get_value_ref<fkyaml::node::mapping_type&>().begin());
         fkyaml::detail::iterator<fkyaml::node> after_plus_itr = iterator + 1;
         REQUIRE(after_plus_itr.key().get_value_ref<const std::string&>() == "test1");
         REQUIRE(after_plus_itr.value().is_boolean());
@@ -208,8 +191,7 @@ TEST_CASE("Iterator_PlusOperator") {
 TEST_CASE("Iterator_PreIncrementOperator") {
     SECTION("sequence iterator") {
         fkyaml::node sequence = {false, true};
-        fkyaml::detail::iterator<fkyaml::node> iterator(
-            fkyaml::detail::sequence_iterator_tag {}, sequence.get_value_ref<fkyaml::node::sequence_type&>().begin());
+        fkyaml::detail::iterator<fkyaml::node> iterator(sequence.get_value_ref<fkyaml::node::sequence_type&>().begin());
         ++iterator;
         REQUIRE(iterator->is_boolean());
         REQUIRE(iterator->get_value<fkyaml::node::boolean_type>() == true);
@@ -217,8 +199,7 @@ TEST_CASE("Iterator_PreIncrementOperator") {
 
     SECTION("mapping iterator") {
         fkyaml::node mapping = {{"test0", false}, {"test1", true}};
-        fkyaml::detail::iterator<fkyaml::node> iterator(
-            fkyaml::detail::mapping_iterator_tag {}, mapping.get_value_ref<fkyaml::node::mapping_type&>().begin());
+        fkyaml::detail::iterator<fkyaml::node> iterator(mapping.get_value_ref<fkyaml::node::mapping_type&>().begin());
         ++iterator;
         REQUIRE(iterator.key().get_value_ref<const std::string&>() == "test1");
         REQUIRE(iterator.value().is_boolean());
@@ -229,8 +210,7 @@ TEST_CASE("Iterator_PreIncrementOperator") {
 TEST_CASE("Iterator_PostIncrementOperator") {
     SECTION("sequence iterator") {
         fkyaml::node sequence = {false, true};
-        fkyaml::detail::iterator<fkyaml::node> iterator(
-            fkyaml::detail::sequence_iterator_tag {}, sequence.get_value_ref<fkyaml::node::sequence_type&>().begin());
+        fkyaml::detail::iterator<fkyaml::node> iterator(sequence.get_value_ref<fkyaml::node::sequence_type&>().begin());
         iterator++;
         REQUIRE(iterator->is_boolean());
         REQUIRE(iterator->get_value<fkyaml::node::boolean_type>() == true);
@@ -238,8 +218,7 @@ TEST_CASE("Iterator_PostIncrementOperator") {
 
     SECTION("mapping iterator") {
         fkyaml::node mapping = {{"test0", false}, {"test1", true}};
-        fkyaml::detail::iterator<fkyaml::node> iterator(
-            fkyaml::detail::mapping_iterator_tag {}, mapping.get_value_ref<fkyaml::node::mapping_type&>().begin());
+        fkyaml::detail::iterator<fkyaml::node> iterator(mapping.get_value_ref<fkyaml::node::mapping_type&>().begin());
         iterator++;
         REQUIRE(iterator.key().get_value_ref<const std::string&>() == "test1");
         REQUIRE(iterator.value().is_boolean());
@@ -250,8 +229,7 @@ TEST_CASE("Iterator_PostIncrementOperator") {
 TEST_CASE("Iterator_CompoundAssignmentOperatorByDifference") {
     SECTION("sequence iterator") {
         fkyaml::node sequence = {false, true};
-        fkyaml::detail::iterator<fkyaml::node> iterator(
-            fkyaml::detail::sequence_iterator_tag {}, sequence.get_value_ref<fkyaml::node::sequence_type&>().end());
+        fkyaml::detail::iterator<fkyaml::node> iterator(sequence.get_value_ref<fkyaml::node::sequence_type&>().end());
         iterator -= 1;
         REQUIRE(iterator->is_boolean());
         REQUIRE(iterator->get_value<fkyaml::node::boolean_type>() == true);
@@ -259,8 +237,7 @@ TEST_CASE("Iterator_CompoundAssignmentOperatorByDifference") {
 
     SECTION("mapping iterator") {
         fkyaml::node mapping = {{"test0", false}, {"test1", true}};
-        fkyaml::detail::iterator<fkyaml::node> iterator(
-            fkyaml::detail::mapping_iterator_tag {}, mapping.get_value_ref<fkyaml::node::mapping_type&>().end());
+        fkyaml::detail::iterator<fkyaml::node> iterator(mapping.get_value_ref<fkyaml::node::mapping_type&>().end());
         iterator -= 1;
         REQUIRE(iterator.key().get_value_ref<const std::string&>() == "test1");
         REQUIRE(iterator.value().is_boolean());
@@ -271,8 +248,7 @@ TEST_CASE("Iterator_CompoundAssignmentOperatorByDifference") {
 TEST_CASE("Iterator_MinusOperator") {
     SECTION("sequence iterator") {
         fkyaml::node sequence = {false, true};
-        fkyaml::detail::iterator<fkyaml::node> iterator(
-            fkyaml::detail::sequence_iterator_tag {}, sequence.get_value_ref<fkyaml::node::sequence_type&>().end());
+        fkyaml::detail::iterator<fkyaml::node> iterator(sequence.get_value_ref<fkyaml::node::sequence_type&>().end());
         fkyaml::detail::iterator<fkyaml::node> after_minus_itr = iterator - 1;
         REQUIRE(after_minus_itr->is_boolean());
         REQUIRE(after_minus_itr->get_value<fkyaml::node::boolean_type>() == true);
@@ -280,8 +256,7 @@ TEST_CASE("Iterator_MinusOperator") {
 
     SECTION("mapping iterator.") {
         fkyaml::node mapping = {{"test0", false}, {"test1", true}};
-        fkyaml::detail::iterator<fkyaml::node> iterator(
-            fkyaml::detail::mapping_iterator_tag {}, mapping.get_value_ref<fkyaml::node::mapping_type&>().end());
+        fkyaml::detail::iterator<fkyaml::node> iterator(mapping.get_value_ref<fkyaml::node::mapping_type&>().end());
         fkyaml::detail::iterator<fkyaml::node> after_minus_itr = iterator - 1;
         REQUIRE(after_minus_itr.key().get_value_ref<const std::string&>() == "test1");
         REQUIRE(after_minus_itr.value().is_boolean());
@@ -292,8 +267,7 @@ TEST_CASE("Iterator_MinusOperator") {
 TEST_CASE("Iterator_PreDecrementOperator") {
     SECTION("sequence iterator") {
         fkyaml::node sequence = {false, true};
-        fkyaml::detail::iterator<fkyaml::node> iterator(
-            fkyaml::detail::sequence_iterator_tag {}, sequence.get_value_ref<fkyaml::node::sequence_type&>().end());
+        fkyaml::detail::iterator<fkyaml::node> iterator(sequence.get_value_ref<fkyaml::node::sequence_type&>().end());
         --iterator;
         REQUIRE(iterator->is_boolean());
         REQUIRE(iterator->get_value<fkyaml::node::boolean_type>() == true);
@@ -301,8 +275,7 @@ TEST_CASE("Iterator_PreDecrementOperator") {
 
     SECTION("mapping iterator") {
         fkyaml::node mapping = {{"test0", false}, {"test1", true}};
-        fkyaml::detail::iterator<fkyaml::node> iterator(
-            fkyaml::detail::mapping_iterator_tag {}, mapping.get_value_ref<fkyaml::node::mapping_type&>().end());
+        fkyaml::detail::iterator<fkyaml::node> iterator(mapping.get_value_ref<fkyaml::node::mapping_type&>().end());
         --iterator;
         REQUIRE(iterator.key().get_value_ref<const std::string&>() == "test1");
         REQUIRE(iterator.value().is_boolean());
@@ -313,8 +286,7 @@ TEST_CASE("Iterator_PreDecrementOperator") {
 TEST_CASE("Iterator_PostDecrementOperator") {
     SECTION("sequence iterator") {
         fkyaml::node sequence = {false, true};
-        fkyaml::detail::iterator<fkyaml::node> iterator(
-            fkyaml::detail::sequence_iterator_tag {}, sequence.get_value_ref<fkyaml::node::sequence_type&>().end());
+        fkyaml::detail::iterator<fkyaml::node> iterator(sequence.get_value_ref<fkyaml::node::sequence_type&>().end());
         iterator--;
         REQUIRE(iterator->is_boolean());
         REQUIRE(iterator->get_value<fkyaml::node::boolean_type>() == true);
@@ -322,8 +294,7 @@ TEST_CASE("Iterator_PostDecrementOperator") {
 
     SECTION("mapping iterator") {
         fkyaml::node mapping = {{"test0", false}, {"test1", true}};
-        fkyaml::detail::iterator<fkyaml::node> iterator(
-            fkyaml::detail::mapping_iterator_tag {}, mapping.get_value_ref<fkyaml::node::mapping_type&>().end());
+        fkyaml::detail::iterator<fkyaml::node> iterator(mapping.get_value_ref<fkyaml::node::mapping_type&>().end());
         iterator--;
         REQUIRE(iterator.key().get_value_ref<const std::string&>() == "test1");
         REQUIRE(iterator.value().is_boolean());
@@ -334,29 +305,23 @@ TEST_CASE("Iterator_PostDecrementOperator") {
 TEST_CASE("Iterator_EqualToOperator") {
     SECTION("sequence iterator") {
         fkyaml::node sequence = {false, true};
-        fkyaml::detail::iterator<fkyaml::node> lhs(
-            fkyaml::detail::sequence_iterator_tag {}, sequence.get_value_ref<fkyaml::node::sequence_type&>().begin());
-        fkyaml::detail::iterator<fkyaml::node> rhs(
-            fkyaml::detail::sequence_iterator_tag {}, sequence.get_value_ref<fkyaml::node::sequence_type&>().begin());
+        fkyaml::detail::iterator<fkyaml::node> lhs(sequence.get_value_ref<fkyaml::node::sequence_type&>().begin());
+        fkyaml::detail::iterator<fkyaml::node> rhs(sequence.get_value_ref<fkyaml::node::sequence_type&>().begin());
         REQUIRE(lhs == rhs);
     }
 
     SECTION("mapping iterator") {
         fkyaml::node mapping = {{"test0", false}, {"test1", true}};
-        fkyaml::detail::iterator<fkyaml::node> lhs(
-            fkyaml::detail::mapping_iterator_tag {}, mapping.get_value_ref<fkyaml::node::mapping_type&>().begin());
-        fkyaml::detail::iterator<fkyaml::node> rhs(
-            fkyaml::detail::mapping_iterator_tag {}, mapping.get_value_ref<fkyaml::node::mapping_type&>().begin());
+        fkyaml::detail::iterator<fkyaml::node> lhs(mapping.get_value_ref<fkyaml::node::mapping_type&>().begin());
+        fkyaml::detail::iterator<fkyaml::node> rhs(mapping.get_value_ref<fkyaml::node::mapping_type&>().begin());
         REQUIRE(lhs == rhs);
     }
 
     SECTION("equality check between different type iterators") {
         fkyaml::node sequence = {false, true};
-        fkyaml::detail::iterator<fkyaml::node> lhs(
-            fkyaml::detail::sequence_iterator_tag {}, sequence.get_value_ref<fkyaml::node::sequence_type&>().begin());
+        fkyaml::detail::iterator<fkyaml::node> lhs(sequence.get_value_ref<fkyaml::node::sequence_type&>().begin());
         fkyaml::node mapping = {{"test0", false}, {"test1", true}};
-        fkyaml::detail::iterator<fkyaml::node> rhs(
-            fkyaml::detail::mapping_iterator_tag {}, mapping.get_value_ref<fkyaml::node::mapping_type&>().begin());
+        fkyaml::detail::iterator<fkyaml::node> rhs(mapping.get_value_ref<fkyaml::node::mapping_type&>().begin());
         REQUIRE_THROWS_AS(lhs == rhs, fkyaml::exception);
     }
 }
@@ -364,31 +329,25 @@ TEST_CASE("Iterator_EqualToOperator") {
 TEST_CASE("Iterator_NotEqualToOperator") {
     SECTION("sequence iterator.") {
         fkyaml::node sequence = {false, true};
-        fkyaml::detail::iterator<fkyaml::node> lhs(
-            fkyaml::detail::sequence_iterator_tag {}, sequence.get_value_ref<fkyaml::node::sequence_type&>().begin());
-        fkyaml::detail::iterator<fkyaml::node> rhs(
-            fkyaml::detail::sequence_iterator_tag {}, sequence.get_value_ref<fkyaml::node::sequence_type&>().begin());
+        fkyaml::detail::iterator<fkyaml::node> lhs(sequence.get_value_ref<fkyaml::node::sequence_type&>().begin());
+        fkyaml::detail::iterator<fkyaml::node> rhs(sequence.get_value_ref<fkyaml::node::sequence_type&>().begin());
         ++rhs;
         REQUIRE(lhs != rhs);
     }
 
     SECTION("mapping iterator") {
         fkyaml::node mapping = {{"test0", false}, {"test1", true}};
-        fkyaml::detail::iterator<fkyaml::node> lhs(
-            fkyaml::detail::mapping_iterator_tag {}, mapping.get_value_ref<fkyaml::node::mapping_type&>().begin());
-        fkyaml::detail::iterator<fkyaml::node> rhs(
-            fkyaml::detail::mapping_iterator_tag {}, mapping.get_value_ref<fkyaml::node::mapping_type&>().begin());
+        fkyaml::detail::iterator<fkyaml::node> lhs(mapping.get_value_ref<fkyaml::node::mapping_type&>().begin());
+        fkyaml::detail::iterator<fkyaml::node> rhs(mapping.get_value_ref<fkyaml::node::mapping_type&>().begin());
         ++rhs;
         REQUIRE(lhs != rhs);
     }
 
     SECTION("equality check between different type iterators") {
         fkyaml::node sequence = {false, true};
-        fkyaml::detail::iterator<fkyaml::node> lhs(
-            fkyaml::detail::sequence_iterator_tag {}, sequence.get_value_ref<fkyaml::node::sequence_type&>().begin());
+        fkyaml::detail::iterator<fkyaml::node> lhs(sequence.get_value_ref<fkyaml::node::sequence_type&>().begin());
         fkyaml::node mapping = {{"test0", false}, {"test1", true}};
-        fkyaml::detail::iterator<fkyaml::node> rhs(
-            fkyaml::detail::mapping_iterator_tag {}, mapping.get_value_ref<fkyaml::node::mapping_type&>().begin());
+        fkyaml::detail::iterator<fkyaml::node> rhs(mapping.get_value_ref<fkyaml::node::mapping_type&>().begin());
         REQUIRE_THROWS_AS(lhs == rhs, fkyaml::exception);
     }
 }
@@ -396,10 +355,8 @@ TEST_CASE("Iterator_NotEqualToOperator") {
 TEST_CASE("Iterator_LessThanOperator") {
     SECTION("sequence iterator") {
         fkyaml::node sequence = {false, true};
-        fkyaml::detail::iterator<fkyaml::node> lhs(
-            fkyaml::detail::sequence_iterator_tag {}, sequence.get_value_ref<fkyaml::node::sequence_type&>().begin());
-        fkyaml::detail::iterator<fkyaml::node> rhs(
-            fkyaml::detail::sequence_iterator_tag {}, sequence.get_value_ref<fkyaml::node::sequence_type&>().begin());
+        fkyaml::detail::iterator<fkyaml::node> lhs(sequence.get_value_ref<fkyaml::node::sequence_type&>().begin());
+        fkyaml::detail::iterator<fkyaml::node> rhs(sequence.get_value_ref<fkyaml::node::sequence_type&>().begin());
         REQUIRE_FALSE(lhs < rhs);
         ++rhs;
         REQUIRE(lhs < rhs);
@@ -407,20 +364,16 @@ TEST_CASE("Iterator_LessThanOperator") {
 
     SECTION("mapping iterator") {
         fkyaml::node mapping = {{"test0", false}, {"test1", true}};
-        fkyaml::detail::iterator<fkyaml::node> lhs(
-            fkyaml::detail::mapping_iterator_tag {}, mapping.get_value_ref<fkyaml::node::mapping_type&>().begin());
-        fkyaml::detail::iterator<fkyaml::node> rhs(
-            fkyaml::detail::mapping_iterator_tag {}, mapping.get_value_ref<fkyaml::node::mapping_type&>().begin());
+        fkyaml::detail::iterator<fkyaml::node> lhs(mapping.get_value_ref<fkyaml::node::mapping_type&>().begin());
+        fkyaml::detail::iterator<fkyaml::node> rhs(mapping.get_value_ref<fkyaml::node::mapping_type&>().begin());
         REQUIRE_THROWS_AS(lhs < rhs, fkyaml::exception);
     }
 
     SECTION("less-than check between different type iterators") {
         fkyaml::node sequence = {false, true};
-        fkyaml::detail::iterator<fkyaml::node> lhs(
-            fkyaml::detail::sequence_iterator_tag {}, sequence.get_value_ref<fkyaml::node::sequence_type&>().begin());
+        fkyaml::detail::iterator<fkyaml::node> lhs(sequence.get_value_ref<fkyaml::node::sequence_type&>().begin());
         fkyaml::node mapping = {{"test0", false}, {"test1", true}};
-        fkyaml::detail::iterator<fkyaml::node> rhs(
-            fkyaml::detail::mapping_iterator_tag {}, mapping.get_value_ref<fkyaml::node::mapping_type&>().begin());
+        fkyaml::detail::iterator<fkyaml::node> rhs(mapping.get_value_ref<fkyaml::node::mapping_type&>().begin());
         REQUIRE_THROWS_AS(lhs < rhs, fkyaml::exception);
     }
 }
@@ -428,10 +381,8 @@ TEST_CASE("Iterator_LessThanOperator") {
 TEST_CASE("Iterator_LessThanOrEqualToOperator") {
     SECTION("sequence iterator") {
         fkyaml::node sequence = {false, true};
-        fkyaml::detail::iterator<fkyaml::node> lhs(
-            fkyaml::detail::sequence_iterator_tag {}, sequence.get_value_ref<fkyaml::node::sequence_type&>().begin());
-        fkyaml::detail::iterator<fkyaml::node> rhs(
-            fkyaml::detail::sequence_iterator_tag {}, sequence.get_value_ref<fkyaml::node::sequence_type&>().begin());
+        fkyaml::detail::iterator<fkyaml::node> lhs(sequence.get_value_ref<fkyaml::node::sequence_type&>().begin());
+        fkyaml::detail::iterator<fkyaml::node> rhs(sequence.get_value_ref<fkyaml::node::sequence_type&>().begin());
         ++lhs;
         REQUIRE_FALSE(lhs <= rhs);
         --lhs;
@@ -442,20 +393,16 @@ TEST_CASE("Iterator_LessThanOrEqualToOperator") {
 
     SECTION("mapping iterator") {
         fkyaml::node mapping = {{"test0", false}, {"test1", true}};
-        fkyaml::detail::iterator<fkyaml::node> lhs(
-            fkyaml::detail::mapping_iterator_tag {}, mapping.get_value_ref<fkyaml::node::mapping_type&>().begin());
-        fkyaml::detail::iterator<fkyaml::node> rhs(
-            fkyaml::detail::mapping_iterator_tag {}, mapping.get_value_ref<fkyaml::node::mapping_type&>().begin());
+        fkyaml::detail::iterator<fkyaml::node> lhs(mapping.get_value_ref<fkyaml::node::mapping_type&>().begin());
+        fkyaml::detail::iterator<fkyaml::node> rhs(mapping.get_value_ref<fkyaml::node::mapping_type&>().begin());
         REQUIRE_THROWS_AS(lhs <= rhs, fkyaml::exception);
     }
 
     SECTION("less-than-or-equal-to check between different type iterators") {
         fkyaml::node sequence = {false, true};
-        fkyaml::detail::iterator<fkyaml::node> lhs(
-            fkyaml::detail::sequence_iterator_tag {}, sequence.get_value_ref<fkyaml::node::sequence_type&>().begin());
+        fkyaml::detail::iterator<fkyaml::node> lhs(sequence.get_value_ref<fkyaml::node::sequence_type&>().begin());
         fkyaml::node mapping = {{"test0", false}, {"test1", true}};
-        fkyaml::detail::iterator<fkyaml::node> rhs(
-            fkyaml::detail::mapping_iterator_tag {}, mapping.get_value_ref<fkyaml::node::mapping_type&>().begin());
+        fkyaml::detail::iterator<fkyaml::node> rhs(mapping.get_value_ref<fkyaml::node::mapping_type&>().begin());
         REQUIRE_THROWS_AS(lhs <= rhs, fkyaml::exception);
     }
 }
@@ -463,10 +410,8 @@ TEST_CASE("Iterator_LessThanOrEqualToOperator") {
 TEST_CASE("Iterator_GreaterThanOperator") {
     SECTION("sequence iterator") {
         fkyaml::node sequence = {false, true};
-        fkyaml::detail::iterator<fkyaml::node> lhs(
-            fkyaml::detail::sequence_iterator_tag {}, sequence.get_value_ref<fkyaml::node::sequence_type&>().begin());
-        fkyaml::detail::iterator<fkyaml::node> rhs(
-            fkyaml::detail::sequence_iterator_tag {}, sequence.get_value_ref<fkyaml::node::sequence_type&>().begin());
+        fkyaml::detail::iterator<fkyaml::node> lhs(sequence.get_value_ref<fkyaml::node::sequence_type&>().begin());
+        fkyaml::detail::iterator<fkyaml::node> rhs(sequence.get_value_ref<fkyaml::node::sequence_type&>().begin());
         REQUIRE_FALSE(lhs > rhs);
         ++lhs;
         REQUIRE(lhs > rhs);
@@ -474,20 +419,16 @@ TEST_CASE("Iterator_GreaterThanOperator") {
 
     SECTION("mapping iterator") {
         fkyaml::node mapping = {{"test0", false}, {"test1", true}};
-        fkyaml::detail::iterator<fkyaml::node> lhs(
-            fkyaml::detail::mapping_iterator_tag {}, mapping.get_value_ref<fkyaml::node::mapping_type&>().begin());
-        fkyaml::detail::iterator<fkyaml::node> rhs(
-            fkyaml::detail::mapping_iterator_tag {}, mapping.get_value_ref<fkyaml::node::mapping_type&>().begin());
+        fkyaml::detail::iterator<fkyaml::node> lhs(mapping.get_value_ref<fkyaml::node::mapping_type&>().begin());
+        fkyaml::detail::iterator<fkyaml::node> rhs(mapping.get_value_ref<fkyaml::node::mapping_type&>().begin());
         REQUIRE_THROWS_AS(lhs > rhs, fkyaml::exception);
     }
 
     SECTION("greater-than check between different type iterators") {
         fkyaml::node sequence = {false, true};
-        fkyaml::detail::iterator<fkyaml::node> lhs(
-            fkyaml::detail::sequence_iterator_tag {}, sequence.get_value_ref<fkyaml::node::sequence_type&>().begin());
+        fkyaml::detail::iterator<fkyaml::node> lhs(sequence.get_value_ref<fkyaml::node::sequence_type&>().begin());
         fkyaml::node mapping = {{"test0", false}, {"test1", true}};
-        fkyaml::detail::iterator<fkyaml::node> rhs(
-            fkyaml::detail::mapping_iterator_tag {}, mapping.get_value_ref<fkyaml::node::mapping_type&>().begin());
+        fkyaml::detail::iterator<fkyaml::node> rhs(mapping.get_value_ref<fkyaml::node::mapping_type&>().begin());
         REQUIRE_THROWS_AS(lhs > rhs, fkyaml::exception);
     }
 }
@@ -495,10 +436,8 @@ TEST_CASE("Iterator_GreaterThanOperator") {
 TEST_CASE("Iterator_GreaterThanOrEqualToOperator") {
     SECTION("sequence iterator") {
         fkyaml::node sequence = {false, true};
-        fkyaml::detail::iterator<fkyaml::node> lhs(
-            fkyaml::detail::sequence_iterator_tag {}, sequence.get_value_ref<fkyaml::node::sequence_type&>().begin());
-        fkyaml::detail::iterator<fkyaml::node> rhs(
-            fkyaml::detail::sequence_iterator_tag {}, sequence.get_value_ref<fkyaml::node::sequence_type&>().begin());
+        fkyaml::detail::iterator<fkyaml::node> lhs(sequence.get_value_ref<fkyaml::node::sequence_type&>().begin());
+        fkyaml::detail::iterator<fkyaml::node> rhs(sequence.get_value_ref<fkyaml::node::sequence_type&>().begin());
         ++rhs;
         REQUIRE_FALSE(lhs >= rhs);
         --rhs;
@@ -509,20 +448,16 @@ TEST_CASE("Iterator_GreaterThanOrEqualToOperator") {
 
     SECTION("mapping iterator") {
         fkyaml::node mapping = {{"test0", false}, {"test1", true}};
-        fkyaml::detail::iterator<fkyaml::node> lhs(
-            fkyaml::detail::mapping_iterator_tag {}, mapping.get_value_ref<fkyaml::node::mapping_type&>().begin());
-        fkyaml::detail::iterator<fkyaml::node> rhs(
-            fkyaml::detail::mapping_iterator_tag {}, mapping.get_value_ref<fkyaml::node::mapping_type&>().begin());
+        fkyaml::detail::iterator<fkyaml::node> lhs(mapping.get_value_ref<fkyaml::node::mapping_type&>().begin());
+        fkyaml::detail::iterator<fkyaml::node> rhs(mapping.get_value_ref<fkyaml::node::mapping_type&>().begin());
         REQUIRE_THROWS_AS(lhs >= rhs, fkyaml::exception);
     }
 
     SECTION("greater-than-or-equal-to check between different type iterators") {
         fkyaml::node sequence = {false, true};
-        fkyaml::detail::iterator<fkyaml::node> lhs(
-            fkyaml::detail::sequence_iterator_tag {}, sequence.get_value_ref<fkyaml::node::sequence_type&>().begin());
+        fkyaml::detail::iterator<fkyaml::node> lhs(sequence.get_value_ref<fkyaml::node::sequence_type&>().begin());
         fkyaml::node mapping = {{"test0", false}, {"test1", true}};
-        fkyaml::detail::iterator<fkyaml::node> rhs(
-            fkyaml::detail::mapping_iterator_tag {}, mapping.get_value_ref<fkyaml::node::mapping_type&>().begin());
+        fkyaml::detail::iterator<fkyaml::node> rhs(mapping.get_value_ref<fkyaml::node::mapping_type&>().begin());
         REQUIRE_THROWS_AS(lhs >= rhs, fkyaml::exception);
     }
 }
@@ -530,15 +465,13 @@ TEST_CASE("Iterator_GreaterThanOrEqualToOperator") {
 TEST_CASE("Iterator_TypeGetter") {
     SECTION("sequence iterator") {
         fkyaml::node sequence = {false, true};
-        fkyaml::detail::iterator<fkyaml::node> iterator(
-            fkyaml::detail::sequence_iterator_tag {}, sequence.get_value_ref<fkyaml::node::sequence_type&>().begin());
+        fkyaml::detail::iterator<fkyaml::node> iterator(sequence.get_value_ref<fkyaml::node::sequence_type&>().begin());
         REQUIRE(iterator.type() == fkyaml::detail::iterator_t::SEQUENCE);
     }
 
     SECTION("mapping iterator") {
         fkyaml::node mapping = {{"test0", false}, {"test1", true}};
-        fkyaml::detail::iterator<fkyaml::node> iterator(
-            fkyaml::detail::mapping_iterator_tag {}, mapping.get_value_ref<fkyaml::node::mapping_type&>().begin());
+        fkyaml::detail::iterator<fkyaml::node> iterator(mapping.get_value_ref<fkyaml::node::mapping_type&>().begin());
         REQUIRE(iterator.type() == fkyaml::detail::iterator_t::MAPPING);
     }
 }
@@ -546,15 +479,13 @@ TEST_CASE("Iterator_TypeGetter") {
 TEST_CASE("Iterator_KeyGetter") {
     SECTION("sequence iterator") {
         fkyaml::node sequence = {false, true};
-        fkyaml::detail::iterator<fkyaml::node> iterator(
-            fkyaml::detail::sequence_iterator_tag {}, sequence.get_value_ref<fkyaml::node::sequence_type&>().begin());
+        fkyaml::detail::iterator<fkyaml::node> iterator(sequence.get_value_ref<fkyaml::node::sequence_type&>().begin());
         REQUIRE_THROWS_AS(iterator.key(), fkyaml::exception);
     }
 
     SECTION("mapping iterator") {
         fkyaml::node mapping = {{"test0", false}, {"test1", true}};
-        fkyaml::detail::iterator<fkyaml::node> iterator(
-            fkyaml::detail::mapping_iterator_tag {}, mapping.get_value_ref<fkyaml::node::mapping_type&>().begin());
+        fkyaml::detail::iterator<fkyaml::node> iterator(mapping.get_value_ref<fkyaml::node::mapping_type&>().begin());
         REQUIRE_NOTHROW(iterator.key());
         REQUIRE(iterator.key().get_value_ref<const std::string&>() == "test0");
     }
@@ -563,16 +494,14 @@ TEST_CASE("Iterator_KeyGetter") {
 TEST_CASE("Iterator_ValueGetter") {
     SECTION("sequence iterator") {
         fkyaml::node sequence = {false, true};
-        fkyaml::detail::iterator<fkyaml::node> iterator(
-            fkyaml::detail::sequence_iterator_tag {}, sequence.get_value_ref<fkyaml::node::sequence_type&>().begin());
+        fkyaml::detail::iterator<fkyaml::node> iterator(sequence.get_value_ref<fkyaml::node::sequence_type&>().begin());
         REQUIRE(iterator.value().is_boolean());
         REQUIRE(iterator.value().get_value<fkyaml::node::boolean_type>() == false);
     }
 
     SECTION("mapping iterator") {
         fkyaml::node mapping = {{"test0", false}, {"test1", true}};
-        fkyaml::detail::iterator<fkyaml::node> iterator(
-            fkyaml::detail::mapping_iterator_tag {}, mapping.get_value_ref<fkyaml::node::mapping_type&>().begin());
+        fkyaml::detail::iterator<fkyaml::node> iterator(mapping.get_value_ref<fkyaml::node::mapping_type&>().begin());
         REQUIRE(iterator.value().is_boolean());
         REQUIRE(iterator.value().get_value<fkyaml::node::boolean_type>() == false);
     }

--- a/test/unit_test/test_node_class.cpp
+++ b/test/unit_test/test_node_class.cpp
@@ -3425,6 +3425,46 @@ TEST_CASE("Node_Begin") {
     }
 }
 
+TEST_CASE("Node_ConstBegin") {
+    SECTION("container nodes") {
+        auto node = GENERATE(fkyaml::node::sequence(), fkyaml::node::mapping());
+
+        SECTION("non-const non-alias container node") {
+            REQUIRE_NOTHROW(node.cbegin());
+        }
+
+        SECTION("const non-alias container node") {
+            const fkyaml::node const_node = node;
+            REQUIRE_NOTHROW(const_node.cbegin());
+        }
+
+        SECTION("non-const alias container node") {
+            node.add_anchor_name("anchor_name");
+            fkyaml::node alias = fkyaml::node::alias_of(node);
+            REQUIRE_NOTHROW(alias.cbegin());
+        }
+
+        SECTION("non-const alias container node") {
+            node.add_anchor_name("anchor_name");
+            const fkyaml::node alias = fkyaml::node::alias_of(node);
+            REQUIRE_NOTHROW(alias.cbegin());
+        }
+    }
+
+    SECTION("scalar nodes") {
+        auto node = GENERATE(fkyaml::node(), fkyaml::node(false), fkyaml::node(0), fkyaml::node(0.0), fkyaml::node(""));
+
+        SECTION("non-const node") {
+            REQUIRE_THROWS_AS(node.cbegin(), fkyaml::type_error);
+        }
+
+        SECTION("const node") {
+            const fkyaml::node const_node = node;
+            REQUIRE_THROWS_AS(const_node.cbegin(), fkyaml::type_error);
+        }
+    }
+}
+
 TEST_CASE("Node_End") {
     SECTION("container nodes") {
         auto node = GENERATE(fkyaml::node::sequence(), fkyaml::node::mapping());
@@ -3449,15 +3489,6 @@ TEST_CASE("Node_End") {
             const fkyaml::node alias = fkyaml::node::alias_of(node);
             REQUIRE_NOTHROW(alias.end());
         }
-
-        SECTION("non-const range-based for-loop compatibility") {
-            REQUIRE_NOTHROW(node.end());
-        }
-
-        SECTION("const range-based for-loop compatibility") {
-            const fkyaml::node const_node = node;
-            REQUIRE_NOTHROW(const_node.end());
-        }
     }
 
     SECTION("scalar nodes") {
@@ -3470,6 +3501,46 @@ TEST_CASE("Node_End") {
         SECTION("const throwing node") {
             const fkyaml::node const_node = node;
             REQUIRE_THROWS_AS(const_node.end(), fkyaml::type_error);
+        }
+    }
+}
+
+TEST_CASE("Node_ConstEnd") {
+    SECTION("container nodes") {
+        auto node = GENERATE(fkyaml::node::sequence(), fkyaml::node::mapping());
+
+        SECTION("non-const non-alias container node") {
+            REQUIRE_NOTHROW(node.cend());
+        }
+
+        SECTION("const non-alias container node") {
+            const fkyaml::node const_node = node;
+            REQUIRE_NOTHROW(const_node.cend());
+        }
+
+        SECTION("non-const alias container node") {
+            node.add_anchor_name("anchor_name");
+            fkyaml::node alias = fkyaml::node::alias_of(node);
+            REQUIRE_NOTHROW(alias.cend());
+        }
+
+        SECTION("non-const alias container node") {
+            node.add_anchor_name("anchor_name");
+            const fkyaml::node alias = fkyaml::node::alias_of(node);
+            REQUIRE_NOTHROW(alias.cend());
+        }
+    }
+
+    SECTION("scalar nodes") {
+        auto node = GENERATE(fkyaml::node(), fkyaml::node(false), fkyaml::node(0), fkyaml::node(0.0), fkyaml::node(""));
+
+        SECTION("non-const throwing node") {
+            REQUIRE_THROWS_AS(node.cend(), fkyaml::type_error);
+        }
+
+        SECTION("const throwing node") {
+            const fkyaml::node const_node = node;
+            REQUIRE_THROWS_AS(const_node.cend(), fkyaml::type_error);
         }
     }
 }


### PR DESCRIPTION
This PR adds the following changes:  

* The following legacy container types are added to the basic_node template class as its member types.  
  The `iterator` and `const_iterator` of `basic_node` refer to them when instantiating their types.  
  |name|description|associated type|
  |---|---|---|
  |value_type|type of elements of a container node|basic_node|
  |reference|type of reference to an element of a container node|basic_node&|
  |const_reference|type of const reference to an element of a container node|const basic_node&|
  |pointer|type of pointer to an element of a container node|basic_node*|
  |const_pointer|type of const pointer to an element of a container node|const basic_node*|
  |size_type|type to represent container node sizes|std::size_t|
  |size_type|type to represent differences between elements of a container node|std::ptrdiff_t|
* basic_node's `iterator` and `const_iterator` objects are now compatible regarding:
  * copy construction/assignment
    * `const_iterator` objects still cannot be assigned to or used for constructing `iterator` objects so the const-ness of `const_iterator` is not casted away.
  * relational comparisons
    * `operator==`, `operator!=`
    * `operator<`, `operator<=`, `operator>`, `operator>=`
* New member functions `cbegin()` and `cend()` are added to `basic_node`.  
  They always return a `const_iterator` object to the first and past-the-last element respectively just like those provided in STL container types.

The test suite and the API documentation contents have also been updated according to the above changes.

---

## Pull Request Checklist

Read the [CONTRIBUTING.md](https://github.com/fktn-k/fkYAML/blob/develop/CONTRIBUTING.md) file for detailed information.  

- [x] Changes are described in the pull request or in a referenced [issue](https://github.com/fktn-k/fkYAML/issues).
- [x] The test suite compiles and runs without any error.
- [x] [The code coverage](https://coveralls.io/github/fktn-k/fkYAML) on your branch is 100%.
- [x] The documentation is updated if you added/changed a feature.

## Please don't

- The C++11 support varies between different **compilers** and versions. Please note the [list of supported compilers](https://github.com/fktn-k/fkYAML/blob/develop/README.md#supported-compilers). Some compilers like GCC 4.7 (and earlier), Clang 3.3 (and earlier), or Microsoft Visual Studio 13.0 and earlier are known not to work due to missing or incomplete C++11 support. Please refrain from proposing changes that work around these compiler's limitations with `#ifdef`s or other means.
- Please refrain from proposing changes that would **break [YAML](https://yaml.org/) specifications**. If you propose a conformant extension of YAML to be supported by the library, please motivate this extension.
- Please do not open pull requests that address **multiple issues**.
