### PR TITLE
Resolve useless-cast & old-style-cast warnings

### DIFF
--- a/.github/workflows/ubuntu.yml
+++ b/.github/workflows/ubuntu.yml
@@ -204,6 +204,12 @@ jobs:
     container: silkeh/clang:${{matrix.compiler}}
 
     steps:
+    - name: Edit repository URLs for old ubuntu releases.
+      run: |
+        sed -i s/deb.debian.org/archive.debian.org/g /etc/apt/sources.list
+        sed -i s/security.debian.org/archive.debian.org/g /etc/apt/sources.list
+      if: ${{ matrix.compiler == '3.4' || matrix.compiler == '3.5' || matrix.compiler == '3.6' || matrix.compiler == '3.7' || matrix.compiler == '3.8' || matrix.compiler == '3.9' || matrix.compiler == '7' || matrix.compiler == '8' || matrix.compiler == '9' || matrix.compiler == '10' }}
+
     - name: Install git and unzip
       run: |
         apt-get update
@@ -240,6 +246,12 @@ jobs:
     container: gcc:${{matrix.compiler}}
 
     steps:
+    - name: Edit repository URLs for old ubuntu releases.
+      run: |
+        sed -i s/deb.debian.org/archive.debian.org/g /etc/apt/sources.list
+        sed -i s/security.debian.org/archive.debian.org/g /etc/apt/sources.list
+      if: ${{ matrix.compiler == '7' || matrix.compiler == '8' }}
+
     - name: Install git and unzip
       run: |
         apt-get update

--- a/include/fkYAML/detail/encodings/utf_encodings.hpp
+++ b/include/fkYAML/detail/encodings/utf_encodings.hpp
@@ -203,8 +203,7 @@ inline void from_utf16(
         encoded_size = 2;
     }
     else if (first < 0xD800u || 0xE000u <= first) {
-        const auto utf8_chunk =
-            static_cast<uint32_t>(0xE08080u | ((first & 0xF000u) << 4) | ((first & 0x0FC0u) << 2) | (first & 0x3Fu));
+        const uint32_t utf8_chunk = 0xE08080u | ((first & 0xF000u) << 4) | ((first & 0x0FC0u) << 2) | (first & 0x3Fu);
         utf8[0] = static_cast<uint8_t>(utf8_chunk >> 16);
         utf8[1] = static_cast<uint8_t>(utf8_chunk >> 8);
         utf8[2] = static_cast<uint8_t>(utf8_chunk);
@@ -214,9 +213,8 @@ inline void from_utf16(
     else if (first <= 0xDBFFu && 0xDC00u <= second && second <= 0xDFFFu) {
         // surrogate pair
         const uint32_t code_point = 0x10000u + ((first & 0x03FFu) << 10) + (second & 0x03FFu);
-        const auto utf8_chunk = static_cast<uint32_t>(
-            0xF0808080u | ((code_point & 0x1C0000u) << 6) | ((code_point & 0x03F000u) << 4) |
-            ((code_point & 0x0FC0u) << 2) | (code_point & 0x3Fu));
+        const uint32_t utf8_chunk = 0xF0808080u | ((code_point & 0x1C0000u) << 6) | ((code_point & 0x03F000u) << 4) |
+                                    ((code_point & 0x0FC0u) << 2) | (code_point & 0x3Fu);
         utf8[0] = static_cast<uint8_t>(utf8_chunk >> 24);
         utf8[1] = static_cast<uint8_t>(utf8_chunk >> 16);
         utf8[2] = static_cast<uint8_t>(utf8_chunk >> 8);
@@ -245,17 +243,15 @@ inline void from_utf32(const char32_t utf32, std::array<uint8_t, 4>& utf8, uint3
         encoded_size = 2;
     }
     else if (utf32 <= 0xFFFFu) {
-        const auto utf8_chunk =
-            static_cast<uint32_t>(0xE08080u | ((utf32 & 0xF000u) << 4) | ((utf32 & 0x0FC0u) << 2) | (utf32 & 0x3F));
+        const uint32_t utf8_chunk = 0xE08080u | ((utf32 & 0xF000u) << 4) | ((utf32 & 0x0FC0u) << 2) | (utf32 & 0x3F);
         utf8[0] = static_cast<uint8_t>(utf8_chunk >> 16);
         utf8[1] = static_cast<uint8_t>(utf8_chunk >> 8);
         utf8[2] = static_cast<uint8_t>(utf8_chunk);
         encoded_size = 3;
     }
     else if (utf32 <= 0x10FFFFu) {
-        const auto utf8_chunk = static_cast<uint32_t>(
-            0xF0808080u | ((utf32 & 0x1C0000u) << 6) | ((utf32 & 0x03F000u) << 4) | ((utf32 & 0x0FC0u) << 2) |
-            (utf32 & 0x3Fu));
+        const uint32_t utf8_chunk = 0xF0808080u | ((utf32 & 0x1C0000u) << 6) | ((utf32 & 0x03F000u) << 4) |
+                                    ((utf32 & 0x0FC0u) << 2) | (utf32 & 0x3Fu);
         utf8[0] = static_cast<uint8_t>(utf8_chunk >> 24);
         utf8[1] = static_cast<uint8_t>(utf8_chunk >> 16);
         utf8[2] = static_cast<uint8_t>(utf8_chunk >> 8);

--- a/include/fkYAML/node.hpp
+++ b/include/fkYAML/node.hpp
@@ -1990,7 +1990,7 @@ inline fkyaml::node FK_YAML_QUOTE_OPERATOR(const char32_t* s, std::size_t n) {
 /// @param n The size of `s`.
 /// @return The resulting `node` object deserialized from `s`.
 inline fkyaml::node FK_YAML_QUOTE_OPERATOR(const char8_t* s, std::size_t n) {
-    return fkyaml::node::deserialize((const char8_t*)s, (const char8_t*)s + n);
+    return fkyaml::node::deserialize(s, s + n);
 }
 
 #if defined(__clang__)

--- a/single_include/fkYAML/node.hpp
+++ b/single_include/fkYAML/node.hpp
@@ -2015,8 +2015,7 @@ inline void from_utf16(
         encoded_size = 2;
     }
     else if (first < 0xD800u || 0xE000u <= first) {
-        const auto utf8_chunk =
-            static_cast<uint32_t>(0xE08080u | ((first & 0xF000u) << 4) | ((first & 0x0FC0u) << 2) | (first & 0x3Fu));
+        const uint32_t utf8_chunk = 0xE08080u | ((first & 0xF000u) << 4) | ((first & 0x0FC0u) << 2) | (first & 0x3Fu);
         utf8[0] = static_cast<uint8_t>(utf8_chunk >> 16);
         utf8[1] = static_cast<uint8_t>(utf8_chunk >> 8);
         utf8[2] = static_cast<uint8_t>(utf8_chunk);
@@ -2026,9 +2025,8 @@ inline void from_utf16(
     else if (first <= 0xDBFFu && 0xDC00u <= second && second <= 0xDFFFu) {
         // surrogate pair
         const uint32_t code_point = 0x10000u + ((first & 0x03FFu) << 10) + (second & 0x03FFu);
-        const auto utf8_chunk = static_cast<uint32_t>(
-            0xF0808080u | ((code_point & 0x1C0000u) << 6) | ((code_point & 0x03F000u) << 4) |
-            ((code_point & 0x0FC0u) << 2) | (code_point & 0x3Fu));
+        const uint32_t utf8_chunk = 0xF0808080u | ((code_point & 0x1C0000u) << 6) | ((code_point & 0x03F000u) << 4) |
+                                    ((code_point & 0x0FC0u) << 2) | (code_point & 0x3Fu);
         utf8[0] = static_cast<uint8_t>(utf8_chunk >> 24);
         utf8[1] = static_cast<uint8_t>(utf8_chunk >> 16);
         utf8[2] = static_cast<uint8_t>(utf8_chunk >> 8);
@@ -2057,17 +2055,15 @@ inline void from_utf32(const char32_t utf32, std::array<uint8_t, 4>& utf8, uint3
         encoded_size = 2;
     }
     else if (utf32 <= 0xFFFFu) {
-        const auto utf8_chunk =
-            static_cast<uint32_t>(0xE08080u | ((utf32 & 0xF000u) << 4) | ((utf32 & 0x0FC0u) << 2) | (utf32 & 0x3F));
+        const uint32_t utf8_chunk = 0xE08080u | ((utf32 & 0xF000u) << 4) | ((utf32 & 0x0FC0u) << 2) | (utf32 & 0x3F);
         utf8[0] = static_cast<uint8_t>(utf8_chunk >> 16);
         utf8[1] = static_cast<uint8_t>(utf8_chunk >> 8);
         utf8[2] = static_cast<uint8_t>(utf8_chunk);
         encoded_size = 3;
     }
     else if (utf32 <= 0x10FFFFu) {
-        const auto utf8_chunk = static_cast<uint32_t>(
-            0xF0808080u | ((utf32 & 0x1C0000u) << 6) | ((utf32 & 0x03F000u) << 4) | ((utf32 & 0x0FC0u) << 2) |
-            (utf32 & 0x3Fu));
+        const uint32_t utf8_chunk = 0xF0808080u | ((utf32 & 0x1C0000u) << 6) | ((utf32 & 0x03F000u) << 4) |
+                                    ((utf32 & 0x0FC0u) << 2) | (utf32 & 0x3Fu);
         utf8[0] = static_cast<uint8_t>(utf8_chunk >> 24);
         utf8[1] = static_cast<uint8_t>(utf8_chunk >> 16);
         utf8[2] = static_cast<uint8_t>(utf8_chunk >> 8);
@@ -14644,7 +14640,7 @@ inline fkyaml::node FK_YAML_QUOTE_OPERATOR(const char32_t* s, std::size_t n) {
 /// @param n The size of `s`.
 /// @return The resulting `node` object deserialized from `s`.
 inline fkyaml::node FK_YAML_QUOTE_OPERATOR(const char8_t* s, std::size_t n) {
-    return fkyaml::node::deserialize((const char8_t*)s, (const char8_t*)s + n);
+    return fkyaml::node::deserialize(s, s + n);
 }
 
 #if defined(__clang__)

--- a/tests/unit_test/CMakeLists.txt
+++ b/tests/unit_test/CMakeLists.txt
@@ -120,6 +120,7 @@ target_compile_options(
       -Wall -Wextra -Werror -pedantic -Wpedantic -Wdeprecated --all-warnings --extra-warnings
       -Wno-deprecated-declarations # for testing deprecated functions
       -Wno-self-move # necessary to build the detail::iterator class test
+      -Wold-style-cast # regression test for https://github.com/fktn-k/fkYAML/issues/495
     >
     # Clang
     $<$<CXX_COMPILER_ID:Clang>:

--- a/tests/unit_test/test_scalar_conv.cpp
+++ b/tests/unit_test/test_scalar_conv.cpp
@@ -62,7 +62,7 @@ TEST_CASE("ScalarConv_atoi") {
     SECTION("decimal number with an explicit plus sign") {
         std::string input = "+64";
         REQUIRE(fkyaml::detail::atoi(input.begin(), input.end(), integer) == true);
-        REQUIRE(integer == int32_t(64));
+        REQUIRE(integer == 64);
     }
 
     SECTION("hexadecimal number with different writings in alphabets") {

--- a/tests/unit_test/test_str_view_class.cpp
+++ b/tests/unit_test/test_str_view_class.cpp
@@ -215,7 +215,7 @@ TEST_CASE("StrView_Compare") {
     // skip checks of comparisons with a large string object if int == ptrdiff_t
     if (static_cast<std::ptrdiff_t>(std::numeric_limits<int>::max()) < std::numeric_limits<std::ptrdiff_t>::max()) {
         constexpr std::size_t long_str_size = static_cast<std::size_t>(std::numeric_limits<int>::max()) + 4u;
-        char* p_long_str = (char*)std::malloc(long_str_size);
+        char* p_long_str = static_cast<char*>(std::malloc(long_str_size));
         for (std::size_t i = 0; i < long_str_size - 1; i++) {
             p_long_str[i] = 'a';
         }


### PR DESCRIPTION
This PR resolves warnings emitted during building the unit test app with `-Wuseless-cast` and `-Wold-styld-cast`.  
Also, errors in updating apt repositories have been fixed since Debian Buster repositories have been moved as outdated.  
---

## Pull Request Checklist

Read the [CONTRIBUTING.md](https://github.com/fktn-k/fkYAML/blob/develop/.github/CONTRIBUTING.md) file for detailed information.  

- [x] Changes are described in the pull request or in a referenced [issue](https://github.com/fktn-k/fkYAML/issues).
- [x] The test suite compiles and runs without any error.
- [x] [The code coverage](https://coveralls.io/github/fktn-k/fkYAML) on your branch is 100%.
- [ ] The documentation is updated if you added/changed a feature.

## Please don't

- The C++11 support varies between different **compilers** and versions. Please note the [list of supported compilers](https://github.com/fktn-k/fkYAML/blob/develop/README.md#supported-compilers). Some compilers like GCC 4.7 (and earlier), Clang 3.3 (and earlier), or Microsoft Visual Studio 13.0 and earlier are known not to work due to missing or incomplete C++11 support. Please refrain from proposing changes that work around these compiler's limitations with `#ifdef`s or other means.
- Please refrain from proposing changes that would **break [YAML](https://yaml.org/) specifications**. If you propose a conformant extension of YAML to be supported by the library, please motivate this extension.
- Please do not open pull requests that address **multiple issues**.
