### PR TITLE
Removing typo, extra `--config` in tutorial bash

### DIFF
--- a/docs/docs/tutorials/index.md
+++ b/docs/docs/tutorials/index.md
@@ -98,7 +98,7 @@ After creating a tutorial project with the above files, execute the following co
 ```bash
 $ cd /path/to/tutorial/
 $ cmake -B build -S . -DCMAKE_BUILD_TYPE=Release
-$ cmake --build build --config --config Release
+$ cmake --build build --config Release
 ```
 
 Congratulation! You've got an application which loads a YAML file and then outputs the content on the console.  


### PR DESCRIPTION
I got tripped up this morning by this, contributing back so the next lazy copy-paste tutorial learner doesn't have to make the same mistake!

---

## Pull Request Checklist

Read the [CONTRIBUTING.md](https://github.com/fktn-k/fkYAML/blob/develop/CONTRIBUTING.md) file for detailed information.  

- [x] Changes are described in the pull request or in a referenced [issue](https://github.com/fktn-k/fkYAML/issues).
- [x] The test suite compiles and runs without any error.
- [x] [The code coverage](https://coveralls.io/github/fktn-k/fkYAML) on your branch is 100%.
- [ ] The documentation is updated if you added/changed a feature.

## Please don't

- The C++11 support varies between different **compilers** and versions. Please note the [list of supported compilers](https://github.com/fktn-k/fkYAML/blob/develop/README.md#supported-compilers). Some compilers like GCC 4.7 (and earlier), Clang 3.3 (and earlier), or Microsoft Visual Studio 13.0 and earlier are known not to work due to missing or incomplete C++11 support. Please refrain from proposing changes that work around these compiler's limitations with `#ifdef`s or other means.
- Please refrain from proposing changes that would **break [YAML](https://yaml.org/) specifications**. If you propose a conformant extension of YAML to be supported by the library, please motivate this extension.
- Please do not open pull requests that address **multiple issues**.
