### PR TITLE
Fix parsing block mapping entry after an empty block sequence entry

### DIFF
--- a/include/fkYAML/detail/input/deserializer.hpp
+++ b/include/fkYAML/detail/input/deserializer.hpp
@@ -1213,7 +1213,28 @@ private:
                     switch (cur_context.state) {
                     case context_state_t::BLOCK_MAPPING_EXPLICIT_KEY:
                     case context_state_t::BLOCK_MAPPING_EXPLICIT_VALUE:
+                        m_context_stack.emplace_back(line, indent, context_state_t::BLOCK_MAPPING, mp_current_node);
+                        break;
                     case context_state_t::BLOCK_SEQUENCE_ENTRY:
+                        if FK_YAML_UNLIKELY (cur_context.indent >= indent) {
+                            // This handles combination of empty block sequence entry and block mapping entry with the
+                            // same indentation level, for examples:
+                            // ```yaml
+                            // foo:
+                            //   bar:
+                            //   -         # These entries are indented
+                            //   baz: 123  # with the same width.
+                            // # ^^^
+                            // ```
+                            pop_to_parent_node(line, indent, [indent](const parse_context& c) {
+                                return c.state == context_state_t::BLOCK_MAPPING && indent == c.indent;
+                            });
+                            add_new_key(std::move(node), line, indent);
+                            indent = lexer.get_last_token_begin_pos();
+                            line = lexer.get_lines_processed();
+                            return;
+                        }
+
                         m_context_stack.emplace_back(line, indent, context_state_t::BLOCK_MAPPING, mp_current_node);
                         break;
                     default:

--- a/tests/unit_test/test_deserializer_class.cpp
+++ b/tests/unit_test/test_deserializer_class.cpp
@@ -1119,6 +1119,7 @@ TEST_CASE("Deserializer_BlockMapping") {
         REQUIRE(root["baz"].is_null());
     }
 
+    // regression test for https://github.com/fktn-k/fkYAML/issues/487
     SECTION("block mapping after an empty block sequence entry (same indentation)") {
         std::string input = "test:\n"
                             "    - coords:\n"

--- a/tests/unit_test/test_deserializer_class.cpp
+++ b/tests/unit_test/test_deserializer_class.cpp
@@ -1118,6 +1118,74 @@ TEST_CASE("Deserializer_BlockMapping") {
         REQUIRE(root["bar"]["bar"].is_null());
         REQUIRE(root["baz"].is_null());
     }
+
+    SECTION("block mapping after an empty block sequence entry (same indentation)") {
+        std::string input = "test:\n"
+                            "    - coords:\n"
+                            "      -\n"
+                            "      -\n"
+                            "      name: \"a\"\n";
+        REQUIRE_NOTHROW(root = deserializer.deserialize(fkyaml::detail::input_adapter(input)));
+
+        REQUIRE(root.is_mapping());
+        REQUIRE(root.size() == 1);
+        REQUIRE(root.contains("test"));
+
+        fkyaml::node& test_node = root["test"];
+        REQUIRE(test_node.is_sequence());
+        REQUIRE(test_node.size() == 1);
+
+        fkyaml::node& test_0_node = test_node[0];
+        REQUIRE(test_0_node.is_mapping());
+        REQUIRE(test_0_node.size() == 2);
+        REQUIRE(test_0_node.contains("coords"));
+        REQUIRE(test_0_node.contains("name"));
+
+        fkyaml::node& test_0_coords_node = test_0_node["coords"];
+        REQUIRE(test_0_coords_node.is_sequence());
+        REQUIRE(test_0_coords_node.size() == 2);
+
+        REQUIRE(test_0_coords_node[0].is_null());
+        REQUIRE(test_0_coords_node[1].is_null());
+
+        fkyaml::node& test_0_name_node = test_0_node["name"];
+        REQUIRE(test_0_name_node.is_string());
+        REQUIRE(test_0_name_node.as_str() == "a");
+    }
+
+    SECTION("block mapping after an empty block sequence entry (less indented)") {
+        std::string input = "test:\n"
+                            "    - coords:\n"
+                            "        -\n"
+                            "        -\n"
+                            "      name: \"a\"\n";
+        REQUIRE_NOTHROW(root = deserializer.deserialize(fkyaml::detail::input_adapter(input)));
+
+        REQUIRE(root.is_mapping());
+        REQUIRE(root.size() == 1);
+        REQUIRE(root.contains("test"));
+
+        fkyaml::node& test_node = root["test"];
+        REQUIRE(test_node.is_sequence());
+        REQUIRE(test_node.size() == 1);
+
+        fkyaml::node& test_0_node = test_node[0];
+        REQUIRE(test_0_node.is_mapping());
+        REQUIRE(test_0_node.size() == 2);
+        REQUIRE(test_0_node.contains("coords"));
+        REQUIRE(test_0_node.contains("name"));
+
+        fkyaml::node& test_0_coords_node = test_0_node["coords"];
+        REQUIRE(test_0_coords_node.is_sequence());
+        REQUIRE(test_0_coords_node.size() == 2);
+
+        REQUIRE(test_0_coords_node[0].is_null());
+        REQUIRE(test_0_coords_node[1].is_null());
+
+        fkyaml::node& test_0_name_node = test_0_node["name"];
+        REQUIRE(test_0_name_node.is_string());
+        REQUIRE(test_0_name_node.as_str() == "a");
+    }
 }
 
 TEST_CASE("Deserializer_FlowContainerKey") {


### PR DESCRIPTION
Fixes #487.  
See #484 for details.  

---

## Pull Request Checklist

Read the [CONTRIBUTING.md](https://github.com/fktn-k/fkYAML/blob/develop/CONTRIBUTING.md) file for detailed information.  

- [x] Changes are described in the pull request or in a referenced [issue](https://github.com/fktn-k/fkYAML/issues).
- [x] The test suite compiles and runs without any error.
- [x] [The code coverage](https://coveralls.io/github/fktn-k/fkYAML) on your branch is 100%.
- [x] The documentation is updated if you added/changed a feature.

## Please don't

- The C++11 support varies between different **compilers** and versions. Please note the [list of supported compilers](https://github.com/fktn-k/fkYAML/blob/develop/README.md#supported-compilers). Some compilers like GCC 4.7 (and earlier), Clang 3.3 (and earlier), or Microsoft Visual Studio 13.0 and earlier are known not to work due to missing or incomplete C++11 support. Please refrain from proposing changes that work around these compiler's limitations with `#ifdef`s or other means.
- Please refrain from proposing changes that would **break [YAML](https://yaml.org/) specifications**. If you propose a conformant extension of YAML to be supported by the library, please motivate this extension.
- Please do not open pull requests that address **multiple issues**.
