### PR TITLE
Fix conversions from empty tuples

### DIFF
--- a/include/fkYAML/detail/conversions/to_node.hpp
+++ b/include/fkYAML/detail/conversions/to_node.hpp
@@ -148,20 +148,31 @@ inline void to_node(BasicNodeType& n, const std::pair<T, U>& p) {
 /// @tparam ...Idx Index sequence values for std::tuple value types.
 /// @param n A basic_node object.
 /// @param t A std::tuple object.
-/// @param _ Index sequence values (unused)
+/// @param _ An index sequence. (unused)
 template <typename BasicNodeType, typename... Types, std::size_t... Idx>
 inline void to_node_tuple_impl(BasicNodeType& n, const std::tuple<Types...>& t, index_sequence<Idx...> /*unused*/) {
     n = {std::get<Idx>(t)...};
 }
 
-/// @brief to_node function for std::tuple objects.
+/// @brief to_node function for std::tuple objects with no value types.
+/// @note This implementation is needed since calling `to_node_tuple_impl()` with an empty tuple creates a null node.
 /// @tparam BasicNodeType A basic_node template instance type.
-/// @tparam ...Types The value types of std::tuple.
+/// @param n A basic_node object.
+/// @param _ A std::tuple object. (unused)
+template <typename BasicNodeType>
+inline void to_node(BasicNodeType& n, const std::tuple<>& /*unused*/) {
+    n = BasicNodeType::sequence();
+}
+
+/// @brief to_node function for std::tuple objects with at least one value type.
+/// @tparam BasicNodeType A basic_node template instance type.
+/// @tparam ...FirstType The first value types of std::tuple.
+/// @tparam ...RestTypes The rest value types of std::tuple. (maybe empty)
 /// @param n A basic_node object.
 /// @param t A std::tuple object.
-template <typename BasicNodeType, typename... Types>
-inline void to_node(BasicNodeType& n, const std::tuple<Types...>& t) {
-    to_node_tuple_impl(n, t, index_sequence_for<Types...> {});
+template <typename BasicNodeType, typename FirstType, typename... RestTypes>
+inline void to_node(BasicNodeType& n, const std::tuple<FirstType, RestTypes...>& t) {
+    to_node_tuple_impl(n, t, index_sequence_for<FirstType, RestTypes...> {});
 }
 
 /// @brief to_node function for BasicNodeType::mapping_type objects.

--- a/single_include/fkYAML/node.hpp
+++ b/single_include/fkYAML/node.hpp
@@ -12298,20 +12298,31 @@ inline void to_node(BasicNodeType& n, const std::pair<T, U>& p) {
 /// @tparam ...Idx Index sequence values for std::tuple value types.
 /// @param n A basic_node object.
 /// @param t A std::tuple object.
-/// @param _ Index sequence values (unused)
+/// @param _ An index sequence. (unused)
 template <typename BasicNodeType, typename... Types, std::size_t... Idx>
 inline void to_node_tuple_impl(BasicNodeType& n, const std::tuple<Types...>& t, index_sequence<Idx...> /*unused*/) {
     n = {std::get<Idx>(t)...};
 }
 
-/// @brief to_node function for std::tuple objects.
+/// @brief to_node function for std::tuple objects with no value types.
+/// @note This implementation is needed since calling `to_node_tuple_impl()` with an empty tuple creates a null node.
 /// @tparam BasicNodeType A basic_node template instance type.
-/// @tparam ...Types The value types of std::tuple.
+/// @param n A basic_node object.
+/// @param _ A std::tuple object. (unused)
+template <typename BasicNodeType>
+inline void to_node(BasicNodeType& n, const std::tuple<>& /*unused*/) {
+    n = BasicNodeType::sequence();
+}
+
+/// @brief to_node function for std::tuple objects with at least one value type.
+/// @tparam BasicNodeType A basic_node template instance type.
+/// @tparam ...FirstType The first value types of std::tuple.
+/// @tparam ...RestTypes The rest value types of std::tuple. (maybe empty)
 /// @param n A basic_node object.
 /// @param t A std::tuple object.
-template <typename BasicNodeType, typename... Types>
-inline void to_node(BasicNodeType& n, const std::tuple<Types...>& t) {
-    to_node_tuple_impl(n, t, index_sequence_for<Types...> {});
+template <typename BasicNodeType, typename FirstType, typename... RestTypes>
+inline void to_node(BasicNodeType& n, const std::tuple<FirstType, RestTypes...>& t) {
+    to_node_tuple_impl(n, t, index_sequence_for<FirstType, RestTypes...> {});
 }
 
 /// @brief to_node function for BasicNodeType::mapping_type objects.

--- a/tests/unit_test/test_node_class.cpp
+++ b/tests/unit_test/test_node_class.cpp
@@ -4110,6 +4110,11 @@ TEST_CASE("Node_GetValue_GetValueInplace") {
         REQUIRE(std::get<0>(tuple_val_inplace) == 123);
         REQUIRE(std::get<1>(tuple_val_inplace) == "test");
         REQUIRE(std::get<2>(tuple_val_inplace) == true);
+
+        fkyaml::node empty_seq = fkyaml::node::sequence();
+        REQUIRE_NOTHROW(empty_seq.get_value<std::tuple<>>());
+        std::tuple<> empty_tuple_inplace {};
+        REQUIRE_NOTHROW(empty_seq.get_value_inplace(empty_tuple_inplace));
     }
 
 #ifdef FK_YAML_HAS_CXX_17

--- a/tests/unit_test/test_node_class.cpp
+++ b/tests/unit_test/test_node_class.cpp
@@ -441,6 +441,12 @@ TEST_CASE("Node_CtorWithCompatibleType") {
 
         fkyaml::node tuple(tuple_val);
         validate(tuple);
+
+        // regression test for https://github.com/fktn-k/fkYAML/pull/467
+        std::tuple<> empty_tuple_val {};
+        fkyaml::node empty_tuple_node(empty_tuple_val);
+        REQUIRE(empty_tuple_node.is_sequence());
+        REQUIRE(empty_tuple_node.empty());
     }
 
     // mapping-like types


### PR DESCRIPTION
This PR fixes wrong conversions from `std::tuple<>` to `basic_node`.  
That was introduced in the PR #465.  
`std::tuple<>` was converted to a null node while an empty sequence was (and still is) converted to `std::tuple<>`.  
Now, `std::tuple<>` and an empty sequence are guranteed to be converted to each other.  

```cpp
// BEFORE the fix
std::tuple<> t {};
fkyaml::node n = t; // `n` used to be converted as a null scalar node.

// AFTER the fix
fkyaml::node n = t; // `n` is now converted as an empty sequence node.
```

---

## Pull Request Checklist

Read the [CONTRIBUTING.md](https://github.com/fktn-k/fkYAML/blob/develop/CONTRIBUTING.md) file for detailed information.  

- [x] Changes are described in the pull request or in a referenced [issue](https://github.com/fktn-k/fkYAML/issues).
- [x] The test suite compiles and runs without any error.
- [x] [The code coverage](https://coveralls.io/github/fktn-k/fkYAML) on your branch is 100%.
- [x] The documentation is updated if you added/changed a feature.

## Please don't

- The C++11 support varies between different **compilers** and versions. Please note the [list of supported compilers](https://github.com/fktn-k/fkYAML/blob/develop/README.md#supported-compilers). Some compilers like GCC 4.7 (and earlier), Clang 3.3 (and earlier), or Microsoft Visual Studio 13.0 and earlier are known not to work due to missing or incomplete C++11 support. Please refrain from proposing changes that work around these compiler's limitations with `#ifdef`s or other means.
- Please refrain from proposing changes that would **break [YAML](https://yaml.org/) specifications**. If you propose a conformant extension of YAML to be supported by the library, please motivate this extension.
- Please do not open pull requests that address **multiple issues**.
