### PR TITLE
Fix brace initialization of empty collection nodes (issue #502)

### DIFF
--- a/docs/docs/api/basic_node/constructor.md
+++ b/docs/docs/api/basic_node/constructor.md
@@ -98,6 +98,8 @@ Available overloads are:
 
         `#!cpp fkyaml::node n {true};` will create a sequence of 1 boolean value, not a boolean value alone. This is because [overload resolution in C++ prioritizes a constructor with a single initializer list argument is prioritized to the others](https://en.cppreference.com/w/cpp/language/overload_resolution). In such cases, change the code to `#! fkyaml::node n(true);` instead.
 
+        As an exception, `#!cpp fkyaml::node n {fkyaml::node::mapping()};` creates an empty mapping node and `#!cpp fkyaml::node n {fkyaml::node::sequence()};` creates an empty sequence node.
+
 ## **Template Parameters**
 
 ***CompatibleType***

--- a/include/fkYAML/detail/node_ref_storage.hpp
+++ b/include/fkYAML/detail/node_ref_storage.hpp
@@ -32,13 +32,15 @@ public:
     /// @brief Construct a new node ref storage object with an rvalue basic_node object.
     /// @param n An rvalue basic_node object.
     explicit node_ref_storage(node_type&& n) noexcept(std::is_nothrow_move_constructible<node_type>::value)
-        : m_owned_value(std::move(n)) {
+        : m_owned_value(std::move(n)),
+          m_has_node_ref(true) {
     }
 
     /// @brief Construct a new node ref storage object with an lvalue basic_node object.
     /// @param n An lvalue basic_node object.
     explicit node_ref_storage(const node_type& n) noexcept
-        : m_value_ref(&n) {
+        : m_value_ref(&n),
+          m_has_node_ref(true) {
     }
 
     /// @brief Construct a new node ref storage object with a std::initializer_list object.
@@ -76,11 +78,17 @@ public:
         return m_value_ref ? *m_value_ref : std::move(m_owned_value);
     }
 
+    bool has_node_ref() const noexcept {
+        return m_has_node_ref;
+    }
+
 private:
     /// A storage for a basic_node object given with rvalue reference.
     mutable node_type m_owned_value = nullptr;
     /// A pointer to a basic_node object given with lvalue reference.
     const node_type* m_value_ref = nullptr;
+    /// Whether this object was constructed directly from a basic_node object.
+    bool m_has_node_ref = false;
 };
 
 FK_YAML_DETAIL_NAMESPACE_END

--- a/include/fkYAML/detail/node_ref_storage.hpp
+++ b/include/fkYAML/detail/node_ref_storage.hpp
@@ -28,17 +28,23 @@ class node_ref_storage {
 
     using node_type = BasicNodeType;
 
+    template <typename... Args>
+    struct has_single_basic_node_arg : std::false_type {};
+
+    template <typename Arg>
+    struct has_single_basic_node_arg<Arg> : is_basic_node<Arg> {};
+
 public:
     /// @brief Construct a new node ref storage object with an rvalue basic_node object.
     /// @param n An rvalue basic_node object.
-    node_ref_storage(node_type&& n) noexcept(std::is_nothrow_move_constructible<node_type>::value)
+    explicit node_ref_storage(node_type&& n) noexcept(std::is_nothrow_move_constructible<node_type>::value)
         : m_owned_value(std::move(n)),
           m_has_node_ref(true) {
     }
 
     /// @brief Construct a new node ref storage object with an lvalue basic_node object.
     /// @param n An lvalue basic_node object.
-    node_ref_storage(const node_type& n) noexcept
+    explicit node_ref_storage(const node_type& n) noexcept
         : m_value_ref(&n),
           m_has_node_ref(true) {
     }
@@ -54,7 +60,8 @@ public:
     /// @param args Arguments to construct a basic_node object.
     template <typename... Args, enable_if_t<std::is_constructible<node_type, Args...>::value, int> = 0>
     node_ref_storage(Args&&... args)
-        : m_owned_value(std::forward<Args>(args)...) {
+        : m_owned_value(std::forward<Args>(args)...),
+          m_has_node_ref(has_single_basic_node_arg<Args...>::value) {
     }
 
     // allow only move construct/assignment

--- a/include/fkYAML/detail/node_ref_storage.hpp
+++ b/include/fkYAML/detail/node_ref_storage.hpp
@@ -31,14 +31,14 @@ class node_ref_storage {
 public:
     /// @brief Construct a new node ref storage object with an rvalue basic_node object.
     /// @param n An rvalue basic_node object.
-    explicit node_ref_storage(node_type&& n) noexcept(std::is_nothrow_move_constructible<node_type>::value)
+    node_ref_storage(node_type&& n) noexcept(std::is_nothrow_move_constructible<node_type>::value)
         : m_owned_value(std::move(n)),
           m_has_node_ref(true) {
     }
 
     /// @brief Construct a new node ref storage object with an lvalue basic_node object.
     /// @param n An lvalue basic_node object.
-    explicit node_ref_storage(const node_type& n) noexcept
+    node_ref_storage(const node_type& n) noexcept
         : m_value_ref(&n),
           m_has_node_ref(true) {
     }

--- a/include/fkYAML/node.hpp
+++ b/include/fkYAML/node.hpp
@@ -373,6 +373,15 @@ public:
     /// @param[in] init A initializer list of basic_node objects.
     /// @sa https://fktn-k.github.io/fkYAML/api/basic_node/constructor/
     basic_node(initializer_list_t init) {
+        if (init.size() == 1 && init.begin()->has_node_ref()) {
+            const auto& node_ref = *init.begin();
+            if ((node_ref->is_sequence() || node_ref->is_mapping()) && node_ref->empty() && !node_ref->is_anchor() &&
+                !node_ref->has_tag_name()) {
+                basic_node(node_ref.release()).swap(*this);
+                return;
+            }
+        }
+
         bool is_mapping =
             std::all_of(init.begin(), init.end(), [](const detail::node_ref_storage<basic_node>& node_ref) {
                 // Do not use is_sequence_impl() since node_ref may be an anchor or alias.

--- a/single_include/fkYAML/node.hpp
+++ b/single_include/fkYAML/node.hpp
@@ -10933,14 +10933,14 @@ class node_ref_storage {
 public:
     /// @brief Construct a new node ref storage object with an rvalue basic_node object.
     /// @param n An rvalue basic_node object.
-    explicit node_ref_storage(node_type&& n) noexcept(std::is_nothrow_move_constructible<node_type>::value)
+    node_ref_storage(node_type&& n) noexcept(std::is_nothrow_move_constructible<node_type>::value)
         : m_owned_value(std::move(n)),
           m_has_node_ref(true) {
     }
 
     /// @brief Construct a new node ref storage object with an lvalue basic_node object.
     /// @param n An lvalue basic_node object.
-    explicit node_ref_storage(const node_type& n) noexcept
+    node_ref_storage(const node_type& n) noexcept
         : m_value_ref(&n),
           m_has_node_ref(true) {
     }

--- a/single_include/fkYAML/node.hpp
+++ b/single_include/fkYAML/node.hpp
@@ -10930,17 +10930,23 @@ class node_ref_storage {
 
     using node_type = BasicNodeType;
 
+    template <typename... Args>
+    struct has_single_basic_node_arg : std::false_type {};
+
+    template <typename Arg>
+    struct has_single_basic_node_arg<Arg> : is_basic_node<Arg> {};
+
 public:
     /// @brief Construct a new node ref storage object with an rvalue basic_node object.
     /// @param n An rvalue basic_node object.
-    node_ref_storage(node_type&& n) noexcept(std::is_nothrow_move_constructible<node_type>::value)
+    explicit node_ref_storage(node_type&& n) noexcept(std::is_nothrow_move_constructible<node_type>::value)
         : m_owned_value(std::move(n)),
           m_has_node_ref(true) {
     }
 
     /// @brief Construct a new node ref storage object with an lvalue basic_node object.
     /// @param n An lvalue basic_node object.
-    node_ref_storage(const node_type& n) noexcept
+    explicit node_ref_storage(const node_type& n) noexcept
         : m_value_ref(&n),
           m_has_node_ref(true) {
     }
@@ -10956,7 +10962,8 @@ public:
     /// @param args Arguments to construct a basic_node object.
     template <typename... Args, enable_if_t<std::is_constructible<node_type, Args...>::value, int> = 0>
     node_ref_storage(Args&&... args)
-        : m_owned_value(std::forward<Args>(args)...) {
+        : m_owned_value(std::forward<Args>(args)...),
+          m_has_node_ref(has_single_basic_node_arg<Args...>::value) {
     }
 
     // allow only move construct/assignment

--- a/single_include/fkYAML/node.hpp
+++ b/single_include/fkYAML/node.hpp
@@ -10934,13 +10934,15 @@ public:
     /// @brief Construct a new node ref storage object with an rvalue basic_node object.
     /// @param n An rvalue basic_node object.
     explicit node_ref_storage(node_type&& n) noexcept(std::is_nothrow_move_constructible<node_type>::value)
-        : m_owned_value(std::move(n)) {
+        : m_owned_value(std::move(n)),
+          m_has_node_ref(true) {
     }
 
     /// @brief Construct a new node ref storage object with an lvalue basic_node object.
     /// @param n An lvalue basic_node object.
     explicit node_ref_storage(const node_type& n) noexcept
-        : m_value_ref(&n) {
+        : m_value_ref(&n),
+          m_has_node_ref(true) {
     }
 
     /// @brief Construct a new node ref storage object with a std::initializer_list object.
@@ -10978,11 +10980,17 @@ public:
         return m_value_ref ? *m_value_ref : std::move(m_owned_value);
     }
 
+    bool has_node_ref() const noexcept {
+        return m_has_node_ref;
+    }
+
 private:
     /// A storage for a basic_node object given with rvalue reference.
     mutable node_type m_owned_value = nullptr;
     /// A pointer to a basic_node object given with lvalue reference.
     const node_type* m_value_ref = nullptr;
+    /// Whether this object was constructed directly from a basic_node object.
+    bool m_has_node_ref = false;
 };
 
 FK_YAML_DETAIL_NAMESPACE_END
@@ -13101,6 +13109,15 @@ public:
     /// @param[in] init A initializer list of basic_node objects.
     /// @sa https://fktn-k.github.io/fkYAML/api/basic_node/constructor/
     basic_node(initializer_list_t init) {
+        if (init.size() == 1 && init.begin()->has_node_ref()) {
+            const auto& node_ref = *init.begin();
+            if ((node_ref->is_sequence() || node_ref->is_mapping()) && node_ref->empty() && !node_ref->is_anchor() &&
+                !node_ref->has_tag_name()) {
+                basic_node(node_ref.release()).swap(*this);
+                return;
+            }
+        }
+
         bool is_mapping =
             std::all_of(init.begin(), init.end(), [](const detail::node_ref_storage<basic_node>& node_ref) {
                 // Do not use is_sequence_impl() since node_ref may be an anchor or alias.

--- a/tests/unit_test/test_node_class.cpp
+++ b/tests/unit_test/test_node_class.cpp
@@ -814,6 +814,35 @@ TEST_CASE("Node_InitializerListCtor") {
     REQUIRE(node[fkyaml::node {{"bar", nullptr}}]["baz"].as_str() == "qux");
 }
 
+TEST_CASE("Node_InitializerListCtorWithSingleEmptyCollectionNode") {
+    SECTION("empty mapping node") {
+        const fkyaml::node expected = fkyaml::node::mapping();
+        const fkyaml::node actual {fkyaml::node::mapping()};
+
+        REQUIRE(actual.get_type() == expected.get_type());
+        REQUIRE(actual.is_mapping());
+        REQUIRE(actual.empty());
+    }
+
+    SECTION("empty sequence node") {
+        const fkyaml::node expected = fkyaml::node::sequence();
+        const fkyaml::node actual {fkyaml::node::sequence()};
+
+        REQUIRE(actual.get_type() == expected.get_type());
+        REQUIRE(actual.is_sequence());
+        REQUIRE(actual.empty());
+    }
+
+    SECTION("single scalar still creates a sequence") {
+        const fkyaml::node actual {"test"};
+
+        REQUIRE(actual.is_sequence());
+        REQUIRE(actual.size() == 1);
+        REQUIRE(actual[0].is_string());
+        REQUIRE(actual[0].as_str() == "test");
+    }
+}
+
 TEST_CASE("Node_CopyAssignmentOperator") {
     fkyaml::node node(123);
     fkyaml::node copied(true);

--- a/tests/unit_test/test_node_class.cpp
+++ b/tests/unit_test/test_node_class.cpp
@@ -2835,6 +2835,18 @@ TEST_CASE("Node_GetAnchorName") {
     }
 }
 
+TEST_CASE("Node_AnchorNodeDestructorWithDuplicateAnchorName") {
+    {
+        auto first = fkyaml::node::mapping();
+        first.add_anchor_name("anchor");
+
+        auto second = fkyaml::node::sequence();
+        second.add_anchor_name("anchor");
+    }
+
+    SUCCEED();
+}
+
 TEST_CASE("Node_AddAnchorName") {
     fkyaml::node node;
     std::string anchor_name = "anchor_name";


### PR DESCRIPTION
This PR introduces a narrow fix for brace initialization of empty collection nodes.

When code uses:

```cpp
const fkyaml::node node{fkyaml::node::mapping()};
```

the initializer-list constructor is selected, so the empty mapping node was previously treated as a single sequence element. As a result, the constructed node became a sequence instead of preserving the mapping type.

This change tracks whether an initializer-list entry was created directly from a `basic_node`, then unwraps only the narrow case where the list contains exactly one empty mapping or empty sequence node without node properties.

The fix intentionally keeps existing scalar initializer-list behavior unchanged. For example, `node{"test"}` still creates a one-element sequence, as documented.

Added regression coverage for:
- `node{node::mapping()}` preserving mapping type
- `node{node::sequence()}` preserving sequence type
- `node{"test"}` still creating a one-element sequence

---

## Pull Request Checklist

Read the [CONTRIBUTING.md](https://github.com/fktn-k/fkYAML/blob/develop/.github/CONTRIBUTING.md) file for detailed information.  

- [x] Changes are described in the pull request or in a referenced [issue](https://github.com/fktn-k/fkYAML/issues).
- [x] The test suite compiles and runs without any error.
- [ ] [The code coverage](https://coveralls.io/github/fktn-k/fkYAML) on your branch is 100%.
- [ ] The documentation is updated if you added/changed a feature.

## Please don't

- The C++11 support varies between different **compilers** and versions. Please note the [list of supported compilers](https://github.com/fktn-k/fkYAML/blob/develop/README.md#supported-compilers). Some compilers like GCC 4.7 (and earlier), Clang 3.3 (and earlier), or Microsoft Visual Studio 13.0 and earlier are known not to work due to missing or incomplete C++11 support. Please refrain from proposing changes that work around these compiler's limitations with `#ifdef`s or other means.
- Please refrain from proposing changes that would **break [YAML](https://yaml.org/) specifications**. If you propose a conformant extension of YAML to be supported by the library, please motivate this extension.
- Please do not open pull requests that address **multiple issues**.
