### PR TITLE
support std::forward_list in from_node

### DIFF
--- a/docs/mkdocs/docs/api/basic_node/get_value.md
+++ b/docs/mkdocs/docs/api/basic_node/get_value.md
@@ -36,15 +36,26 @@ This API makes a copy of the value, and if the copying costs too much, or if you
 
     This library implements conversions from a sequence node to a number of STL container types whose element type is not a key-value pair. The implementation can be used for custom container types, but they need to have both `iterator` member type and `insert()` member function. The test suite confirms successful conversions to the following types.
     
-    * [std::vector](https://en.cppreference.com/w/cpp/container/vector), [std::deque](https://en.cppreference.com/w/cpp/container/deque), [std::list](https://en.cppreference.com/w/cpp/container/list) *(sequence containers)*
-    * [std::set](https://en.cppreference.com/w/cpp/container/set), [std::multiset](https://en.cppreference.com/w/cpp/container/multiset) *(associative containers for keys)*
-    * [std::unordered_set](https://en.cppreference.com/w/cpp/container/unordered_set), [std::unordered_multiset](https://en.cppreference.com/w/cpp/container/unordered_multiset) *(unordered associative containers for keys)*
-
-    And you can also convert to these types which do not have `insert()` member function though.
-
-    * [std::array](https://en.cppreference.com/w/cpp/container/array), [std::valarray](https://en.cppreference.com/w/cpp/numeric/valarray) *(sequence containers)*
-    * [std::stack](https://en.cppreference.com/w/cpp/container/stack), [std::queue](https://en.cppreference.com/w/cpp/container/queue), [std::priority_queue](https://en.cppreference.com/w/cpp/container/priority_queue) *(sequence container adapters)*
-    * [std::pair](https://en.cppreference.com/w/cpp/utility/pair), [std::tuple](https://en.cppreference.com/w/cpp/utility/tuple)
+    * *Sequence Containers*
+        * [std::array](https://en.cppreference.com/w/cpp/container/array)
+        * [std::vector](https://en.cppreference.com/w/cpp/container/vector)
+        * [std::deque](https://en.cppreference.com/w/cpp/container/deque)
+        * [std::forward_list](https://en.cppreference.com/w/cpp/container/forward_list)
+        * [std::list](https://en.cppreference.com/w/cpp/container/list)
+    * *Associative Containers for Keys*
+        * [std::set](https://en.cppreference.com/w/cpp/container/set)
+        * [std::multiset](https://en.cppreference.com/w/cpp/container/multiset)
+    * *Unordered Associative Containers for Keys*
+        * [std::unordered_set](https://en.cppreference.com/w/cpp/container/unordered_set)
+        * [std::unordered_multiset](https://en.cppreference.com/w/cpp/container/unordered_multiset)
+    * *Container Adapters*
+        * [std::stack](https://en.cppreference.com/w/cpp/container/stack)
+        * [std::queue](https://en.cppreference.com/w/cpp/container/queue)
+        * [std::priority_queue](https://en.cppreference.com/w/cpp/container/priority_queue)
+    * *Others*
+        * [std::valarray](https://en.cppreference.com/w/cpp/numeric/valarray)
+        * [std::pair](https://en.cppreference.com/w/cpp/utility/pair)
+        * [std::tuple](https://en.cppreference.com/w/cpp/utility/tuple)
 
     Note that the above types cannot be converted from a non-sequence node, which results in throwing a [type_error](../exception/type_error.md).
 
@@ -52,8 +63,12 @@ This API makes a copy of the value, and if the copying costs too much, or if you
 
     This library implements conversions from a mapping node to STL container types whose element type is a key-value pair. The implementation can be used for custom container types, but they need to have `key_type`, `mapped_type` and `value_type` member types and `emplace()` member function. The test suite confirms successful conversions to the following types.
 
-    * [std::map](https://en.cppreference.com/w/cpp/container/map), [std::multimap](https://en.cppreference.com/w/cpp/container/multimap) *(associative containers for key-value pairs)*
-    * [std::unordered_map](https://en.cppreference.com/w/cpp/container/unordered_map), [std::unordered_multi_map](https://en.cppreference.com/w/cpp/container/unordered_multimap) *(unordered associative containers for key-value pairs)*
+    * *Associative Containers for Key-Value Pairs*
+        * [std::map](https://en.cppreference.com/w/cpp/container/map)
+        * [std::multimap](https://en.cppreference.com/w/cpp/container/multimap)
+    * *Unordered Associative Containers for Key-Value Pairs*
+        * [std::unordered_map](https://en.cppreference.com/w/cpp/container/unordered_map)
+        * [std::unordered_multi_map](https://en.cppreference.com/w/cpp/container/unordered_multimap) *(unordered associative containers for key-value pairs)*
 
 ???+ Note "Convert from a Null or Numeric Scalar Node"
 

--- a/single_include/fkYAML/node.hpp
+++ b/single_include/fkYAML/node.hpp
@@ -10998,6 +10998,7 @@ FK_YAML_DETAIL_NAMESPACE_END
 
 #include <array>
 #include <cmath>
+#include <forward_list>
 #include <limits>
 #include <utility>
 #include <valarray>
@@ -11184,6 +11185,30 @@ inline auto from_node(const BasicNodeType& n, std::valarray<T>& va)
     }
 }
 
+/// @brief from_node function for std::forward_list objects whose element type must be a basic_node template instance
+/// type or a compatible type. This function is necessary since insert function is not implemented for
+/// std::forward_list.
+/// @tparam BasicNodeType A basic_node template instance type.
+/// @tparam T Element type of std::forward_list.
+/// @tparam Alloc Allocator type of std::forward_list.
+/// @param n A basic_node object.
+/// @param fl A std::forward_list object.
+template <typename BasicNodeType, typename T, typename Alloc>
+inline auto from_node(const BasicNodeType& n, std::forward_list<T, Alloc>& fl)
+    -> decltype(n.template get_value<T>(), void()) {
+    if FK_YAML_UNLIKELY (!n.is_sequence()) {
+        throw type_error("The target node value is not sequence type.", n.get_type());
+    }
+
+    fl.clear();
+
+    // std::forward_list does not have insert function.
+    auto insert_pos_itr = fl.before_begin();
+    for (const auto& elem : n) {
+        insert_pos_itr = fl.emplace_after(insert_pos_itr, elem.template get_value<T>());
+    }
+}
+
 /// @brief from_node function for container objects of only keys or values, e.g., std::vector or std::set, whose element
 /// type must be a basic_node template instance type or a compatible type.
 /// @tparam BasicNodeType A basic_node template instance type.
@@ -11202,6 +11227,8 @@ inline auto from_node(const BasicNodeType& n, CompatSeqType& s)
     if FK_YAML_UNLIKELY (!n.is_sequence()) {
         throw type_error("The target node value is not sequence type.", n.get_type());
     }
+
+    s.clear();
 
     // call reserve function first if it's available (like std::vector).
     call_reserve_if_available<CompatSeqType>::call(s, n.size());
@@ -11227,6 +11254,11 @@ inline auto from_node(const BasicNodeType& n, SeqContainerAdapter& ca)
     -> decltype(n.template get_value<typename SeqContainerAdapter::value_type>(), ca.push(std::declval<typename SeqContainerAdapter::value_type>()), void()) {
     if FK_YAML_UNLIKELY (!n.is_sequence()) {
         throw type_error("The target node value is not sequence type.", n.get_type());
+    }
+
+    // clear existing elements manually since clear function is not implemeneted for container adapter classes.
+    while (!ca.empty()) {
+        ca.pop();
     }
 
     for (const auto& elem : n) {
@@ -11255,6 +11287,7 @@ inline auto from_node(const BasicNodeType& n, CompatMapType& m)
         throw type_error("The target node value type is not mapping type.", n.get_type());
     }
 
+    m.clear();
     call_reserve_if_available<CompatMapType>::call(m, n.size());
 
     for (const auto& pair : n.template get_value_ref<const typename BasicNodeType::mapping_type&>()) {


### PR DESCRIPTION
This PR adds support for `std::forward_list` in conversion from a basic_node by calling `get_value()` and `get_value_inplace()`.  
The documentation has also been updated according to the above change.  

Furthermore, since the current test suite covers not 100% of lines/branches of the codebase (I just didn't check the coverage score), some test cases have been added. Now the test suite covers 100% of the lines/branches again!    

---

## Pull Request Checklist

Read the [CONTRIBUTING.md](https://github.com/fktn-k/fkYAML/blob/develop/CONTRIBUTING.md) file for detailed information.  

- [x] Changes are described in the pull request or in a referenced [issue](https://github.com/fktn-k/fkYAML/issues).
- [x] The test suite compiles and runs without any error.
- [x] [The code coverage](https://coveralls.io/github/fktn-k/fkYAML) on your branch is 100%.
- [x] The documentation is updated if you added/changed a feature.

## Please don't

- The C++11 support varies between different **compilers** and versions. Please note the [list of supported compilers](https://github.com/fktn-k/fkYAML/blob/develop/README.md#supported-compilers). Some compilers like GCC 4.7 (and earlier), Clang 3.3 (and earlier), or Microsoft Visual Studio 13.0 and earlier are known not to work due to missing or incomplete C++11 support. Please refrain from proposing changes that work around these compiler's limitations with `#ifdef`s or other means.
- Please refrain from proposing changes that would **break [YAML](https://yaml.org/) specifications**. If you propose a conformant extension of YAML to be supported by the library, please motivate this extension.
- Please do not open pull requests that address **multiple issues**.
