### PR TITLE
Fix `tool` directory typo and add CMake policy for the benchmark build

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -110,6 +110,10 @@ if(FK_YAML_RUN_IWYU)
   add_subdirectory(tools/iwyu)
 endif()
 
+if(FK_YAML_RUN_BENCHMARK AND (NOT DEFINED CMAKE_POLICY_VERSION_MINIMUM OR CMAKE_POLICY_VERSION_MINIMUM VERSION_LESS 3.5))
+  set(CMAKE_POLICY_VERSION_MINIMUM 3.5)
+endif()
+
 if(FK_YAML_RUN_BENCHMARK)
   add_subdirectory(tools/benchmark)
 endif()

--- a/README.md
+++ b/README.md
@@ -207,14 +207,14 @@ Testing of the library with [the YAML test suite](https://github.com/yaml/yaml-t
 
 ## Benchmarking
 
-Though efficiency is not everything, speed and memory consumption are very important characteristics for C++ developers. Regarding speed, benchmarking scores are now available with [the dedicated benchmarking tool](./tool/benchmark/README.md) for the parsing.  
+Though efficiency is not everything, speed and memory consumption are very important characteristics for C++ developers. Regarding speed, benchmarking scores are now available with [the dedicated benchmarking tool](./tools/benchmark/README.md) for the parsing.  
 The following tables are created from the benchmarking results in the following environment:  
 
 * CPU: AMD Ryzen 7 5800H @3.20GHz
 * OS: Ubuntu22.04 (WSL2)
 * Compiler: g++11.4.0
 
-### Parsing [ubuntu.yml](https://github.com/fktn-k/fkYAML/blob/develop/tool/benchmark/cases/ubuntu.yml)
+### Parsing [ubuntu.yml](https://github.com/fktn-k/fkYAML/blob/develop/tools/benchmark/cases/ubuntu.yml)
 
 | Benchmark                          | processed bytes per second (Release) |
 | ---------------------------------- | ------------------------------------ |
@@ -224,7 +224,7 @@ The following tables are created from the benchmarking results in the following 
 | rapidyaml<br>(with immutable buff) | 133.311Mi/s                          |
 | yaml-cpp                           | 9.07876Mi/s                          |
 
-### Parsing [citm_catalog.json](https://github.com/fktn-k/fkYAML/blob/develop/tool/benchmark/cases/citm_catalog.json)
+### Parsing [citm_catalog.json](https://github.com/fktn-k/fkYAML/blob/develop/tools/benchmark/cases/citm_catalog.json)
 
 | Benchmark                          | processed bytes per second (Release) |
 | ---------------------------------- | ------------------------------------ |
@@ -234,7 +234,7 @@ The following tables are created from the benchmarking results in the following 
 | rapidyaml<br>(with immutable buff) | 140.375Mi/s                          |
 | yaml-cpp                           | 14.3192Mi/s                          |
 
-### Parsing [citm_catalog.yml](https://github.com/fktn-k/fkYAML/blob/develop/tool/benchmark/cases/citm_catalog.yml)
+### Parsing [citm_catalog.yml](https://github.com/fktn-k/fkYAML/blob/develop/tools/benchmark/cases/citm_catalog.yml)
 
 | Benchmark                          | processed bytes per second (Release) |
 | ---------------------------------- | ------------------------------------ |

--- a/docs/docs/index.md
+++ b/docs/docs/index.md
@@ -213,7 +213,7 @@ The following tables are created from the benchmarking results in the following 
 * OS: Ubuntu22.04 (WSL2)
 * Compiler: g++11.4.0
 
-### Parsing [ubuntu.yml](https://github.com/fktn-k/fkYAML/blob/develop/tool/benchmark/cases/ubuntu.yml)
+### Parsing [ubuntu.yml](https://github.com/fktn-k/fkYAML/blob/develop/tools/benchmark/cases/ubuntu.yml)
 
 | Benchmark                          | processed bytes per second (Release) |
 | ---------------------------------- | ------------------------------------ |
@@ -223,7 +223,7 @@ The following tables are created from the benchmarking results in the following 
 | rapidyaml<br>(with immutable buff) | 133.311Mi/s                          |
 | yaml-cpp                           | 9.07876Mi/s                          |
 
-### Parsing [citm_catalog.json](https://github.com/fktn-k/fkYAML/blob/develop/tool/benchmark/cases/citm_catalog.json)
+### Parsing [citm_catalog.json](https://github.com/fktn-k/fkYAML/blob/develop/tools/benchmark/cases/citm_catalog.json)
 
 | Benchmark                          | processed bytes per second (Release) |
 | ---------------------------------- | ------------------------------------ |
@@ -233,7 +233,7 @@ The following tables are created from the benchmarking results in the following 
 | rapidyaml<br>(with immutable buff) | 140.375Mi/s                          |
 | yaml-cpp                           | 14.3192Mi/s                          |
 
-### Parsing [citm_catalog.yml](https://github.com/fktn-k/fkYAML/blob/develop/tool/benchmark/cases/citm_catalog.yml)
+### Parsing [citm_catalog.yml](https://github.com/fktn-k/fkYAML/blob/develop/tools/benchmark/cases/citm_catalog.yml)
 
 | Benchmark                          | processed bytes per second (Release) |
 | ---------------------------------- | ------------------------------------ |

--- a/tools/benchmark/README.md
+++ b/tools/benchmark/README.md
@@ -29,7 +29,7 @@ Build and run this tool with the following commands:
 
 ```bash
 $ cd path/to/fkYAML
-$ cmake -S . -B build -DCMAKE_BUILD_TYPE={Debug|Release} -DFK_YAML_RUN_BENCHMARK=ON
+$ cmake -S . -B build -DCMAKE_BUILD_TYPE={Debug|Release} -DFK_YAML_RUN_BENCHMARK=ON -DCMAKE_POLICY_VERSION_MINIMUM=3.5
 $ cmake --build build --config {Debug|Release}
 
 # You can specify an arbitrary input file such as /foo/bar/sample.yml or /foo/bar/sample.json

--- a/tools/benchmark/README.md
+++ b/tools/benchmark/README.md
@@ -29,7 +29,7 @@ Build and run this tool with the following commands:
 
 ```bash
 $ cd path/to/fkYAML
-$ cmake -S . -B build -DCMAKE_BUILD_TYPE={Debug|Release} -DFK_YAML_RUN_BENCHMARK=ON -DCMAKE_POLICY_VERSION_MINIMUM=3.5
+$ cmake -S . -B build -DCMAKE_BUILD_TYPE={Debug|Release} -DFK_YAML_RUN_BENCHMARK=ON
 $ cmake --build build --config {Debug|Release}
 
 # You can specify an arbitrary input file such as /foo/bar/sample.yml or /foo/bar/sample.json

--- a/tools/benchmark/README.md
+++ b/tools/benchmark/README.md
@@ -9,7 +9,7 @@ Currently, the following C++ YAML libraries tagged with the specified versions r
 * [rapidyaml](https://github.com/biojppm/rapidyaml) ([v0.7.2](https://github.com/biojppm/rapidyaml/releases/tag/v0.7.2))
 * [yaml-cpp](https://github.com/jbeder/yaml-cpp) ([0.8.0](https://github.com/jbeder/yaml-cpp/releases/tag/0.8.0))
 
-Currently, the following files are located in the [tool/benchmark/cases](https://github.com/fktn-k/fkYAML/tree/develop/tool/benchmark/cases) directory for benchmarking:  
+Currently, the following files are located in the [tools/benchmark/cases](https://github.com/fktn-k/fkYAML/tree/develop/tools/benchmark/cases) directory for benchmarking:  
 
 * ubuntu.yml
   * a copy from the [.github/workflows](https://github.com/fktn-k/fkYAML/tree/develop/.github/workflows) directory at the point of the commit [7092059](https://github.com/fktn-k/fkYAML/commit/709205948966a8415b76aa8a87371133a04fd675)
@@ -33,7 +33,7 @@ $ cmake -S . -B build -DCMAKE_BUILD_TYPE={Debug|Release} -DFK_YAML_RUN_BENCHMARK
 $ cmake --build build --config {Debug|Release}
 
 # You can specify an arbitrary input file such as /foo/bar/sample.yml or /foo/bar/sample.json
-$ ./build/tool/benchmark/benchmarker ./tool/benchmark/macos.yml
+$ ./build/tools/benchmark/benchmarker ./tools/benchmark/macos.yml
 ```
 
 Then, you should see a console ouput from the Google Benchmark library in the following format.  

--- a/tools/benchmark/cases/ubuntu.yml
+++ b/tools/benchmark/cases/ubuntu.yml
@@ -11,7 +11,7 @@ on:
       - include/**
       - single_include/**
       - test/**
-      - tool/**
+      - tools/**
       - .clang-tidy
       - CMakeLists.txt
       - Makefile
@@ -22,7 +22,7 @@ on:
       - include/**
       - single_include/**
       - test/**
-      - tool/**
+      - tools/**
       - .clang-tidy
       - CMakeLists.txt
       - Makefile


### PR DESCRIPTION
This PR fixes a minor typo in the `tool` directory name (actually it should be `tools`) and resolves a build issue with `yaml-cpp` caused by an outdated CMake version.

---

## Pull Request Checklist

Read the [CONTRIBUTING.md](https://github.com/fktn-k/fkYAML/blob/develop/.github/CONTRIBUTING.md) file for detailed information.  

- [x] Changes are described in the pull request or in a referenced [issue](https://github.com/fktn-k/fkYAML/issues).
- [x] The test suite compiles and runs without any error.
- [x] [The code coverage](https://coveralls.io/github/fktn-k/fkYAML) on your branch is 100%.
- [x] The documentation is updated if you added/changed a feature.

## Please don't

- The C++11 support varies between different **compilers** and versions. Please note the [list of supported compilers](https://github.com/fktn-k/fkYAML/blob/develop/README.md#supported-compilers). Some compilers like GCC 4.7 (and earlier), Clang 3.3 (and earlier), or Microsoft Visual Studio 13.0 and earlier are known not to work due to missing or incomplete C++11 support. Please refrain from proposing changes that work around these compiler's limitations with `#ifdef`s or other means.
- Please refrain from proposing changes that would **break [YAML](https://yaml.org/) specifications**. If you propose a conformant extension of YAML to be supported by the library, please motivate this extension.
- Please do not open pull requests that address **multiple issues**.
