### PR TITLE
Fix example builds with incorrectly indented document markers

### DIFF
--- a/.github/workflows/ubuntu.yml
+++ b/.github/workflows/ubuntu.yml
@@ -129,6 +129,17 @@ jobs:
       - name: Run Clang Sanitizers
         run: make clang-sanitizers
 
+  ci_examples:
+    runs-on: ubuntu-latest
+
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          submodules: recursive
+
+      - name: Build examples
+        run: make examples
+
   ci_test_clang_cxx_standards:
     runs-on: ubuntu-latest
     container: silkeh/clang:latest

--- a/examples/apis/basic_node/deserialize_docs_char_array.cpp
+++ b/examples/apis/basic_node/deserialize_docs_char_array.cpp
@@ -14,18 +14,18 @@
 int main() {
     // deserialize a YAML string.
     char input[] = R"(
-    %YAML 1.2
-    ---
-    foo: true
-    bar: 123
-    baz: 3.14
-    ...
-    %TAG ! tag:test.com,2000:
-    ---
-    null: one
-    false: 456
-    TRUE: 1.414
-    )";
+%YAML 1.2
+---
+foo: true
+bar: 123
+baz: 3.14
+...
+%TAG ! tag:test.com,2000:
+---
+null: one
+false: 456
+TRUE: 1.414
+)";
     std::vector<fkyaml::node> docs = fkyaml::node::deserialize_docs(input);
 
     // check the deserialization result.

--- a/examples/apis/basic_node/deserialize_docs_iterators.cpp
+++ b/examples/apis/basic_node/deserialize_docs_iterators.cpp
@@ -16,18 +16,18 @@
 int main() {
     // deserialize a YAML string.
     std::string input = R"(
-    %YAML 1.2
-    ---
-    foo: true
-    bar: 123
-    baz: 3.14
-    ...
-    %TAG ! tag:test.com,2000:
-    ---
-    null: one
-    false: 456
-    TRUE: 1.414
-    )";
+%YAML 1.2
+---
+foo: true
+bar: 123
+baz: 3.14
+...
+%TAG ! tag:test.com,2000:
+---
+null: one
+false: 456
+TRUE: 1.414
+)";
     std::vector<fkyaml::node> docs = fkyaml::node::deserialize_docs(std::begin(input), std::end(input));
 
     // check the deserialization result.

--- a/examples/apis/basic_node/deserialize_docs_string.cpp
+++ b/examples/apis/basic_node/deserialize_docs_string.cpp
@@ -15,18 +15,18 @@
 int main() {
     // deserialize a YAML string.
     std::string s = R"(
-    %YAML 1.2
-    ---
-    foo: true
-    bar: 123
-    baz: 3.14
-    ...
-    %TAG ! tag:test.com,2000:
-    ---
-    null: one
-    false: 456
-    TRUE: 1.414
-    )";
+%YAML 1.2
+---
+foo: true
+bar: 123
+baz: 3.14
+...
+%TAG ! tag:test.com,2000:
+---
+null: one
+false: 456
+TRUE: 1.414
+)";
     std::vector<fkyaml::node> docs = fkyaml::node::deserialize_docs(s);
 
     // check the deserialization result.


### PR DESCRIPTION
This PR fixes examples which contains incorrect indentation of document markers.  
Furthermore, a workflow job is added to check example builds to avoid similar issues in the future.  

---

## Pull Request Checklist

Read the [CONTRIBUTING.md](https://github.com/fktn-k/fkYAML/blob/develop/CONTRIBUTING.md) file for detailed information.  

- [x] Changes are described in the pull request or in a referenced [issue](https://github.com/fktn-k/fkYAML/issues).
- [x] The test suite compiles and runs without any error.
- [x] [The code coverage](https://coveralls.io/github/fktn-k/fkYAML) on your branch is 100%.
- [x] The documentation is updated if you added/changed a feature.

## Please don't

- The C++11 support varies between different **compilers** and versions. Please note the [list of supported compilers](https://github.com/fktn-k/fkYAML/blob/develop/README.md#supported-compilers). Some compilers like GCC 4.7 (and earlier), Clang 3.3 (and earlier), or Microsoft Visual Studio 13.0 and earlier are known not to work due to missing or incomplete C++11 support. Please refrain from proposing changes that work around these compiler's limitations with `#ifdef`s or other means.
- Please refrain from proposing changes that would **break [YAML](https://yaml.org/) specifications**. If you propose a conformant extension of YAML to be supported by the library, please motivate this extension.
- Please do not open pull requests that address **multiple issues**.
