### PR TITLE
Resolve CMake deprecation warning

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 3.8)
+cmake_minimum_required(VERSION 3.8...3.10)
 
 ################################
 #   Project name and version   #

--- a/test/cmake_add_subdirectory_test/project/CMakeLists.txt
+++ b/test/cmake_add_subdirectory_test/project/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 3.8)
+cmake_minimum_required(VERSION 3.8...3.10)
 
 project(CMakeAddSubDirectoryTestProject)
 

--- a/test/cmake_fetch_content_test/project/CMakeLists.txt
+++ b/test/cmake_fetch_content_test/project/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 3.11.0)
+cmake_minimum_required(VERSION 3.11)
 
 project("CMakeFetchContentTestProject")
 

--- a/test/cmake_find_package_test/project/CMakeLists.txt
+++ b/test/cmake_find_package_test/project/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 3.8)
+cmake_minimum_required(VERSION 3.8...3.10)
 
 project(CMakeFindPackageTestProject)
 

--- a/test/cmake_target_include_directories_test/project/CMakeLists.txt
+++ b/test/cmake_target_include_directories_test/project/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 3.8)
+cmake_minimum_required(VERSION 3.8...3.10)
 
 project(CMakeTargetIncludeDirectoriesTestProject)
 


### PR DESCRIPTION
Starting with CMake 3.31 (used in the ubuntu-24.04 runner), cmake_minimum_required() emits a warning against the minimum required version begin less than 3.10 like [this](https://github.com/fktn-k/fkYAML/actions/runs/12259711278/job/34202574102#step:3:7).  
To resolve it, this PR adds a policy_max version for cmake_minimum_required() calls as described in [the official document](https://cmake.org/cmake/help/latest/command/cmake_minimum_required.html).  

Note the same warning is still emitted in the catch2's cmakelists file, where I cannot do anything...

---

## Pull Request Checklist

Read the [CONTRIBUTING.md](https://github.com/fktn-k/fkYAML/blob/develop/CONTRIBUTING.md) file for detailed information.  

- [x] Changes are described in the pull request or in a referenced [issue](https://github.com/fktn-k/fkYAML/issues).
- [x] The test suite compiles and runs without any error.
- [x] [The code coverage](https://coveralls.io/github/fktn-k/fkYAML) on your branch is 100%.
- [x] The documentation is updated if you added/changed a feature.

## Please don't

- The C++11 support varies between different **compilers** and versions. Please note the [list of supported compilers](https://github.com/fktn-k/fkYAML/blob/develop/README.md#supported-compilers). Some compilers like GCC 4.7 (and earlier), Clang 3.3 (and earlier), or Microsoft Visual Studio 13.0 and earlier are known not to work due to missing or incomplete C++11 support. Please refrain from proposing changes that work around these compiler's limitations with `#ifdef`s or other means.
- Please refrain from proposing changes that would **break [YAML](https://yaml.org/) specifications**. If you propose a conformant extension of YAML to be supported by the library, please motivate this extension.
- Please do not open pull requests that address **multiple issues**.
