### PR TITLE
Add test cases for serializing root empty collections

### DIFF
--- a/.github/workflows/ubuntu.yml
+++ b/.github/workflows/ubuntu.yml
@@ -21,8 +21,8 @@ on:
       - cmake/**
       - include/**
       - single_include/**
-      - test/**
-      - tool/**
+      - tests/**
+      - tools/**
       - .clang-tidy
       - CMakeLists.txt
       - Makefile

--- a/tests/unit_test/test_serializer_class.cpp
+++ b/tests/unit_test/test_serializer_class.cpp
@@ -58,6 +58,16 @@ TEST_CASE("Serializer_EmptyCollectionNode") {
         std::string expected = "foo: {}\n";
         REQUIRE(serializer.serialize(map) == expected);
     }
+
+    SECTION("root empty sequence") {
+        std::string expected = "[]\n";
+        REQUIRE(serializer.serialize(seq) == expected);
+    }
+
+    SECTION("root empty mapping") {
+        std::string expected = "{}\n";
+        REQUIRE(serializer.serialize(map) == expected);
+    }
 }
 
 TEST_CASE("Serializer_NullNode") {


### PR DESCRIPTION
This PR adds test cases for serializing a root empty sequence/mapping fixed by the PR #460.  

---

## Pull Request Checklist

Read the [CONTRIBUTING.md](https://github.com/fktn-k/fkYAML/blob/develop/CONTRIBUTING.md) file for detailed information.  

- [x] Changes are described in the pull request or in a referenced [issue](https://github.com/fktn-k/fkYAML/issues).
- [x] The test suite compiles and runs without any error.
- [x] [The code coverage](https://coveralls.io/github/fktn-k/fkYAML) on your branch is 100%.
- [x] The documentation is updated if you added/changed a feature.

## Please don't

- The C++11 support varies between different **compilers** and versions. Please note the [list of supported compilers](https://github.com/fktn-k/fkYAML/blob/develop/README.md#supported-compilers). Some compilers like GCC 4.7 (and earlier), Clang 3.3 (and earlier), or Microsoft Visual Studio 13.0 and earlier are known not to work due to missing or incomplete C++11 support. Please refrain from proposing changes that work around these compiler's limitations with `#ifdef`s or other means.
- Please refrain from proposing changes that would **break [YAML](https://yaml.org/) specifications**. If you propose a conformant extension of YAML to be supported by the library, please motivate this extension.
- Please do not open pull requests that address **multiple issues**.
