### PR TITLE
Fix bad indentation detection for block collection entries

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -161,7 +161,7 @@ update-version: fkYAML.natvis update-project-version update-sources update-git-t
 # pre-requisites: lcov
 lcov-coverage:
 	cmake -B build_coverage -S . -DCMAKE_BUILD_TYPE=Debug -DFK_YAML_CODE_COVERAGE=ON
-	cmake --build build_coverage --config Debug --target generate_test_coverage -j $(JOBS)
+	cmake --build build_coverage --config Debug --target generate_test_coverage
 
 # pre-requisites: genhtml lcov
 html-coverage: lcov-coverage

--- a/include/fkYAML/detail/input/deserializer.hpp
+++ b/include/fkYAML/detail/input/deserializer.hpp
@@ -1279,7 +1279,7 @@ private:
             throw parse_error("Detected invalid indentation.", line, indent);
         }
 
-        uint32_t pop_num = static_cast<uint32_t>(std::distance(m_context_stack.rbegin(), itr));
+        const auto pop_num = static_cast<uint32_t>(std::distance(m_context_stack.rbegin(), itr));
 
         // move back to the parent block mapping.
         for (uint32_t i = 0; i < pop_num; i++) {

--- a/include/fkYAML/detail/input/deserializer.hpp
+++ b/include/fkYAML/detail/input/deserializer.hpp
@@ -56,6 +56,7 @@ class basic_deserializer {
         BLOCK_MAPPING_EXPLICIT_VALUE, //!< The underlying node is an explicit block mapping value.
         MAPPING_VALUE,                //!< The underlying node is a block mapping value.
         BLOCK_SEQUENCE,               //!< The underlying node is a block sequence.
+        BLOCK_SEQUENCE_ENTRY,         //!< The underlying node is a block sequence entry.
         FLOW_SEQUENCE,                //!< The underlying node is a flow sequence.
         FLOW_SEQUENCE_KEY,            //!< The underlying node is a flow sequence as a key.
         FLOW_MAPPING,                 //!< The underlying node is a flow mapping.
@@ -164,6 +165,7 @@ private:
         lexical_token token {};
 
         basic_node_type root;
+        mp_current_node = &root;
         mp_meta = root.mp_meta;
 
         // parse directives first.
@@ -176,16 +178,24 @@ private:
 
         switch (token.type) {
         case lexical_token_t::SEQUENCE_BLOCK_PREFIX: {
-            root = basic_node_type::sequence();
+            root = basic_node_type::sequence({basic_node_type()});
             apply_directive_set(root);
             if (found_props) {
                 // If node properties are found before the block sequence entry prefix, the properties belong to the
                 // root sequence node.
                 apply_node_properties(root);
             }
+
             parse_context context(
                 lexer.get_lines_processed(), lexer.get_last_token_begin_pos(), context_state_t::BLOCK_SEQUENCE, &root);
+            m_context_stack.emplace_back(context);
+
+            mp_current_node = &(root.template get_value_ref<sequence_type&>().back());
+            apply_directive_set(*mp_current_node);
+            context.state = context_state_t::BLOCK_SEQUENCE_ENTRY;
+            context.p_node = mp_current_node;
             m_context_stack.emplace_back(std::move(context));
+
             token = lexer.get_next_token();
             line = lexer.get_lines_processed();
             indent = lexer.get_last_token_begin_pos();
@@ -263,8 +273,6 @@ private:
             // Do nothing since current document has no contents.
             break;
         }
-
-        mp_current_node = &root;
 
         // parse YAML nodes recursively
         deserialize_node(lexer, token, line, indent, last_type);
@@ -391,25 +399,31 @@ private:
             case lexical_token_t::EXPLICIT_KEY_PREFIX: {
                 const bool needs_to_move_back = indent == 0 || indent < m_context_stack.back().indent;
                 if (needs_to_move_back) {
-                    pop_to_parent_node(line, indent, [indent](const parse_context& c) { return indent > c.indent; });
+                    pop_to_parent_node(line, indent, [indent](const parse_context& c) {
+                        return c.state == context_state_t::BLOCK_MAPPING && indent == c.indent;
+                    });
                 }
 
-                if FK_YAML_UNLIKELY (mp_current_node->is_null()) {
-                    // This path is needed in case the input contains nested explicit keys like the following YAML
-                    // snippet:
+                switch (m_context_stack.back().state) {
+                case context_state_t::MAPPING_VALUE:
+                case context_state_t::BLOCK_MAPPING_EXPLICIT_KEY:
+                case context_state_t::BLOCK_MAPPING_EXPLICIT_VALUE:
+                case context_state_t::BLOCK_SEQUENCE_ENTRY:
+                    // This path is needed in case the input contains nested explicit keys.
                     // ```yaml
-                    // ? ? foo
-                    //   : bar
-                    // : baz
+                    // foo:
+                    //   ? ? foo
+                    //     : bar
+                    //   : ? baz
+                    //     : - ? qux
+                    //         : 123
                     // ```
                     *mp_current_node = basic_node_type::mapping();
                     apply_directive_set(*mp_current_node);
-                }
-
-                if (m_context_stack.back().state == context_state_t::BLOCK_SEQUENCE) {
-                    auto& seq = mp_current_node->template get_value_ref<sequence_type&>();
-                    seq.emplace_back(basic_node_type::mapping());
-                    m_context_stack.emplace_back(line, indent, context_state_t::BLOCK_MAPPING, &(seq.back()));
+                    m_context_stack.emplace_back(line, indent, context_state_t::BLOCK_MAPPING, mp_current_node);
+                    break;
+                default:
+                    break;
                 }
 
                 token = lexer.get_next_token();
@@ -417,14 +431,22 @@ private:
                     // heap-allocated node will be freed in handling the corresponding KEY_SEPARATOR event
                     auto* p_node = new basic_node_type(node_type::SEQUENCE);
                     m_context_stack.emplace_back(line, indent, context_state_t::BLOCK_MAPPING_EXPLICIT_KEY, p_node);
-                    mp_current_node = m_context_stack.back().p_node;
-                    apply_directive_set(*mp_current_node);
+
+                    apply_directive_set(*p_node);
                     parse_context context(
                         lexer.get_lines_processed(),
                         lexer.get_last_token_begin_pos(),
                         context_state_t::BLOCK_SEQUENCE,
-                        mp_current_node);
+                        p_node);
+                    m_context_stack.emplace_back(context);
+
+                    p_node->template get_value_ref<sequence_type&>().emplace_back(basic_node_type());
+                    mp_current_node = &(p_node->template get_value_ref<sequence_type&>().back());
+                    apply_directive_set(*mp_current_node);
+                    context.state = context_state_t::BLOCK_SEQUENCE_ENTRY;
+                    context.p_node = mp_current_node;
                     m_context_stack.emplace_back(std::move(context));
+
                     break;
                 }
 
@@ -439,8 +461,12 @@ private:
                 continue;
             }
             case lexical_token_t::KEY_SEPARATOR: {
-                const bool is_empty_seq = mp_current_node->is_sequence() && mp_current_node->empty();
-                if FK_YAML_UNLIKELY (is_empty_seq) {
+                FK_YAML_ASSERT(!m_context_stack.empty());
+                if FK_YAML_UNLIKELY (m_context_stack.back().state == context_state_t::BLOCK_SEQUENCE_ENTRY) {
+                    // empty mapping keys are not supported.
+                    // ```yaml
+                    // - : foo
+                    // ```
                     throw parse_error("sequence key should not be empty.", line, indent);
                 }
 
@@ -495,13 +521,20 @@ private:
 
                     if (token.type == lexical_token_t::SEQUENCE_BLOCK_PREFIX) {
                         // a key separator preceding block sequence entries
-                        *mp_current_node = basic_node_type::sequence();
+                        *mp_current_node = basic_node_type::sequence({basic_node_type()});
                         apply_directive_set(*mp_current_node);
                         apply_node_properties(*mp_current_node);
                         auto& cur_context = m_context_stack.back();
                         cur_context.line = line;
                         cur_context.indent = indent;
                         cur_context.state = context_state_t::BLOCK_SEQUENCE;
+
+                        mp_current_node = &(mp_current_node->template get_value_ref<sequence_type&>().back());
+                        apply_directive_set(*mp_current_node);
+                        parse_context entry_context = cur_context;
+                        entry_context.state = context_state_t::BLOCK_SEQUENCE_ENTRY;
+                        entry_context.p_node = mp_current_node;
+                        m_context_stack.emplace_back(std::move(entry_context));
 
                         token = lexer.get_next_token();
                         line = lexer.get_lines_processed();
@@ -527,11 +560,10 @@ private:
                             // https://github.com/fktn-k/fkYAML/issues/368 for more details.
                             line = line_after_props;
                             indent = lexer.get_last_token_begin_pos();
-                            mp_current_node->template get_value_ref<sequence_type&>().emplace_back(
-                                basic_node_type::mapping());
-                            mp_current_node = &mp_current_node->template get_value_ref<sequence_type&>().back();
+                            *mp_current_node = basic_node_type::mapping();
                             m_context_stack.emplace_back(
                                 line_after_props, indent, context_state_t::BLOCK_MAPPING, mp_current_node);
+                            apply_directive_set(*mp_current_node);
                             apply_node_properties(*mp_current_node);
                         }
 
@@ -571,13 +603,19 @@ private:
                     key_node, basic_node_type());
                 mp_current_node = &(m_context_stack.back().p_node->operator[](std::move(key_node)));
                 m_context_stack.emplace_back(
-                    line, indent, context_state_t::BLOCK_MAPPING_EXPLICIT_VALUE, mp_current_node);
+                    old_line, old_indent, context_state_t::BLOCK_MAPPING_EXPLICIT_VALUE, mp_current_node);
 
                 if (token.type == lexical_token_t::SEQUENCE_BLOCK_PREFIX) {
-                    *mp_current_node = basic_node_type::sequence();
+                    *mp_current_node = basic_node_type::sequence({basic_node_type()});
                     apply_directive_set(*mp_current_node);
                     apply_node_properties(*mp_current_node);
                     m_context_stack.emplace_back(line, indent, context_state_t::BLOCK_SEQUENCE, mp_current_node);
+
+                    mp_current_node = &(mp_current_node->template get_value_ref<sequence_type&>().back());
+                    parse_context entry_context = m_context_stack.back();
+                    entry_context.state = context_state_t::BLOCK_SEQUENCE_ENTRY;
+                    entry_context.p_node = mp_current_node;
+                    m_context_stack.emplace_back(std::move(entry_context));
                     break;
                 }
 
@@ -597,22 +635,38 @@ private:
                 // ```
                 continue;
             case lexical_token_t::SEQUENCE_BLOCK_PREFIX: {
-                const bool is_further_nested = m_context_stack.back().indent < indent;
-                if (is_further_nested) {
-                    mp_current_node->template get_value_ref<sequence_type&>().emplace_back(basic_node_type::sequence());
-                    mp_current_node = &(mp_current_node->template get_value_ref<sequence_type&>().back());
+                FK_YAML_ASSERT(!m_context_stack.empty());
+                const uint32_t parent_indent = m_context_stack.back().indent;
+                if (indent == parent_indent) {
+                    // If the previous block sequence entry is empty, just move to the parent context.
+                    // ```yaml
+                    // foo:
+                    //   -
+                    //   - bar
+                    // # ^ (here)
+                    // # -> {foo: [null, bar]}
+                    // ```
+                    pop_to_parent_node(line, indent, [indent](const parse_context& c) {
+                        return c.state == context_state_t::BLOCK_SEQUENCE;
+                    });
+                }
+                else if (indent < parent_indent) {
+                    pop_to_parent_node(line, indent, [indent](const parse_context& c) {
+                        return c.state == context_state_t::BLOCK_SEQUENCE && indent == c.indent;
+                    });
+                }
+                else if (parent_indent < indent) {
+                    *mp_current_node = basic_node_type::sequence();
                     m_context_stack.emplace_back(line, indent, context_state_t::BLOCK_SEQUENCE, mp_current_node);
                     apply_directive_set(*mp_current_node);
                     apply_node_properties(*mp_current_node);
-                    break;
                 }
 
-                // move back to the previous sequence if necessary.
-                while (m_context_stack.back().state != context_state_t::BLOCK_SEQUENCE ||
-                       indent != m_context_stack.back().indent) {
-                    m_context_stack.pop_back();
-                }
-                mp_current_node = m_context_stack.back().p_node;
+                auto& seq = mp_current_node->template get_value_ref<sequence_type&>();
+                seq.emplace_back(basic_node_type());
+                mp_current_node = &(seq.back());
+                apply_directive_set(*mp_current_node);
+                m_context_stack.emplace_back(line, indent, context_state_t::BLOCK_SEQUENCE_ENTRY, mp_current_node);
                 break;
             }
             case lexical_token_t::SEQUENCE_FLOW_BEGIN:
@@ -1069,12 +1123,23 @@ private:
         if (mp_current_node->is_sequence()) {
             if (m_flow_context_depth > 0) {
                 if FK_YAML_UNLIKELY (m_flow_token_state != flow_token_state_t::NEEDS_VALUE_OR_SUFFIX) {
+                    // Flow sequence entries are not allowed to be empty.
+                    // ```yaml
+                    // [foo,,bar]
+                    // ```
                     throw parse_error("flow sequence entry is found without separated with a comma.", line, indent);
                 }
+
                 m_flow_token_state = flow_token_state_t::NEEDS_SEPARATOR_OR_SUFFIX;
             }
 
             mp_current_node->template get_value_ref<sequence_type&>().emplace_back(std::move(node_value));
+
+            if (m_flow_context_depth == 0) {
+                FK_YAML_ASSERT(!m_context_stack.empty());
+                FK_YAML_ASSERT(m_context_stack.back().state == context_state_t::BLOCK_SEQUENCE_ENTRY);
+                m_context_stack.pop_back();
+            }
             return;
         }
 
@@ -1121,19 +1186,20 @@ private:
         else if (token.type == lexical_token_t::KEY_SEPARATOR) {
             if FK_YAML_UNLIKELY (line != lexer.get_lines_processed()) {
                 // This path is for explicit mapping key separator like:
-                //
                 // ```yaml
                 //   ? foo
                 //   : bar
                 // # ^ this separator
                 // ```
                 assign_node_value(std::move(node), line, indent);
-                if (m_context_stack.back().state != context_state_t::BLOCK_MAPPING_EXPLICIT_KEY) {
-                    mp_current_node = m_context_stack.back().p_node;
-                    m_context_stack.pop_back();
-                }
                 indent = lexer.get_last_token_begin_pos();
                 line = lexer.get_lines_processed();
+
+                if (m_context_stack.back().state != context_state_t::BLOCK_MAPPING_EXPLICIT_KEY) {
+                    pop_to_parent_node(line, indent, [indent](const parse_context& c) {
+                        return c.state == context_state_t::BLOCK_MAPPING_EXPLICIT_KEY && indent == c.indent;
+                    });
+                }
                 return;
             }
 
@@ -1143,6 +1209,7 @@ private:
                     switch (cur_context.state) {
                     case context_state_t::BLOCK_MAPPING_EXPLICIT_KEY:
                     case context_state_t::BLOCK_MAPPING_EXPLICIT_VALUE:
+                    case context_state_t::BLOCK_SEQUENCE_ENTRY:
                         m_context_stack.emplace_back(line, indent, context_state_t::BLOCK_MAPPING, mp_current_node);
                         break;
                     default:
@@ -1194,21 +1261,15 @@ private:
     void pop_to_parent_node(uint32_t line, uint32_t indent, Pred&& pred) {
         FK_YAML_ASSERT(!m_context_stack.empty());
 
-        uint32_t pop_num = 0;
-        if (indent == 0) {
-            pop_num = static_cast<uint32_t>(m_context_stack.size() - 1);
+        // LCOV_EXCL_START
+        auto itr = std::find_if(m_context_stack.rbegin(), m_context_stack.rend(), std::forward<Pred>(pred));
+        // LCOV_EXCL_STOP
+        const bool is_indent_valid = (itr != m_context_stack.rend());
+        if FK_YAML_UNLIKELY (!is_indent_valid) {
+            throw parse_error("Detected invalid indentation.", line, indent);
         }
-        else {
-            // LCOV_EXCL_START
-            auto itr = std::find_if(m_context_stack.rbegin(), m_context_stack.rend(), std::forward<Pred>(pred));
-            // LCOV_EXCL_STOP
-            const bool is_indent_valid = (itr != m_context_stack.rend());
-            if FK_YAML_UNLIKELY (!is_indent_valid) {
-                throw parse_error("Detected invalid indentation.", line, indent);
-            }
 
-            pop_num = static_cast<uint32_t>(std::distance(m_context_stack.rbegin(), itr));
-        }
+        uint32_t pop_num = static_cast<uint32_t>(std::distance(m_context_stack.rbegin(), itr));
 
         // move back to the parent block mapping.
         for (uint32_t i = 0; i < pop_num; i++) {

--- a/include/fkYAML/detail/input/deserializer.hpp
+++ b/include/fkYAML/detail/input/deserializer.hpp
@@ -1032,6 +1032,15 @@ private:
                     return (c.state == context_state_t::BLOCK_MAPPING) && (indent == c.indent);
                 });
             }
+            else if (mp_current_node->is_mapping() && !mp_current_node->empty()) {
+                // bad indentation like the following YAML:
+                // ```yaml
+                // foo: true
+                //   baz: 123
+                // # ^
+                // ```
+                throw parse_error("bad indentation of a mapping entry.", line, indent);
+            }
         }
         else if FK_YAML_UNLIKELY (m_flow_token_state != flow_token_state_t::NEEDS_VALUE_OR_SUFFIX) {
             throw parse_error("Flow mapping entry is found without separated with a comma.", line, indent);

--- a/include/fkYAML/detail/input/deserializer.hpp
+++ b/include/fkYAML/detail/input/deserializer.hpp
@@ -656,6 +656,16 @@ private:
                     });
                 }
                 else if (parent_indent < indent) {
+                    if FK_YAML_UNLIKELY (m_context_stack.back().state == context_state_t::BLOCK_SEQUENCE) {
+                        // bad indentation like the following YAML:
+                        // ```yaml
+                        // - "foo"
+                        //   - bar
+                        // # ^
+                        // ```
+                        throw parse_error("bad indentation of a mapping entry.", line, indent);
+                    }
+
                     *mp_current_node = basic_node_type::sequence();
                     m_context_stack.emplace_back(line, indent, context_state_t::BLOCK_SEQUENCE, mp_current_node);
                     apply_directive_set(*mp_current_node);

--- a/include/fkYAML/detail/input/deserializer.hpp
+++ b/include/fkYAML/detail/input/deserializer.hpp
@@ -643,7 +643,7 @@ private:
                     // # ^ (here)
                     // # -> {foo: [null, bar]}
                     // ```
-                    pop_to_parent_node(line, indent, [indent](const parse_context& c) {
+                    pop_to_parent_node(line, indent, [](const parse_context& c) {
                         return c.state == context_state_t::BLOCK_SEQUENCE;
                     });
                 }

--- a/single_include/fkYAML/node.hpp
+++ b/single_include/fkYAML/node.hpp
@@ -7650,7 +7650,7 @@ private:
                     // # ^ (here)
                     // # -> {foo: [null, bar]}
                     // ```
-                    pop_to_parent_node(line, indent, [indent](const parse_context& c) {
+                    pop_to_parent_node(line, indent, [](const parse_context& c) {
                         return c.state == context_state_t::BLOCK_SEQUENCE;
                     });
                 }

--- a/single_include/fkYAML/node.hpp
+++ b/single_include/fkYAML/node.hpp
@@ -8039,6 +8039,15 @@ private:
                     return (c.state == context_state_t::BLOCK_MAPPING) && (indent == c.indent);
                 });
             }
+            else if (mp_current_node->is_mapping() && !mp_current_node->empty()) {
+                // bad indentation like the following YAML:
+                // ```yaml
+                // foo: true
+                //   baz: 123
+                // # ^
+                // ```
+                throw parse_error("bad indentation of a mapping entry.", line, indent);
+            }
         }
         else if FK_YAML_UNLIKELY (m_flow_token_state != flow_token_state_t::NEEDS_VALUE_OR_SUFFIX) {
             throw parse_error("Flow mapping entry is found without separated with a comma.", line, indent);

--- a/test/unit_test/test_deserializer_class.cpp
+++ b/test/unit_test/test_deserializer_class.cpp
@@ -2104,6 +2104,43 @@ TEST_CASE("Deserializer_FlowMapping") {
     }
 }
 
+TEST_CASE("Deserializer_BadIndentation") {
+    fkyaml::detail::basic_deserializer<fkyaml::node> deserializer;
+    fkyaml::node root;
+
+    SECTION("implicit mapping entries") {
+        std::string input = "abc: def ghi\n"
+                            "  jkl: mno";
+
+        REQUIRE_THROWS_AS(root = deserializer.deserialize(fkyaml::detail::input_adapter(input)), fkyaml::parse_error);
+    }
+
+    SECTION("nested implicit mapping entry") {
+        std::string input = "abc:\n"
+                            "  def: ghi\n"
+                            "    jkl: mno";
+
+        REQUIRE_THROWS_AS(root = deserializer.deserialize(fkyaml::detail::input_adapter(input)), fkyaml::parse_error);
+    }
+
+    // regression test for https://github.com/fktn-k/fkYAML/issues/449
+    SECTION("implicit mapping entries with a value on a separate line") {
+        std::string input = "abc:\n"
+                            "  def ghi\n"
+                            "  jkl: mno";
+
+        REQUIRE_THROWS_AS(root = deserializer.deserialize(fkyaml::detail::input_adapter(input)), fkyaml::parse_error);
+    }
+
+    SECTION("explicit mapping entry with an implicit mapping as its key") {
+        std::string input = "? abc: def\n"
+                            "    def: ghi\n"
+                            ": jkl: mno";
+
+        REQUIRE_THROWS_AS(root = deserializer.deserialize(fkyaml::detail::input_adapter(input)), fkyaml::parse_error);
+    }
+}
+
 TEST_CASE("Deserializer_InputWithComment") {
     fkyaml::detail::basic_deserializer<fkyaml::node> deserializer;
     fkyaml::node root;

--- a/test/unit_test/test_deserializer_class.cpp
+++ b/test/unit_test/test_deserializer_class.cpp
@@ -315,15 +315,6 @@ TEST_CASE("Deserializer_ScalarConversionErrorHandling") {
     REQUIRE_THROWS_AS(root = deserializer.deserialize(fkyaml::detail::input_adapter(input)), fkyaml::parse_error);
 }
 
-TEST_CASE("Deserializer_InvalidIndentation") {
-    fkyaml::detail::basic_deserializer<fkyaml::node> deserializer;
-    fkyaml::node root;
-
-    REQUIRE_THROWS_AS(
-        root = deserializer.deserialize(fkyaml::detail::input_adapter("foo:\n  bar: baz\n qux: true")),
-        fkyaml::parse_error);
-}
-
 TEST_CASE("Deserializer_DuplicateKeys") {
     fkyaml::detail::basic_deserializer<fkyaml::node> deserializer;
     fkyaml::node root;
@@ -702,6 +693,27 @@ TEST_CASE("Deserializer_BlockSequence") {
         fkyaml::node& foo_baz_node = foo_node["baz"];
         REQUIRE(foo_baz_node.is_boolean());
         REQUIRE(foo_baz_node.get_value<bool>() == true);
+    }
+
+    SECTION("empty block sequence entries") {
+        std::string input = "- -\n"
+                            "  - 123\n"
+                            "  -\n"
+                            "-\n";
+        REQUIRE_NOTHROW(root = deserializer.deserialize(fkyaml::detail::input_adapter(input)));
+
+        REQUIRE(root.is_sequence());
+        REQUIRE(root.size() == 2);
+
+        fkyaml::node& root_0 = root[0];
+        REQUIRE(root_0.is_sequence());
+        REQUIRE(root_0.size() == 3);
+        REQUIRE(root_0[0].is_null());
+        REQUIRE(root_0[1].is_integer());
+        REQUIRE(root_0[1].get_value<int>() == 123);
+        REQUIRE(root_0[2].is_null());
+
+        REQUIRE(root[1].is_null());
     }
 }
 
@@ -1622,6 +1634,42 @@ TEST_CASE("Deserializer_ExplicitBlockMapping") {
         REQUIRE(root_2_bazfalse_456_seqmapkey_0_qux789_mapkey_node.is_float_number());
         REQUIRE(root_2_bazfalse_456_seqmapkey_0_qux789_mapkey_node.get_value<double>() == 1.41);
     }
+
+    SECTION("nested explicit mapping keys in various ways") {
+        std::string input = "foo:\n"
+                            "  ? ? foo\n"
+                            "    : bar\n"
+                            "  : ? baz\n"
+                            "    : - ? qux\n"
+                            "        : 123\n";
+        REQUIRE_NOTHROW(root = deserializer.deserialize(fkyaml::detail::input_adapter(input)));
+
+        REQUIRE(root.is_mapping());
+        REQUIRE(root.size() == 1);
+        REQUIRE(root.contains("foo"));
+
+        fkyaml::node& foo_node = root["foo"];
+        REQUIRE(foo_node.is_mapping());
+        REQUIRE(foo_node.size() == 1);
+        fkyaml::node map_key = {{"foo", "bar"}};
+        REQUIRE(foo_node.contains(map_key));
+
+        fkyaml::node& foo_inner_node = foo_node[map_key];
+        REQUIRE(foo_inner_node.is_mapping());
+        REQUIRE(foo_inner_node.size() == 1);
+        REQUIRE(foo_inner_node.contains("baz"));
+
+        fkyaml::node& foo_inner_baz_node = foo_inner_node["baz"];
+        REQUIRE(foo_inner_baz_node.is_sequence());
+        REQUIRE(foo_inner_baz_node.size() == 1);
+
+        fkyaml::node& foo_inner_baz_0_node = foo_inner_baz_node[0];
+        REQUIRE(foo_inner_baz_0_node.is_mapping());
+        REQUIRE(foo_inner_baz_0_node.size() == 1);
+        REQUIRE(foo_inner_baz_0_node.contains("qux"));
+        REQUIRE(foo_inner_baz_0_node["qux"].is_integer());
+        REQUIRE(foo_inner_baz_0_node["qux"].get_value<int>() == 123);
+    }
 }
 
 TEST_CASE("Deserializer_FlowSequence") {
@@ -2115,10 +2163,18 @@ TEST_CASE("Deserializer_BadIndentation") {
         REQUIRE_THROWS_AS(root = deserializer.deserialize(fkyaml::detail::input_adapter(input)), fkyaml::parse_error);
     }
 
-    SECTION("nested implicit mapping entry") {
+    SECTION("nested implicit mapping entry with too much indentation") {
         std::string input = "abc:\n"
                             "  def: ghi\n"
                             "    jkl: mno";
+
+        REQUIRE_THROWS_AS(root = deserializer.deserialize(fkyaml::detail::input_adapter(input)), fkyaml::parse_error);
+    }
+
+    SECTION("nested implicit mapping entry with less indentation") {
+        std::string input = "foo:\n"
+                            "  bar: baz\n"
+                            " qux: true";
 
         REQUIRE_THROWS_AS(root = deserializer.deserialize(fkyaml::detail::input_adapter(input)), fkyaml::parse_error);
     }
@@ -2136,6 +2192,20 @@ TEST_CASE("Deserializer_BadIndentation") {
         std::string input = "? abc: def\n"
                             "    def: ghi\n"
                             ": jkl: mno";
+
+        REQUIRE_THROWS_AS(root = deserializer.deserialize(fkyaml::detail::input_adapter(input)), fkyaml::parse_error);
+    }
+
+    SECTION("block sequence entries") {
+        std::string input = "- \"abc\"\n"
+                            " - def";
+
+        REQUIRE_THROWS_AS(root = deserializer.deserialize(fkyaml::detail::input_adapter(input)), fkyaml::parse_error);
+    }
+
+    SECTION("nested block sequence entries") {
+        std::string input = "- - \"abc\"\n"
+                            "    - def\n";
 
         REQUIRE_THROWS_AS(root = deserializer.deserialize(fkyaml::detail::input_adapter(input)), fkyaml::parse_error);
     }


### PR DESCRIPTION
This PR fixes detecting bad indentations for block sequence/mapping entries as reported in the issue #449.  
Also, the way of managing parse contexts has been improved by separating `BLOCK_SEQUENCE_ENTRY` from `BLOCK_SEQUENCE` in the enum class `context_state_t` for the above fix.  
That allows for block sequence entries to be empty and they are now properly parsed.  
```yaml
# The following YAML was parsed as `[foo, [123], bar]` before.
# Now the result is `[foo, [123, null], null, bar]`.
- foo
- - 123
  -
-
- bar
```

---

## Pull Request Checklist

Read the [CONTRIBUTING.md](https://github.com/fktn-k/fkYAML/blob/develop/CONTRIBUTING.md) file for detailed information.  

- [x] Changes are described in the pull request or in a referenced [issue](https://github.com/fktn-k/fkYAML/issues).
- [x] The test suite compiles and runs without any error.
- [x] [The code coverage](https://coveralls.io/github/fktn-k/fkYAML) on your branch is 100%.
- [x] The documentation is updated if you added/changed a feature.

## Please don't

- The C++11 support varies between different **compilers** and versions. Please note the [list of supported compilers](https://github.com/fktn-k/fkYAML/blob/develop/README.md#supported-compilers). Some compilers like GCC 4.7 (and earlier), Clang 3.3 (and earlier), or Microsoft Visual Studio 13.0 and earlier are known not to work due to missing or incomplete C++11 support. Please refrain from proposing changes that work around these compiler's limitations with `#ifdef`s or other means.
- Please refrain from proposing changes that would **break [YAML](https://yaml.org/) specifications**. If you propose a conformant extension of YAML to be supported by the library, please motivate this extension.
- Please do not open pull requests that address **multiple issues**.
