### PR TITLE
Disable the fail-fast option for GitHub Actions workflow jobs

### DIFF
--- a/.github/workflows/macos.yml
+++ b/.github/workflows/macos.yml
@@ -31,6 +31,7 @@ jobs:
     timeout-minutes: 10
     runs-on: macos-latest
     strategy:
+      fail-fast: false
       matrix:
         build_type: [ Debug, Release ]
         single_header: ["ON", "OFF"]
@@ -56,6 +57,7 @@ jobs:
     timeout-minutes: 10
     runs-on: macos-13
     strategy:
+      fail-fast: false
       matrix:
         xcode: [ '14.1', '14.2', '14.3.1', '15.0.1', '15.1', '15.2' ]
         build_type: [ Debug, Release ]
@@ -82,6 +84,7 @@ jobs:
     timeout-minutes: 10
     runs-on: macos-14
     strategy:
+      fail-fast: false
       matrix:
         # The macos-14 runner image will contain only Xcode 15.x versions due to support policy changes.
         # Xcode 16.x versions are tested with the macos-15 runner image.
@@ -111,6 +114,7 @@ jobs:
     timeout-minutes: 10
     runs-on: macos-15
     strategy:
+      fail-fast: false
       matrix:
         # The macos-14 runner image will contain only Xcode 16.x versions.
         # See https://github.com/actions/runner-images/issues/10703 for more details.

--- a/.github/workflows/ubuntu.yml
+++ b/.github/workflows/ubuntu.yml
@@ -40,6 +40,7 @@ jobs:
     timeout-minutes: 10
     runs-on: ubuntu-latest
     strategy:
+      fail-fast: false
       matrix:
         build_type: [ Debug, Release ]
         use_single_header: ["ON", "OFF"]

--- a/.github/workflows/windows.yml
+++ b/.github/workflows/windows.yml
@@ -34,6 +34,7 @@ jobs:
     timeout-minutes: 10
     runs-on: windows-2019
     strategy:
+      fail-fast: false
       matrix:
         arch: [ Win32, x64 ]
         build_type: [ Debug, Release ]
@@ -58,6 +59,7 @@ jobs:
     timeout-minutes: 10
     runs-on: windows-2022
     strategy:
+      fail-fast: false
       matrix:
         arch: [ Win32, x64 ]
         build_type: [ Debug, Release ]
@@ -82,6 +84,7 @@ jobs:
     timeout-minutes: 10
     runs-on: windows-2022
     strategy:
+      fail-fast: false
       matrix:
         cxx_standards: [ "11", "14", "17", "20", "23" ]
         build_type: [ Debug, Release ]
@@ -105,6 +108,7 @@ jobs:
     timeout-minutes: 10
     runs-on: ${{matrix.os}}
     strategy:
+      fail-fast: false
       matrix:
         os: [ windows-2019, windows-2022 ]
         build_type: [ Debug, Release ]


### PR DESCRIPTION
This PR disables the `fail-fast` option for the jobs with different build types(Debug/Release) and/or compiler versions in order to make it easier to debug issues in some specific sets of build configurations.  
Nothing else is changed.  

---

## Pull Request Checklist

Read the [CONTRIBUTING.md](https://github.com/fktn-k/fkYAML/blob/develop/CONTRIBUTING.md) file for detailed information.  

- [x] Changes are described in the pull request or in a referenced [issue](https://github.com/fktn-k/fkYAML/issues).
- [x] The test suite compiles and runs without any error.
- [x] [The code coverage](https://coveralls.io/github/fktn-k/fkYAML) on your branch is 100%.
- [x] The documentation is updated if you added/changed a feature.

## Please don't

- The C++11 support varies between different **compilers** and versions. Please note the [list of supported compilers](https://github.com/fktn-k/fkYAML/blob/develop/README.md#supported-compilers). Some compilers like GCC 4.7 (and earlier), Clang 3.3 (and earlier), or Microsoft Visual Studio 13.0 and earlier are known not to work due to missing or incomplete C++11 support. Please refrain from proposing changes that work around these compiler's limitations with `#ifdef`s or other means.
- Please refrain from proposing changes that would **break [YAML](https://yaml.org/) specifications**. If you propose a conformant extension of YAML to be supported by the library, please motivate this extension.
- Please do not open pull requests that address **multiple issues**.
