### PR TITLE
Fix errors in checking out to a branch in a forked repository (part2)

### DIFF
--- a/.github/workflows/coverage.yml
+++ b/.github/workflows/coverage.yml
@@ -12,8 +12,8 @@ on:
       - tests/**
       - CMakeLists.txt
       - Makefile
-  # to grant pull-requests write permission to fork repos as well
-  pull_request_target:
+  # Run on pull requests from both branches and forks.
+  pull_request:
     paths:
       - .github/workflows/coverage.yml
       - cmake/**
@@ -28,13 +28,14 @@ jobs:
     timeout-minutes: 10
     runs-on: ubuntu-22.04
     permissions:
+      contents: read
       pull-requests: write
 
     steps:
     - uses: actions/checkout@v7
       with:
         repository: ${{github.event.pull_request.head.repo.full_name}}
-        ref: ${{github.head_ref}}
+        ref: ${{github.event.pull_request.head.sha}}
         persist-credentials: false
 
     - name: Install lcov

--- a/.github/workflows/format_check.yml
+++ b/.github/workflows/format_check.yml
@@ -14,8 +14,8 @@ on:
       - tools/amalgamation/**
       - CMakeLists.txt
       - .clang-format
-  # to grant contents write permission to fork repos as well
-  pull_request_target:
+  # Run on pull requests from both branches and forks.
+  pull_request:
     paths:
       - .github/workflows/format_check.yml
       - include/**
@@ -36,13 +36,14 @@ jobs:
     timeout-minutes: 10
     runs-on: ubuntu-latest
     permissions:
+      contents: read
       pull-requests: write
 
     steps:
     - uses: actions/checkout@v7
       with:
         repository: ${{github.event.pull_request.head.repo.full_name}}
-        ref: ${{github.head_ref}}
+        ref: ${{github.event.pull_request.head.sha}}
         persist-credentials: false
 
     - name: Run clang-format style check
@@ -56,13 +57,13 @@ jobs:
       env:
         PR_NUMBER: ${{github.event.number}}
       run: |
-        git diff --patch --no-color > ${{github.workspace}}/format_diff_pr${{PR_NUMBER}}.patch
-        if [ -s ${{github.workspace}}/format_diff_pr${{PR_NUMBER}}.patch ]; then
+        git diff --patch --no-color > ${{github.workspace}}/format_diff_pr${{env.PR_NUMBER}}.patch
+        if [ -s ${{github.workspace}}/format_diff_pr${{env.PR_NUMBER}}.patch ]; then
           echo "The source code has not been formatted/amalgamated correctly. Diff:"
-          cat ${{github.workspace}}/format_diff_pr${{PR_NUMBER}}.patch
+          cat ${{github.workspace}}/format_diff_pr${{env.PR_NUMBER}}.patch
           echo "has_diff=true" >> $GITHUB_OUTPUT
-          echo "Patch file created: format_diff_pr${{PR_NUMBER}}.patch"
-          echo "patch_file_name=format_diff_pr${{PR_NUMBER}}.patch" >> $GITHUB_OUTPUT
+          echo "Patch file created: format_diff_pr${{env.PR_NUMBER}}.patch"
+          echo "patch_file_name=format_diff_pr${{env.PR_NUMBER}}.patch" >> $GITHUB_OUTPUT
           exit 1
         else
           echo "No formatting issues detected."


### PR DESCRIPTION
This PR proposes an additional fix to the issue where `git checkout` to a branch in a forked repository fails in the GitHub Actions workflows.
Since those workflows does not make a commit in the current implementation, and since `actions/checkout@v7` forbids such a checking out by default, this PR changes the trigger type of the workflows from `pull_request_target` to `pull_request` to give the context more restricted capabilities.

No functional changes for the library are made in this PR.

---

## Pull Request Checklist

Read the [CONTRIBUTING.md](https://github.com/fktn-k/fkYAML/blob/develop/.github/CONTRIBUTING.md) file for detailed information.  

- [x] Changes are described in the pull request or in a referenced [issue](https://github.com/fktn-k/fkYAML/issues).
- [x] The test suite compiles and runs without any error.
- [x] [The code coverage](https://coveralls.io/github/fktn-k/fkYAML) on your branch is 100%.
- [x] The documentation is updated if you added/changed a feature.

## Please don't

- The C++11 support varies between different **compilers** and versions. Please note the [list of supported compilers](https://github.com/fktn-k/fkYAML/blob/develop/README.md#supported-compilers). Some compilers like GCC 4.7 (and earlier), Clang 3.3 (and earlier), or Microsoft Visual Studio 13.0 and earlier are known not to work due to missing or incomplete C++11 support. Please refrain from proposing changes that work around these compiler's limitations with `#ifdef`s or other means.
- Please refrain from proposing changes that would **break [YAML](https://yaml.org/) specifications**. If you propose a conformant extension of YAML to be supported by the library, please motivate this extension.
- Please do not open pull requests that address **multiple issues**.
