### PR TITLE
Add test cases for serializing empty collection nodes

### DIFF
--- a/include/fkYAML/detail/output/serializer.hpp
+++ b/include/fkYAML/detail/output/serializer.hpp
@@ -155,16 +155,22 @@ private:
                     str += " ";
                     serialize_node(seq_item, cur_indent, str);
                     str += "\n";
+                    continue;
                 }
-                else if (seq_item.is_sequence() && seq_item.size() == 0) {
-                    str += " []\n";
-                }
-                else if (seq_item.is_mapping() && seq_item.size() == 0) {
-                    str += " {}\n";
-                }
-                else {
+
+                const bool is_empty = seq_item.empty();
+                if (!is_empty) {
                     str += "\n";
                     serialize_node(seq_item, cur_indent + 2, str);
+                    continue;
+                }
+
+                // an empty sequence or mapping
+                if (seq_item.is_sequence()) {
+                    str += " []\n";
+                }
+                else /*seq_item.is_mapping()*/ {
+                    str += " {}\n";
                 }
             }
             break;
@@ -212,16 +218,22 @@ private:
                     str += " ";
                     serialize_node(*itr, cur_indent, str);
                     str += "\n";
+                    continue;
                 }
-                else if (itr->is_sequence() && itr->size() == 0) {
-                    str += " []\n";
-                }
-                else if (itr->is_mapping() && itr->size() == 0) {
-                    str += " {}\n";
-                }
-                else {
+
+                const bool is_empty = itr->empty();
+                if (!is_empty) {
                     str += "\n";
                     serialize_node(*itr, cur_indent + 2, str);
+                    continue;
+                }
+
+                // an empty sequence or mapping
+                if (itr->is_sequence()) {
+                    str += " []\n";
+                }
+                else /*itr->is_mapping()*/ {
+                    str += " {}\n";
                 }
             }
             break;

--- a/single_include/fkYAML/node.hpp
+++ b/single_include/fkYAML/node.hpp
@@ -10529,16 +10529,22 @@ private:
                     str += " ";
                     serialize_node(seq_item, cur_indent, str);
                     str += "\n";
+                    continue;
                 }
-                else if (seq_item.is_sequence() && seq_item.size() == 0) {
-                    str += " []\n";
-                }
-                else if (seq_item.is_mapping() && seq_item.size() == 0) {
-                    str += " {}\n";
-                }
-                else {
+
+                const bool is_empty = seq_item.empty();
+                if (!is_empty) {
                     str += "\n";
                     serialize_node(seq_item, cur_indent + 2, str);
+                    continue;
+                }
+
+                // an empty sequence or mapping
+                if (seq_item.is_sequence()) {
+                    str += " []\n";
+                }
+                else /*seq_item.is_mapping()*/ {
+                    str += " {}\n";
                 }
             }
             break;
@@ -10586,16 +10592,22 @@ private:
                     str += " ";
                     serialize_node(*itr, cur_indent, str);
                     str += "\n";
+                    continue;
                 }
-                else if (itr->is_sequence() && itr->size() == 0) {
-                    str += " []\n";
-                }
-                else if (itr->is_mapping() && itr->size() == 0) {
-                    str += " {}\n";
-                }
-                else {
+
+                const bool is_empty = itr->empty();
+                if (!is_empty) {
                     str += "\n";
                     serialize_node(*itr, cur_indent + 2, str);
+                    continue;
+                }
+
+                // an empty sequence or mapping
+                if (itr->is_sequence()) {
+                    str += " []\n";
+                }
+                else /*itr->is_mapping()*/ {
+                    str += " {}\n";
                 }
             }
             break;

--- a/tests/unit_test/test_serializer_class.cpp
+++ b/tests/unit_test/test_serializer_class.cpp
@@ -30,6 +30,36 @@ TEST_CASE("Serializer_MappingNode") {
     REQUIRE(serializer.serialize(node_str_pair.first) == node_str_pair.second);
 }
 
+TEST_CASE("Serializer_EmptyCollectionNode") {
+    auto seq = fkyaml::node::sequence();
+    auto map = fkyaml::node::mapping();
+    fkyaml::detail::basic_serializer<fkyaml::node> serializer;
+
+    SECTION("child sequence item is an empty sequence node") {
+        seq.get_value_ref<fkyaml::node::sequence_type&>().emplace_back(fkyaml::node::sequence());
+        std::string expected = "- []\n";
+        REQUIRE(serializer.serialize(seq) == expected);
+    }
+
+    SECTION("child sequence item is an empty mapping node") {
+        seq.get_value_ref<fkyaml::node::sequence_type&>().emplace_back(fkyaml::node::mapping());
+        std::string expected = "- {}\n";
+        REQUIRE(serializer.serialize(seq) == expected);
+    }
+
+    SECTION("mapping value is an empty sequence node") {
+        map["foo"] = seq;
+        std::string expected = "foo: []\n";
+        REQUIRE(serializer.serialize(map) == expected);
+    }
+
+    SECTION("mapping value is an empty mapping node") {
+        map["foo"] = fkyaml::node::mapping();
+        std::string expected = "foo: {}\n";
+        REQUIRE(serializer.serialize(map) == expected);
+    }
+}
+
 TEST_CASE("Serializer_NullNode") {
     fkyaml::detail::basic_serializer<fkyaml::node> serializer;
     fkyaml::node node;


### PR DESCRIPTION
This PR adds some test cases which validate serialization results from empty collection nodes.  
The bug fix itself has already been addressed in the PR #456, so the changes in the library sources are only for improvements in readability and coverage.  

---

## Pull Request Checklist

Read the [CONTRIBUTING.md](https://github.com/fktn-k/fkYAML/blob/develop/CONTRIBUTING.md) file for detailed information.  

- [x] Changes are described in the pull request or in a referenced [issue](https://github.com/fktn-k/fkYAML/issues).
- [x] The test suite compiles and runs without any error.
- [x] [The code coverage](https://coveralls.io/github/fktn-k/fkYAML) on your branch is 100%.
- [x] The documentation is updated if you added/changed a feature.

## Please don't

- The C++11 support varies between different **compilers** and versions. Please note the [list of supported compilers](https://github.com/fktn-k/fkYAML/blob/develop/README.md#supported-compilers). Some compilers like GCC 4.7 (and earlier), Clang 3.3 (and earlier), or Microsoft Visual Studio 13.0 and earlier are known not to work due to missing or incomplete C++11 support. Please refrain from proposing changes that work around these compiler's limitations with `#ifdef`s or other means.
- Please refrain from proposing changes that would **break [YAML](https://yaml.org/) specifications**. If you propose a conformant extension of YAML to be supported by the library, please motivate this extension.
- Please do not open pull requests that address **multiple issues**.
