### PR TITLE
Fix bugs in the format_check and coverage workflows

### DIFF
--- a/.github/workflows/coverage.yml
+++ b/.github/workflows/coverage.yml
@@ -86,4 +86,4 @@ jobs:
           |:-----|:-----------------------------------------------------|
           | ID   | ${{steps.upload_artifact_step.outputs.artifact-id}}  |
           | URL  | ${{steps.upload_artifact_step.outputs.artifact-url}} |
-        comment_tag: notification
+        comment-tag: coverage_notification

--- a/.github/workflows/format_check.yml
+++ b/.github/workflows/format_check.yml
@@ -72,11 +72,11 @@ jobs:
 
     - name: Upload patch
       id: upload_artifact_step
-      if: steps.diff.output.has_diff == 'true'
+      if: steps.format_diff.outputs.has_diff == 'true'
       uses: actions/upload-artifact@v7
       with:
-        name: ${{steps.diff.output.patch_file_name}}
-        path: ${{steps.diff.output.patch_file_name}}
+        name: ${{steps.format_diff.outputs.patch_file_name}}
+        path: ${{steps.format_diff.outputs.patch_file_name}}
         overwrite: true
 
     - name: Notify the artifact URL
@@ -88,8 +88,8 @@ jobs:
           The source code has not been formatted/amalgamated correctly in the commit [${{github.event.pull_request.head.sha}}](https://github.com/${{github.repository}}/commit/${{github.event.pull_request.head.sha}}).
           Please download and apply the patch to fix it.
 
-          | Name | ${{steps.diff.output.patch_file_name}}.zip           |
+          | Name | ${{steps.format_diff.outputs.patch_file_name}}.zip           |
           |:-----|:-----------------------------------------------------|
           | ID   | ${{steps.upload_artifact_step.outputs.artifact-id}}  |
           | URL  | ${{steps.upload_artifact_step.outputs.artifact-url}} |
-        comment_tag: notification
+        comment-tag: format_notification


### PR DESCRIPTION
This pull request updates the workflow configuration files to fix variable references and standardize notification tags.
The main changes ensure that the correct output variables are used in the format check workflow and that notification tags are consistent and more descriptive.

* **Workflow variable fixes:**
  * Updated jobs for the format_check workflow to use the correct output variable names from the `format_diff` step instead of the old `diff` step for artifact naming and conditional checks. 
* **Notification tag standardization:**
  * Changed the notification comment tag fields from `comment-tag: notification` to more specific tags:
    * `coverage_notification` for the coverage workflow
    * `format_notification` for the format_check workflow
 
---

## Pull Request Checklist

Read the [CONTRIBUTING.md](https://github.com/fktn-k/fkYAML/blob/develop/.github/CONTRIBUTING.md) file for detailed information.  

- [x] Changes are described in the pull request or in a referenced [issue](https://github.com/fktn-k/fkYAML/issues).
- [x] The test suite compiles and runs without any error.
- [x] [The code coverage](https://coveralls.io/github/fktn-k/fkYAML) on your branch is 100%.
- [x] The documentation is updated if you added/changed a feature.

## Please don't

- The C++11 support varies between different **compilers** and versions. Please note the [list of supported compilers](https://github.com/fktn-k/fkYAML/blob/develop/README.md#supported-compilers). Some compilers like GCC 4.7 (and earlier), Clang 3.3 (and earlier), or Microsoft Visual Studio 13.0 and earlier are known not to work due to missing or incomplete C++11 support. Please refrain from proposing changes that work around these compiler's limitations with `#ifdef`s or other means.
- Please refrain from proposing changes that would **break [YAML](https://yaml.org/) specifications**. If you propose a conformant extension of YAML to be supported by the library, please motivate this extension.
- Please do not open pull requests that address **multiple issues**.