### PR TITLE
Relax iterator requirements for deserialization

### DIFF
--- a/docs/docs/api/basic_node/deserialize.md
+++ b/docs/docs/api/basic_node/deserialize.md
@@ -52,7 +52,7 @@ Throws a [`fkyaml::exception`](../exception/index.md) if the deserialization pro
 ***`ItrType`***
 :   Type of a compatible iterator, for instance:
 
-    * a pair of iterators such as return values of `std::string::begin()` and `std::string::end()`
+    * a pair of iterators which implement the [LegacyInputIterator] requirements, e.g., return values of `std::string::begin()` and `std::string::begin()`
     * a pair of pointers such as `ptr` and `ptr + len`
 
 ## **Parameters**

--- a/docs/docs/api/basic_node/deserialize_docs.md
+++ b/docs/docs/api/basic_node/deserialize_docs.md
@@ -34,7 +34,7 @@ Since this function shares a large portion of internal implementation with the [
 ***`ItrType`***
 :   Type of a compatible iterator, for instance:
 
-    * a pair of iterators such as return values of `std::string::begin()` and `std::string::end()`
+    * a pair of iterators which implement the [LegacyInputIterator] requirements, e.g., return values of `std::string::begin()` and `std::string::begin()`
     * a pair of pointers such as `ptr` and `ptr + len`
 
 ## **Parameters**

--- a/include/fkYAML/detail/encodings/utf_encode_detector.hpp
+++ b/include/fkYAML/detail/encodings/utf_encode_detector.hpp
@@ -103,8 +103,9 @@ struct utf_encode_detector<ItrType, enable_if_t<is_iterator_of<ItrType, char>::v
         // the inner curly braces are necessary for older compilers
         std::array<uint8_t, 4> bytes {{}};
         bytes.fill(0xFFu);
-        for (int i = 0; i < 4 && begin + i != end; i++) {
-            bytes[i] = static_cast<uint8_t>(begin[i]); // NOLINT(cppcoreguidelines-pro-bounds-constant-array-index)
+        auto current = begin;
+        for (int i = 0; i < 4 && current != end; i++, ++current) {
+            bytes[i] = static_cast<uint8_t>(*current); // NOLINT(cppcoreguidelines-pro-bounds-constant-array-index)
         }
 
         bool has_bom = false;
@@ -148,8 +149,9 @@ struct utf_encode_detector<ItrType, enable_if_t<is_iterator_of<ItrType, char8_t>
 
         std::array<uint8_t, 4> bytes {};
         bytes.fill(0xFFu);
-        for (int i = 0; i < 4 && begin + i != end; i++) {
-            bytes[i] = uint8_t(begin[i]); // NOLINT(cppcoreguidelines-pro-bounds-constant-array-index)
+        auto current = begin;
+        for (int i = 0; i < 4 && current != end; i++, ++current) {
+            bytes[i] = uint8_t(*current); // NOLINT(cppcoreguidelines-pro-bounds-constant-array-index)
         }
 
         bool has_bom = false;
@@ -186,12 +188,13 @@ struct utf_encode_detector<ItrType, enable_if_t<is_iterator_of<ItrType, char16_t
         // the inner curly braces are necessary for older compilers
         std::array<uint8_t, 4> bytes {{}};
         bytes.fill(0xFFu);
-        for (int i = 0; i < 2 && begin + i != end; i++) {
+        auto current = begin;
+        for (int i = 0; i < 2 && current != end; i++, ++current) {
             // NOLINTBEGIN(cppcoreguidelines-pro-bounds-constant-array-index)
-            const char16_t elem = begin[i];
+            const char16_t elem = *current;
             const int idx_base = i * 2;
-            bytes[idx_base] = static_cast<uint8_t>((elem & 0xFF00u) >> 8);
-            bytes[idx_base + 1] = static_cast<uint8_t>(elem & 0xFFu);
+            bytes[idx_base] = static_cast<uint8_t>(elem >> 8);
+            bytes[idx_base + 1] = static_cast<uint8_t>(elem);
             // NOLINTEND(cppcoreguidelines-pro-bounds-constant-array-index)
         }
 
@@ -227,10 +230,10 @@ struct utf_encode_detector<ItrType, enable_if_t<is_iterator_of<ItrType, char32_t
         // the inner curly braces are necessary for older compilers
         std::array<uint8_t, 4> bytes {{}};
         const char32_t elem = *begin;
-        bytes[0] = static_cast<uint8_t>((elem & 0xFF000000u) >> 24);
-        bytes[1] = static_cast<uint8_t>((elem & 0x00FF0000u) >> 16);
-        bytes[2] = static_cast<uint8_t>((elem & 0x0000FF00u) >> 8);
-        bytes[3] = static_cast<uint8_t>(elem & 0x000000FFu);
+        bytes[0] = static_cast<uint8_t>(elem >> 24);
+        bytes[1] = static_cast<uint8_t>(elem >> 16);
+        bytes[2] = static_cast<uint8_t>(elem >> 8);
+        bytes[3] = static_cast<uint8_t>(elem);
 
         bool has_bom = false;
         const utf_encode_t encode_type = detect_encoding_type(bytes, has_bom);

--- a/include/fkYAML/detail/input/input_adapter.hpp
+++ b/include/fkYAML/detail/input/input_adapter.hpp
@@ -1013,7 +1013,7 @@ inline iterator_input_adapter<ItrType> create_iterator_input_adapter(ItrType beg
 template <typename ItrType>
 inline iterator_input_adapter<ItrType> input_adapter(ItrType begin, ItrType end) {
     bool is_contiguous = true;
-    const auto size = static_cast<ptrdiff_t>(std::distance(begin, end));
+    const auto size = std::distance(begin, end);
 
     // Check if `begin` & `end` are contiguous iterators.
     // Getting distance between begin and (end - 1) avoids dereferencing an invalid sentinel.
@@ -1052,18 +1052,15 @@ struct container_input_adapter_factory {};
 template <typename ContainerType>
 struct container_input_adapter_factory<
     ContainerType, void_t<decltype(begin(std::declval<ContainerType>()), end(std::declval<ContainerType>()))>> {
-    /// Whether ContainerType is a contiguous container.
-    static constexpr bool is_contiguous = is_contiguous_container<ContainerType>::value;
-
     /// A type for resulting input adapter object.
-    using adapter_type = decltype(create_iterator_input_adapter(
-        begin(std::declval<ContainerType>()), end(std::declval<ContainerType>()), is_contiguous));
+    using adapter_type =
+        decltype(input_adapter(begin(std::declval<ContainerType>()), end(std::declval<ContainerType>())));
 
     /// @brief A factory method of input adapter objects for the target container objects.
     /// @param container A container-like input object.
     /// @return adapter_type An iterator_input_adapter object.
     static adapter_type create(const ContainerType& container) {
-        return create_iterator_input_adapter(begin(container), end(container), is_contiguous);
+        return input_adapter(begin(container), end(container));
     }
 };
 

--- a/include/fkYAML/detail/input/input_adapter.hpp
+++ b/include/fkYAML/detail/input/input_adapter.hpp
@@ -95,17 +95,20 @@ private:
         IterType current = m_begin;
         std::deque<IterType> cr_itrs {};
         while (current != m_end) {
-            const auto first = static_cast<uint8_t>(*current++);
+            const auto first = static_cast<uint8_t>(*current);
             const uint32_t num_bytes = utf8::get_num_bytes(first);
 
             switch (num_bytes) {
             case 1:
                 if FK_YAML_UNLIKELY (first == 0x0D /*CR*/) {
-                    cr_itrs.emplace_back(std::prev(current));
+                    cr_itrs.emplace_back(current);
                 }
+                ++current;
                 break;
             case 2: {
-                const auto second = static_cast<uint8_t>(*current++);
+                ++current;
+                const auto second = static_cast<uint8_t>(*current);
+                ++current;
                 const bool is_valid = utf8::validate(first, second);
                 if FK_YAML_UNLIKELY (!is_valid) {
                     throw fkyaml::invalid_encoding("Invalid UTF-8 encoding.", {first, second});
@@ -113,8 +116,11 @@ private:
                 break;
             }
             case 3: {
-                const auto second = static_cast<uint8_t>(*current++);
-                const auto third = static_cast<uint8_t>(*current++);
+                ++current;
+                const auto second = static_cast<uint8_t>(*current);
+                ++current;
+                const auto third = static_cast<uint8_t>(*current);
+                ++current;
                 const bool is_valid = utf8::validate(first, second, third);
                 if FK_YAML_UNLIKELY (!is_valid) {
                     throw fkyaml::invalid_encoding("Invalid UTF-8 encoding.", {first, second, third});
@@ -122,9 +128,13 @@ private:
                 break;
             }
             case 4: {
-                const auto second = static_cast<uint8_t>(*current++);
-                const auto third = static_cast<uint8_t>(*current++);
-                const auto fourth = static_cast<uint8_t>(*current++);
+                ++current;
+                const auto second = static_cast<uint8_t>(*current);
+                ++current;
+                const auto third = static_cast<uint8_t>(*current);
+                ++current;
+                const auto fourth = static_cast<uint8_t>(*current);
+                ++current;
                 const bool is_valid = utf8::validate(first, second, third, fourth);
                 if FK_YAML_UNLIKELY (!is_valid) {
                     throw fkyaml::invalid_encoding("Invalid UTF-8 encoding.", {first, second, third, fourth});
@@ -139,7 +149,8 @@ private:
         const bool is_contiguous_no_cr = cr_itrs.empty() && m_is_contiguous;
         if FK_YAML_LIKELY (is_contiguous_no_cr) {
             // The input iterators (begin, end) can be used as-is during parsing.
-            return str_view {m_begin, m_end};
+            FK_YAML_ASSERT(m_begin != m_end);
+            return str_view {&*m_begin, static_cast<std::size_t>(std::distance(m_begin, m_end))};
         }
 
         m_buffer.reserve(std::distance(m_begin, m_end) - cr_itrs.size());
@@ -180,8 +191,10 @@ private:
         IterType current = m_begin;
         while (current != m_end || encoded_buf_size != 0) {
             while (current != m_end && encoded_buf_size < 2) {
-                auto utf16 = static_cast<char16_t>(static_cast<uint8_t>(*current++) << shift_bits[0]);
-                utf16 |= static_cast<char16_t>(static_cast<uint8_t>(*current++) << shift_bits[1]);
+                auto utf16 = static_cast<char16_t>(static_cast<uint8_t>(*current) << shift_bits[0]);
+                ++current;
+                utf16 |= static_cast<char16_t>(static_cast<uint8_t>(*current) << shift_bits[1]);
+                ++current;
 
                 // skip appending CRs.
                 if FK_YAML_LIKELY (utf16 != char16_t(0x000Du)) {
@@ -231,10 +244,14 @@ private:
 
         IterType current = m_begin;
         while (current != m_end) {
-            auto utf32 = static_cast<char32_t>(*current++ << shift_bits[0]);
-            utf32 |= static_cast<char32_t>(*current++ << shift_bits[1]);
-            utf32 |= static_cast<char32_t>(*current++ << shift_bits[2]);
-            utf32 |= static_cast<char32_t>(*current++ << shift_bits[3]);
+            auto utf32 = static_cast<char32_t>(*current << shift_bits[0]);
+            ++current;
+            utf32 |= static_cast<char32_t>(*current << shift_bits[1]);
+            ++current;
+            utf32 |= static_cast<char32_t>(*current << shift_bits[2]);
+            ++current;
+            utf32 |= static_cast<char32_t>(*current << shift_bits[3]);
+            ++current;
 
             if FK_YAML_LIKELY (utf32 != char32_t(0x0000000Du)) {
                 utf8::from_utf32(utf32, utf8_buffer, utf8_buf_size);
@@ -300,17 +317,20 @@ public:
         IterType current = m_begin;
         std::deque<IterType> cr_itrs {};
         while (current != m_end) {
-            const auto first = static_cast<uint8_t>(*current++);
+            const auto first = static_cast<uint8_t>(*current);
             const uint32_t num_bytes = utf8::get_num_bytes(first);
 
             switch (num_bytes) {
             case 1:
                 if FK_YAML_UNLIKELY (first == 0x0D /*CR*/) {
-                    cr_itrs.emplace_back(std::prev(current));
+                    cr_itrs.emplace_back(current);
                 }
+                ++current;
                 break;
             case 2: {
-                const auto second = static_cast<uint8_t>(*current++);
+                ++current;
+                const auto second = static_cast<uint8_t>(*current);
+                ++current;
                 const bool is_valid = utf8::validate(first, second);
                 if FK_YAML_UNLIKELY (!is_valid) {
                     throw fkyaml::invalid_encoding("Invalid UTF-8 encoding.", {first, second});
@@ -318,8 +338,11 @@ public:
                 break;
             }
             case 3: {
-                const auto second = static_cast<uint8_t>(*current++);
-                const auto third = static_cast<uint8_t>(*current++);
+                ++current;
+                const auto second = static_cast<uint8_t>(*current);
+                ++current;
+                const auto third = static_cast<uint8_t>(*current);
+                ++current;
                 const bool is_valid = utf8::validate(first, second, third);
                 if FK_YAML_UNLIKELY (!is_valid) {
                     throw fkyaml::invalid_encoding("Invalid UTF-8 encoding.", {first, second, third});
@@ -327,9 +350,13 @@ public:
                 break;
             }
             case 4: {
-                const auto second = static_cast<uint8_t>(*current++);
-                const auto third = static_cast<uint8_t>(*current++);
-                const auto fourth = static_cast<uint8_t>(*current++);
+                ++current;
+                const auto second = static_cast<uint8_t>(*current);
+                ++current;
+                const auto third = static_cast<uint8_t>(*current);
+                ++current;
+                const auto fourth = static_cast<uint8_t>(*current);
+                ++current;
                 const bool is_valid = utf8::validate(first, second, third, fourth);
                 if FK_YAML_UNLIKELY (!is_valid) {
                     throw fkyaml::invalid_encoding("Invalid UTF-8 encoding.", {first, second, third, fourth});
@@ -417,7 +444,8 @@ public:
         IterType current = m_begin;
         while (current != m_end || encoded_buf_size != 0) {
             while (current != m_end && encoded_buf_size < 2) {
-                char16_t utf16 = *current++;
+                char16_t utf16 = *current;
+                ++current;
                 utf16 = static_cast<char16_t>(((utf16 & 0x00FFu) << shift_bits) | ((utf16 & 0xFF00u) >> shift_bits));
 
                 if FK_YAML_LIKELY (utf16 != char16_t(0x000Du)) {
@@ -506,7 +534,8 @@ public:
 
         IterType current = m_begin;
         while (current != m_end) {
-            const char32_t tmp = *current++;
+            const char32_t tmp = *current;
+            ++current;
             const auto utf32 = static_cast<char32_t>(
                 ((tmp & 0xFF000000u) >> shift_bits[0]) | ((tmp & 0x00FF0000u) >> shift_bits[1]) |
                 ((tmp & 0x0000FF00u) << shift_bits[2]) | ((tmp & 0x000000FFu) << shift_bits[3]));
@@ -983,18 +1012,15 @@ inline iterator_input_adapter<ItrType> create_iterator_input_adapter(ItrType beg
 /// @return iterator_input_adapter<ItrType> An iterator_input_adapter object for the target iterator type.
 template <typename ItrType>
 inline iterator_input_adapter<ItrType> input_adapter(ItrType begin, ItrType end) {
-    constexpr bool is_random_access_itr =
-        std::is_same<typename std::iterator_traits<ItrType>::iterator_category, std::random_access_iterator_tag>::value;
+    bool is_contiguous = true;
+    const auto size = static_cast<ptrdiff_t>(std::distance(begin, end));
 
     // Check if `begin` & `end` are contiguous iterators.
     // Getting distance between begin and (end - 1) avoids dereferencing an invalid sentinel.
-    bool is_contiguous = false;
-    if (is_random_access_itr) {
-        const auto size = static_cast<ptrdiff_t>(std::distance(begin, end - 1));
-
-        using CharPtr = remove_cvref_t<typename std::iterator_traits<ItrType>::pointer>;
-        CharPtr p_begin = &*begin;
-        CharPtr p_second_last = &*(end - 1);
+    if FK_YAML_LIKELY (size > 0) {
+        using char_ptr_t = remove_cvref_t<typename std::iterator_traits<ItrType>::pointer>;
+        char_ptr_t p_begin = &*begin;
+        char_ptr_t p_second_last = &*std::next(begin, size - 1);
         is_contiguous = (p_second_last - p_begin == size);
     }
     return create_iterator_input_adapter(begin, end, is_contiguous);

--- a/include/fkYAML/detail/input/input_adapter.hpp
+++ b/include/fkYAML/detail/input/input_adapter.hpp
@@ -103,12 +103,9 @@ private:
                 if FK_YAML_UNLIKELY (first == 0x0D /*CR*/) {
                     cr_itrs.emplace_back(current);
                 }
-                ++current;
                 break;
             case 2: {
-                ++current;
-                const auto second = static_cast<uint8_t>(*current);
-                ++current;
+                const auto second = static_cast<uint8_t>(*++current);
                 const bool is_valid = utf8::validate(first, second);
                 if FK_YAML_UNLIKELY (!is_valid) {
                     throw fkyaml::invalid_encoding("Invalid UTF-8 encoding.", {first, second});
@@ -116,11 +113,8 @@ private:
                 break;
             }
             case 3: {
-                ++current;
-                const auto second = static_cast<uint8_t>(*current);
-                ++current;
-                const auto third = static_cast<uint8_t>(*current);
-                ++current;
+                const auto second = static_cast<uint8_t>(*++current);
+                const auto third = static_cast<uint8_t>(*++current);
                 const bool is_valid = utf8::validate(first, second, third);
                 if FK_YAML_UNLIKELY (!is_valid) {
                     throw fkyaml::invalid_encoding("Invalid UTF-8 encoding.", {first, second, third});
@@ -128,13 +122,9 @@ private:
                 break;
             }
             case 4: {
-                ++current;
-                const auto second = static_cast<uint8_t>(*current);
-                ++current;
-                const auto third = static_cast<uint8_t>(*current);
-                ++current;
-                const auto fourth = static_cast<uint8_t>(*current);
-                ++current;
+                const auto second = static_cast<uint8_t>(*++current);
+                const auto third = static_cast<uint8_t>(*++current);
+                const auto fourth = static_cast<uint8_t>(*++current);
                 const bool is_valid = utf8::validate(first, second, third, fourth);
                 if FK_YAML_UNLIKELY (!is_valid) {
                     throw fkyaml::invalid_encoding("Invalid UTF-8 encoding.", {first, second, third, fourth});
@@ -144,6 +134,8 @@ private:
             default:           // LCOV_EXCL_LINE
                 unreachable(); // LCOV_EXCL_LINE
             }
+
+            ++current;
         }
 
         const bool is_contiguous_no_cr = cr_itrs.empty() && m_is_contiguous;
@@ -192,8 +184,7 @@ private:
         while (current != m_end || encoded_buf_size != 0) {
             while (current != m_end && encoded_buf_size < 2) {
                 auto utf16 = static_cast<char16_t>(static_cast<uint8_t>(*current) << shift_bits[0]);
-                ++current;
-                utf16 |= static_cast<char16_t>(static_cast<uint8_t>(*current) << shift_bits[1]);
+                utf16 |= static_cast<char16_t>(static_cast<uint8_t>(*++current) << shift_bits[1]);
                 ++current;
 
                 // skip appending CRs.
@@ -325,12 +316,9 @@ public:
                 if FK_YAML_UNLIKELY (first == 0x0D /*CR*/) {
                     cr_itrs.emplace_back(current);
                 }
-                ++current;
                 break;
             case 2: {
-                ++current;
-                const auto second = static_cast<uint8_t>(*current);
-                ++current;
+                const auto second = static_cast<uint8_t>(*++current);
                 const bool is_valid = utf8::validate(first, second);
                 if FK_YAML_UNLIKELY (!is_valid) {
                     throw fkyaml::invalid_encoding("Invalid UTF-8 encoding.", {first, second});
@@ -338,11 +326,8 @@ public:
                 break;
             }
             case 3: {
-                ++current;
-                const auto second = static_cast<uint8_t>(*current);
-                ++current;
-                const auto third = static_cast<uint8_t>(*current);
-                ++current;
+                const auto second = static_cast<uint8_t>(*++current);
+                const auto third = static_cast<uint8_t>(*++current);
                 const bool is_valid = utf8::validate(first, second, third);
                 if FK_YAML_UNLIKELY (!is_valid) {
                     throw fkyaml::invalid_encoding("Invalid UTF-8 encoding.", {first, second, third});
@@ -350,13 +335,9 @@ public:
                 break;
             }
             case 4: {
-                ++current;
-                const auto second = static_cast<uint8_t>(*current);
-                ++current;
-                const auto third = static_cast<uint8_t>(*current);
-                ++current;
-                const auto fourth = static_cast<uint8_t>(*current);
-                ++current;
+                const auto second = static_cast<uint8_t>(*++current);
+                const auto third = static_cast<uint8_t>(*++current);
+                const auto fourth = static_cast<uint8_t>(*++current);
                 const bool is_valid = utf8::validate(first, second, third, fourth);
                 if FK_YAML_UNLIKELY (!is_valid) {
                     throw fkyaml::invalid_encoding("Invalid UTF-8 encoding.", {first, second, third, fourth});
@@ -366,6 +347,8 @@ public:
             default:           // LCOV_EXCL_LINE
                 unreachable(); // LCOV_EXCL_LINE
             }
+
+            ++current;
         }
 
         m_buffer.reserve(std::distance(m_begin, m_end) - cr_itrs.size());

--- a/include/fkYAML/detail/meta/input_adapter_traits.hpp
+++ b/include/fkYAML/detail/meta/input_adapter_traits.hpp
@@ -9,18 +9,11 @@
 #ifndef FK_YAML_DETAIL_META_INPUT_ADAPTER_TRAITS_HPP
 #define FK_YAML_DETAIL_META_INPUT_ADAPTER_TRAITS_HPP
 
-#include <array>
-#include <string>
 #include <type_traits>
-#include <vector>
 
 #include <fkYAML/detail/macros/define_macros.hpp>
 #include <fkYAML/detail/meta/detect.hpp>
 #include <fkYAML/detail/meta/stl_supplement.hpp>
-
-#if defined(FK_YAML_HAS_CXX_17) && FK_YAML_HAS_INCLUDE(<string_view>)
-#include <string_view>
-#endif
 
 FK_YAML_DETAIL_NAMESPACE_BEGIN
 
@@ -60,44 +53,6 @@ struct is_input_adapter : std::false_type {};
 template <typename InputAdapterType>
 struct is_input_adapter<InputAdapterType, enable_if_t<has_get_buffer_view<InputAdapterType>::value>> : std::true_type {
 };
-
-/////////////////////////////////////////////////
-//   traits for contiguous iterator detection
-/////////////////////////////////////////////////
-
-/// @brief Type traits to check if T is a container which has contiguous bytes.
-/// @tparam T A target type.
-template <typename T>
-struct is_contiguous_container : std::false_type {};
-
-/// @brief A partial specialization of is_contiguous_container if T is a std::array.
-/// @tparam T Element type.
-/// @tparam N Maximum number of elements.
-template <typename T, std::size_t N>
-struct is_contiguous_container<std::array<T, N>> : std::true_type {};
-
-/// @brief A partial specialization of is_contiguous_container if T is a std::basic_string.
-/// @tparam CharT Character type.
-/// @tparam Traits Character traits type.
-/// @tparam Alloc Allocator type.
-template <typename CharT, typename Traits, typename Alloc>
-struct is_contiguous_container<std::basic_string<CharT, Traits, Alloc>> : std::true_type {};
-
-#ifdef FK_YAML_HAS_CXX_17
-
-/// @brief A partial specialization of is_contiguous_container if T is a std::basic_string_view.
-/// @tparam CharT Character type.
-/// @tparam Traits Character traits type.
-template <typename CharT, typename Traits>
-struct is_contiguous_container<std::basic_string_view<CharT, Traits>> : std::true_type {};
-
-#endif // defined(FK_YAML_HAS_CXX_20)
-
-/// @brief A partial specialization of is_contiguous_container if T is a std::vector.
-/// @tparam T Element type.
-/// @tparam Alloc Allocator type.
-template <typename T, typename Alloc>
-struct is_contiguous_container<std::vector<T, Alloc>> : std::true_type {};
 
 FK_YAML_DETAIL_NAMESPACE_END
 

--- a/include/fkYAML/node.hpp
+++ b/include/fkYAML/node.hpp
@@ -431,7 +431,10 @@ public:
     }
 
     /// @brief Deserialize the first YAML document in the input ranged by the iterators into a basic_node object.
-    /// @tparam ItrType Type of a compatible iterator.
+    /// @note
+    /// Iterators must satisfy the LegacyInputIterator requirements.
+    /// See https://en.cppreference.com/w/cpp/named_req/InputIterator.
+    /// @tparam ItrType Type of a compatible iterator
     /// @param[in] begin An iterator to the first element of an input sequence.
     /// @param[in] end An iterator to the past-the-last element of an input sequence.
     /// @return The resulting basic_node object deserialized from the pair of iterators.

--- a/single_include/fkYAML/node.hpp
+++ b/single_include/fkYAML/node.hpp
@@ -8976,12 +8976,9 @@ private:
                 if FK_YAML_UNLIKELY (first == 0x0D /*CR*/) {
                     cr_itrs.emplace_back(current);
                 }
-                ++current;
                 break;
             case 2: {
-                ++current;
-                const auto second = static_cast<uint8_t>(*current);
-                ++current;
+                const auto second = static_cast<uint8_t>(*++current);
                 const bool is_valid = utf8::validate(first, second);
                 if FK_YAML_UNLIKELY (!is_valid) {
                     throw fkyaml::invalid_encoding("Invalid UTF-8 encoding.", {first, second});
@@ -8989,11 +8986,8 @@ private:
                 break;
             }
             case 3: {
-                ++current;
-                const auto second = static_cast<uint8_t>(*current);
-                ++current;
-                const auto third = static_cast<uint8_t>(*current);
-                ++current;
+                const auto second = static_cast<uint8_t>(*++current);
+                const auto third = static_cast<uint8_t>(*++current);
                 const bool is_valid = utf8::validate(first, second, third);
                 if FK_YAML_UNLIKELY (!is_valid) {
                     throw fkyaml::invalid_encoding("Invalid UTF-8 encoding.", {first, second, third});
@@ -9001,13 +8995,9 @@ private:
                 break;
             }
             case 4: {
-                ++current;
-                const auto second = static_cast<uint8_t>(*current);
-                ++current;
-                const auto third = static_cast<uint8_t>(*current);
-                ++current;
-                const auto fourth = static_cast<uint8_t>(*current);
-                ++current;
+                const auto second = static_cast<uint8_t>(*++current);
+                const auto third = static_cast<uint8_t>(*++current);
+                const auto fourth = static_cast<uint8_t>(*++current);
                 const bool is_valid = utf8::validate(first, second, third, fourth);
                 if FK_YAML_UNLIKELY (!is_valid) {
                     throw fkyaml::invalid_encoding("Invalid UTF-8 encoding.", {first, second, third, fourth});
@@ -9017,6 +9007,8 @@ private:
             default:           // LCOV_EXCL_LINE
                 unreachable(); // LCOV_EXCL_LINE
             }
+
+            ++current;
         }
 
         const bool is_contiguous_no_cr = cr_itrs.empty() && m_is_contiguous;
@@ -9065,8 +9057,7 @@ private:
         while (current != m_end || encoded_buf_size != 0) {
             while (current != m_end && encoded_buf_size < 2) {
                 auto utf16 = static_cast<char16_t>(static_cast<uint8_t>(*current) << shift_bits[0]);
-                ++current;
-                utf16 |= static_cast<char16_t>(static_cast<uint8_t>(*current) << shift_bits[1]);
+                utf16 |= static_cast<char16_t>(static_cast<uint8_t>(*++current) << shift_bits[1]);
                 ++current;
 
                 // skip appending CRs.
@@ -9198,12 +9189,9 @@ public:
                 if FK_YAML_UNLIKELY (first == 0x0D /*CR*/) {
                     cr_itrs.emplace_back(current);
                 }
-                ++current;
                 break;
             case 2: {
-                ++current;
-                const auto second = static_cast<uint8_t>(*current);
-                ++current;
+                const auto second = static_cast<uint8_t>(*++current);
                 const bool is_valid = utf8::validate(first, second);
                 if FK_YAML_UNLIKELY (!is_valid) {
                     throw fkyaml::invalid_encoding("Invalid UTF-8 encoding.", {first, second});
@@ -9211,11 +9199,8 @@ public:
                 break;
             }
             case 3: {
-                ++current;
-                const auto second = static_cast<uint8_t>(*current);
-                ++current;
-                const auto third = static_cast<uint8_t>(*current);
-                ++current;
+                const auto second = static_cast<uint8_t>(*++current);
+                const auto third = static_cast<uint8_t>(*++current);
                 const bool is_valid = utf8::validate(first, second, third);
                 if FK_YAML_UNLIKELY (!is_valid) {
                     throw fkyaml::invalid_encoding("Invalid UTF-8 encoding.", {first, second, third});
@@ -9223,13 +9208,9 @@ public:
                 break;
             }
             case 4: {
-                ++current;
-                const auto second = static_cast<uint8_t>(*current);
-                ++current;
-                const auto third = static_cast<uint8_t>(*current);
-                ++current;
-                const auto fourth = static_cast<uint8_t>(*current);
-                ++current;
+                const auto second = static_cast<uint8_t>(*++current);
+                const auto third = static_cast<uint8_t>(*++current);
+                const auto fourth = static_cast<uint8_t>(*++current);
                 const bool is_valid = utf8::validate(first, second, third, fourth);
                 if FK_YAML_UNLIKELY (!is_valid) {
                     throw fkyaml::invalid_encoding("Invalid UTF-8 encoding.", {first, second, third, fourth});
@@ -9239,6 +9220,8 @@ public:
             default:           // LCOV_EXCL_LINE
                 unreachable(); // LCOV_EXCL_LINE
             }
+
+            ++current;
         }
 
         m_buffer.reserve(std::distance(m_begin, m_end) - cr_itrs.size());

--- a/tests/unit_test/test_node_class.cpp
+++ b/tests/unit_test/test_node_class.cpp
@@ -830,7 +830,7 @@ TEST_CASE("Node_CopyAssignmentOperator") {
 //
 
 /// @brief
-/// A utility iterator class which implements LegacyInputIterator and.
+/// A utility iterator class which implements LegacyInputIterator.
 /// https://en.cppreference.com/w/cpp/named_req/InputIterator
 template <typename T>
 class legacy_input_iterator {
@@ -858,10 +858,6 @@ public:
 
     reference operator*() noexcept {
         return *mp_val;
-    }
-
-    pointer operator->() noexcept {
-        return mp_val;
     }
 
     bool operator==(const legacy_input_iterator& rhs) const noexcept {


### PR DESCRIPTION
`deserialize()` and `deserialize_docs()` roughly requires iterators to be [random access iterators](https://en.cppreference.com/w/cpp/named_req/RandomAccessIterator) as noted in the discussion #477 despite that the same behavior can be achieved with [input iterators](https://en.cppreference.com/w/cpp/named_req/InputIterator).  
The requirements have then been relaxed so those APIs can be executed with input iterators, which covers much more use cases.  
In particular, with iterators(`i`, `j`) the following expressions must be well-formed:
* `++i`
* `*i`
* `i == j`
* `i != j`

---

## Pull Request Checklist

Read the [CONTRIBUTING.md](https://github.com/fktn-k/fkYAML/blob/develop/CONTRIBUTING.md) file for detailed information.  

- [x] Changes are described in the pull request or in a referenced [issue](https://github.com/fktn-k/fkYAML/issues).
- [x] The test suite compiles and runs without any error.
- [x] [The code coverage](https://coveralls.io/github/fktn-k/fkYAML) on your branch is 100%.
- [x] The documentation is updated if you added/changed a feature.

## Please don't

- The C++11 support varies between different **compilers** and versions. Please note the [list of supported compilers](https://github.com/fktn-k/fkYAML/blob/develop/README.md#supported-compilers). Some compilers like GCC 4.7 (and earlier), Clang 3.3 (and earlier), or Microsoft Visual Studio 13.0 and earlier are known not to work due to missing or incomplete C++11 support. Please refrain from proposing changes that work around these compiler's limitations with `#ifdef`s or other means.
- Please refrain from proposing changes that would **break [YAML](https://yaml.org/) specifications**. If you propose a conformant extension of YAML to be supported by the library, please motivate this extension.
- Please do not open pull requests that address **multiple issues**.
