### PR TITLE
Add fuzz test for parsing YAML inputs

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -126,7 +126,7 @@ endif()
 #   Build the test apps   #
 ###########################
 
-if(FK_YAML_BUILD_TEST OR FK_YAML_BUILD_ALL_TEST)
+if(FK_YAML_BUILD_TEST OR FK_YAML_BUILD_FUZZ_TEST OR FK_YAML_BUILD_ALL_TEST)
   include(CTest)
   enable_testing()
   add_subdirectory(tests)

--- a/Makefile
+++ b/Makefile
@@ -73,6 +73,11 @@ valgrind:
 	cmake --build build_valgrind --config Debug -j $(JOBS)
 	ctest -C Debug -T memcheck --test-dir build_valgrind --output-on-failure -j $(JOBS)
 
+# pre-requisites: clang
+fuzz-test:
+	CXX=clang++ cmake -B build_fuzz_test -S . -DCMAKE_BUILD_TYPE=Debug -DFK_YAML_BUILD_FUZZ_TEST=ON
+	cmake --build build_fuzz_test --target run_fuzz_test
+
 ###########################
 #   Source Amalgamation   #
 ###########################

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -1,4 +1,69 @@
+############################################
+#   configure C++ standard for unit test   #
+############################################
+
+# determine C++ standard used in unit test app.
+if("${FK_YAML_TEST_TARGET_CXX_STANDARD}" STREQUAL "")
+  # Apply minimum required C++ standard checked by default.
+  set(FK_YAML_TEST_TARGET_CXX_STANDARD 11)
+endif()
+
+# detect C++ standards supported by the compiler.
+foreach(feature ${CMAKE_CXX_COMPILE_FEATURES})
+  if(${feature} STREQUAL cxx_std_11)
+    set(FK_YAML_COMPILER_SUPPORTS_CXX_11 ON)
+  elseif(${feature} STREQUAL cxx_std_14)
+    set(FK_YAML_COMPILER_SUPPORTS_CXX_14 ON)
+  elseif(${feature} STREQUAL cxx_std_17)
+    set(FK_YAML_COMPILER_SUPPORTS_CXX_17 ON)
+  elseif(${feature} STREQUAL cxx_std_20)
+    set(FK_YAML_COMPILER_SUPPORTS_CXX_20 ON)
+  elseif(${feature} STREQUAL cxx_std_23)
+    set(FK_YAML_COMPILER_SUPPORTS_CXX_23 ON)
+  endif()
+endforeach()
+
+# check if the determined C++ standard is supported by the compiler.
+if(NOT FK_YAML_COMPILER_SUPPORTS_CXX_${FK_YAML_TEST_TARGET_CXX_STANDARD})
+  message(WARNING "The target compiler does not support C++${FK_YAML_TEST_TARGET_CXX_STANDARD}. Stop configuring unit test app.")
+  return()
+endif()
+
+############################################################
+#   Configure common compile options for unit/fuzz tests   #
+############################################################
+
+add_library(common_test_config INTERFACE)
+target_link_libraries(
+  common_test_config
+  INTERFACE
+    ${FK_YAML_TARGET_NAME}
+)
+target_compile_features(
+  common_test_config
+  INTERFACE
+    cxx_std_${FK_YAML_TEST_TARGET_CXX_STANDARD}
+)
+set_target_properties(
+  common_test_config
+  PROPERTIES
+    CXX_EXTENSIONS OFF
+)
+target_compile_definitions(
+  common_test_config
+  INTERFACE
+    $<$<CONFIG:Release>:NDEBUG>
+)
+
+#############################
+#   Register test targets   #
+#############################
+
 add_subdirectory(unit_test)
+
+if(FK_YAML_BUILD_FUZZ_TEST)
+  add_subdirectory(fuzz_test)
+endif()
 
 if(FK_YAML_BUILD_ALL_TEST)
   add_subdirectory(cmake_add_subdirectory_test)

--- a/tests/fuzz_test/CMakeLists.txt
+++ b/tests/fuzz_test/CMakeLists.txt
@@ -1,0 +1,55 @@
+############################################
+#   Download data files for fuzz testing   #
+############################################
+
+include(FetchContent)
+FetchContent_Declare(
+  fuzz_test_data
+  GIT_REPOSITORY https://github.com/fktn-k/fkyaml_fuzz_test_data.git
+  GIT_TAG        main
+)
+FetchContent_MakeAvailable(fuzz_test_data)
+
+#############################################
+#   Build fuzz test executable for fkYAML   #
+#############################################
+
+add_executable(
+  fuzz_test
+  fuzzer_parse_yaml.cpp
+)
+target_link_libraries(
+  fuzz_test
+  PRIVATE
+    common_test_config
+)
+target_compile_options(
+  fuzz_test
+  PRIVATE
+    -fsanitize=fuzzer,address,undefined
+    -g
+    -O1
+)
+target_link_options(
+  fuzz_test
+  PRIVATE
+    -fsanitize=fuzzer,address,undefined
+)
+
+#
+#   Configure custom target to run the fuzz test executable with the corpus data
+#
+
+add_custom_command(
+  TARGET fuzz_test
+  POST_BUILD
+  COMMAND ${CMAKE_COMMAND} -E copy_directory
+          ${fuzz_test_data_SOURCE_DIR}/corpus
+          $<TARGET_FILE_DIR:fuzz_test>/corpus
+)
+add_custom_target(
+  run_fuzz_test
+  COMMAND $<TARGET_FILE:fuzz_test> corpus/generated corpus/seeds -dict=corpus/yaml.dict -artifact_prefix=corpus/findings/ -max_total_time=300
+  WORKING_DIRECTORY $<TARGET_FILE_DIR:fuzz_test>
+  DEPENDS fuzz_test
+)

--- a/tests/fuzz_test/fuzzer_parse_yaml.cpp
+++ b/tests/fuzz_test/fuzzer_parse_yaml.cpp
@@ -1,0 +1,21 @@
+//  _______   __ __   __  _____   __  __  __
+// |   __| |_/  |  \_/  |/  _  \ /  \/  \|  |     fkYAML: A C++ header-only YAML library (supporting code)
+// |   __|  _  < \_   _/|  ___  |    _   |  |___  version 0.4.3
+// |__|  |_| \__|  |_|  |_|   |_|___||___|______| https://github.com/fktn-k/fkYAML
+//
+// SPDX-FileCopyrightText: 2023-2026 Kensuke Fukutani <fktn.dev@gmail.com>
+// SPDX-License-Identifier: MIT
+
+#include <fkYAML/node.hpp>
+
+extern "C" int LLVMFuzzerTestOneInput(const uint8_t* data, size_t size) {
+    try {
+        const char* data_str = reinterpret_cast<const char*>(data);
+        fkyaml::node n = fkyaml::node::deserialize(data_str, data_str + size);
+        (void)n;
+    }
+    catch (const fkyaml::exception& e) {
+        (void)e;
+    }
+    return 0;
+}

--- a/tests/unit_test/CMakeLists.txt
+++ b/tests/unit_test/CMakeLists.txt
@@ -40,37 +40,6 @@ FetchContent_Declare(
 FetchContent_MakeAvailable(doctest)
 include(${doctest_SOURCE_DIR}/scripts/cmake/doctest.cmake)
 
-############################################
-#   configure C++ standard for unit test   #
-############################################
-
-# determine C++ standard used in unit test app.
-if("${FK_YAML_TEST_TARGET_CXX_STANDARD}" STREQUAL "")
-  # Apply minimum required C++ standard checked by default.
-  set(FK_YAML_TEST_TARGET_CXX_STANDARD 11)
-endif()
-
-# detect C++ standards supported by the compiler.
-foreach(feature ${CMAKE_CXX_COMPILE_FEATURES})
-  if(${feature} STREQUAL cxx_std_11)
-    set(FK_YAML_COMPILER_SUPPORTS_CXX_11 ON)
-  elseif(${feature} STREQUAL cxx_std_14)
-    set(FK_YAML_COMPILER_SUPPORTS_CXX_14 ON)
-  elseif(${feature} STREQUAL cxx_std_17)
-    set(FK_YAML_COMPILER_SUPPORTS_CXX_17 ON)
-  elseif(${feature} STREQUAL cxx_std_20)
-    set(FK_YAML_COMPILER_SUPPORTS_CXX_20 ON)
-  elseif(${feature} STREQUAL cxx_std_23)
-    set(FK_YAML_COMPILER_SUPPORTS_CXX_23 ON)
-  endif()
-endforeach()
-
-# check if the determined C++ standard is supported by the compiler.
-if(NOT FK_YAML_COMPILER_SUPPORTS_CXX_${FK_YAML_TEST_TARGET_CXX_STANDARD})
-  message(WARNING "The target compiler does not support C++${FK_YAML_TEST_TARGET_CXX_STANDARD}. Stop configuring unit test app.")
-  return()
-endif()
-
 ######################################
 #   Prepare to use test data files   #
 ######################################
@@ -93,26 +62,6 @@ target_include_directories(
   INTERFACE
     "${CMAKE_CURRENT_BINARY_DIR}/include"
     "${doctest_SOURCE_DIR}"
-)
-target_link_libraries(
-  unit_test_config
-  INTERFACE
-    ${FK_YAML_TARGET_NAME}
-)
-target_compile_features(
-  unit_test_config
-  INTERFACE
-    cxx_std_${FK_YAML_TEST_TARGET_CXX_STANDARD}
-)
-set_target_properties(
-  unit_test_config
-  PROPERTIES
-    CXX_EXTENTIONS OFF
-)
-target_compile_definitions(
-  unit_test_config
-  INTERFACE
-    $<$<CONFIG:Release>:NDEBUG>
 )
 
 # Configure compile options according to the target compiler.
@@ -266,7 +215,12 @@ add_executable(
   main.cpp
 )
 
-target_link_libraries(${TEST_TARGET} PRIVATE unit_test_config)
+target_link_libraries(
+  ${TEST_TARGET}
+  PRIVATE
+    common_test_config
+    unit_test_config
+)
 
 doctest_discover_tests(${TEST_TARGET})
 


### PR DESCRIPTION
This PR introduces the fuzz test using [libFuzzer](https://llvm.org/docs/LibFuzzer.html).
Corpus data is incorporated during a build from [fkyaml_fuzz_test_data](https://github.com/fktn-k/fkyaml_fuzz_test_data) which will be maintained separately from this repository.

Execute `make fuzz-test` to run the fuzz test.

---

## Pull Request Checklist

Read the [CONTRIBUTING.md](https://github.com/fktn-k/fkYAML/blob/develop/.github/CONTRIBUTING.md) file for detailed information.  

- [x] Changes are described in the pull request or in a referenced [issue](https://github.com/fktn-k/fkYAML/issues).
- [x] The test suite compiles and runs without any error.
- [x] [The code coverage](https://coveralls.io/github/fktn-k/fkYAML) on your branch is 100%.
- [x] The documentation is updated if you added/changed a feature.

## Please don't

- The C++11 support varies between different **compilers** and versions. Please note the [list of supported compilers](https://github.com/fktn-k/fkYAML/blob/develop/README.md#supported-compilers). Some compilers like GCC 4.7 (and earlier), Clang 3.3 (and earlier), or Microsoft Visual Studio 13.0 and earlier are known not to work due to missing or incomplete C++11 support. Please refrain from proposing changes that work around these compiler's limitations with `#ifdef`s or other means.
- Please refrain from proposing changes that would **break [YAML](https://yaml.org/) specifications**. If you propose a conformant extension of YAML to be supported by the library, please motivate this extension.
- Please do not open pull requests that address **multiple issues**.
