### PR TITLE
Fix error in parsing empty inputs

### DIFF
--- a/include/fkYAML/detail/input/input_adapter.hpp
+++ b/include/fkYAML/detail/input/input_adapter.hpp
@@ -66,6 +66,10 @@ public:
     /// @brief Get view into the input buffer contents.
     /// @return View into the input buffer contents.
     str_view get_buffer_view() {
+        if FK_YAML_UNLIKELY (m_begin == m_end) {
+            return {};
+        }
+
         m_buffer.clear();
 
         switch (m_encode_type) {
@@ -289,6 +293,10 @@ public:
     /// @brief Get view into the input buffer contents.
     /// @return View into the input buffer contents.
     str_view get_buffer_view() {
+        if FK_YAML_UNLIKELY (m_begin == m_end) {
+            return {};
+        }
+
         IterType current = m_begin;
         std::deque<IterType> cr_itrs {};
         while (current != m_end) {
@@ -391,6 +399,10 @@ public:
     /// @brief Get view into the input buffer contents.
     /// @return View into the input buffer contents.
     str_view get_buffer_view() {
+        if FK_YAML_UNLIKELY (m_begin == m_end) {
+            return {};
+        }
+
         const int shift_bits = (m_encode_type == utf_encode_t::UTF_16BE) ? 0 : 8;
 
         std::array<char16_t, 2> encoded_buffer {{0, 0}};
@@ -473,6 +485,10 @@ public:
     /// @brief Get view into the input buffer contents.
     /// @return View into the input buffer contents.
     str_view get_buffer_view() {
+        if FK_YAML_UNLIKELY (m_begin == m_end) {
+            return {};
+        }
+
         int shift_bits[4] {0, 0, 0, 0};
         if (m_encode_type == utf_encode_t::UTF_32LE) {
             shift_bits[0] = 24;
@@ -564,6 +580,7 @@ private:
     str_view get_buffer_view_utf8() {
         FK_YAML_ASSERT(m_encode_type == utf_encode_t::UTF_8);
 
+        m_buffer.clear();
         char tmp_buf[256] {};
         constexpr std::size_t buf_size = sizeof(tmp_buf) / sizeof(tmp_buf[0]);
         std::size_t read_size = 0;
@@ -582,6 +599,10 @@ private:
             } while (p_cr != p_end);
 
             m_buffer.append(p_current, p_end);
+        }
+
+        if FK_YAML_UNLIKELY (m_buffer.empty()) {
+            return {};
         }
 
         auto current = m_buffer.begin();
@@ -765,6 +786,7 @@ private:
     str_view get_buffer_view_utf8() {
         FK_YAML_ASSERT(m_encode_type == utf_encode_t::UTF_8);
 
+        m_buffer.clear();
         char tmp_buf[256] {};
         do {
             m_istream->read(&tmp_buf[0], 256);
@@ -788,6 +810,10 @@ private:
 
             m_buffer.append(p_current, p_end);
         } while (!m_istream->eof());
+
+        if FK_YAML_UNLIKELY (m_buffer.empty()) {
+            return {};
+        }
 
         auto current = m_buffer.begin();
         auto end = m_buffer.end();

--- a/include/fkYAML/detail/input/input_adapter.hpp
+++ b/include/fkYAML/detail/input/input_adapter.hpp
@@ -769,6 +769,9 @@ private:
         do {
             m_istream->read(&tmp_buf[0], 256);
             const auto read_size = static_cast<std::size_t>(m_istream->gcount());
+            if FK_YAML_UNLIKELY (read_size == 0) {
+                break;
+            }
 
             char* p_current = &tmp_buf[0];
             char* p_end = p_current + read_size;

--- a/single_include/fkYAML/node.hpp
+++ b/single_include/fkYAML/node.hpp
@@ -9658,6 +9658,9 @@ private:
         do {
             m_istream->read(&tmp_buf[0], 256);
             const auto read_size = static_cast<std::size_t>(m_istream->gcount());
+            if FK_YAML_UNLIKELY (read_size == 0) {
+                break;
+            }
 
             char* p_current = &tmp_buf[0];
             char* p_end = p_current + read_size;

--- a/single_include/fkYAML/node.hpp
+++ b/single_include/fkYAML/node.hpp
@@ -8955,6 +8955,10 @@ public:
     /// @brief Get view into the input buffer contents.
     /// @return View into the input buffer contents.
     str_view get_buffer_view() {
+        if FK_YAML_UNLIKELY (m_begin == m_end) {
+            return {};
+        }
+
         m_buffer.clear();
 
         switch (m_encode_type) {
@@ -9178,6 +9182,10 @@ public:
     /// @brief Get view into the input buffer contents.
     /// @return View into the input buffer contents.
     str_view get_buffer_view() {
+        if FK_YAML_UNLIKELY (m_begin == m_end) {
+            return {};
+        }
+
         IterType current = m_begin;
         std::deque<IterType> cr_itrs {};
         while (current != m_end) {
@@ -9280,6 +9288,10 @@ public:
     /// @brief Get view into the input buffer contents.
     /// @return View into the input buffer contents.
     str_view get_buffer_view() {
+        if FK_YAML_UNLIKELY (m_begin == m_end) {
+            return {};
+        }
+
         const int shift_bits = (m_encode_type == utf_encode_t::UTF_16BE) ? 0 : 8;
 
         std::array<char16_t, 2> encoded_buffer {{0, 0}};
@@ -9362,6 +9374,10 @@ public:
     /// @brief Get view into the input buffer contents.
     /// @return View into the input buffer contents.
     str_view get_buffer_view() {
+        if FK_YAML_UNLIKELY (m_begin == m_end) {
+            return {};
+        }
+
         int shift_bits[4] {0, 0, 0, 0};
         if (m_encode_type == utf_encode_t::UTF_32LE) {
             shift_bits[0] = 24;
@@ -9453,6 +9469,7 @@ private:
     str_view get_buffer_view_utf8() {
         FK_YAML_ASSERT(m_encode_type == utf_encode_t::UTF_8);
 
+        m_buffer.clear();
         char tmp_buf[256] {};
         constexpr std::size_t buf_size = sizeof(tmp_buf) / sizeof(tmp_buf[0]);
         std::size_t read_size = 0;
@@ -9471,6 +9488,10 @@ private:
             } while (p_cr != p_end);
 
             m_buffer.append(p_current, p_end);
+        }
+
+        if FK_YAML_UNLIKELY (m_buffer.empty()) {
+            return {};
         }
 
         auto current = m_buffer.begin();
@@ -9654,6 +9675,7 @@ private:
     str_view get_buffer_view_utf8() {
         FK_YAML_ASSERT(m_encode_type == utf_encode_t::UTF_8);
 
+        m_buffer.clear();
         char tmp_buf[256] {};
         do {
             m_istream->read(&tmp_buf[0], 256);
@@ -9677,6 +9699,10 @@ private:
 
             m_buffer.append(p_current, p_end);
         } while (!m_istream->eof());
+
+        if FK_YAML_UNLIKELY (m_buffer.empty()) {
+            return {};
+        }
 
         auto current = m_buffer.begin();
         auto end = m_buffer.end();

--- a/tests/unit_test/test_deserializer_class.cpp
+++ b/tests/unit_test/test_deserializer_class.cpp
@@ -14,6 +14,9 @@ TEST_CASE("Deserializer_EmptyInput") {
     fkyaml::detail::basic_deserializer<fkyaml::node> deserializer;
     fkyaml::node root;
 
+    REQUIRE_NOTHROW(root = deserializer.deserialize(fkyaml::detail::input_adapter("")));
+    REQUIRE(root.is_null());
+
     REQUIRE_NOTHROW(root = deserializer.deserialize(fkyaml::detail::input_adapter(" ")));
     REQUIRE(root.is_null());
 }

--- a/tests/unit_test/test_input_adapter.cpp
+++ b/tests/unit_test/test_input_adapter.cpp
@@ -29,13 +29,6 @@
 #define ENABLE_C4996
 #endif
 
-namespace /* file-scoped global variable for test cases */
-{
-
-constexpr char input_file_path[] = FK_YAML_TEST_DATA_DIR "/input_adapter_test_data.txt";
-
-} // namespace
-
 TEST_CASE("InputAdapter_IteratorInputAdapterProvider") {
     char input[] = "test";
 
@@ -141,7 +134,7 @@ TEST_CASE("InputAdapter_FileInputAdapterProvider") {
 
     SECTION("valid FILE object pointer") {
         DISABLE_C4996
-        FILE* p_file = std::fopen(input_file_path, "r");
+        FILE* p_file = std::fopen(FK_YAML_TEST_DATA_DIR "/input_adapter_test_data.txt", "r");
         ENABLE_C4996
 
         REQUIRE(p_file != nullptr);
@@ -159,7 +152,7 @@ TEST_CASE("InputAdapter_StreamInputAdapterProvider") {
     }
 
     SECTION("valid stream") {
-        std::ifstream ifs(input_file_path);
+        std::ifstream ifs(FK_YAML_TEST_DATA_DIR "/input_adapter_test_data.txt");
         REQUIRE(ifs);
         auto input_adapter = fkyaml::detail::input_adapter(ifs);
         REQUIRE(std::is_same<decltype(input_adapter), fkyaml::detail::stream_input_adapter>::value);
@@ -284,7 +277,7 @@ TEST_CASE("InputAdapter_EmptyInput") {
     }
 }
 
-TEST_CASE("InputAdapter_FillBuffer_UTF8N") {
+TEST_CASE("InputAdapter_GetBufferView_UTF8N") {
     SECTION("iterator_input_adapter with a char array") {
         char input[] = "test source.";
         auto input_adapter = fkyaml::detail::input_adapter(input);
@@ -372,7 +365,7 @@ TEST_CASE("InputAdapter_FillBuffer_UTF8N") {
     }
 }
 
-TEST_CASE("InputAdapter_FillBuffer_UTF8BOM") {
+TEST_CASE("InputAdapter_GetBufferView_UTF8BOM") {
     SECTION("iterator_input_adapter with a char array") {
         char input[] = {
             char(0xEFu), char(0xBBu), char(0xBFu), 't', 'e', 's', 't', ' ', 's', 'o', 'u', 'r', 'c', 'e', '.', 0};
@@ -463,7 +456,7 @@ TEST_CASE("InputAdapter_FillBuffer_UTF8BOM") {
     }
 }
 
-TEST_CASE("InputAdapter_FillBuffer_UTF16BEN") {
+TEST_CASE("InputAdapter_GetBufferView_UTF16BEN") {
     SECTION("iterator_input_adapter with a char array") {
         char input[] = {0, 0x61, 0x30, 0x42, char(0xD8u), 0x40, char(0xDCu), 0x0B, 0, 0x52, 0};
         auto input_adapter = fkyaml::detail::input_adapter(input);
@@ -589,7 +582,7 @@ TEST_CASE("InputAdapter_FillBuffer_UTF16BEN") {
     }
 }
 
-TEST_CASE("InputAdapter_FillBuffer_UTF16BEBOM") {
+TEST_CASE("InputAdapter_GetBufferView_UTF16BEBOM") {
     SECTION("iterator_input_adapter with a char array") {
         char input[] = {
             char(0xFEu), char(0xFFu), 0, 0x61, 0x30, 0x42, char(0xD8u), 0x40, char(0xDCu), 0x0B, 0, 0x52, 0};
@@ -714,7 +707,7 @@ TEST_CASE("InputAdapter_FillBuffer_UTF16BEBOM") {
     }
 }
 
-TEST_CASE("InputAdapter_FillBuffer_UTF16LEN") {
+TEST_CASE("InputAdapter_GetBufferView_UTF16LEN") {
     SECTION("iterator_input_adapter with a char array") {
         char input[] = {0x61, 0, 0x42, 0x30, 0x40, char(0xD8u), 0x0B, char(0xDCu), 0x52, 0, 0};
         auto input_adapter = fkyaml::detail::input_adapter(input);
@@ -838,7 +831,7 @@ TEST_CASE("InputAdapter_FillBuffer_UTF16LEN") {
     }
 }
 
-TEST_CASE("InputAdapter_FillBuffer_UTF16LEBOM") {
+TEST_CASE("InputAdapter_GetBufferView_UTF16LEBOM") {
     SECTION("iterator_input_adapter with a char array") {
         char input[] = {
             char(0xFFu), char(0xFEu), 0x61, 0, 0x42, 0x30, 0x40, char(0xD8u), 0x0B, char(0xDCu), 0x52, 0, 0};
@@ -964,7 +957,7 @@ TEST_CASE("InputAdapter_FillBuffer_UTF16LEBOM") {
     }
 }
 
-TEST_CASE("InputAdapter_FillBuffer_UTF32BEN") {
+TEST_CASE("InputAdapter_GetBufferView_UTF32BEN") {
     SECTION("iterator_input_adapter with a char array") {
         char input[] = {0, 0, 0, 0x61, 0, 0, 0x30, 0x42, 0, 0x02, 0, 0x0B, 0};
         auto input_adapter = fkyaml::detail::input_adapter(input);
@@ -1082,7 +1075,7 @@ TEST_CASE("InputAdapter_FillBuffer_UTF32BEN") {
     }
 }
 
-TEST_CASE("InputAdapter_FillBuffer_UTF32BEBOM") {
+TEST_CASE("InputAdapter_GetBufferView_UTF32BEBOM") {
     SECTION("iterator_input_adapter with a char array") {
         char input[] = {0, 0, char(0xFEu), char(0xFFu), 0, 0, 0, 0x61, 0, 0, 0x30, 0x42, 0, 0x02, 0, 0x0B, 0};
         auto input_adapter = fkyaml::detail::input_adapter(input);
@@ -1200,7 +1193,7 @@ TEST_CASE("InputAdapter_FillBuffer_UTF32BEBOM") {
     }
 }
 
-TEST_CASE("InputAdapter_FillBuffer_UTF32LEN") {
+TEST_CASE("InputAdapter_GetBufferView_UTF32LEN") {
     SECTION("iterator_input_adapter with a char array") {
         char input[] = {0x61, 0, 0, 0, 0x42, 0x30, 0, 0, 0x0B, 0, 0x02, 0, 0};
         auto input_adapter = fkyaml::detail::input_adapter(input);
@@ -1318,7 +1311,7 @@ TEST_CASE("InputAdapter_FillBuffer_UTF32LEN") {
     }
 }
 
-TEST_CASE("InputAdapter_FillBuffer_UTF32LEBOM") {
+TEST_CASE("InputAdapter_GetBufferView_UTF32LEBOM") {
     SECTION("iterator_input_adapter with a char array") {
         char input[] = {char(0xFFu), char(0xFEu), 0, 0, 0x61, 0, 0, 0, 0x42, 0x30, 0, 0, 0x0B, 0, 0x02, 0, 0};
         auto input_adapter = fkyaml::detail::input_adapter(input);
@@ -1436,7 +1429,7 @@ TEST_CASE("InputAdapter_FillBuffer_UTF32LEBOM") {
     }
 }
 
-TEST_CASE("InputAdapter_FillBuffer_UTF8CharsValidation") {
+TEST_CASE("InputAdapter_GetBufferView_UTF8CharsValidation") {
     /////////////////////////////////
     //   UTF-8 1-Byte Characters   //
     /////////////////////////////////
@@ -1774,7 +1767,7 @@ TEST_CASE("InputAdapter_FillBuffer_UTF8CharsValidation") {
     }
 }
 
-TEST_CASE("InputAdapter_FillBuffer_UTF8NewlineCodeNormalization") {
+TEST_CASE("InputAdapter_GetBufferView_UTF8NewlineCodeNormalization") {
     SECTION("iterator_input_adapter (char)") {
         char input[] = "test\r\ndata\r\n";
         auto input_adapter = fkyaml::detail::input_adapter(input);
@@ -1863,7 +1856,7 @@ TEST_CASE("InputAdapter_FillBuffer_UTF8NewlineCodeNormalization") {
     }
 }
 
-TEST_CASE("InputAdapter_FillBuffer_UTF16BENewlineCodeNormalization") {
+TEST_CASE("InputAdapter_GetBufferView_UTF16BENewlineCodeNormalization") {
     SECTION("iterator_input_adapter (char)") {
         char input[] = {0, char(0x74), 0, char(0x65), 0, char(0x73), 0, char(0x74), 0, char(0x0D),
                         0, char(0x0A), 0, char(0x64), 0, char(0x61), 0, char(0x74), 0, char(0x61),
@@ -1965,7 +1958,7 @@ TEST_CASE("InputAdapter_FillBuffer_UTF16BENewlineCodeNormalization") {
     }
 }
 
-TEST_CASE("InputAdapter_FillBuffer_UTF32BENewlineCodeNormalization") {
+TEST_CASE("InputAdapter_GetBufferView_UTF32BENewlineCodeNormalization") {
     SECTION("iterator_input_adapter (char)") {
         char input[] = {0, 0, 0, char(0x74), 0, 0, 0, char(0x65), 0, 0, 0, char(0x73), 0, 0, 0, char(0x74),
                         0, 0, 0, char(0x0D), 0, 0, 0, char(0x0A), 0, 0, 0, char(0x64), 0, 0, 0, char(0x61),

--- a/tests/unit_test/test_input_adapter.cpp
+++ b/tests/unit_test/test_input_adapter.cpp
@@ -49,7 +49,7 @@ TEST_CASE("InputAdapter_IteratorInputAdapterProvider") {
         REQUIRE(std::is_same<decltype(input_adapter), fkyaml::detail::iterator_input_adapter<char*>>::value);
     }
 
-#ifdef FK_YAML_HAS_CXX_20
+#if FK_YAML_HAS_CHAR8_T
     SECTION("C-style char8_t array") {
         char8_t input8[] = u8"test";
         auto input_adapter = fkyaml::detail::input_adapter(input8);
@@ -115,7 +115,7 @@ TEST_CASE("InputAdapter_IteratorInputAdapterProvider") {
     }
 #endif
 
-#ifdef FK_YAML_HAS_CXX_20
+#if FK_YAML_HAS_CHAR8_T
     SECTION("std::u8string") {
         std::u8string input_str(u8"test");
         auto input_adapter = fkyaml::detail::input_adapter(input_str);
@@ -163,6 +163,124 @@ TEST_CASE("InputAdapter_StreamInputAdapterProvider") {
         REQUIRE(ifs);
         auto input_adapter = fkyaml::detail::input_adapter(ifs);
         REQUIRE(std::is_same<decltype(input_adapter), fkyaml::detail::stream_input_adapter>::value);
+    }
+}
+
+TEST_CASE("InputAdapter_EmptyInput") {
+    SECTION("C-style char array") {
+        char input[] = "";
+        auto input_adapter = fkyaml::detail::input_adapter(input);
+        auto view = input_adapter.get_buffer_view();
+        REQUIRE(view.empty());
+    }
+
+#if FK_YAML_HAS_CHAR8_T
+    SECTION("C-style char8_t array") {
+        char8_t input[] = u8"";
+        auto input_adapter = fkyaml::detail::input_adapter(input);
+        auto view = input_adapter.get_buffer_view();
+        REQUIRE(view.empty());
+    }
+#endif
+
+    SECTION("C-style char16_t array") {
+        char16_t input[] = u"";
+        auto input_adapter = fkyaml::detail::input_adapter(input);
+        auto view = input_adapter.get_buffer_view();
+        REQUIRE(view.empty());
+    }
+
+    SECTION("C-style char32_t array") {
+        char32_t input[] = U"";
+        auto input_adapter = fkyaml::detail::input_adapter(input);
+        auto view = input_adapter.get_buffer_view();
+        REQUIRE(view.empty());
+    }
+
+    ////////////////////////////////////////////////////////
+
+    SECTION("std::string") {
+        std::string input {};
+        auto input_adapter = fkyaml::detail::input_adapter(input);
+        auto view = input_adapter.get_buffer_view();
+        REQUIRE(view.empty());
+    }
+
+    SECTION("std::u16string") {
+        std::u16string input {};
+        auto input_adapter = fkyaml::detail::input_adapter(input);
+        auto view = input_adapter.get_buffer_view();
+        REQUIRE(view.empty());
+    }
+
+    SECTION("std::u32string") {
+        std::u32string input {};
+        auto input_adapter = fkyaml::detail::input_adapter(input);
+        auto view = input_adapter.get_buffer_view();
+        REQUIRE(view.empty());
+    }
+
+#ifdef FK_YAML_HAS_CXX_17
+    SECTION("std::string_view") {
+        std::string_view input {};
+        auto input_adapter = fkyaml::detail::input_adapter(input);
+        auto view = input_adapter.get_buffer_view();
+        REQUIRE(view.empty());
+    }
+
+    SECTION("std::u16string_view") {
+        using namespace std::string_view_literals;
+        std::u16string_view input = u""sv;
+        auto input_adapter = fkyaml::detail::input_adapter(input);
+        auto view = input_adapter.get_buffer_view();
+        REQUIRE(view.empty());
+    }
+
+    SECTION("std::u32string_view") {
+        using namespace std::string_view_literals;
+        std::u32string_view input = U""sv;
+        auto input_adapter = fkyaml::detail::input_adapter(input);
+        auto view = input_adapter.get_buffer_view();
+        REQUIRE(view.empty());
+    }
+#endif
+
+#if FK_YAML_HAS_CHAR8_T
+    SECTION("std::u8string") {
+        std::u8string input {};
+        auto input_adapter = fkyaml::detail::input_adapter(input);
+        auto view = input_adapter.get_buffer_view();
+        REQUIRE(view.empty());
+    }
+
+    SECTION("std::u8string_view") {
+        using namespace std::string_view_literals;
+        std::u8string_view input = u8""sv;
+        auto input_adapter = fkyaml::detail::input_adapter(input);
+        auto view = input_adapter.get_buffer_view();
+        REQUIRE(view.empty());
+    }
+#endif
+
+    SECTION("FILE object pointer") {
+        DISABLE_C4996
+        FILE* p_file = std::fopen(FK_YAML_TEST_DATA_DIR "/input_adapter_test_data_empty.txt", "r");
+        ENABLE_C4996
+
+        REQUIRE(p_file != nullptr);
+        auto input_adapter = fkyaml::detail::input_adapter(p_file);
+        auto view = input_adapter.get_buffer_view();
+        REQUIRE(view.empty());
+
+        std::fclose(p_file);
+    }
+
+    SECTION("input stream") {
+        std::ifstream ifs(FK_YAML_TEST_DATA_DIR "/input_adapter_test_data_empty.txt");
+        REQUIRE(ifs);
+        auto input_adapter = fkyaml::detail::input_adapter(ifs);
+        auto view = input_adapter.get_buffer_view();
+        REQUIRE(view.empty());
     }
 }
 
@@ -1677,7 +1795,7 @@ TEST_CASE("InputAdapter_FillBuffer_UTF8NewlineCodeNormalization") {
         REQUIRE(buffer[9] == '\n');
     }
 
-#ifdef FK_YAML_HAS_CXX_20
+#if FK_YAML_HAS_CHAR8_T
     SECTION("iterator_input_adapter (char)") {
         char8_t input[] = u8"test\r\ndata\r\n";
         auto input_adapter = fkyaml::detail::input_adapter(input);


### PR DESCRIPTION
This bug was introduced in the previous PR #470 and this PR fixes it by adding a check of the size read from an input stream.  
Several test cases for a variety of empty inputs have also been added so a similar bug can be found before merging changes in the future.  

---

## Pull Request Checklist

Read the [CONTRIBUTING.md](https://github.com/fktn-k/fkYAML/blob/develop/CONTRIBUTING.md) file for detailed information.  

- [x] Changes are described in the pull request or in a referenced [issue](https://github.com/fktn-k/fkYAML/issues).
- [x] The test suite compiles and runs without any error.
- [x] [The code coverage](https://coveralls.io/github/fktn-k/fkYAML) on your branch is 100%.
- [x] The documentation is updated if you added/changed a feature.

## Please don't

- The C++11 support varies between different **compilers** and versions. Please note the [list of supported compilers](https://github.com/fktn-k/fkYAML/blob/develop/README.md#supported-compilers). Some compilers like GCC 4.7 (and earlier), Clang 3.3 (and earlier), or Microsoft Visual Studio 13.0 and earlier are known not to work due to missing or incomplete C++11 support. Please refrain from proposing changes that work around these compiler's limitations with `#ifdef`s or other means.
- Please refrain from proposing changes that would **break [YAML](https://yaml.org/) specifications**. If you propose a conformant extension of YAML to be supported by the library, please motivate this extension.
- Please do not open pull requests that address **multiple issues**.
