### PR TITLE
Improve handling node properties in deserialization

### DIFF
--- a/include/fkYAML/detail/input/deserializer.hpp
+++ b/include/fkYAML/detail/input/deserializer.hpp
@@ -260,9 +260,9 @@ private:
                 }
 
                 if (m_needs_tag_impl) {
-                    m_root_tag_name = std::move(m_tag_name);
+                    m_root_tag_name = m_tag_name;
                     m_needs_tag_impl = false;
-                    m_tag_name.clear();
+                    m_tag_name = {};
                 }
 
                 line = lexer.get_lines_processed();
@@ -1055,7 +1055,7 @@ private:
                         lexer.get_last_token_begin_pos());
                 }
 
-                m_tag_name.assign(token.str.begin(), token.str.end());
+                m_tag_name = token.str;
                 m_needs_tag_impl = true;
 
                 if (!m_needs_anchor_impl) {
@@ -1237,8 +1237,8 @@ private:
                         m_root_anchor_name.clear();
                     }
                     if (!m_root_tag_name.empty()) {
-                        mp_current_node->add_tag_name(std::move(m_root_tag_name));
-                        m_root_tag_name.clear();
+                        mp_current_node->add_tag_name(std::string(m_root_tag_name.begin(), m_root_tag_name.end()));
+                        m_root_tag_name = {};
                     }
                 }
             }
@@ -1293,9 +1293,9 @@ private:
         }
 
         if (m_needs_tag_impl) {
-            node.add_tag_name(m_tag_name);
+            node.add_tag_name(std::string(m_tag_name.begin(), m_tag_name.end()));
             m_needs_tag_impl = false;
-            m_tag_name.clear();
+            m_tag_name = {};
         }
     }
 
@@ -1323,11 +1323,11 @@ private:
     /// The last YAML anchor name.
     std::string m_anchor_name;
     /// The last tag name.
-    std::string m_tag_name;
+    str_view m_tag_name;
     /// The root YAML anchor name. (maybe empty and unused)
     std::string m_root_anchor_name;
     /// The root tag name. (maybe empty and unused)
-    std::string m_root_tag_name;
+    str_view m_root_tag_name;
 };
 
 FK_YAML_DETAIL_NAMESPACE_END

--- a/include/fkYAML/detail/input/deserializer.hpp
+++ b/include/fkYAML/detail/input/deserializer.hpp
@@ -254,9 +254,9 @@ private:
                 // If node properties and a followed node are on the different line, the properties belong to the root
                 // node.
                 if (m_needs_anchor_impl) {
-                    m_root_anchor_name = std::move(m_anchor_name);
+                    m_root_anchor_name = m_anchor_name;
                     m_needs_anchor_impl = false;
-                    m_anchor_name.clear();
+                    m_anchor_name = {};
                 }
 
                 if (m_needs_tag_impl) {
@@ -1037,7 +1037,7 @@ private:
                         lexer.get_last_token_begin_pos());
                 }
 
-                m_anchor_name.assign(token.str.begin(), token.str.end());
+                m_anchor_name = token.str;
                 m_needs_anchor_impl = true;
 
                 if (!m_needs_tag_impl) {
@@ -1233,8 +1233,9 @@ private:
 
                     // apply node properties if any to the root mapping node.
                     if (!m_root_anchor_name.empty()) {
-                        mp_current_node->add_anchor_name(std::move(m_root_anchor_name));
-                        m_root_anchor_name.clear();
+                        mp_current_node->add_anchor_name(
+                            std::string(m_root_anchor_name.begin(), m_root_anchor_name.end()));
+                        m_root_anchor_name = {};
                     }
                     if (!m_root_tag_name.empty()) {
                         mp_current_node->add_tag_name(std::string(m_root_tag_name.begin(), m_root_tag_name.end()));
@@ -1287,9 +1288,9 @@ private:
     /// @param node A node type object to be set YAML node properties.
     void apply_node_properties(basic_node_type& node) {
         if (m_needs_anchor_impl) {
-            node.add_anchor_name(m_anchor_name);
+            node.add_anchor_name(std::string(m_anchor_name.begin(), m_anchor_name.end()));
             m_needs_anchor_impl = false;
-            m_anchor_name.clear();
+            m_anchor_name = {};
         }
 
         if (m_needs_tag_impl) {
@@ -1321,11 +1322,11 @@ private:
     /// A flag to determine the need for a value separator or a flow suffix to follow.
     flow_token_state_t m_flow_token_state {flow_token_state_t::NEEDS_VALUE_OR_SUFFIX};
     /// The last YAML anchor name.
-    std::string m_anchor_name;
+    str_view m_anchor_name;
     /// The last tag name.
     str_view m_tag_name;
     /// The root YAML anchor name. (maybe empty and unused)
-    std::string m_root_anchor_name;
+    str_view m_root_anchor_name;
     /// The root tag name. (maybe empty and unused)
     str_view m_root_tag_name;
 };

--- a/include/fkYAML/detail/input/tag_resolver.hpp
+++ b/include/fkYAML/detail/input/tag_resolver.hpp
@@ -34,19 +34,18 @@ public:
     /// @brief Resolve the input tag name into an expanded tag name prepended with a registered prefix.
     /// @param tag The input tag name.
     /// @return The type of a node deduced from the given tag name.
-    static tag_t resolve_tag(const std::string& tag, const std::shared_ptr<doc_metainfo_type>& directives) {
+    static tag_t resolve_tag(const str_view tag, const std::shared_ptr<doc_metainfo_type>& directives) {
         const std::string normalized = normalize_tag_name(tag, directives);
         return convert_to_tag_type(normalized);
     }
 
 private:
-    static std::string normalize_tag_name(
-        const std::string& tag, const std::shared_ptr<doc_metainfo_type>& directives) {
+    static std::string normalize_tag_name(const str_view tag, const std::shared_ptr<doc_metainfo_type>& directives) {
         if FK_YAML_UNLIKELY (tag.empty()) {
             throw invalid_tag("tag must not be empty.", "");
         }
         if FK_YAML_UNLIKELY (tag[0] != '!') {
-            throw invalid_tag("tag must start with \'!\'", tag.c_str());
+            throw invalid_tag("tag must start with \'!\'", std::string(tag.begin(), tag.end()).c_str());
         }
 
         if (tag.size() == 1) {
@@ -56,7 +55,7 @@ private:
             //   * tag:yaml.org,2002:str
             // See the "Non-Specific Tags" section in https://yaml.org/spec/1.2.2/#691-node-tags.
             // The interpretation cannot take place here because the input lacks the corresponding value.
-            return tag;
+            return {tag.begin(), tag.end()};
         }
 
         std::string normalized {"!<"};
@@ -66,11 +65,13 @@ private:
             const bool is_null_or_empty = !directives || directives->secondary_handle_prefix.empty();
             if (is_null_or_empty) {
                 normalized.append(default_secondary_handle_prefix.begin(), default_secondary_handle_prefix.end());
-                normalized += tag.substr(2);
             }
             else {
-                normalized += directives->secondary_handle_prefix + tag.substr(2);
+                normalized += directives->secondary_handle_prefix;
             }
+
+            const str_view body = tag.substr(2);
+            normalized.append(body.begin(), body.end());
             break;
         }
         case '<':
@@ -78,16 +79,20 @@ private:
                 const bool is_null_or_empty = !directives || directives->primary_handle_prefix.empty();
                 if (is_null_or_empty) {
                     normalized.append(default_primary_handle_prefix.begin(), default_primary_handle_prefix.end());
-                    return normalized + tag.substr(3);
                 }
-                return normalized + directives->primary_handle_prefix + tag.substr(3);
+                else {
+                    normalized += directives->primary_handle_prefix;
+                }
+
+                const str_view body = tag.substr(3);
+                return normalized.append(body.begin(), body.end());
             }
 
             // verbatim tags must be delivered as-is to the application.
             // See https://yaml.org/spec/1.2.2/#691-node-tags for more details.
-            return tag;
+            return {tag.begin(), tag.end()};
         default: {
-            auto tag_end_pos = tag.find_first_of('!', 1);
+            const std::size_t tag_end_pos = tag.find_first_of('!', 1);
 
             // handle a named handle (!tag!suffix -> !<[tag][suffix]>)
             if (tag_end_pos != std::string::npos) {
@@ -96,14 +101,17 @@ private:
 
                 const bool is_null_or_empty = !directives || directives->named_handle_map.empty();
                 if FK_YAML_UNLIKELY (is_null_or_empty) {
-                    throw invalid_tag("named handle has not been registered.", tag.c_str());
+                    throw invalid_tag(
+                        "named handle has not been registered.", std::string(tag.begin(), tag.end()).c_str());
                 }
 
                 // find the extracted named handle in the map.
-                auto named_handle_itr = directives->named_handle_map.find(tag.substr(0, tag_end_pos + 1));
+                const str_view named_handle = tag.substr(0, tag_end_pos + 1);
+                auto named_handle_itr = directives->named_handle_map.find({named_handle.begin(), named_handle.end()});
                 auto end_itr = directives->named_handle_map.end();
                 if FK_YAML_UNLIKELY (named_handle_itr == end_itr) {
-                    throw invalid_tag("named handle has not been registered.", tag.c_str());
+                    throw invalid_tag(
+                        "named handle has not been registered.", std::string(tag.begin(), tag.end()).c_str());
                 }
 
                 // The YAML spec prohibits expanding the percent-encoded characters (%xx -> a UTF-8 byte).
@@ -111,7 +119,8 @@ private:
                 // See https://yaml.org/spec/1.2.2/#56-miscellaneous-characters for more details.
 
                 normalized += named_handle_itr->second;
-                normalized.append(tag.begin() + (static_cast<std::ptrdiff_t>(tag_end_pos) + 1), tag.end());
+                const str_view body = tag.substr(tag_end_pos + 1);
+                normalized.append(body.begin(), body.end());
                 break;
             }
 
@@ -119,12 +128,13 @@ private:
             const bool is_null_or_empty = !directives || directives->primary_handle_prefix.empty();
             if (is_null_or_empty) {
                 normalized.append(default_primary_handle_prefix.begin(), default_primary_handle_prefix.end());
-                normalized += tag.substr(1);
             }
             else {
-                normalized += directives->primary_handle_prefix + tag.substr(1);
+                normalized += directives->primary_handle_prefix;
             }
 
+            const str_view body = tag.substr(1);
+            normalized.append(body.begin(), body.end());
             break;
         }
         }

--- a/single_include/fkYAML/node.hpp
+++ b/single_include/fkYAML/node.hpp
@@ -6603,19 +6603,18 @@ public:
     /// @brief Resolve the input tag name into an expanded tag name prepended with a registered prefix.
     /// @param tag The input tag name.
     /// @return The type of a node deduced from the given tag name.
-    static tag_t resolve_tag(const std::string& tag, const std::shared_ptr<doc_metainfo_type>& directives) {
+    static tag_t resolve_tag(const str_view tag, const std::shared_ptr<doc_metainfo_type>& directives) {
         const std::string normalized = normalize_tag_name(tag, directives);
         return convert_to_tag_type(normalized);
     }
 
 private:
-    static std::string normalize_tag_name(
-        const std::string& tag, const std::shared_ptr<doc_metainfo_type>& directives) {
+    static std::string normalize_tag_name(const str_view tag, const std::shared_ptr<doc_metainfo_type>& directives) {
         if FK_YAML_UNLIKELY (tag.empty()) {
             throw invalid_tag("tag must not be empty.", "");
         }
         if FK_YAML_UNLIKELY (tag[0] != '!') {
-            throw invalid_tag("tag must start with \'!\'", tag.c_str());
+            throw invalid_tag("tag must start with \'!\'", std::string(tag.begin(), tag.end()).c_str());
         }
 
         if (tag.size() == 1) {
@@ -6625,7 +6624,7 @@ private:
             //   * tag:yaml.org,2002:str
             // See the "Non-Specific Tags" section in https://yaml.org/spec/1.2.2/#691-node-tags.
             // The interpretation cannot take place here because the input lacks the corresponding value.
-            return tag;
+            return {tag.begin(), tag.end()};
         }
 
         std::string normalized {"!<"};
@@ -6635,11 +6634,13 @@ private:
             const bool is_null_or_empty = !directives || directives->secondary_handle_prefix.empty();
             if (is_null_or_empty) {
                 normalized.append(default_secondary_handle_prefix.begin(), default_secondary_handle_prefix.end());
-                normalized += tag.substr(2);
             }
             else {
-                normalized += directives->secondary_handle_prefix + tag.substr(2);
+                normalized += directives->secondary_handle_prefix;
             }
+
+            const str_view body = tag.substr(2);
+            normalized.append(body.begin(), body.end());
             break;
         }
         case '<':
@@ -6647,16 +6648,20 @@ private:
                 const bool is_null_or_empty = !directives || directives->primary_handle_prefix.empty();
                 if (is_null_or_empty) {
                     normalized.append(default_primary_handle_prefix.begin(), default_primary_handle_prefix.end());
-                    return normalized + tag.substr(3);
                 }
-                return normalized + directives->primary_handle_prefix + tag.substr(3);
+                else {
+                    normalized += directives->primary_handle_prefix;
+                }
+
+                const str_view body = tag.substr(3);
+                return normalized.append(body.begin(), body.end());
             }
 
             // verbatim tags must be delivered as-is to the application.
             // See https://yaml.org/spec/1.2.2/#691-node-tags for more details.
-            return tag;
+            return {tag.begin(), tag.end()};
         default: {
-            auto tag_end_pos = tag.find_first_of('!', 1);
+            const std::size_t tag_end_pos = tag.find_first_of('!', 1);
 
             // handle a named handle (!tag!suffix -> !<[tag][suffix]>)
             if (tag_end_pos != std::string::npos) {
@@ -6665,14 +6670,17 @@ private:
 
                 const bool is_null_or_empty = !directives || directives->named_handle_map.empty();
                 if FK_YAML_UNLIKELY (is_null_or_empty) {
-                    throw invalid_tag("named handle has not been registered.", tag.c_str());
+                    throw invalid_tag(
+                        "named handle has not been registered.", std::string(tag.begin(), tag.end()).c_str());
                 }
 
                 // find the extracted named handle in the map.
-                auto named_handle_itr = directives->named_handle_map.find(tag.substr(0, tag_end_pos + 1));
+                const str_view named_handle = tag.substr(0, tag_end_pos + 1);
+                auto named_handle_itr = directives->named_handle_map.find({named_handle.begin(), named_handle.end()});
                 auto end_itr = directives->named_handle_map.end();
                 if FK_YAML_UNLIKELY (named_handle_itr == end_itr) {
-                    throw invalid_tag("named handle has not been registered.", tag.c_str());
+                    throw invalid_tag(
+                        "named handle has not been registered.", std::string(tag.begin(), tag.end()).c_str());
                 }
 
                 // The YAML spec prohibits expanding the percent-encoded characters (%xx -> a UTF-8 byte).
@@ -6680,7 +6688,8 @@ private:
                 // See https://yaml.org/spec/1.2.2/#56-miscellaneous-characters for more details.
 
                 normalized += named_handle_itr->second;
-                normalized.append(tag.begin() + (static_cast<std::ptrdiff_t>(tag_end_pos) + 1), tag.end());
+                const str_view body = tag.substr(tag_end_pos + 1);
+                normalized.append(body.begin(), body.end());
                 break;
             }
 
@@ -6688,12 +6697,13 @@ private:
             const bool is_null_or_empty = !directives || directives->primary_handle_prefix.empty();
             if (is_null_or_empty) {
                 normalized.append(default_primary_handle_prefix.begin(), default_primary_handle_prefix.end());
-                normalized += tag.substr(1);
             }
             else {
-                normalized += directives->primary_handle_prefix + tag.substr(1);
+                normalized += directives->primary_handle_prefix;
             }
 
+            const str_view body = tag.substr(1);
+            normalized.append(body.begin(), body.end());
             break;
         }
         }
@@ -7267,9 +7277,9 @@ private:
                 }
 
                 if (m_needs_tag_impl) {
-                    m_root_tag_name = std::move(m_tag_name);
+                    m_root_tag_name = m_tag_name;
                     m_needs_tag_impl = false;
-                    m_tag_name.clear();
+                    m_tag_name = {};
                 }
 
                 line = lexer.get_lines_processed();
@@ -8062,7 +8072,7 @@ private:
                         lexer.get_last_token_begin_pos());
                 }
 
-                m_tag_name.assign(token.str.begin(), token.str.end());
+                m_tag_name = token.str;
                 m_needs_tag_impl = true;
 
                 if (!m_needs_anchor_impl) {
@@ -8244,8 +8254,8 @@ private:
                         m_root_anchor_name.clear();
                     }
                     if (!m_root_tag_name.empty()) {
-                        mp_current_node->add_tag_name(std::move(m_root_tag_name));
-                        m_root_tag_name.clear();
+                        mp_current_node->add_tag_name(std::string(m_root_tag_name.begin(), m_root_tag_name.end()));
+                        m_root_tag_name = {};
                     }
                 }
             }
@@ -8300,9 +8310,9 @@ private:
         }
 
         if (m_needs_tag_impl) {
-            node.add_tag_name(m_tag_name);
+            node.add_tag_name(std::string(m_tag_name.begin(), m_tag_name.end()));
             m_needs_tag_impl = false;
-            m_tag_name.clear();
+            m_tag_name = {};
         }
     }
 
@@ -8330,11 +8340,11 @@ private:
     /// The last YAML anchor name.
     std::string m_anchor_name;
     /// The last tag name.
-    std::string m_tag_name;
+    str_view m_tag_name;
     /// The root YAML anchor name. (maybe empty and unused)
     std::string m_root_anchor_name;
     /// The root tag name. (maybe empty and unused)
-    std::string m_root_tag_name;
+    str_view m_root_tag_name;
 };
 
 FK_YAML_DETAIL_NAMESPACE_END

--- a/single_include/fkYAML/node.hpp
+++ b/single_include/fkYAML/node.hpp
@@ -7271,9 +7271,9 @@ private:
                 // If node properties and a followed node are on the different line, the properties belong to the root
                 // node.
                 if (m_needs_anchor_impl) {
-                    m_root_anchor_name = std::move(m_anchor_name);
+                    m_root_anchor_name = m_anchor_name;
                     m_needs_anchor_impl = false;
-                    m_anchor_name.clear();
+                    m_anchor_name = {};
                 }
 
                 if (m_needs_tag_impl) {
@@ -8054,7 +8054,7 @@ private:
                         lexer.get_last_token_begin_pos());
                 }
 
-                m_anchor_name.assign(token.str.begin(), token.str.end());
+                m_anchor_name = token.str;
                 m_needs_anchor_impl = true;
 
                 if (!m_needs_tag_impl) {
@@ -8250,8 +8250,9 @@ private:
 
                     // apply node properties if any to the root mapping node.
                     if (!m_root_anchor_name.empty()) {
-                        mp_current_node->add_anchor_name(std::move(m_root_anchor_name));
-                        m_root_anchor_name.clear();
+                        mp_current_node->add_anchor_name(
+                            std::string(m_root_anchor_name.begin(), m_root_anchor_name.end()));
+                        m_root_anchor_name = {};
                     }
                     if (!m_root_tag_name.empty()) {
                         mp_current_node->add_tag_name(std::string(m_root_tag_name.begin(), m_root_tag_name.end()));
@@ -8304,9 +8305,9 @@ private:
     /// @param node A node type object to be set YAML node properties.
     void apply_node_properties(basic_node_type& node) {
         if (m_needs_anchor_impl) {
-            node.add_anchor_name(m_anchor_name);
+            node.add_anchor_name(std::string(m_anchor_name.begin(), m_anchor_name.end()));
             m_needs_anchor_impl = false;
-            m_anchor_name.clear();
+            m_anchor_name = {};
         }
 
         if (m_needs_tag_impl) {
@@ -8338,11 +8339,11 @@ private:
     /// A flag to determine the need for a value separator or a flow suffix to follow.
     flow_token_state_t m_flow_token_state {flow_token_state_t::NEEDS_VALUE_OR_SUFFIX};
     /// The last YAML anchor name.
-    std::string m_anchor_name;
+    str_view m_anchor_name;
     /// The last tag name.
     str_view m_tag_name;
     /// The root YAML anchor name. (maybe empty and unused)
-    std::string m_root_anchor_name;
+    str_view m_root_anchor_name;
     /// The root tag name. (maybe empty and unused)
     str_view m_root_tag_name;
 };

--- a/tests/unit_test/test_tag_resolver_class.cpp
+++ b/tests/unit_test/test_tag_resolver_class.cpp
@@ -98,7 +98,10 @@ TEST_CASE("TagResolver_ResolveTag") {
     }
 
     SECTION("invalid tag name with empty document_metainfo<fkyaml::node>") {
-        const fkyaml::detail::str_view tag = GENERATE("", "invalid", "!invalid!tag");
+        auto tag = GENERATE(
+            fkyaml::detail::str_view(""),
+            fkyaml::detail::str_view("invalid"),
+            fkyaml::detail::str_view("!invalid!tag"));
 
         REQUIRE_THROWS_AS(
             fkyaml::detail::tag_resolver<fkyaml::node>::resolve_tag(tag, directives), fkyaml::invalid_tag);

--- a/tests/unit_test/test_tag_resolver_class.cpp
+++ b/tests/unit_test/test_tag_resolver_class.cpp
@@ -11,7 +11,7 @@
 #include <fkYAML/node.hpp>
 
 TEST_CASE("TagResolver_ResolveTag") {
-    using test_pair_t = std::pair<std::string, fkyaml::detail::tag_t>;
+    using test_pair_t = std::pair<fkyaml::detail::str_view, fkyaml::detail::tag_t>;
 
     fkyaml::detail::tag_t tag_type {};
     std::shared_ptr<fkyaml::detail::document_metainfo<fkyaml::node>> directives {};
@@ -98,7 +98,7 @@ TEST_CASE("TagResolver_ResolveTag") {
     }
 
     SECTION("invalid tag name with empty document_metainfo<fkyaml::node>") {
-        auto tag = GENERATE(std::string(""), std::string("invalid"), std::string("!invalid!tag"));
+        const fkyaml::detail::str_view tag = GENERATE("", "invalid", "!invalid!tag");
 
         REQUIRE_THROWS_AS(
             fkyaml::detail::tag_resolver<fkyaml::node>::resolve_tag(tag, directives), fkyaml::invalid_tag);
@@ -109,7 +109,7 @@ TEST_CASE("TagResolver_ResolveTag") {
             new fkyaml::detail::document_metainfo<fkyaml::node>());
         directives->named_handle_map.emplace("!valid!", "tag:example.com,2000");
 
-        auto tag = GENERATE(std::string("!invalid!tag"));
+        const fkyaml::detail::str_view tag = "!invalid!tag";
 
         REQUIRE_THROWS_AS(
             fkyaml::detail::tag_resolver<fkyaml::node>::resolve_tag(tag, directives), fkyaml::invalid_tag);


### PR DESCRIPTION
This PR removes some redundant string allocations for tag/anchor names in the deserialization.  

---

## Pull Request Checklist

Read the [CONTRIBUTING.md](https://github.com/fktn-k/fkYAML/blob/develop/CONTRIBUTING.md) file for detailed information.  

- [x] Changes are described in the pull request or in a referenced [issue](https://github.com/fktn-k/fkYAML/issues).
- [x] The test suite compiles and runs without any error.
- [x] [The code coverage](https://coveralls.io/github/fktn-k/fkYAML) on your branch is 100%.
- [x] The documentation is updated if you added/changed a feature.

## Please don't

- The C++11 support varies between different **compilers** and versions. Please note the [list of supported compilers](https://github.com/fktn-k/fkYAML/blob/develop/README.md#supported-compilers). Some compilers like GCC 4.7 (and earlier), Clang 3.3 (and earlier), or Microsoft Visual Studio 13.0 and earlier are known not to work due to missing or incomplete C++11 support. Please refrain from proposing changes that work around these compiler's limitations with `#ifdef`s or other means.
- Please refrain from proposing changes that would **break [YAML](https://yaml.org/) specifications**. If you propose a conformant extension of YAML to be supported by the library, please motivate this extension.
- Please do not open pull requests that address **multiple issues**.
