### PR TITLE
Allow ':' adjacent to a flow mapping value right after a JSON-like key

### DIFF
--- a/single_include/fkYAML/node.hpp
+++ b/single_include/fkYAML/node.hpp
@@ -3364,10 +3364,10 @@ public:
     /// @brief Construct a new lexical_analyzer object.
     /// @param input_buffer An input buffer.
     explicit lexical_analyzer(str_view input_buffer) noexcept
-        : m_input_buffer(input_buffer),
-          m_cur_itr(m_input_buffer.begin()),
-          m_end_itr(m_input_buffer.end()) {
-        m_pos_tracker.set_target_buffer(m_input_buffer);
+        : m_begin_itr(input_buffer.begin()),
+          m_cur_itr(input_buffer.begin()),
+          m_end_itr(input_buffer.end()) {
+        m_pos_tracker.set_target_buffer(input_buffer);
     }
 
     /// @brief Get the next lexical token by scanning the left of the input buffer.
@@ -3404,18 +3404,47 @@ public:
             case '\t':
             case '\n':
                 return {lexical_token_t::KEY_SEPARATOR};
-            case ',':
-            case '[':
-            case ']':
-            case '{':
-            case '}':
-                if (m_state & flow_context_bit) {
+            default:
+                if ((m_state & flow_context_bit) == 0) {
+                    // in a block context
+                    break;
+                }
+
+                switch (*m_cur_itr) {
+                case ',':
+                case '[':
+                case ']':
+                case '{':
+                case '}':
                     // Flow indicators are not "safe" to be followed in a flow context.
                     // See https://yaml.org/spec/1.2.2/#733-plain-style for more details.
                     return {lexical_token_t::KEY_SEPARATOR};
+                default:
+                    // At least '{' or '[' must precedes this token.
+                    FK_YAML_ASSERT(m_token_begin_itr != m_begin_itr);
+
+                    // if a key inside a flow mapping is JSON-like (surrounded by indicators, see below), YAML allows
+                    // the following value to be specified adjacent to the ":" mapping value indicator.
+                    // ```yaml
+                    // # the following flow mapping entries are all valid.
+                    // {
+                    //   "foo":true,
+                    //   'bar':false,          # 'bar' is actually not JSON but allowed in YAML
+                    //                         # since its surrounded by the single quotes.
+                    //   {[1,2,3]:null}:"baz"
+                    // }
+                    // ```
+                    switch (*(m_token_begin_itr - 1)) {
+                    case '\'':
+                    case '\"':
+                    case ']':
+                    case '}':
+                        return {lexical_token_t::KEY_SEPARATOR};
+                    default:
+                        break;
+                    }
+                    break;
                 }
-                break;
-            default:
                 break;
             }
             break;
@@ -3574,14 +3603,14 @@ public:
 private:
     uint32_t get_current_indent_level(const char* p_line_end) {
         // get the beginning position of the current line.
-        std::size_t line_begin_pos = str_view(m_input_buffer.begin(), p_line_end - 1).find_last_of('\n');
+        std::size_t line_begin_pos = str_view(m_begin_itr, p_line_end - 1).find_last_of('\n');
         if (line_begin_pos == str_view::npos) {
             line_begin_pos = 0;
         }
         else {
             ++line_begin_pos;
         }
-        const char* p_line_begin = m_input_buffer.begin() + line_begin_pos;
+        const char* p_line_begin = m_begin_itr + line_begin_pos;
         const char* cur_itr = p_line_begin;
 
         // get the indentation of the current line.
@@ -4484,8 +4513,8 @@ private:
     }
 
 private:
-    /// An input buffer adapter to be analyzed.
-    str_view m_input_buffer;
+    /// The iterator to the first element in the input buffer.
+    const char* m_begin_itr {};
     /// The iterator to the current character in the input buffer.
     const char* m_cur_itr {};
     /// The iterator to the beginning of the current token.

--- a/tests/unit_test/test_lexical_analyzer_class.cpp
+++ b/tests/unit_test/test_lexical_analyzer_class.cpp
@@ -1876,6 +1876,101 @@ TEST_CASE("LexicalAnalyzer_FlowMapping") {
         REQUIRE_NOTHROW(token = lexer.get_next_token());
         REQUIRE(token.type == fkyaml::detail::lexical_token_t::END_OF_BUFFER);
     }
+
+    SECTION("\':\' is preceded by JSON-like keys and followed by values adjacent to it") {
+        fkyaml::detail::str_view input = "{\n"
+                                         "  \"foo\":123,\n"
+                                         "  \'bar\':true,\n"
+                                         "  [baz]:3.14,\n"
+                                         "  {\"qux\":false}:null\n"
+                                         "}";
+        fkyaml::detail::lexical_analyzer lexer(input);
+
+        REQUIRE_NOTHROW(token = lexer.get_next_token());
+        REQUIRE(token.type == fkyaml::detail::lexical_token_t::MAPPING_FLOW_BEGIN);
+
+        lexer.set_context_state(true);
+
+        REQUIRE_NOTHROW(token = lexer.get_next_token());
+        REQUIRE(token.type == fkyaml::detail::lexical_token_t::DOUBLE_QUOTED_SCALAR);
+        REQUIRE(token.str == "foo");
+
+        REQUIRE_NOTHROW(token = lexer.get_next_token());
+        REQUIRE(token.type == fkyaml::detail::lexical_token_t::KEY_SEPARATOR);
+
+        REQUIRE_NOTHROW(token = lexer.get_next_token());
+        REQUIRE(token.type == fkyaml::detail::lexical_token_t::PLAIN_SCALAR);
+        REQUIRE(token.str == "123");
+
+        REQUIRE_NOTHROW(token = lexer.get_next_token());
+        REQUIRE(token.type == fkyaml::detail::lexical_token_t::VALUE_SEPARATOR);
+
+        REQUIRE_NOTHROW(token = lexer.get_next_token());
+        REQUIRE(token.type == fkyaml::detail::lexical_token_t::SINGLE_QUOTED_SCALAR);
+        REQUIRE(token.str == "bar");
+
+        REQUIRE_NOTHROW(token = lexer.get_next_token());
+        REQUIRE(token.type == fkyaml::detail::lexical_token_t::KEY_SEPARATOR);
+
+        REQUIRE_NOTHROW(token = lexer.get_next_token());
+        REQUIRE(token.type == fkyaml::detail::lexical_token_t::PLAIN_SCALAR);
+        REQUIRE(token.str == "true");
+
+        REQUIRE_NOTHROW(token = lexer.get_next_token());
+        REQUIRE(token.type == fkyaml::detail::lexical_token_t::VALUE_SEPARATOR);
+
+        REQUIRE_NOTHROW(token = lexer.get_next_token());
+        REQUIRE(token.type == fkyaml::detail::lexical_token_t::SEQUENCE_FLOW_BEGIN);
+
+        REQUIRE_NOTHROW(token = lexer.get_next_token());
+        REQUIRE(token.type == fkyaml::detail::lexical_token_t::PLAIN_SCALAR);
+        REQUIRE(token.str == "baz");
+
+        REQUIRE_NOTHROW(token = lexer.get_next_token());
+        REQUIRE(token.type == fkyaml::detail::lexical_token_t::SEQUENCE_FLOW_END);
+
+        REQUIRE_NOTHROW(token = lexer.get_next_token());
+        REQUIRE(token.type == fkyaml::detail::lexical_token_t::KEY_SEPARATOR);
+
+        REQUIRE_NOTHROW(token = lexer.get_next_token());
+        REQUIRE(token.type == fkyaml::detail::lexical_token_t::PLAIN_SCALAR);
+        REQUIRE(token.str == "3.14");
+
+        REQUIRE_NOTHROW(token = lexer.get_next_token());
+        REQUIRE(token.type == fkyaml::detail::lexical_token_t::VALUE_SEPARATOR);
+
+        REQUIRE_NOTHROW(token = lexer.get_next_token());
+        REQUIRE(token.type == fkyaml::detail::lexical_token_t::MAPPING_FLOW_BEGIN);
+
+        REQUIRE_NOTHROW(token = lexer.get_next_token());
+        REQUIRE(token.type == fkyaml::detail::lexical_token_t::DOUBLE_QUOTED_SCALAR);
+        REQUIRE(token.str == "qux");
+
+        REQUIRE_NOTHROW(token = lexer.get_next_token());
+        REQUIRE(token.type == fkyaml::detail::lexical_token_t::KEY_SEPARATOR);
+
+        REQUIRE_NOTHROW(token = lexer.get_next_token());
+        REQUIRE(token.type == fkyaml::detail::lexical_token_t::PLAIN_SCALAR);
+        REQUIRE(token.str == "false");
+
+        REQUIRE_NOTHROW(token = lexer.get_next_token());
+        REQUIRE(token.type == fkyaml::detail::lexical_token_t::MAPPING_FLOW_END);
+
+        REQUIRE_NOTHROW(token = lexer.get_next_token());
+        REQUIRE(token.type == fkyaml::detail::lexical_token_t::KEY_SEPARATOR);
+
+        REQUIRE_NOTHROW(token = lexer.get_next_token());
+        REQUIRE(token.type == fkyaml::detail::lexical_token_t::PLAIN_SCALAR);
+        REQUIRE(token.str == "null");
+
+        REQUIRE_NOTHROW(token = lexer.get_next_token());
+        REQUIRE(token.type == fkyaml::detail::lexical_token_t::MAPPING_FLOW_END);
+
+        lexer.set_context_state(false);
+
+        REQUIRE_NOTHROW(token = lexer.get_next_token());
+        REQUIRE(token.type == fkyaml::detail::lexical_token_t::END_OF_BUFFER);
+    }
 }
 
 TEST_CASE("LexicalAnalyzer_BlockSequence") {

--- a/tests/unit_test/test_lexical_analyzer_class.cpp
+++ b/tests/unit_test/test_lexical_analyzer_class.cpp
@@ -280,11 +280,26 @@ TEST_CASE("LexicalAnalyzer_Colon") {
         REQUIRE(token.type == fkyaml::detail::lexical_token_t::KEY_SEPARATOR);
     }
 
-    SECTION("colon with an always-safe character") {
+    SECTION("colon with an always-safe character (block)") {
         fkyaml::detail::lexical_analyzer lexer(":test");
         REQUIRE_NOTHROW(token = lexer.get_next_token());
         REQUIRE(token.type == fkyaml::detail::lexical_token_t::PLAIN_SCALAR);
         REQUIRE(token.str == ":test");
+    }
+
+    SECTION("colon with an always-safe character (flow)") {
+        fkyaml::detail::lexical_analyzer lexer("[:test]");
+        REQUIRE_NOTHROW(token = lexer.get_next_token());
+        REQUIRE(token.type == fkyaml::detail::lexical_token_t::SEQUENCE_FLOW_BEGIN);
+        lexer.set_context_state(true);
+        REQUIRE_NOTHROW(token = lexer.get_next_token());
+        REQUIRE(token.type == fkyaml::detail::lexical_token_t::PLAIN_SCALAR);
+        REQUIRE(token.str == ":test");
+        REQUIRE_NOTHROW(token = lexer.get_next_token());
+        REQUIRE(token.type == fkyaml::detail::lexical_token_t::SEQUENCE_FLOW_END);
+        REQUIRE_NOTHROW(token = lexer.get_next_token());
+        lexer.set_context_state(false);
+        REQUIRE(token.type == fkyaml::detail::lexical_token_t::END_OF_BUFFER);
     }
 
     SECTION("colon with a flow indicator in a non-flow context") {


### PR DESCRIPTION
This PR makes changes to allow for a flow mapping value to be specified right after the ":" mapping value indicator if its key is JSON-like (surrounded by indicators like `{}`, `[]`, `""` or `''`) since the YAML specification allows that for JSON compatibility (see [here](https://yaml.org/spec/1.2.2/#742-flow-mappings)).  
With the changes, the following YAML (and minified JSON) is now parsed without any problem.  

### YAML
```yaml
{
  "foo":true,
  'bar':false,
  {[1,2,3]:"baz"}:3.14
}
```

### JSON (Minified)
```json
{"foo",true,"bar":false,"baz":null}
```

---

## Pull Request Checklist

Read the [CONTRIBUTING.md](https://github.com/fktn-k/fkYAML/blob/develop/CONTRIBUTING.md) file for detailed information.  

- [x] Changes are described in the pull request or in a referenced [issue](https://github.com/fktn-k/fkYAML/issues).
- [x] The test suite compiles and runs without any error.
- [x] [The code coverage](https://coveralls.io/github/fktn-k/fkYAML) on your branch is 100%.
- [x] The documentation is updated if you added/changed a feature.

## Please don't

- The C++11 support varies between different **compilers** and versions. Please note the [list of supported compilers](https://github.com/fktn-k/fkYAML/blob/develop/README.md#supported-compilers). Some compilers like GCC 4.7 (and earlier), Clang 3.3 (and earlier), or Microsoft Visual Studio 13.0 and earlier are known not to work due to missing or incomplete C++11 support. Please refrain from proposing changes that work around these compiler's limitations with `#ifdef`s or other means.
- Please refrain from proposing changes that would **break [YAML](https://yaml.org/) specifications**. If you propose a conformant extension of YAML to be supported by the library, please motivate this extension.
- Please do not open pull requests that address **multiple issues**.
