### PR TITLE
Fix round-trip issue in float serialization using scientific notation

### DIFF
--- a/include/fkYAML/detail/conversions/to_string.hpp
+++ b/include/fkYAML/detail/conversions/to_string.hpp
@@ -79,10 +79,10 @@ inline enable_if_t<std::is_floating_point<FloatType>::value> to_string(FloatType
     oss << v;
     s = oss.str();
 
-    // If `f` is actually an integer, ".0" must be appended. The result would cause roundtrip issue otherwise.
-    // https://github.com/fktn-k/fkYAML/issues/405
-    const FloatType diff = v - std::floor(v);
-    if (diff < std::numeric_limits<FloatType>::min()) {
+    // If `v` is actually an integer and no scientific notation is used for serialization, ".0" must be appended.
+    // The result would cause a roundtrip issue otherwise. https://github.com/fktn-k/fkYAML/issues/405
+    const std::size_t pos = s.find_first_of(".e");
+    if (pos == std::string::npos) {
         s += ".0";
     }
 }

--- a/single_include/fkYAML/node.hpp
+++ b/single_include/fkYAML/node.hpp
@@ -10341,10 +10341,10 @@ inline enable_if_t<std::is_floating_point<FloatType>::value> to_string(FloatType
     oss << v;
     s = oss.str();
 
-    // If `f` is actually an integer, ".0" must be appended. The result would cause roundtrip issue otherwise.
-    // https://github.com/fktn-k/fkYAML/issues/405
-    const FloatType diff = v - std::floor(v);
-    if (diff < std::numeric_limits<FloatType>::min()) {
+    // If `v` is actually an integer and no scientific notation is used for serialization, ".0" must be appended.
+    // The result would cause a roundtrip issue otherwise. https://github.com/fktn-k/fkYAML/issues/405
+    const std::size_t pos = s.find_first_of(".e");
+    if (pos == std::string::npos) {
         s += ".0";
     }
 }

--- a/test/unit_test/test_serializer_class.cpp
+++ b/test/unit_test/test_serializer_class.cpp
@@ -60,6 +60,8 @@ TEST_CASE("SerializeClassTest_FloatNode", "[SerializeClassTest]") {
         node_str_pair_t(2.10, "2.1"),
         node_str_pair_t(3.14, "3.14"),
         node_str_pair_t(-53.97, "-53.97"),
+        node_str_pair_t(23000000.0, "2.3e+07"),
+        node_str_pair_t(-23000000.0, "-2.3e+07"),
         node_str_pair_t(std::numeric_limits<fkyaml::node::float_number_type>::infinity(), ".inf"),
         node_str_pair_t(-1 * std::numeric_limits<fkyaml::node::float_number_type>::infinity(), "-.inf"),
         node_str_pair_t(std::nan(""), ".nan"));


### PR DESCRIPTION
This PR fixes the issue which has been itroduced by the PR #407 and is reported [here](https://github.com/fktn-k/fkYAML/issues/405#issuecomment-2523117670).  
During the conversion from a floating point value to a string, ".0" is appended only when the following conditions are met:  
1. the floating point value is actually an integer
2. no scientific notation is used for serialization

---

## Pull Request Checklist

Read the [CONTRIBUTING.md](https://github.com/fktn-k/fkYAML/blob/develop/CONTRIBUTING.md) file for detailed information.  

- [x] Changes are described in the pull request or in a referenced [issue](https://github.com/fktn-k/fkYAML/issues).
- [x] The test suite compiles and runs without any error.
- [x] [The code coverage](https://coveralls.io/github/fktn-k/fkYAML) on your branch is 100%.
- [x] The documentation is updated if you added/changed a feature.

## Please don't

- The C++11 support varies between different **compilers** and versions. Please note the [list of supported compilers](https://github.com/fktn-k/fkYAML/blob/develop/README.md#supported-compilers). Some compilers like GCC 4.7 (and earlier), Clang 3.3 (and earlier), or Microsoft Visual Studio 13.0 and earlier are known not to work due to missing or incomplete C++11 support. Please refrain from proposing changes that work around these compiler's limitations with `#ifdef`s or other means.
- Please refrain from proposing changes that would **break [YAML](https://yaml.org/) specifications**. If you propose a conformant extension of YAML to be supported by the library, please motivate this extension.
- Please do not open pull requests that address **multiple issues**.
