### PR TITLE
Harden input adapter against truncated encoded input

### DIFF
--- a/include/fkYAML/detail/input/input_adapter.hpp
+++ b/include/fkYAML/detail/input/input_adapter.hpp
@@ -36,6 +36,17 @@ FK_YAML_DETAIL_NAMESPACE_BEGIN
 template <typename IterType, typename = void>
 class iterator_input_adapter;
 
+template <typename IterType>
+uint8_t read_utf8_byte_or_throw(IterType& current, IterType end, std::initializer_list<uint8_t> bytes_read) {
+    if FK_YAML_UNLIKELY (current == end) {
+        throw fkyaml::invalid_encoding("Invalid UTF-8 encoding.", bytes_read);
+    }
+
+    const auto byte = static_cast<uint8_t>(*current);
+    ++current;
+    return byte;
+}
+
 /// @brief An input adapter for iterators of type char.
 /// @tparam IterType An iterator type.
 template <typename IterType>
@@ -95,17 +106,19 @@ private:
         IterType current = m_begin;
         std::deque<IterType> cr_itrs {};
         while (current != m_end) {
+            const IterType char_itr = current;
             const auto first = static_cast<uint8_t>(*current);
+            ++current;
             const uint32_t num_bytes = utf8::get_num_bytes(first);
 
             switch (num_bytes) {
             case 1:
                 if FK_YAML_UNLIKELY (first == 0x0D /*CR*/) {
-                    cr_itrs.emplace_back(current);
+                    cr_itrs.emplace_back(char_itr);
                 }
                 break;
             case 2: {
-                const auto second = static_cast<uint8_t>(*++current);
+                const auto second = read_utf8_byte_or_throw(current, m_end, {first});
                 const bool is_valid = utf8::validate(first, second);
                 if FK_YAML_UNLIKELY (!is_valid) {
                     throw fkyaml::invalid_encoding("Invalid UTF-8 encoding.", {first, second});
@@ -113,8 +126,8 @@ private:
                 break;
             }
             case 3: {
-                const auto second = static_cast<uint8_t>(*++current);
-                const auto third = static_cast<uint8_t>(*++current);
+                const auto second = read_utf8_byte_or_throw(current, m_end, {first});
+                const auto third = read_utf8_byte_or_throw(current, m_end, {first, second});
                 const bool is_valid = utf8::validate(first, second, third);
                 if FK_YAML_UNLIKELY (!is_valid) {
                     throw fkyaml::invalid_encoding("Invalid UTF-8 encoding.", {first, second, third});
@@ -122,9 +135,9 @@ private:
                 break;
             }
             case 4: {
-                const auto second = static_cast<uint8_t>(*++current);
-                const auto third = static_cast<uint8_t>(*++current);
-                const auto fourth = static_cast<uint8_t>(*++current);
+                const auto second = read_utf8_byte_or_throw(current, m_end, {first});
+                const auto third = read_utf8_byte_or_throw(current, m_end, {first, second});
+                const auto fourth = read_utf8_byte_or_throw(current, m_end, {first, second, third});
                 const bool is_valid = utf8::validate(first, second, third, fourth);
                 if FK_YAML_UNLIKELY (!is_valid) {
                     throw fkyaml::invalid_encoding("Invalid UTF-8 encoding.", {first, second, third, fourth});
@@ -134,8 +147,6 @@ private:
             default:           // LCOV_EXCL_LINE
                 unreachable(); // LCOV_EXCL_LINE
             }
-
-            ++current;
         }
 
         const bool is_contiguous_no_cr = cr_itrs.empty() && m_is_contiguous;
@@ -154,7 +165,7 @@ private:
         }
         m_buffer.append(current, m_end);
 
-        return str_view {m_buffer.begin(), m_buffer.end()};
+        return m_buffer;
     }
 
     /// @brief The concrete implementation of get_buffer_view() for UTF-16 encoded inputs.
@@ -183,8 +194,16 @@ private:
         IterType current = m_begin;
         while (current != m_end || encoded_buf_size != 0) {
             while (current != m_end && encoded_buf_size < 2) {
-                auto utf16 = static_cast<char16_t>(static_cast<uint8_t>(*current) << shift_bits[0]);
-                utf16 |= static_cast<char16_t>(static_cast<uint8_t>(*++current) << shift_bits[1]);
+                const auto first = static_cast<uint8_t>(*current);
+                ++current;
+                if FK_YAML_UNLIKELY (current == m_end) {
+                    throw invalid_encoding(
+                        "Invalid UTF-16 encoding detected.",
+                        std::array<char16_t, 2> {{static_cast<char16_t>(first), 0}});
+                }
+
+                auto utf16 = static_cast<char16_t>(first << shift_bits[0]);
+                utf16 |= static_cast<char16_t>(static_cast<uint8_t>(*current) << shift_bits[1]);
                 ++current;
 
                 // skip appending CRs.
@@ -197,15 +216,22 @@ private:
             uint32_t consumed_size = 0;
             utf8::from_utf16(encoded_buffer, utf8_buffer, consumed_size, utf8_buf_size);
 
+            if FK_YAML_UNLIKELY (consumed_size > encoded_buf_size) {
+                throw invalid_encoding("Invalid UTF-16 encoding detected.", encoded_buffer);
+            }
             if FK_YAML_LIKELY (consumed_size == 1) {
                 encoded_buffer[0] = encoded_buffer[1];
+                encoded_buffer[1] = 0;
+            }
+            else {
+                encoded_buffer[0] = encoded_buffer[1] = 0;
             }
             encoded_buf_size -= consumed_size;
 
             m_buffer.append(reinterpret_cast<const char*>(utf8_buffer.data()), utf8_buf_size);
         }
 
-        return str_view {m_buffer.begin(), m_buffer.end()};
+        return m_buffer;
     }
 
     /// @brief The concrete implementation of get_buffer_view() for UTF-32 encoded inputs.
@@ -235,14 +261,19 @@ private:
 
         IterType current = m_begin;
         while (current != m_end) {
-            auto utf32 = static_cast<char32_t>(*current << shift_bits[0]);
-            ++current;
-            utf32 |= static_cast<char32_t>(*current << shift_bits[1]);
-            ++current;
-            utf32 |= static_cast<char32_t>(*current << shift_bits[2]);
-            ++current;
-            utf32 |= static_cast<char32_t>(*current << shift_bits[3]);
-            ++current;
+            uint8_t chars[4] {};
+            for (auto& c : chars) {
+                if FK_YAML_UNLIKELY (current == m_end) {
+                    throw invalid_encoding("Invalid UTF-32 encoding detected.", char32_t(0));
+                }
+                c = static_cast<uint8_t>(*current);
+                ++current;
+            }
+
+            auto utf32 = static_cast<char32_t>(chars[0] << shift_bits[0]);
+            utf32 |= static_cast<char32_t>(chars[1] << shift_bits[1]);
+            utf32 |= static_cast<char32_t>(chars[2] << shift_bits[2]);
+            utf32 |= static_cast<char32_t>(chars[3] << shift_bits[3]);
 
             if FK_YAML_LIKELY (utf32 != char32_t(0x0000000Du)) {
                 utf8::from_utf32(utf32, utf8_buffer, utf8_buf_size);
@@ -250,7 +281,7 @@ private:
             }
         }
 
-        return str_view {m_buffer.begin(), m_buffer.end()};
+        return m_buffer;
     }
 
 private:
@@ -308,17 +339,19 @@ public:
         IterType current = m_begin;
         std::deque<IterType> cr_itrs {};
         while (current != m_end) {
+            const IterType char_itr = current;
             const auto first = static_cast<uint8_t>(*current);
+            ++current;
             const uint32_t num_bytes = utf8::get_num_bytes(first);
 
             switch (num_bytes) {
             case 1:
                 if FK_YAML_UNLIKELY (first == 0x0D /*CR*/) {
-                    cr_itrs.emplace_back(current);
+                    cr_itrs.emplace_back(char_itr);
                 }
                 break;
             case 2: {
-                const auto second = static_cast<uint8_t>(*++current);
+                const auto second = read_utf8_byte_or_throw(current, m_end, {first});
                 const bool is_valid = utf8::validate(first, second);
                 if FK_YAML_UNLIKELY (!is_valid) {
                     throw fkyaml::invalid_encoding("Invalid UTF-8 encoding.", {first, second});
@@ -326,8 +359,8 @@ public:
                 break;
             }
             case 3: {
-                const auto second = static_cast<uint8_t>(*++current);
-                const auto third = static_cast<uint8_t>(*++current);
+                const auto second = read_utf8_byte_or_throw(current, m_end, {first});
+                const auto third = read_utf8_byte_or_throw(current, m_end, {first, second});
                 const bool is_valid = utf8::validate(first, second, third);
                 if FK_YAML_UNLIKELY (!is_valid) {
                     throw fkyaml::invalid_encoding("Invalid UTF-8 encoding.", {first, second, third});
@@ -335,9 +368,9 @@ public:
                 break;
             }
             case 4: {
-                const auto second = static_cast<uint8_t>(*++current);
-                const auto third = static_cast<uint8_t>(*++current);
-                const auto fourth = static_cast<uint8_t>(*++current);
+                const auto second = read_utf8_byte_or_throw(current, m_end, {first});
+                const auto third = read_utf8_byte_or_throw(current, m_end, {first, second});
+                const auto fourth = read_utf8_byte_or_throw(current, m_end, {first, second, third});
                 const bool is_valid = utf8::validate(first, second, third, fourth);
                 if FK_YAML_UNLIKELY (!is_valid) {
                     throw fkyaml::invalid_encoding("Invalid UTF-8 encoding.", {first, second, third, fourth});
@@ -347,8 +380,6 @@ public:
             default:           // LCOV_EXCL_LINE
                 unreachable(); // LCOV_EXCL_LINE
             }
-
-            ++current;
         }
 
         m_buffer.reserve(std::distance(m_begin, m_end) - cr_itrs.size());
@@ -360,7 +391,7 @@ public:
         }
         std::transform(current, m_end, std::back_inserter(m_buffer), [](char8_t c) { return static_cast<char>(c); });
 
-        return str_view {m_buffer.begin(), m_buffer.end()};
+        return m_buffer;
     }
 
 private:
@@ -440,16 +471,22 @@ public:
             uint32_t consumed_size = 0;
             utf8::from_utf16(encoded_buffer, utf8_buffer, consumed_size, utf8_buf_size);
 
+            if FK_YAML_UNLIKELY (consumed_size > encoded_buf_size) {
+                throw invalid_encoding("Invalid UTF-16 encoding detected.", encoded_buffer);
+            }
             if FK_YAML_LIKELY (consumed_size == 1) {
                 encoded_buffer[0] = encoded_buffer[1];
                 encoded_buffer[1] = 0;
+            }
+            else {
+                encoded_buffer[0] = encoded_buffer[1] = 0;
             }
             encoded_buf_size -= consumed_size;
 
             m_buffer.append(reinterpret_cast<const char*>(utf8_buffer.data()), utf8_buf_size);
         }
 
-        return str_view {m_buffer.begin(), m_buffer.end()};
+        return m_buffer;
     }
 
 private:
@@ -529,7 +566,7 @@ public:
             }
         }
 
-        return str_view {m_buffer.begin(), m_buffer.end()};
+        return m_buffer;
     }
 
 private:
@@ -620,14 +657,15 @@ private:
         auto current = m_buffer.begin();
         auto end = m_buffer.end();
         while (current != end) {
-            const auto first = static_cast<uint8_t>(*current++);
+            const auto first = static_cast<uint8_t>(*current);
+            ++current;
             const uint32_t num_bytes = utf8::get_num_bytes(first);
 
             switch (num_bytes) {
             case 1:
                 break;
             case 2: {
-                const auto second = static_cast<uint8_t>(*current++);
+                const auto second = read_utf8_byte_or_throw(current, end, {first});
                 const bool is_valid = utf8::validate(first, second);
                 if FK_YAML_UNLIKELY (!is_valid) {
                     throw fkyaml::invalid_encoding("Invalid UTF-8 encoding.", {first, second});
@@ -635,8 +673,8 @@ private:
                 break;
             }
             case 3: {
-                const auto second = static_cast<uint8_t>(*current++);
-                const auto third = static_cast<uint8_t>(*current++);
+                const auto second = read_utf8_byte_or_throw(current, end, {first});
+                const auto third = read_utf8_byte_or_throw(current, end, {first, second});
                 const bool is_valid = utf8::validate(first, second, third);
                 if FK_YAML_UNLIKELY (!is_valid) {
                     throw fkyaml::invalid_encoding("Invalid UTF-8 encoding.", {first, second, third});
@@ -644,9 +682,9 @@ private:
                 break;
             }
             case 4: {
-                const auto second = static_cast<uint8_t>(*current++);
-                const auto third = static_cast<uint8_t>(*current++);
-                const auto fourth = static_cast<uint8_t>(*current++);
+                const auto second = read_utf8_byte_or_throw(current, end, {first});
+                const auto third = read_utf8_byte_or_throw(current, end, {first, second});
+                const auto fourth = read_utf8_byte_or_throw(current, end, {first, second, third});
                 const bool is_valid = utf8::validate(first, second, third, fourth);
                 if FK_YAML_UNLIKELY (!is_valid) {
                     throw fkyaml::invalid_encoding("Invalid UTF-8 encoding.", {first, second, third, fourth});
@@ -658,7 +696,7 @@ private:
             }
         }
 
-        return str_view {m_buffer.begin(), m_buffer.end()};
+        return m_buffer;
     }
 
     /// @brief The concrete implementation of get_buffer_view() for UTF-16 encoded inputs.
@@ -681,7 +719,15 @@ private:
         uint32_t utf8_buf_size {0};
 
         while (std::feof(m_file) == 0) {
-            while (encoded_buf_size < 2 && std::fread(&chars[0], sizeof(char), 2, m_file) == 2) {
+            while (encoded_buf_size < 2) {
+                const std::size_t size = std::fread(&chars[0], sizeof(char), 2, m_file);
+                if (size == 0) {
+                    break;
+                }
+                if FK_YAML_UNLIKELY (size != 2) {
+                    throw invalid_encoding("Invalid UTF-16 encoding detected.", std::array<char16_t, 2> {{0, 0}});
+                }
+
                 const auto utf16 = static_cast<char16_t>(
                     (static_cast<uint8_t>(chars[0]) << shift_bits[0]) |
                     (static_cast<uint8_t>(chars[1]) << shift_bits[1]));
@@ -690,19 +736,29 @@ private:
                     encoded_buffer[encoded_buf_size++] = utf16;
                 }
             }
+            if (encoded_buf_size == 0) {
+                break;
+            }
 
             uint32_t consumed_size = 0;
             utf8::from_utf16(encoded_buffer, utf8_buffer, consumed_size, utf8_buf_size);
 
+            if FK_YAML_UNLIKELY (consumed_size > encoded_buf_size) {
+                throw invalid_encoding("Invalid UTF-16 encoding detected.", encoded_buffer);
+            }
             if FK_YAML_LIKELY (consumed_size == 1) {
                 encoded_buffer[0] = encoded_buffer[1];
+                encoded_buffer[1] = 0;
+            }
+            else {
+                encoded_buffer[0] = encoded_buffer[1] = 0;
             }
             encoded_buf_size -= consumed_size;
 
             m_buffer.append(reinterpret_cast<const char*>(utf8_buffer.data()), utf8_buf_size);
         }
 
-        return str_view {m_buffer.begin(), m_buffer.end()};
+        return m_buffer;
     }
 
     /// @brief The concrete implementation of get_buffer_view() for UTF-32 encoded inputs.
@@ -728,8 +784,11 @@ private:
 
         while (std::feof(m_file) == 0) {
             const std::size_t size = std::fread(&chars[0], sizeof(char), 4, m_file);
-            if (size != 4) {
+            if (size == 0) {
                 break;
+            }
+            if FK_YAML_UNLIKELY (size != 4) {
+                throw invalid_encoding("Invalid UTF-32 encoding detected.", char32_t(0));
             }
 
             const auto utf32 = static_cast<char32_t>(
@@ -742,7 +801,7 @@ private:
             }
         }
 
-        return str_view {m_buffer.begin(), m_buffer.end()};
+        return m_buffer;
     }
 
 private:
@@ -830,14 +889,15 @@ private:
         auto current = m_buffer.begin();
         auto end = m_buffer.end();
         while (current != end) {
-            const auto first = static_cast<uint8_t>(*current++);
+            const auto first = static_cast<uint8_t>(*current);
+            ++current;
             const uint32_t num_bytes = utf8::get_num_bytes(first);
 
             switch (num_bytes) {
             case 1:
                 break;
             case 2: {
-                const auto second = static_cast<uint8_t>(*current++);
+                const auto second = read_utf8_byte_or_throw(current, end, {first});
                 const bool is_valid = utf8::validate(first, second);
                 if FK_YAML_UNLIKELY (!is_valid) {
                     throw fkyaml::invalid_encoding("Invalid UTF-8 encoding.", {first, second});
@@ -845,8 +905,8 @@ private:
                 break;
             }
             case 3: {
-                const auto second = static_cast<uint8_t>(*current++);
-                const auto third = static_cast<uint8_t>(*current++);
+                const auto second = read_utf8_byte_or_throw(current, end, {first});
+                const auto third = read_utf8_byte_or_throw(current, end, {first, second});
                 const bool is_valid = utf8::validate(first, second, third);
                 if FK_YAML_UNLIKELY (!is_valid) {
                     throw fkyaml::invalid_encoding("Invalid UTF-8 encoding.", {first, second, third});
@@ -854,9 +914,9 @@ private:
                 break;
             }
             case 4: {
-                const auto second = static_cast<uint8_t>(*current++);
-                const auto third = static_cast<uint8_t>(*current++);
-                const auto fourth = static_cast<uint8_t>(*current++);
+                const auto second = read_utf8_byte_or_throw(current, end, {first});
+                const auto third = read_utf8_byte_or_throw(current, end, {first, second});
+                const auto fourth = read_utf8_byte_or_throw(current, end, {first, second, third});
                 const bool is_valid = utf8::validate(first, second, third, fourth);
                 if FK_YAML_UNLIKELY (!is_valid) {
                     throw fkyaml::invalid_encoding("Invalid UTF-8 encoding.", {first, second, third, fourth});
@@ -868,7 +928,7 @@ private:
             }
         }
 
-        return str_view {m_buffer.begin(), m_buffer.end()};
+        return m_buffer;
     }
 
     /// @brief The concrete implementation of get_buffer_view() for UTF-16 encoded inputs.
@@ -894,8 +954,11 @@ private:
             while (encoded_buf_size < 2) {
                 m_istream->read(&chars[0], 2);
                 const std::streamsize size = m_istream->gcount();
-                if FK_YAML_UNLIKELY (size != 2) {
+                if (size == 0) {
                     break;
+                }
+                if FK_YAML_UNLIKELY (size != 2) {
+                    throw invalid_encoding("Invalid UTF-16 encoding detected.", std::array<char16_t, 2> {{0, 0}});
                 }
 
                 const auto utf16 = static_cast<char16_t>(
@@ -907,19 +970,29 @@ private:
                     encoded_buffer[encoded_buf_size++] = utf16;
                 }
             }
+            if (encoded_buf_size == 0) {
+                break;
+            }
 
             uint32_t consumed_size = 0;
             utf8::from_utf16(encoded_buffer, utf8_buffer, consumed_size, utf8_buf_size);
 
+            if FK_YAML_UNLIKELY (consumed_size > encoded_buf_size) {
+                throw invalid_encoding("Invalid UTF-16 encoding detected.", encoded_buffer);
+            }
             if FK_YAML_LIKELY (consumed_size == 1) {
                 encoded_buffer[0] = encoded_buffer[1];
+                encoded_buffer[1] = 0;
+            }
+            else {
+                encoded_buffer[0] = encoded_buffer[1] = 0;
             }
             encoded_buf_size -= consumed_size;
 
             m_buffer.append(reinterpret_cast<const char*>(utf8_buffer.data()), utf8_buf_size);
         } while (!m_istream->eof());
 
-        return str_view {m_buffer.begin(), m_buffer.end()};
+        return m_buffer;
     }
 
     /// @brief The concrete implementation of get_buffer_view() for UTF-32 encoded inputs.
@@ -946,8 +1019,11 @@ private:
         do {
             m_istream->read(&chars[0], 4);
             const std::streamsize size = m_istream->gcount();
-            if FK_YAML_UNLIKELY (size != 4) {
+            if (size == 0) {
                 break;
+            }
+            if FK_YAML_UNLIKELY (size != 4) {
+                throw invalid_encoding("Invalid UTF-32 encoding detected.", char32_t(0));
             }
 
             const auto utf32 = static_cast<char32_t>(
@@ -960,7 +1036,7 @@ private:
             }
         } while (!m_istream->eof());
 
-        return str_view {m_buffer.begin(), m_buffer.end()};
+        return m_buffer;
     }
 
 private:

--- a/include/fkYAML/detail/input/input_adapter.hpp
+++ b/include/fkYAML/detail/input/input_adapter.hpp
@@ -267,7 +267,7 @@ private:
             uint8_t chars[4] {};
             for (auto& c : chars) {
                 if FK_YAML_UNLIKELY (current == m_end) {
-                    throw invalid_encoding("Invalid UTF-32 encoding detected.", char32_t(0));
+                    throw invalid_encoding("Invalid UTF-32 encoding detected.", static_cast<char32_t>(0));
                 }
                 c = static_cast<uint8_t>(*current);
                 ++current;
@@ -794,7 +794,7 @@ private:
                 break;
             }
             if FK_YAML_UNLIKELY (size != 4) {
-                throw invalid_encoding("Invalid UTF-32 encoding detected.", char32_t(0));
+                throw invalid_encoding("Invalid UTF-32 encoding detected.", static_cast<char32_t>(0));
             }
 
             const auto utf32 = static_cast<char32_t>(
@@ -1029,7 +1029,7 @@ private:
                 break;
             }
             if FK_YAML_UNLIKELY (size != 4) {
-                throw invalid_encoding("Invalid UTF-32 encoding detected.", char32_t(0));
+                throw invalid_encoding("Invalid UTF-32 encoding detected.", static_cast<char32_t>(0));
             }
 
             const auto utf32 = static_cast<char32_t>(

--- a/include/fkYAML/detail/input/input_adapter.hpp
+++ b/include/fkYAML/detail/input/input_adapter.hpp
@@ -212,6 +212,9 @@ private:
                     encoded_buffer[encoded_buf_size++] = utf16;
                 }
             }
+            if (encoded_buf_size == 0) {
+                break;
+            }
 
             uint32_t consumed_size = 0;
             utf8::from_utf16(encoded_buffer, utf8_buffer, consumed_size, utf8_buf_size);
@@ -466,6 +469,9 @@ public:
                     // NOLINTNEXTLINE(cppcoreguidelines-pro-bounds-constant-array-index)
                     encoded_buffer[encoded_buf_size++] = utf16;
                 }
+            }
+            if (encoded_buf_size == 0) {
+                break;
             }
 
             uint32_t consumed_size = 0;

--- a/include/fkYAML/detail/input/input_adapter.hpp
+++ b/include/fkYAML/detail/input/input_adapter.hpp
@@ -219,9 +219,14 @@ private:
             uint32_t consumed_size = 0;
             utf8::from_utf16(encoded_buffer, utf8_buffer, consumed_size, utf8_buf_size);
 
+            // Buffer management guarantees consumed_size <= encoded_buf_size.
+            // Keep this guard to prevent underflow if that invariant changes.
+            // LCOV_EXCL_START
             if FK_YAML_UNLIKELY (consumed_size > encoded_buf_size) {
                 throw invalid_encoding("Invalid UTF-16 encoding detected.", encoded_buffer);
             }
+            // LCOV_EXCL_STOP
+
             if FK_YAML_LIKELY (consumed_size == 1) {
                 encoded_buffer[0] = encoded_buffer[1];
                 encoded_buffer[1] = 0;
@@ -477,9 +482,14 @@ public:
             uint32_t consumed_size = 0;
             utf8::from_utf16(encoded_buffer, utf8_buffer, consumed_size, utf8_buf_size);
 
+            // Buffer management guarantees consumed_size <= encoded_buf_size.
+            // Keep this guard to prevent underflow if that invariant changes.
+            // LCOV_EXCL_START
             if FK_YAML_UNLIKELY (consumed_size > encoded_buf_size) {
                 throw invalid_encoding("Invalid UTF-16 encoding detected.", encoded_buffer);
             }
+            // LCOV_EXCL_STOP
+
             if FK_YAML_LIKELY (consumed_size == 1) {
                 encoded_buffer[0] = encoded_buffer[1];
                 encoded_buffer[1] = 0;
@@ -749,9 +759,14 @@ private:
             uint32_t consumed_size = 0;
             utf8::from_utf16(encoded_buffer, utf8_buffer, consumed_size, utf8_buf_size);
 
+            // Buffer management guarantees consumed_size <= encoded_buf_size.
+            // Keep this guard to prevent underflow if that invariant changes.
+            // LCOV_EXCL_START
             if FK_YAML_UNLIKELY (consumed_size > encoded_buf_size) {
                 throw invalid_encoding("Invalid UTF-16 encoding detected.", encoded_buffer);
             }
+            // LCOV_EXCL_STOP
+
             if FK_YAML_LIKELY (consumed_size == 1) {
                 encoded_buffer[0] = encoded_buffer[1];
                 encoded_buffer[1] = 0;
@@ -983,9 +998,14 @@ private:
             uint32_t consumed_size = 0;
             utf8::from_utf16(encoded_buffer, utf8_buffer, consumed_size, utf8_buf_size);
 
+            // Buffer management guarantees consumed_size <= encoded_buf_size.
+            // Keep this guard to prevent underflow if that invariant changes.
+            // LCOV_EXCL_START
             if FK_YAML_UNLIKELY (consumed_size > encoded_buf_size) {
                 throw invalid_encoding("Invalid UTF-16 encoding detected.", encoded_buffer);
             }
+            // LCOV_EXCL_STOP
+
             if FK_YAML_LIKELY (consumed_size == 1) {
                 encoded_buffer[0] = encoded_buffer[1];
                 encoded_buffer[1] = 0;

--- a/single_include/fkYAML/node.hpp
+++ b/single_include/fkYAML/node.hpp
@@ -9385,6 +9385,9 @@ private:
                     encoded_buffer[encoded_buf_size++] = utf16;
                 }
             }
+            if (encoded_buf_size == 0) {
+                break;
+            }
 
             uint32_t consumed_size = 0;
             utf8::from_utf16(encoded_buffer, utf8_buffer, consumed_size, utf8_buf_size);
@@ -9639,6 +9642,9 @@ public:
                     // NOLINTNEXTLINE(cppcoreguidelines-pro-bounds-constant-array-index)
                     encoded_buffer[encoded_buf_size++] = utf16;
                 }
+            }
+            if (encoded_buf_size == 0) {
+                break;
             }
 
             uint32_t consumed_size = 0;

--- a/single_include/fkYAML/node.hpp
+++ b/single_include/fkYAML/node.hpp
@@ -9209,6 +9209,17 @@ FK_YAML_DETAIL_NAMESPACE_BEGIN
 template <typename IterType, typename = void>
 class iterator_input_adapter;
 
+template <typename IterType>
+uint8_t read_utf8_byte_or_throw(IterType& current, IterType end, std::initializer_list<uint8_t> bytes_read) {
+    if FK_YAML_UNLIKELY (current == end) {
+        throw fkyaml::invalid_encoding("Invalid UTF-8 encoding.", bytes_read);
+    }
+
+    const auto byte = static_cast<uint8_t>(*current);
+    ++current;
+    return byte;
+}
+
 /// @brief An input adapter for iterators of type char.
 /// @tparam IterType An iterator type.
 template <typename IterType>
@@ -9268,17 +9279,19 @@ private:
         IterType current = m_begin;
         std::deque<IterType> cr_itrs {};
         while (current != m_end) {
+            const IterType char_itr = current;
             const auto first = static_cast<uint8_t>(*current);
+            ++current;
             const uint32_t num_bytes = utf8::get_num_bytes(first);
 
             switch (num_bytes) {
             case 1:
                 if FK_YAML_UNLIKELY (first == 0x0D /*CR*/) {
-                    cr_itrs.emplace_back(current);
+                    cr_itrs.emplace_back(char_itr);
                 }
                 break;
             case 2: {
-                const auto second = static_cast<uint8_t>(*++current);
+                const auto second = read_utf8_byte_or_throw(current, m_end, {first});
                 const bool is_valid = utf8::validate(first, second);
                 if FK_YAML_UNLIKELY (!is_valid) {
                     throw fkyaml::invalid_encoding("Invalid UTF-8 encoding.", {first, second});
@@ -9286,8 +9299,8 @@ private:
                 break;
             }
             case 3: {
-                const auto second = static_cast<uint8_t>(*++current);
-                const auto third = static_cast<uint8_t>(*++current);
+                const auto second = read_utf8_byte_or_throw(current, m_end, {first});
+                const auto third = read_utf8_byte_or_throw(current, m_end, {first, second});
                 const bool is_valid = utf8::validate(first, second, third);
                 if FK_YAML_UNLIKELY (!is_valid) {
                     throw fkyaml::invalid_encoding("Invalid UTF-8 encoding.", {first, second, third});
@@ -9295,9 +9308,9 @@ private:
                 break;
             }
             case 4: {
-                const auto second = static_cast<uint8_t>(*++current);
-                const auto third = static_cast<uint8_t>(*++current);
-                const auto fourth = static_cast<uint8_t>(*++current);
+                const auto second = read_utf8_byte_or_throw(current, m_end, {first});
+                const auto third = read_utf8_byte_or_throw(current, m_end, {first, second});
+                const auto fourth = read_utf8_byte_or_throw(current, m_end, {first, second, third});
                 const bool is_valid = utf8::validate(first, second, third, fourth);
                 if FK_YAML_UNLIKELY (!is_valid) {
                     throw fkyaml::invalid_encoding("Invalid UTF-8 encoding.", {first, second, third, fourth});
@@ -9307,8 +9320,6 @@ private:
             default:           // LCOV_EXCL_LINE
                 unreachable(); // LCOV_EXCL_LINE
             }
-
-            ++current;
         }
 
         const bool is_contiguous_no_cr = cr_itrs.empty() && m_is_contiguous;
@@ -9327,7 +9338,7 @@ private:
         }
         m_buffer.append(current, m_end);
 
-        return str_view {m_buffer.begin(), m_buffer.end()};
+        return m_buffer;
     }
 
     /// @brief The concrete implementation of get_buffer_view() for UTF-16 encoded inputs.
@@ -9356,8 +9367,16 @@ private:
         IterType current = m_begin;
         while (current != m_end || encoded_buf_size != 0) {
             while (current != m_end && encoded_buf_size < 2) {
-                auto utf16 = static_cast<char16_t>(static_cast<uint8_t>(*current) << shift_bits[0]);
-                utf16 |= static_cast<char16_t>(static_cast<uint8_t>(*++current) << shift_bits[1]);
+                const auto first = static_cast<uint8_t>(*current);
+                ++current;
+                if FK_YAML_UNLIKELY (current == m_end) {
+                    throw invalid_encoding(
+                        "Invalid UTF-16 encoding detected.",
+                        std::array<char16_t, 2> {{static_cast<char16_t>(first), 0}});
+                }
+
+                auto utf16 = static_cast<char16_t>(first << shift_bits[0]);
+                utf16 |= static_cast<char16_t>(static_cast<uint8_t>(*current) << shift_bits[1]);
                 ++current;
 
                 // skip appending CRs.
@@ -9370,15 +9389,22 @@ private:
             uint32_t consumed_size = 0;
             utf8::from_utf16(encoded_buffer, utf8_buffer, consumed_size, utf8_buf_size);
 
+            if FK_YAML_UNLIKELY (consumed_size > encoded_buf_size) {
+                throw invalid_encoding("Invalid UTF-16 encoding detected.", encoded_buffer);
+            }
             if FK_YAML_LIKELY (consumed_size == 1) {
                 encoded_buffer[0] = encoded_buffer[1];
+                encoded_buffer[1] = 0;
+            }
+            else {
+                encoded_buffer[0] = encoded_buffer[1] = 0;
             }
             encoded_buf_size -= consumed_size;
 
             m_buffer.append(reinterpret_cast<const char*>(utf8_buffer.data()), utf8_buf_size);
         }
 
-        return str_view {m_buffer.begin(), m_buffer.end()};
+        return m_buffer;
     }
 
     /// @brief The concrete implementation of get_buffer_view() for UTF-32 encoded inputs.
@@ -9408,14 +9434,19 @@ private:
 
         IterType current = m_begin;
         while (current != m_end) {
-            auto utf32 = static_cast<char32_t>(*current << shift_bits[0]);
-            ++current;
-            utf32 |= static_cast<char32_t>(*current << shift_bits[1]);
-            ++current;
-            utf32 |= static_cast<char32_t>(*current << shift_bits[2]);
-            ++current;
-            utf32 |= static_cast<char32_t>(*current << shift_bits[3]);
-            ++current;
+            uint8_t chars[4] {};
+            for (auto& c : chars) {
+                if FK_YAML_UNLIKELY (current == m_end) {
+                    throw invalid_encoding("Invalid UTF-32 encoding detected.", char32_t(0));
+                }
+                c = static_cast<uint8_t>(*current);
+                ++current;
+            }
+
+            auto utf32 = static_cast<char32_t>(chars[0] << shift_bits[0]);
+            utf32 |= static_cast<char32_t>(chars[1] << shift_bits[1]);
+            utf32 |= static_cast<char32_t>(chars[2] << shift_bits[2]);
+            utf32 |= static_cast<char32_t>(chars[3] << shift_bits[3]);
 
             if FK_YAML_LIKELY (utf32 != char32_t(0x0000000Du)) {
                 utf8::from_utf32(utf32, utf8_buffer, utf8_buf_size);
@@ -9423,7 +9454,7 @@ private:
             }
         }
 
-        return str_view {m_buffer.begin(), m_buffer.end()};
+        return m_buffer;
     }
 
 private:
@@ -9481,17 +9512,19 @@ public:
         IterType current = m_begin;
         std::deque<IterType> cr_itrs {};
         while (current != m_end) {
+            const IterType char_itr = current;
             const auto first = static_cast<uint8_t>(*current);
+            ++current;
             const uint32_t num_bytes = utf8::get_num_bytes(first);
 
             switch (num_bytes) {
             case 1:
                 if FK_YAML_UNLIKELY (first == 0x0D /*CR*/) {
-                    cr_itrs.emplace_back(current);
+                    cr_itrs.emplace_back(char_itr);
                 }
                 break;
             case 2: {
-                const auto second = static_cast<uint8_t>(*++current);
+                const auto second = read_utf8_byte_or_throw(current, m_end, {first});
                 const bool is_valid = utf8::validate(first, second);
                 if FK_YAML_UNLIKELY (!is_valid) {
                     throw fkyaml::invalid_encoding("Invalid UTF-8 encoding.", {first, second});
@@ -9499,8 +9532,8 @@ public:
                 break;
             }
             case 3: {
-                const auto second = static_cast<uint8_t>(*++current);
-                const auto third = static_cast<uint8_t>(*++current);
+                const auto second = read_utf8_byte_or_throw(current, m_end, {first});
+                const auto third = read_utf8_byte_or_throw(current, m_end, {first, second});
                 const bool is_valid = utf8::validate(first, second, third);
                 if FK_YAML_UNLIKELY (!is_valid) {
                     throw fkyaml::invalid_encoding("Invalid UTF-8 encoding.", {first, second, third});
@@ -9508,9 +9541,9 @@ public:
                 break;
             }
             case 4: {
-                const auto second = static_cast<uint8_t>(*++current);
-                const auto third = static_cast<uint8_t>(*++current);
-                const auto fourth = static_cast<uint8_t>(*++current);
+                const auto second = read_utf8_byte_or_throw(current, m_end, {first});
+                const auto third = read_utf8_byte_or_throw(current, m_end, {first, second});
+                const auto fourth = read_utf8_byte_or_throw(current, m_end, {first, second, third});
                 const bool is_valid = utf8::validate(first, second, third, fourth);
                 if FK_YAML_UNLIKELY (!is_valid) {
                     throw fkyaml::invalid_encoding("Invalid UTF-8 encoding.", {first, second, third, fourth});
@@ -9520,8 +9553,6 @@ public:
             default:           // LCOV_EXCL_LINE
                 unreachable(); // LCOV_EXCL_LINE
             }
-
-            ++current;
         }
 
         m_buffer.reserve(std::distance(m_begin, m_end) - cr_itrs.size());
@@ -9533,7 +9564,7 @@ public:
         }
         std::transform(current, m_end, std::back_inserter(m_buffer), [](char8_t c) { return static_cast<char>(c); });
 
-        return str_view {m_buffer.begin(), m_buffer.end()};
+        return m_buffer;
     }
 
 private:
@@ -9613,16 +9644,22 @@ public:
             uint32_t consumed_size = 0;
             utf8::from_utf16(encoded_buffer, utf8_buffer, consumed_size, utf8_buf_size);
 
+            if FK_YAML_UNLIKELY (consumed_size > encoded_buf_size) {
+                throw invalid_encoding("Invalid UTF-16 encoding detected.", encoded_buffer);
+            }
             if FK_YAML_LIKELY (consumed_size == 1) {
                 encoded_buffer[0] = encoded_buffer[1];
                 encoded_buffer[1] = 0;
+            }
+            else {
+                encoded_buffer[0] = encoded_buffer[1] = 0;
             }
             encoded_buf_size -= consumed_size;
 
             m_buffer.append(reinterpret_cast<const char*>(utf8_buffer.data()), utf8_buf_size);
         }
 
-        return str_view {m_buffer.begin(), m_buffer.end()};
+        return m_buffer;
     }
 
 private:
@@ -9702,7 +9739,7 @@ public:
             }
         }
 
-        return str_view {m_buffer.begin(), m_buffer.end()};
+        return m_buffer;
     }
 
 private:
@@ -9793,14 +9830,15 @@ private:
         auto current = m_buffer.begin();
         auto end = m_buffer.end();
         while (current != end) {
-            const auto first = static_cast<uint8_t>(*current++);
+            const auto first = static_cast<uint8_t>(*current);
+            ++current;
             const uint32_t num_bytes = utf8::get_num_bytes(first);
 
             switch (num_bytes) {
             case 1:
                 break;
             case 2: {
-                const auto second = static_cast<uint8_t>(*current++);
+                const auto second = read_utf8_byte_or_throw(current, end, {first});
                 const bool is_valid = utf8::validate(first, second);
                 if FK_YAML_UNLIKELY (!is_valid) {
                     throw fkyaml::invalid_encoding("Invalid UTF-8 encoding.", {first, second});
@@ -9808,8 +9846,8 @@ private:
                 break;
             }
             case 3: {
-                const auto second = static_cast<uint8_t>(*current++);
-                const auto third = static_cast<uint8_t>(*current++);
+                const auto second = read_utf8_byte_or_throw(current, end, {first});
+                const auto third = read_utf8_byte_or_throw(current, end, {first, second});
                 const bool is_valid = utf8::validate(first, second, third);
                 if FK_YAML_UNLIKELY (!is_valid) {
                     throw fkyaml::invalid_encoding("Invalid UTF-8 encoding.", {first, second, third});
@@ -9817,9 +9855,9 @@ private:
                 break;
             }
             case 4: {
-                const auto second = static_cast<uint8_t>(*current++);
-                const auto third = static_cast<uint8_t>(*current++);
-                const auto fourth = static_cast<uint8_t>(*current++);
+                const auto second = read_utf8_byte_or_throw(current, end, {first});
+                const auto third = read_utf8_byte_or_throw(current, end, {first, second});
+                const auto fourth = read_utf8_byte_or_throw(current, end, {first, second, third});
                 const bool is_valid = utf8::validate(first, second, third, fourth);
                 if FK_YAML_UNLIKELY (!is_valid) {
                     throw fkyaml::invalid_encoding("Invalid UTF-8 encoding.", {first, second, third, fourth});
@@ -9831,7 +9869,7 @@ private:
             }
         }
 
-        return str_view {m_buffer.begin(), m_buffer.end()};
+        return m_buffer;
     }
 
     /// @brief The concrete implementation of get_buffer_view() for UTF-16 encoded inputs.
@@ -9854,7 +9892,15 @@ private:
         uint32_t utf8_buf_size {0};
 
         while (std::feof(m_file) == 0) {
-            while (encoded_buf_size < 2 && std::fread(&chars[0], sizeof(char), 2, m_file) == 2) {
+            while (encoded_buf_size < 2) {
+                const std::size_t size = std::fread(&chars[0], sizeof(char), 2, m_file);
+                if (size == 0) {
+                    break;
+                }
+                if FK_YAML_UNLIKELY (size != 2) {
+                    throw invalid_encoding("Invalid UTF-16 encoding detected.", std::array<char16_t, 2> {{0, 0}});
+                }
+
                 const auto utf16 = static_cast<char16_t>(
                     (static_cast<uint8_t>(chars[0]) << shift_bits[0]) |
                     (static_cast<uint8_t>(chars[1]) << shift_bits[1]));
@@ -9863,19 +9909,29 @@ private:
                     encoded_buffer[encoded_buf_size++] = utf16;
                 }
             }
+            if (encoded_buf_size == 0) {
+                break;
+            }
 
             uint32_t consumed_size = 0;
             utf8::from_utf16(encoded_buffer, utf8_buffer, consumed_size, utf8_buf_size);
 
+            if FK_YAML_UNLIKELY (consumed_size > encoded_buf_size) {
+                throw invalid_encoding("Invalid UTF-16 encoding detected.", encoded_buffer);
+            }
             if FK_YAML_LIKELY (consumed_size == 1) {
                 encoded_buffer[0] = encoded_buffer[1];
+                encoded_buffer[1] = 0;
+            }
+            else {
+                encoded_buffer[0] = encoded_buffer[1] = 0;
             }
             encoded_buf_size -= consumed_size;
 
             m_buffer.append(reinterpret_cast<const char*>(utf8_buffer.data()), utf8_buf_size);
         }
 
-        return str_view {m_buffer.begin(), m_buffer.end()};
+        return m_buffer;
     }
 
     /// @brief The concrete implementation of get_buffer_view() for UTF-32 encoded inputs.
@@ -9901,8 +9957,11 @@ private:
 
         while (std::feof(m_file) == 0) {
             const std::size_t size = std::fread(&chars[0], sizeof(char), 4, m_file);
-            if (size != 4) {
+            if (size == 0) {
                 break;
+            }
+            if FK_YAML_UNLIKELY (size != 4) {
+                throw invalid_encoding("Invalid UTF-32 encoding detected.", char32_t(0));
             }
 
             const auto utf32 = static_cast<char32_t>(
@@ -9915,7 +9974,7 @@ private:
             }
         }
 
-        return str_view {m_buffer.begin(), m_buffer.end()};
+        return m_buffer;
     }
 
 private:
@@ -10003,14 +10062,15 @@ private:
         auto current = m_buffer.begin();
         auto end = m_buffer.end();
         while (current != end) {
-            const auto first = static_cast<uint8_t>(*current++);
+            const auto first = static_cast<uint8_t>(*current);
+            ++current;
             const uint32_t num_bytes = utf8::get_num_bytes(first);
 
             switch (num_bytes) {
             case 1:
                 break;
             case 2: {
-                const auto second = static_cast<uint8_t>(*current++);
+                const auto second = read_utf8_byte_or_throw(current, end, {first});
                 const bool is_valid = utf8::validate(first, second);
                 if FK_YAML_UNLIKELY (!is_valid) {
                     throw fkyaml::invalid_encoding("Invalid UTF-8 encoding.", {first, second});
@@ -10018,8 +10078,8 @@ private:
                 break;
             }
             case 3: {
-                const auto second = static_cast<uint8_t>(*current++);
-                const auto third = static_cast<uint8_t>(*current++);
+                const auto second = read_utf8_byte_or_throw(current, end, {first});
+                const auto third = read_utf8_byte_or_throw(current, end, {first, second});
                 const bool is_valid = utf8::validate(first, second, third);
                 if FK_YAML_UNLIKELY (!is_valid) {
                     throw fkyaml::invalid_encoding("Invalid UTF-8 encoding.", {first, second, third});
@@ -10027,9 +10087,9 @@ private:
                 break;
             }
             case 4: {
-                const auto second = static_cast<uint8_t>(*current++);
-                const auto third = static_cast<uint8_t>(*current++);
-                const auto fourth = static_cast<uint8_t>(*current++);
+                const auto second = read_utf8_byte_or_throw(current, end, {first});
+                const auto third = read_utf8_byte_or_throw(current, end, {first, second});
+                const auto fourth = read_utf8_byte_or_throw(current, end, {first, second, third});
                 const bool is_valid = utf8::validate(first, second, third, fourth);
                 if FK_YAML_UNLIKELY (!is_valid) {
                     throw fkyaml::invalid_encoding("Invalid UTF-8 encoding.", {first, second, third, fourth});
@@ -10041,7 +10101,7 @@ private:
             }
         }
 
-        return str_view {m_buffer.begin(), m_buffer.end()};
+        return m_buffer;
     }
 
     /// @brief The concrete implementation of get_buffer_view() for UTF-16 encoded inputs.
@@ -10067,8 +10127,11 @@ private:
             while (encoded_buf_size < 2) {
                 m_istream->read(&chars[0], 2);
                 const std::streamsize size = m_istream->gcount();
-                if FK_YAML_UNLIKELY (size != 2) {
+                if (size == 0) {
                     break;
+                }
+                if FK_YAML_UNLIKELY (size != 2) {
+                    throw invalid_encoding("Invalid UTF-16 encoding detected.", std::array<char16_t, 2> {{0, 0}});
                 }
 
                 const auto utf16 = static_cast<char16_t>(
@@ -10080,19 +10143,29 @@ private:
                     encoded_buffer[encoded_buf_size++] = utf16;
                 }
             }
+            if (encoded_buf_size == 0) {
+                break;
+            }
 
             uint32_t consumed_size = 0;
             utf8::from_utf16(encoded_buffer, utf8_buffer, consumed_size, utf8_buf_size);
 
+            if FK_YAML_UNLIKELY (consumed_size > encoded_buf_size) {
+                throw invalid_encoding("Invalid UTF-16 encoding detected.", encoded_buffer);
+            }
             if FK_YAML_LIKELY (consumed_size == 1) {
                 encoded_buffer[0] = encoded_buffer[1];
+                encoded_buffer[1] = 0;
+            }
+            else {
+                encoded_buffer[0] = encoded_buffer[1] = 0;
             }
             encoded_buf_size -= consumed_size;
 
             m_buffer.append(reinterpret_cast<const char*>(utf8_buffer.data()), utf8_buf_size);
         } while (!m_istream->eof());
 
-        return str_view {m_buffer.begin(), m_buffer.end()};
+        return m_buffer;
     }
 
     /// @brief The concrete implementation of get_buffer_view() for UTF-32 encoded inputs.
@@ -10119,8 +10192,11 @@ private:
         do {
             m_istream->read(&chars[0], 4);
             const std::streamsize size = m_istream->gcount();
-            if FK_YAML_UNLIKELY (size != 4) {
+            if (size == 0) {
                 break;
+            }
+            if FK_YAML_UNLIKELY (size != 4) {
+                throw invalid_encoding("Invalid UTF-32 encoding detected.", char32_t(0));
             }
 
             const auto utf32 = static_cast<char32_t>(
@@ -10133,7 +10209,7 @@ private:
             }
         } while (!m_istream->eof());
 
-        return str_view {m_buffer.begin(), m_buffer.end()};
+        return m_buffer;
     }
 
 private:

--- a/single_include/fkYAML/node.hpp
+++ b/single_include/fkYAML/node.hpp
@@ -9440,7 +9440,7 @@ private:
             uint8_t chars[4] {};
             for (auto& c : chars) {
                 if FK_YAML_UNLIKELY (current == m_end) {
-                    throw invalid_encoding("Invalid UTF-32 encoding detected.", char32_t(0));
+                    throw invalid_encoding("Invalid UTF-32 encoding detected.", static_cast<char32_t>(0));
                 }
                 c = static_cast<uint8_t>(*current);
                 ++current;
@@ -9967,7 +9967,7 @@ private:
                 break;
             }
             if FK_YAML_UNLIKELY (size != 4) {
-                throw invalid_encoding("Invalid UTF-32 encoding detected.", char32_t(0));
+                throw invalid_encoding("Invalid UTF-32 encoding detected.", static_cast<char32_t>(0));
             }
 
             const auto utf32 = static_cast<char32_t>(
@@ -10202,7 +10202,7 @@ private:
                 break;
             }
             if FK_YAML_UNLIKELY (size != 4) {
-                throw invalid_encoding("Invalid UTF-32 encoding detected.", char32_t(0));
+                throw invalid_encoding("Invalid UTF-32 encoding detected.", static_cast<char32_t>(0));
             }
 
             const auto utf32 = static_cast<char32_t>(

--- a/single_include/fkYAML/node.hpp
+++ b/single_include/fkYAML/node.hpp
@@ -9392,9 +9392,14 @@ private:
             uint32_t consumed_size = 0;
             utf8::from_utf16(encoded_buffer, utf8_buffer, consumed_size, utf8_buf_size);
 
+            // Buffer management guarantees consumed_size <= encoded_buf_size.
+            // Keep this guard to prevent underflow if that invariant changes.
+            // LCOV_EXCL_START
             if FK_YAML_UNLIKELY (consumed_size > encoded_buf_size) {
                 throw invalid_encoding("Invalid UTF-16 encoding detected.", encoded_buffer);
             }
+            // LCOV_EXCL_STOP
+
             if FK_YAML_LIKELY (consumed_size == 1) {
                 encoded_buffer[0] = encoded_buffer[1];
                 encoded_buffer[1] = 0;
@@ -9650,9 +9655,14 @@ public:
             uint32_t consumed_size = 0;
             utf8::from_utf16(encoded_buffer, utf8_buffer, consumed_size, utf8_buf_size);
 
+            // Buffer management guarantees consumed_size <= encoded_buf_size.
+            // Keep this guard to prevent underflow if that invariant changes.
+            // LCOV_EXCL_START
             if FK_YAML_UNLIKELY (consumed_size > encoded_buf_size) {
                 throw invalid_encoding("Invalid UTF-16 encoding detected.", encoded_buffer);
             }
+            // LCOV_EXCL_STOP
+
             if FK_YAML_LIKELY (consumed_size == 1) {
                 encoded_buffer[0] = encoded_buffer[1];
                 encoded_buffer[1] = 0;
@@ -9922,9 +9932,14 @@ private:
             uint32_t consumed_size = 0;
             utf8::from_utf16(encoded_buffer, utf8_buffer, consumed_size, utf8_buf_size);
 
+            // Buffer management guarantees consumed_size <= encoded_buf_size.
+            // Keep this guard to prevent underflow if that invariant changes.
+            // LCOV_EXCL_START
             if FK_YAML_UNLIKELY (consumed_size > encoded_buf_size) {
                 throw invalid_encoding("Invalid UTF-16 encoding detected.", encoded_buffer);
             }
+            // LCOV_EXCL_STOP
+
             if FK_YAML_LIKELY (consumed_size == 1) {
                 encoded_buffer[0] = encoded_buffer[1];
                 encoded_buffer[1] = 0;
@@ -10156,9 +10171,14 @@ private:
             uint32_t consumed_size = 0;
             utf8::from_utf16(encoded_buffer, utf8_buffer, consumed_size, utf8_buf_size);
 
+            // Buffer management guarantees consumed_size <= encoded_buf_size.
+            // Keep this guard to prevent underflow if that invariant changes.
+            // LCOV_EXCL_START
             if FK_YAML_UNLIKELY (consumed_size > encoded_buf_size) {
                 throw invalid_encoding("Invalid UTF-16 encoding detected.", encoded_buffer);
             }
+            // LCOV_EXCL_STOP
+
             if FK_YAML_LIKELY (consumed_size == 1) {
                 encoded_buffer[0] = encoded_buffer[1];
                 encoded_buffer[1] = 0;

--- a/tests/unit_test/test_input_adapter.cpp
+++ b/tests/unit_test/test_input_adapter.cpp
@@ -2003,6 +2003,24 @@ TEST_CASE("InputAdapter_GetBufferView_UTF8NewlineCodeNormalization") {
 }
 
 TEST_CASE("InputAdapter_GetBufferView_UTF16BENewlineCodeNormalization") {
+    SECTION("iterator_input_adapter (char) with a standalone CR") {
+        std::string input {0, char(0x0D)};
+        auto input_adapter = fkyaml::detail::input_adapter(input);
+
+        const fkyaml::detail::str_view buffer = input_adapter.get_buffer_view();
+
+        REQUIRE(buffer.empty());
+    }
+
+    SECTION("iterator_input_adapter (char16_t) with a standalone CR") {
+        std::u16string input {char16_t(0x000Du)};
+        auto input_adapter = fkyaml::detail::input_adapter(input);
+
+        const fkyaml::detail::str_view buffer = input_adapter.get_buffer_view();
+
+        REQUIRE(buffer.empty());
+    }
+
     SECTION("iterator_input_adapter (char)") {
         char input[] = {0, char(0x74), 0, char(0x65), 0, char(0x73), 0, char(0x74), 0, char(0x0D),
                         0, char(0x0A), 0, char(0x64), 0, char(0x61), 0, char(0x74), 0, char(0x61),

--- a/tests/unit_test/test_input_adapter.cpp
+++ b/tests/unit_test/test_input_adapter.cpp
@@ -8,6 +8,7 @@
 
 #include <cstdio>
 #include <fstream>
+#include <sstream>
 #include <string>
 
 #include <catch2/catch.hpp>
@@ -538,6 +539,20 @@ TEST_CASE("InputAdapter_GetBufferView_UTF16BEN") {
         REQUIRE(buffer[9] == char(0x5Au));
     }
 
+    SECTION("iterator_input_adapter with truncated UTF-16 bytes") {
+        std::string input {0, 0x61, 0};
+        auto input_adapter = fkyaml::detail::input_adapter(input);
+
+        REQUIRE_THROWS_AS(input_adapter.get_buffer_view(), fkyaml::invalid_encoding);
+    }
+
+    SECTION("iterator_input_adapter with a dangling high surrogate after a surrogate pair") {
+        std::u16string input {char16_t(0x0061u), char16_t(0xD840u), char16_t(0xDC0Bu), char16_t(0xD840u)};
+        auto input_adapter = fkyaml::detail::input_adapter(input);
+
+        REQUIRE_THROWS_AS(input_adapter.get_buffer_view(), fkyaml::invalid_encoding);
+    }
+
     SECTION("file_input_adapter") {
         DISABLE_C4996
         FILE* p_file = std::fopen(FK_YAML_TEST_DATA_DIR "/input_adapter_test_data_utf16ben.txt", "r");
@@ -688,6 +703,44 @@ TEST_CASE("InputAdapter_GetBufferView_UTF16BEBOM") {
         std::fclose(p_file);
     }
 
+    SECTION("file_input_adapter with only a BOM") {
+        DISABLE_C4996
+        FILE* p_file = std::tmpfile();
+        ENABLE_C4996
+
+        REQUIRE(p_file != nullptr);
+        const char input[] = {char(0xFEu), char(0xFFu)};
+        REQUIRE(std::fwrite(input, sizeof(char), sizeof(input), p_file) == sizeof(input));
+        std::rewind(p_file);
+
+        auto input_adapter = fkyaml::detail::input_adapter(p_file);
+        REQUIRE(std::is_same<decltype(input_adapter), fkyaml::detail::file_input_adapter>::value);
+
+        fkyaml::detail::str_view buffer = input_adapter.get_buffer_view();
+
+        REQUIRE(buffer.empty());
+
+        std::fclose(p_file);
+    }
+
+    SECTION("file_input_adapter with truncated UTF-16 bytes after a BOM") {
+        DISABLE_C4996
+        FILE* p_file = std::tmpfile();
+        ENABLE_C4996
+
+        REQUIRE(p_file != nullptr);
+        const char input[] = {char(0xFEu), char(0xFFu), 0};
+        REQUIRE(std::fwrite(input, sizeof(char), sizeof(input), p_file) == sizeof(input));
+        std::rewind(p_file);
+
+        auto input_adapter = fkyaml::detail::input_adapter(p_file);
+        REQUIRE(std::is_same<decltype(input_adapter), fkyaml::detail::file_input_adapter>::value);
+
+        REQUIRE_THROWS_AS(input_adapter.get_buffer_view(), fkyaml::invalid_encoding);
+
+        std::fclose(p_file);
+    }
+
     SECTION("stream_input_adapter") {
         std::ifstream ifs(FK_YAML_TEST_DATA_DIR "/input_adapter_test_data_utf16bebom.txt");
         auto input_adapter = fkyaml::detail::input_adapter(ifs);
@@ -704,6 +757,24 @@ TEST_CASE("InputAdapter_GetBufferView_UTF16BEBOM") {
         REQUIRE(buffer[6] == char(0x80u));
         REQUIRE(buffer[7] == char(0x8Bu));
         REQUIRE(buffer[8] == char(0x52u));
+    }
+
+    SECTION("stream_input_adapter with only a BOM") {
+        std::stringstream ss(std::string {char(0xFEu), char(0xFFu)});
+        auto input_adapter = fkyaml::detail::input_adapter(ss);
+        REQUIRE(std::is_same<decltype(input_adapter), fkyaml::detail::stream_input_adapter>::value);
+
+        fkyaml::detail::str_view buffer = input_adapter.get_buffer_view();
+
+        REQUIRE(buffer.empty());
+    }
+
+    SECTION("stream_input_adapter with truncated UTF-16 bytes after a BOM") {
+        std::stringstream ss(std::string {char(0xFEu), char(0xFFu), 0});
+        auto input_adapter = fkyaml::detail::input_adapter(ss);
+        REQUIRE(std::is_same<decltype(input_adapter), fkyaml::detail::stream_input_adapter>::value);
+
+        REQUIRE_THROWS_AS(input_adapter.get_buffer_view(), fkyaml::invalid_encoding);
     }
 }
 
@@ -995,6 +1066,13 @@ TEST_CASE("InputAdapter_GetBufferView_UTF32BEN") {
         REQUIRE(buffer[7] == char(0x8Bu));
     }
 
+    SECTION("iterator_input_adapter with truncated UTF-32 bytes") {
+        std::string input {0, 0, 0, 0x61, 0};
+        auto input_adapter = fkyaml::detail::input_adapter(input);
+
+        REQUIRE_THROWS_AS(input_adapter.get_buffer_view(), fkyaml::invalid_encoding);
+    }
+
     SECTION("iterator_input_adapter with a char32_t array") {
         char32_t input[] = {0x00000061u, 0x00003042u, 0x0002000Bu, 0x00000000};
         auto input_adapter = fkyaml::detail::input_adapter(input);
@@ -1174,6 +1252,24 @@ TEST_CASE("InputAdapter_GetBufferView_UTF32BEBOM") {
         std::fclose(p_file);
     }
 
+    SECTION("file_input_adapter with truncated UTF-32 bytes after a BOM") {
+        DISABLE_C4996
+        FILE* p_file = std::tmpfile();
+        ENABLE_C4996
+
+        REQUIRE(p_file != nullptr);
+        const char input[] = {0, 0, char(0xFEu), char(0xFFu), 0};
+        REQUIRE(std::fwrite(input, sizeof(char), sizeof(input), p_file) == sizeof(input));
+        std::rewind(p_file);
+
+        auto input_adapter = fkyaml::detail::input_adapter(p_file);
+        REQUIRE(std::is_same<decltype(input_adapter), fkyaml::detail::file_input_adapter>::value);
+
+        REQUIRE_THROWS_AS(input_adapter.get_buffer_view(), fkyaml::invalid_encoding);
+
+        std::fclose(p_file);
+    }
+
     SECTION("stream_input_adapter") {
         std::ifstream ifs(FK_YAML_TEST_DATA_DIR "/input_adapter_test_data_utf32bebom.txt");
         auto input_adapter = fkyaml::detail::input_adapter(ifs);
@@ -1190,6 +1286,14 @@ TEST_CASE("InputAdapter_GetBufferView_UTF32BEBOM") {
         REQUIRE(buffer[5] == char(0xA0u));
         REQUIRE(buffer[6] == char(0x80u));
         REQUIRE(buffer[7] == char(0x8Bu));
+    }
+
+    SECTION("stream_input_adapter with truncated UTF-32 bytes after a BOM") {
+        std::stringstream ss(std::string {0, 0, char(0xFEu), char(0xFFu), 0});
+        auto input_adapter = fkyaml::detail::input_adapter(ss);
+        REQUIRE(std::is_same<decltype(input_adapter), fkyaml::detail::stream_input_adapter>::value);
+
+        REQUIRE_THROWS_AS(input_adapter.get_buffer_view(), fkyaml::invalid_encoding);
     }
 }
 
@@ -1761,6 +1865,48 @@ TEST_CASE("InputAdapter_GetBufferView_UTF8CharsValidation") {
     SECTION("stream_input_adapter with invalid 4-byte UTF-8 encodings") {
         std::ifstream ifs(FK_YAML_TEST_DATA_DIR "/input_adapter_test_data_utf8n_invalid_4byte_char.txt");
         auto input_adapter = fkyaml::detail::input_adapter(ifs);
+        REQUIRE(std::is_same<decltype(input_adapter), fkyaml::detail::stream_input_adapter>::value);
+
+        REQUIRE_THROWS_AS(input_adapter.get_buffer_view(), fkyaml::invalid_encoding);
+    }
+
+    SECTION("iterator_input_adapter with truncated multi-byte UTF-8 encodings") {
+        std::string input {char(0xE3u), char(0x81u)};
+        auto input_adapter = fkyaml::detail::input_adapter(input);
+
+        REQUIRE_THROWS_AS(input_adapter.get_buffer_view(), fkyaml::invalid_encoding);
+    }
+
+#if FK_YAML_HAS_CHAR8_T
+    SECTION("iterator_input_adapter with truncated multi-byte UTF-8 encodings using char8_t") {
+        std::u8string input {char8_t(0xE3u), char8_t(0x81u)};
+        auto input_adapter = fkyaml::detail::input_adapter(input);
+
+        REQUIRE_THROWS_AS(input_adapter.get_buffer_view(), fkyaml::invalid_encoding);
+    }
+#endif
+
+    SECTION("file_input_adapter with truncated multi-byte UTF-8 encodings") {
+        DISABLE_C4996
+        FILE* p_file = std::tmpfile();
+        ENABLE_C4996
+
+        REQUIRE(p_file != nullptr);
+        const char input[] = {char(0xE3u), char(0x81u)};
+        REQUIRE(std::fwrite(input, sizeof(char), sizeof(input), p_file) == sizeof(input));
+        std::rewind(p_file);
+
+        auto input_adapter = fkyaml::detail::input_adapter(p_file);
+        REQUIRE(std::is_same<decltype(input_adapter), fkyaml::detail::file_input_adapter>::value);
+
+        REQUIRE_THROWS_AS(input_adapter.get_buffer_view(), fkyaml::invalid_encoding);
+
+        std::fclose(p_file);
+    }
+
+    SECTION("stream_input_adapter with truncated multi-byte UTF-8 encodings") {
+        std::stringstream ss(std::string {char(0xE3u), char(0x81u)});
+        auto input_adapter = fkyaml::detail::input_adapter(ss);
         REQUIRE(std::is_same<decltype(input_adapter), fkyaml::detail::stream_input_adapter>::value);
 
         REQUIRE_THROWS_AS(input_adapter.get_buffer_view(), fkyaml::invalid_encoding);


### PR DESCRIPTION
This PR hardens the input adapters against truncated UTF-8/16/32 input and fixes the potential `encoded_buf_size` underflow reported in #492.

Changes:
- Validate that all required bytes are available before decoding
- Prevent UTF-16 buffer-size underflow
- Clear consumed UTF-16 code units to avoid reusing stale data
- Reject incomplete input consistently across iterator, `FILE*`, and stream adapters
- Correctly handle BOM-only input and standalone UTF-16 carriage returns
- Safely create views for empty normalized buffers
- Add regression tests for truncated input, dangling UTF-16 surrogates, BOM-only input, and standalone carriage returns

All 367 unit tests pass and finally solves #492.

---

## Pull Request Checklist

Read the [CONTRIBUTING.md](https://github.com/fktn-k/fkYAML/blob/develop/.github/CONTRIBUTING.md) file for detailed information.  

- [x] Changes are described in the pull request or in a referenced [issue](https://github.com/fktn-k/fkYAML/issues).
- [x] The test suite compiles and runs without any error.
- [ ] [The code coverage](https://coveralls.io/github/fktn-k/fkYAML) on your branch is 100%.
- [x] The documentation is updated if you added/changed a feature.

## Please don't

- The C++11 support varies between different **compilers** and versions. Please note the [list of supported compilers](https://github.com/fktn-k/fkYAML/blob/develop/README.md#supported-compilers). Some compilers like GCC 4.7 (and earlier), Clang 3.3 (and earlier), or Microsoft Visual Studio 13.0 and earlier are known not to work due to missing or incomplete C++11 support. Please refrain from proposing changes that work around these compiler's limitations with `#ifdef`s or other means.
- Please refrain from proposing changes that would **break [YAML](https://yaml.org/) specifications**. If you propose a conformant extension of YAML to be supported by the library, please motivate this extension.
- Please do not open pull requests that address **multiple issues**.
