### PR TITLE
fix: Fixed a bug where serialize didn't write out empty vectors and mappings

### DIFF
--- a/include/fkYAML/detail/output/serializer.hpp
+++ b/include/fkYAML/detail/output/serializer.hpp
@@ -156,6 +156,12 @@ private:
                     serialize_node(seq_item, cur_indent, str);
                     str += "\n";
                 }
+                else if (seq_item.is_sequence() && seq_item.size() == 0) {
+                    str += " []\n";
+                }
+                else if (seq_item.is_mapping() && seq_item.size() == 0) {
+                    str += " {}\n";
+                }
                 else {
                     str += "\n";
                     serialize_node(seq_item, cur_indent + 2, str);
@@ -206,6 +212,12 @@ private:
                     str += " ";
                     serialize_node(*itr, cur_indent, str);
                     str += "\n";
+                }
+                else if (itr->is_sequence() && itr->size() == 0) {
+                    str += " []\n";
+                }
+                else if (itr->is_mapping() && itr->size() == 0) {
+                    str += " {}\n";
                 }
                 else {
                     str += "\n";


### PR DESCRIPTION
Fixed a bug where serialize didn't write out empty vectors and mappings in a correct way. I have not added a test case, but I tested it in my code and it behaved as expected. Adding a test case at some point would be good.

Regarding the test cases, I couldn't get that to run when I followed the instructions, and don't have time to dig into why. I did test it using my own code though, and it seems to work.
---

## Pull Request Checklist

Read the [CONTRIBUTING.md](https://github.com/fktn-k/fkYAML/blob/develop/CONTRIBUTING.md) file for detailed information.  

- [X ] Changes are described in the pull request or in a referenced [issue](https://github.com/fktn-k/fkYAML/issues).
- [ ] The test suite compiles and runs without any error.
- [ ] [The code coverage](https://coveralls.io/github/fktn-k/fkYAML) on your branch is 100%.
- [X] The documentation is updated if you added/changed a feature.

## Please don't

- The C++11 support varies between different **compilers** and versions. Please note the [list of supported compilers](https://github.com/fktn-k/fkYAML/blob/develop/README.md#supported-compilers). Some compilers like GCC 4.7 (and earlier), Clang 3.3 (and earlier), or Microsoft Visual Studio 13.0 and earlier are known not to work due to missing or incomplete C++11 support. Please refrain from proposing changes that work around these compiler's limitations with `#ifdef`s or other means.
- Please refrain from proposing changes that would **break [YAML](https://yaml.org/) specifications**. If you propose a conformant extension of YAML to be supported by the library, please motivate this extension.
- Please do not open pull requests that address **multiple issues**.
