### PR TITLE
Fix errors in checking out to a branch in a forked repository

### DIFF
--- a/.github/workflows/coverage.yml
+++ b/.github/workflows/coverage.yml
@@ -33,7 +33,9 @@ jobs:
     steps:
     - uses: actions/checkout@v7
       with:
+        repository: ${{github.event.pull_request.head.repo.full_name}}
         ref: ${{github.head_ref}}
+        persist-credentials: false
 
     - name: Install lcov
       run: |

--- a/.github/workflows/format_check.yml
+++ b/.github/workflows/format_check.yml
@@ -41,7 +41,9 @@ jobs:
     steps:
     - uses: actions/checkout@v7
       with:
+        repository: ${{github.event.pull_request.head.repo.full_name}}
         ref: ${{github.head_ref}}
+        persist-credentials: false
 
     - name: Run clang-format style check
       run: ${{github.workspace}}/scripts/run_clang_format.sh


### PR DESCRIPTION
This PR fixes an issue where `git checkout` in the GitHub Actions workflows triggered on `pull_request_target` events.
That was because `actions/checkout` was not correctly configured to look up the target branch in the forked repository; with the previous configuration, only this `fktn-k/fkYAML` repository was looked up for the branch.
So, the configuration has been corrected to correctly decide in which repository the proposed patch is made.

---

## Pull Request Checklist

Read the [CONTRIBUTING.md](https://github.com/fktn-k/fkYAML/blob/develop/.github/CONTRIBUTING.md) file for detailed information.  

- [x] Changes are described in the pull request or in a referenced [issue](https://github.com/fktn-k/fkYAML/issues).
- [x] The test suite compiles and runs without any error.
- [x] [The code coverage](https://coveralls.io/github/fktn-k/fkYAML) on your branch is 100%.
- [x] The documentation is updated if you added/changed a feature.

## Please don't

- The C++11 support varies between different **compilers** and versions. Please note the [list of supported compilers](https://github.com/fktn-k/fkYAML/blob/develop/README.md#supported-compilers). Some compilers like GCC 4.7 (and earlier), Clang 3.3 (and earlier), or Microsoft Visual Studio 13.0 and earlier are known not to work due to missing or incomplete C++11 support. Please refrain from proposing changes that work around these compiler's limitations with `#ifdef`s or other means.
- Please refrain from proposing changes that would **break [YAML](https://yaml.org/) specifications**. If you propose a conformant extension of YAML to be supported by the library, please motivate this extension.
- Please do not open pull requests that address **multiple issues**.
