### PR TITLE
Fix project compilation on GCC compilers

### DIFF
--- a/include/fkYAML/node.hpp
+++ b/include/fkYAML/node.hpp
@@ -1951,12 +1951,18 @@ inline namespace yaml_literals {
 #pragma clang diagnostic ignored "-Wdeprecated"
 #endif
 
+#if defined(__GNUC__) && (__GNUC__ > 6)
+#define FK_YAML_QUOTE_OPERATOR operator""_yaml
+#else
+#define FK_YAML_QUOTE_OPERATOR operator"" _yaml
+#endif
+
 /// @brief The user-defined string literal which deserializes a `char` array into a `node` object.
 /// @param s An input `char` array.
 /// @param n The size of `s`.
 /// @return The resulting `node` object deserialized from `s`.
 /// @sa https://fktn-k.github.io/fkYAML/api/operator_literal_yaml/
-inline fkyaml::node operator"" _yaml(const char* s, std::size_t n) {
+inline fkyaml::node FK_YAML_QUOTE_OPERATOR(const char* s, std::size_t n) {
     return fkyaml::node::deserialize(s, s + n);
 }
 
@@ -1965,7 +1971,7 @@ inline fkyaml::node operator"" _yaml(const char* s, std::size_t n) {
 /// @param n The size of `s`.
 /// @return The resulting `node` object deserialized from `s`.
 /// @sa https://fktn-k.github.io/fkYAML/api/operator_literal_yaml/
-inline fkyaml::node operator"" _yaml(const char16_t* s, std::size_t n) {
+inline fkyaml::node FK_YAML_QUOTE_OPERATOR(const char16_t* s, std::size_t n) {
     return fkyaml::node::deserialize(s, s + n);
 }
 
@@ -1974,7 +1980,7 @@ inline fkyaml::node operator"" _yaml(const char16_t* s, std::size_t n) {
 /// @param n The size of `s`.
 /// @return The resulting `node` object deserialized from `s`.
 /// @sa https://fktn-k.github.io/fkYAML/api/operator_literal_yaml/
-inline fkyaml::node operator"" _yaml(const char32_t* s, std::size_t n) {
+inline fkyaml::node FK_YAML_QUOTE_OPERATOR(const char32_t* s, std::size_t n) {
     return fkyaml::node::deserialize(s, s + n);
 }
 
@@ -1983,7 +1989,7 @@ inline fkyaml::node operator"" _yaml(const char32_t* s, std::size_t n) {
 /// @param s An input `char8_t` array.
 /// @param n The size of `s`.
 /// @return The resulting `node` object deserialized from `s`.
-inline fkyaml::node operator"" _yaml(const char8_t* s, std::size_t n) {
+inline fkyaml::node FK_YAML_QUOTE_OPERATOR(const char8_t* s, std::size_t n) {
     return fkyaml::node::deserialize((const char8_t*)s, (const char8_t*)s + n);
 }
 

--- a/single_include/fkYAML/node.hpp
+++ b/single_include/fkYAML/node.hpp
@@ -14604,12 +14604,18 @@ inline namespace yaml_literals {
 #pragma clang diagnostic ignored "-Wdeprecated"
 #endif
 
+#if defined(__GNUC__) && (__GNUC__ > 6)
+#define FK_YAML_QUOTE_OPERATOR operator""_yaml
+#else
+#define FK_YAML_QUOTE_OPERATOR operator"" _yaml
+#endif
+
 /// @brief The user-defined string literal which deserializes a `char` array into a `node` object.
 /// @param s An input `char` array.
 /// @param n The size of `s`.
 /// @return The resulting `node` object deserialized from `s`.
 /// @sa https://fktn-k.github.io/fkYAML/api/operator_literal_yaml/
-inline fkyaml::node operator"" _yaml(const char* s, std::size_t n) {
+inline fkyaml::node FK_YAML_QUOTE_OPERATOR(const char* s, std::size_t n) {
     return fkyaml::node::deserialize(s, s + n);
 }
 
@@ -14618,7 +14624,7 @@ inline fkyaml::node operator"" _yaml(const char* s, std::size_t n) {
 /// @param n The size of `s`.
 /// @return The resulting `node` object deserialized from `s`.
 /// @sa https://fktn-k.github.io/fkYAML/api/operator_literal_yaml/
-inline fkyaml::node operator"" _yaml(const char16_t* s, std::size_t n) {
+inline fkyaml::node FK_YAML_QUOTE_OPERATOR(const char16_t* s, std::size_t n) {
     return fkyaml::node::deserialize(s, s + n);
 }
 
@@ -14627,7 +14633,7 @@ inline fkyaml::node operator"" _yaml(const char16_t* s, std::size_t n) {
 /// @param n The size of `s`.
 /// @return The resulting `node` object deserialized from `s`.
 /// @sa https://fktn-k.github.io/fkYAML/api/operator_literal_yaml/
-inline fkyaml::node operator"" _yaml(const char32_t* s, std::size_t n) {
+inline fkyaml::node FK_YAML_QUOTE_OPERATOR(const char32_t* s, std::size_t n) {
     return fkyaml::node::deserialize(s, s + n);
 }
 
@@ -14636,7 +14642,7 @@ inline fkyaml::node operator"" _yaml(const char32_t* s, std::size_t n) {
 /// @param s An input `char8_t` array.
 /// @param n The size of `s`.
 /// @return The resulting `node` object deserialized from `s`.
-inline fkyaml::node operator"" _yaml(const char8_t* s, std::size_t n) {
+inline fkyaml::node FK_YAML_QUOTE_OPERATOR(const char8_t* s, std::size_t n) {
     return fkyaml::node::deserialize((const char8_t*)s, (const char8_t*)s + n);
 }
 


### PR DESCRIPTION
This PR fixes an issue with project compilation on GCC compilers.
Looks like the newer GCC versions shows `-Werror=deprecated-literal-operator` when the project is building.

I prepared a simple fix that check whether compiler is `__GNUC__` and the version is newer than `6`.
If yes, a new macro - `FK_YAML_QUOTE_OPERATOR` will use `operator""_yaml`, otherwise `operator"" _yaml`.

---

## Pull Request Checklist

Read the [CONTRIBUTING.md](https://github.com/fktn-k/fkYAML/blob/develop/.github/CONTRIBUTING.md) file for detailed information.  

- [x] Changes are described in the pull request or in a referenced [issue](https://github.com/fktn-k/fkYAML/issues).
- [x] The test suite compiles and runs without any error.
- [x] [The code coverage](https://coveralls.io/github/fktn-k/fkYAML) on your branch is 100%.
- [ ] The documentation is updated if you added/changed a feature.

## Please don't

- The C++11 support varies between different **compilers** and versions. Please note the [list of supported compilers](https://github.com/fktn-k/fkYAML/blob/develop/README.md#supported-compilers). Some compilers like GCC 4.7 (and earlier), Clang 3.3 (and earlier), or Microsoft Visual Studio 13.0 and earlier are known not to work due to missing or incomplete C++11 support. Please refrain from proposing changes that work around these compiler's limitations with `#ifdef`s or other means.
- Please refrain from proposing changes that would **break [YAML](https://yaml.org/) specifications**. If you propose a conformant extension of YAML to be supported by the library, please motivate this extension.
- Please do not open pull requests that address **multiple issues**.
