### PR TITLE
Fix document marker detections

### DIFF
--- a/include/fkYAML/detail/input/deserializer.hpp
+++ b/include/fkYAML/detail/input/deserializer.hpp
@@ -992,9 +992,15 @@ private:
                 continue;
             }
             // these tokens end parsing the current YAML document.
-            case lexical_token_t::END_OF_BUFFER: // This handles an empty input.
+            case lexical_token_t::END_OF_BUFFER:
+                // This handles an empty input.
+                last_type = token.type;
+                return;
             case lexical_token_t::END_OF_DIRECTIVES:
             case lexical_token_t::END_OF_DOCUMENT:
+                if FK_YAML_UNLIKELY (m_flow_context_depth > 0) {
+                    throw parse_error("An invalid document marker found in a flow collection", line, indent);
+                }
                 last_type = token.type;
                 return;
             // no way to come here while lexically analyzing document contents.

--- a/tests/unit_test/test_deserializer_class.cpp
+++ b/tests/unit_test/test_deserializer_class.cpp
@@ -3232,6 +3232,20 @@ TEST_CASE("Deserializer_DocumentWithMarkers") {
         REQUIRE(foo_node.is_string());
         REQUIRE(foo_node.get_value_ref<std::string&>() == "one");
     }
+
+    SECTION("invalid directives end marker(---) in a flow collection") {
+        std::string input = "[\n"
+                            "---\n"
+                            "]";
+        REQUIRE_THROWS_AS(root = deserializer.deserialize(fkyaml::detail::input_adapter(input)), fkyaml::parse_error);
+    }
+
+    SECTION("invalid document end marker(...) in a flow collection") {
+        std::string input = "[\n"
+                            "...\n"
+                            "]";
+        REQUIRE_THROWS_AS(root = deserializer.deserialize(fkyaml::detail::input_adapter(input)), fkyaml::parse_error);
+    }
 }
 
 TEST_CASE("Deserializer_MultipleDocuments") {


### PR DESCRIPTION
This PR fixes document marker (`---` and `...`) detections since the current lexer implementation doesn't check whether those markers is at the beginning of a line or not, which makes it impossible to distinguish the following tokens with different meanings in YAML grammer.  
```yaml
--- # this is a directives end marker
  --- # this is a plain scalar
```

Also, the parser now emit an error if a document marker is found in a flow collection since the marker terminates the parsing and the corresponding ending character of the flow collection is regarded as missing:  
```yaml
[   # the corresponding `]` character is not found in this document since
--- # this marker terminates the parsing of the document.
]
```

---

## Pull Request Checklist

Read the [CONTRIBUTING.md](https://github.com/fktn-k/fkYAML/blob/develop/CONTRIBUTING.md) file for detailed information.  

- [x] Changes are described in the pull request or in a referenced [issue](https://github.com/fktn-k/fkYAML/issues).
- [x] The test suite compiles and runs without any error.
- [x] [The code coverage](https://coveralls.io/github/fktn-k/fkYAML) on your branch is 100%.
- [x] The documentation is updated if you added/changed a feature.

## Please don't

- The C++11 support varies between different **compilers** and versions. Please note the [list of supported compilers](https://github.com/fktn-k/fkYAML/blob/develop/README.md#supported-compilers). Some compilers like GCC 4.7 (and earlier), Clang 3.3 (and earlier), or Microsoft Visual Studio 13.0 and earlier are known not to work due to missing or incomplete C++11 support. Please refrain from proposing changes that work around these compiler's limitations with `#ifdef`s or other means.
- Please refrain from proposing changes that would **break [YAML](https://yaml.org/) specifications**. If you propose a conformant extension of YAML to be supported by the library, please motivate this extension.
- Please do not open pull requests that address **multiple issues**.
