### PR TITLE
Fix comment prefix check

### DIFF
--- a/include/fkYAML/detail/input/lexical_analyzer.hpp
+++ b/include/fkYAML/detail/input/lexical_analyzer.hpp
@@ -396,6 +396,16 @@ private:
     /// @brief Skip until a newline code or a null character is found.
     void scan_comment() {
         FK_YAML_ASSERT(*m_cur_itr == '#');
+        if FK_YAML_LIKELY (m_cur_itr != m_begin_itr) {
+            switch (*(m_cur_itr - 1)) {
+            case ' ':
+            case '\t':
+            case '\n':
+                break;
+            default:
+                emit_error("Comment must not begin right after non-break characters");
+            }
+        }
         skip_until_line_end();
     }
 

--- a/single_include/fkYAML/node.hpp
+++ b/single_include/fkYAML/node.hpp
@@ -3698,6 +3698,16 @@ private:
     /// @brief Skip until a newline code or a null character is found.
     void scan_comment() {
         FK_YAML_ASSERT(*m_cur_itr == '#');
+        if FK_YAML_LIKELY (m_cur_itr != m_begin_itr) {
+            switch (*(m_cur_itr - 1)) {
+            case ' ':
+            case '\t':
+            case '\n':
+                break;
+            default:
+                emit_error("Comment must not begin right after non-break characters");
+            }
+        }
         skip_until_line_end();
     }
 

--- a/tests/unit_test/test_lexical_analyzer_class.cpp
+++ b/tests/unit_test/test_lexical_analyzer_class.cpp
@@ -235,6 +235,31 @@ TEST_CASE("LexicalAnalyzer_EndOfDocuments") {
     REQUIRE(token.type == fkyaml::detail::lexical_token_t::END_OF_BUFFER);
 }
 
+TEST_CASE("LexicalAnalyzer_Comment") {
+    fkyaml::detail::lexical_token token;
+
+    SECTION("valid comments") {
+        auto input = GENERATE(
+            fkyaml::detail::str_view("# comment"),
+            fkyaml::detail::str_view(" # comment"),
+            fkyaml::detail::str_view("\t# comment\n"),
+            fkyaml::detail::str_view("\n# comment"));
+        fkyaml::detail::lexical_analyzer lexer(input);
+        REQUIRE_NOTHROW(token = lexer.get_next_token());
+        REQUIRE(token.type == fkyaml::detail::lexical_token_t::END_OF_BUFFER);
+    }
+
+    // regression test for https://github.com/fktn-k/fkYAML/pull/469
+    SECTION("invalid comments") {
+        fkyaml::detail::str_view input("\'foo\'#invalid");
+        fkyaml::detail::lexical_analyzer lexer(input);
+        REQUIRE_NOTHROW(token = lexer.get_next_token());
+        REQUIRE(token.type == fkyaml::detail::lexical_token_t::SINGLE_QUOTED_SCALAR);
+        REQUIRE(token.str == "foo");
+        REQUIRE_THROWS_AS(lexer.get_next_token(), fkyaml::parse_error);
+    }
+}
+
 TEST_CASE("LexicalAnalyzer_Colon") {
     fkyaml::detail::lexical_token token;
 


### PR DESCRIPTION
Although the YAML specification doesn't allow a comment to be followed right after non-break characters, the current lexer implementation doesn't detect such an invalid comment usage.  
```yaml
"foo"# invalid comment
```

This PR therefore fixes the implementation so the lexer emits an error when the '#' comment prefix doesn't meet all the following checks:  
* it is the first character in the input buffer, or
* it follows after a white space character (` ` or `\t`) or a line break ('\n' or `\r\n`)

---

## Pull Request Checklist

Read the [CONTRIBUTING.md](https://github.com/fktn-k/fkYAML/blob/develop/CONTRIBUTING.md) file for detailed information.  

- [x] Changes are described in the pull request or in a referenced [issue](https://github.com/fktn-k/fkYAML/issues).
- [x] The test suite compiles and runs without any error.
- [x] [The code coverage](https://coveralls.io/github/fktn-k/fkYAML) on your branch is 100%.
- [x] The documentation is updated if you added/changed a feature.

## Please don't

- The C++11 support varies between different **compilers** and versions. Please note the [list of supported compilers](https://github.com/fktn-k/fkYAML/blob/develop/README.md#supported-compilers). Some compilers like GCC 4.7 (and earlier), Clang 3.3 (and earlier), or Microsoft Visual Studio 13.0 and earlier are known not to work due to missing or incomplete C++11 support. Please refrain from proposing changes that work around these compiler's limitations with `#ifdef`s or other means.
- Please refrain from proposing changes that would **break [YAML](https://yaml.org/) specifications**. If you propose a conformant extension of YAML to be supported by the library, please motivate this extension.
- Please do not open pull requests that address **multiple issues**.
