### PR TITLE
Fix crashes and memory leaks found during fuzz test

### DIFF
--- a/include/fkYAML/detail/input/deserializer.hpp
+++ b/include/fkYAML/detail/input/deserializer.hpp
@@ -641,7 +641,9 @@ private:
                 // ```
                 continue;
             case lexical_token_t::SEQUENCE_BLOCK_PREFIX: {
-                FK_YAML_ASSERT(!m_context_stack.empty());
+                if FK_YAML_UNLIKELY (m_context_stack.empty()) {
+                    throw parse_error("invalid block sequence entry is found.", line, indent);
+                }
                 const uint32_t parent_indent = m_context_stack.back().indent;
                 if (indent == parent_indent) {
                     // If the previous block sequence entry is empty, just move to the parent context.
@@ -688,6 +690,10 @@ private:
             case lexical_token_t::SEQUENCE_FLOW_BEGIN:
                 if (m_flow_context_depth == 0) {
                     lexer.set_context_state(true);
+
+                    if FK_YAML_UNLIKELY (m_context_stack.empty()) {
+                        throw parse_error("invalid flow sequence beginning is found.", line, indent);
+                    }
 
                     if (indent <= m_context_stack.back().indent) {
                         pop_to_parent_node(line, indent, [indent](const parse_context& c) {
@@ -745,22 +751,10 @@ private:
                     lexer.set_context_state(false);
                 }
 
-                // find the corresponding flow sequence beginning.
-                auto itr = std::find_if( // LCOV_EXCL_LINE
-                    m_context_stack.rbegin(),
-                    m_context_stack.rend(),
-                    [](const parse_context& c) {
-                        switch (c.state) {
-                        case context_state_t::FLOW_SEQUENCE_KEY:
-                        case context_state_t::FLOW_SEQUENCE:
-                            return true;
-                        default:
-                            return false;
-                        }
-                    });
-
-                const bool is_valid = itr != m_context_stack.rend();
-                if FK_YAML_UNLIKELY (!is_valid) {
+                const bool has_valid_beginning =
+                    !m_context_stack.empty() && (m_context_stack.back().state == context_state_t::FLOW_SEQUENCE ||
+                                                 m_context_stack.back().state == context_state_t::FLOW_SEQUENCE_KEY);
+                if FK_YAML_UNLIKELY (!has_valid_beginning) {
                     throw parse_error("No corresponding flow sequence beginning is found.", line, indent);
                 }
 
@@ -811,6 +805,10 @@ private:
             case lexical_token_t::MAPPING_FLOW_BEGIN:
                 if (m_flow_context_depth == 0) {
                     lexer.set_context_state(true);
+
+                    if FK_YAML_UNLIKELY (m_context_stack.empty()) {
+                        throw parse_error("invalid flow mapping beginning is found.", line, indent);
+                    }
 
                     if (indent <= m_context_stack.back().indent) {
                         pop_to_parent_node(line, indent, [indent](const parse_context& c) {
@@ -871,22 +869,10 @@ private:
                     lexer.set_context_state(false);
                 }
 
-                // find the corresponding flow mapping beginning.
-                auto itr = std::find_if( // LCOV_EXCL_LINE
-                    m_context_stack.rbegin(),
-                    m_context_stack.rend(),
-                    [](const parse_context& c) {
-                        switch (c.state) {
-                        case context_state_t::FLOW_MAPPING_KEY:
-                        case context_state_t::FLOW_MAPPING:
-                            return true;
-                        default:
-                            return false;
-                        }
-                    });
-
-                const bool is_valid = itr != m_context_stack.rend();
-                if FK_YAML_UNLIKELY (!is_valid) {
+                const bool has_valid_beginning =
+                    !m_context_stack.empty() && (m_context_stack.back().state == context_state_t::FLOW_MAPPING ||
+                                                 m_context_stack.back().state == context_state_t::FLOW_MAPPING_KEY);
+                if FK_YAML_UNLIKELY (!has_valid_beginning) {
                     throw parse_error("No corresponding flow mapping beginning is found.", line, indent);
                 }
 
@@ -935,7 +921,9 @@ private:
                 continue;
             }
             case lexical_token_t::VALUE_SEPARATOR:
-                FK_YAML_ASSERT(m_flow_context_depth > 0);
+                if FK_YAML_UNLIKELY (m_flow_context_depth == 0) {
+                    throw parse_error("invalid value separator is found.", line, indent);
+                }
                 if FK_YAML_UNLIKELY (m_flow_token_state != flow_token_state_t::NEEDS_SEPARATOR_OR_SUFFIX) {
                     throw parse_error("invalid value separator is found.", line, indent);
                 }
@@ -1144,7 +1132,9 @@ private:
     /// @param node_value A rvalue basic_node_type object to be assigned to the current node.
     void assign_node_value(basic_node_type&& node_value, const uint32_t line, const uint32_t indent) {
         if (mp_current_node->is_sequence()) {
-            FK_YAML_ASSERT(m_flow_context_depth > 0);
+            if FK_YAML_UNLIKELY (m_flow_context_depth == 0) {
+                throw parse_error("invalid block sequence entry is found.", line, indent);
+            }
 
             if FK_YAML_UNLIKELY (m_flow_token_state != flow_token_state_t::NEEDS_VALUE_OR_SUFFIX) {
                 // Flow sequence entries are not allowed to be empty.
@@ -1208,6 +1198,10 @@ private:
                 assign_node_value(std::move(node), line, indent);
                 indent = lexer.get_last_token_begin_pos();
                 line = lexer.get_lines_processed();
+
+                if (m_context_stack.empty()) {
+                    throw parse_error("invalid explicit mapping key separator is found.", line, indent);
+                }
 
                 if (m_context_stack.back().state != context_state_t::BLOCK_MAPPING_EXPLICIT_KEY) {
                     pop_to_parent_node(line, indent, [indent](const parse_context& c) {

--- a/include/fkYAML/detail/input/lexical_analyzer.hpp
+++ b/include/fkYAML/detail/input/lexical_analyzer.hpp
@@ -1003,7 +1003,9 @@ private:
         }
 
         if (indicated_indent == 0) {
-            FK_YAML_ASSERT(base_indent < cur_indent);
+            if FK_YAML_UNLIKELY (base_indent >= cur_indent) {
+                emit_error("The first non-empty line in the block scalar is less indented.");
+            }
             indicated_indent = cur_indent - base_indent;
         }
         else if FK_YAML_UNLIKELY (cur_indent < base_indent + indicated_indent) {

--- a/single_include/fkYAML/node.hpp
+++ b/single_include/fkYAML/node.hpp
@@ -4231,7 +4231,9 @@ private:
         }
 
         if (indicated_indent == 0) {
-            FK_YAML_ASSERT(base_indent < cur_indent);
+            if FK_YAML_UNLIKELY (base_indent >= cur_indent) {
+                emit_error("The first non-empty line in the block scalar is less indented.");
+            }
             indicated_indent = cur_indent - base_indent;
         }
         else if FK_YAML_UNLIKELY (cur_indent < base_indent + indicated_indent) {
@@ -8058,7 +8060,9 @@ private:
                 // ```
                 continue;
             case lexical_token_t::SEQUENCE_BLOCK_PREFIX: {
-                FK_YAML_ASSERT(!m_context_stack.empty());
+                if FK_YAML_UNLIKELY (m_context_stack.empty()) {
+                    throw parse_error("invalid block sequence entry is found.", line, indent);
+                }
                 const uint32_t parent_indent = m_context_stack.back().indent;
                 if (indent == parent_indent) {
                     // If the previous block sequence entry is empty, just move to the parent context.
@@ -8105,6 +8109,10 @@ private:
             case lexical_token_t::SEQUENCE_FLOW_BEGIN:
                 if (m_flow_context_depth == 0) {
                     lexer.set_context_state(true);
+
+                    if FK_YAML_UNLIKELY (m_context_stack.empty()) {
+                        throw parse_error("invalid flow sequence beginning is found.", line, indent);
+                    }
 
                     if (indent <= m_context_stack.back().indent) {
                         pop_to_parent_node(line, indent, [indent](const parse_context& c) {
@@ -8162,22 +8170,10 @@ private:
                     lexer.set_context_state(false);
                 }
 
-                // find the corresponding flow sequence beginning.
-                auto itr = std::find_if( // LCOV_EXCL_LINE
-                    m_context_stack.rbegin(),
-                    m_context_stack.rend(),
-                    [](const parse_context& c) {
-                        switch (c.state) {
-                        case context_state_t::FLOW_SEQUENCE_KEY:
-                        case context_state_t::FLOW_SEQUENCE:
-                            return true;
-                        default:
-                            return false;
-                        }
-                    });
-
-                const bool is_valid = itr != m_context_stack.rend();
-                if FK_YAML_UNLIKELY (!is_valid) {
+                const bool has_valid_beginning =
+                    !m_context_stack.empty() && (m_context_stack.back().state == context_state_t::FLOW_SEQUENCE ||
+                                                 m_context_stack.back().state == context_state_t::FLOW_SEQUENCE_KEY);
+                if FK_YAML_UNLIKELY (!has_valid_beginning) {
                     throw parse_error("No corresponding flow sequence beginning is found.", line, indent);
                 }
 
@@ -8228,6 +8224,10 @@ private:
             case lexical_token_t::MAPPING_FLOW_BEGIN:
                 if (m_flow_context_depth == 0) {
                     lexer.set_context_state(true);
+
+                    if FK_YAML_UNLIKELY (m_context_stack.empty()) {
+                        throw parse_error("invalid flow mapping beginning is found.", line, indent);
+                    }
 
                     if (indent <= m_context_stack.back().indent) {
                         pop_to_parent_node(line, indent, [indent](const parse_context& c) {
@@ -8288,22 +8288,10 @@ private:
                     lexer.set_context_state(false);
                 }
 
-                // find the corresponding flow mapping beginning.
-                auto itr = std::find_if( // LCOV_EXCL_LINE
-                    m_context_stack.rbegin(),
-                    m_context_stack.rend(),
-                    [](const parse_context& c) {
-                        switch (c.state) {
-                        case context_state_t::FLOW_MAPPING_KEY:
-                        case context_state_t::FLOW_MAPPING:
-                            return true;
-                        default:
-                            return false;
-                        }
-                    });
-
-                const bool is_valid = itr != m_context_stack.rend();
-                if FK_YAML_UNLIKELY (!is_valid) {
+                const bool has_valid_beginning =
+                    !m_context_stack.empty() && (m_context_stack.back().state == context_state_t::FLOW_MAPPING ||
+                                                 m_context_stack.back().state == context_state_t::FLOW_MAPPING_KEY);
+                if FK_YAML_UNLIKELY (!has_valid_beginning) {
                     throw parse_error("No corresponding flow mapping beginning is found.", line, indent);
                 }
 
@@ -8352,7 +8340,9 @@ private:
                 continue;
             }
             case lexical_token_t::VALUE_SEPARATOR:
-                FK_YAML_ASSERT(m_flow_context_depth > 0);
+                if FK_YAML_UNLIKELY (m_flow_context_depth == 0) {
+                    throw parse_error("invalid value separator is found.", line, indent);
+                }
                 if FK_YAML_UNLIKELY (m_flow_token_state != flow_token_state_t::NEEDS_SEPARATOR_OR_SUFFIX) {
                     throw parse_error("invalid value separator is found.", line, indent);
                 }
@@ -8561,7 +8551,9 @@ private:
     /// @param node_value A rvalue basic_node_type object to be assigned to the current node.
     void assign_node_value(basic_node_type&& node_value, const uint32_t line, const uint32_t indent) {
         if (mp_current_node->is_sequence()) {
-            FK_YAML_ASSERT(m_flow_context_depth > 0);
+            if FK_YAML_UNLIKELY (m_flow_context_depth == 0) {
+                throw parse_error("invalid block sequence entry is found.", line, indent);
+            }
 
             if FK_YAML_UNLIKELY (m_flow_token_state != flow_token_state_t::NEEDS_VALUE_OR_SUFFIX) {
                 // Flow sequence entries are not allowed to be empty.
@@ -8625,6 +8617,10 @@ private:
                 assign_node_value(std::move(node), line, indent);
                 indent = lexer.get_last_token_begin_pos();
                 line = lexer.get_lines_processed();
+
+                if (m_context_stack.empty()) {
+                    throw parse_error("invalid explicit mapping key separator is found.", line, indent);
+                }
 
                 if (m_context_stack.back().state != context_state_t::BLOCK_MAPPING_EXPLICIT_KEY) {
                     pop_to_parent_node(line, indent, [indent](const parse_context& c) {

--- a/tests/unit_test/CMakeLists.txt
+++ b/tests/unit_test/CMakeLists.txt
@@ -187,6 +187,7 @@ add_executable(
   test_custom_from_node.cpp
   test_deserializer_class.cpp
   test_exception_class.cpp
+  test_fuzz_regression.cpp
   test_input_adapter.cpp
   test_iterator_class.cpp
   test_lexical_analyzer_class.cpp

--- a/tests/unit_test/test_deserializer_class.cpp
+++ b/tests/unit_test/test_deserializer_class.cpp
@@ -47,16 +47,48 @@ TEST_CASE("Deserializer_KeySeparator") {
         REQUIRE(root[""].is_string());
         REQUIRE(root[""].as_str() == "foo");
     }
+
+    SUBCASE("invalid explicit mapping key separator after root scalar") {
+        const std::string input_str = "foo\n: bar";
+
+        bool thrown = false;
+        try {
+            root = deserializer.deserialize(fkyaml::detail::input_adapter(input_str));
+        }
+        catch (const fkyaml::parse_error& e) {
+            thrown = true;
+            const std::string msg(e.what());
+            REQUIRE(msg.find("invalid explicit mapping key separator is found.") != std::string::npos);
+        }
+
+        REQUIRE(thrown);
+    }
 }
 
 TEST_CASE("Deserializer_ValueSeparator") {
     fkyaml::detail::basic_deserializer<fkyaml::node> deserializer;
     fkyaml::node root;
 
-    auto input_str = GENERATE(std::string("test: [ foo, bar ]"), std::string("test: { foo: bar, buz: val }"));
-    REQUIRE_NOTHROW(root = deserializer.deserialize(fkyaml::detail::input_adapter(input_str)));
-    REQUIRE(root.is_mapping());
-    REQUIRE(root.size() == 1);
+    SUBCASE("valid separators in flow context") {
+        auto input_str = GENERATE(std::string("test: [ foo, bar ]"), std::string("test: { foo: bar, buz: val }"));
+        REQUIRE_NOTHROW(root = deserializer.deserialize(fkyaml::detail::input_adapter(input_str)));
+        REQUIRE(root.is_mapping());
+        REQUIRE(root.size() == 1);
+    }
+
+    SUBCASE("invalid separator outside flow context") {
+        auto input_str = GENERATE(std::string(","), std::string(" ,"));
+        REQUIRE_THROWS_AS(
+            root = deserializer.deserialize(fkyaml::detail::input_adapter(input_str)), fkyaml::parse_error);
+    }
+}
+
+TEST_CASE("Deserializer_InvalidStructureAfterRootScalar") {
+    fkyaml::detail::basic_deserializer<fkyaml::node> deserializer;
+    fkyaml::node root;
+
+    auto input_str = GENERATE(std::string("ke\n["), std::string("ke\n{"), std::string("ke\n]"), std::string("ke\n}"));
+    REQUIRE_THROWS_AS(root = deserializer.deserialize(fkyaml::detail::input_adapter(input_str)), fkyaml::parse_error);
 }
 
 TEST_CASE("Deserializer_NullValue") {

--- a/tests/unit_test/test_fuzz_regression.cpp
+++ b/tests/unit_test/test_fuzz_regression.cpp
@@ -1,0 +1,67 @@
+//  _______   __ __   __  _____   __  __  __
+// |   __| |_/  |  \_/  |/  _  \ /  \/  \|  |     fkYAML: A C++ header-only YAML library (supporting code)
+// |   __|  _  < \_   _/|  ___  |    _   |  |___  version 0.4.3
+// |__|  |_| \__|  |_|  |_|   |_|___||___|______| https://github.com/fktn-k/fkYAML
+//
+// SPDX-FileCopyrightText: 2023-2026 Kensuke Fukutani <fktn.dev@gmail.com>
+// SPDX-License-Identifier: MIT
+
+#include <doctest/doctest.h>
+#include <fkYAML/node.hpp>
+
+TEST_CASE("FuzzRegression") {
+    fkyaml::node root;
+    const char* p_begin = nullptr;
+    const char* p_end = nullptr;
+
+    SUBCASE("malformed UTF-16 input") {
+        uint8_t input[] = {0x01, 0x00, 0x0a};
+        p_begin = reinterpret_cast<const char*>(input);
+        p_end = p_begin + sizeof(input);
+        REQUIRE_THROWS_AS(root = fkyaml::node::deserialize(p_begin, p_end), fkyaml::invalid_encoding);
+    }
+
+    SUBCASE("invalid context transition") {
+        const char input[] = "o- 1\n"
+                             "- trueot:\n"
+                             "  ch\n"
+                             "i";
+        p_begin = input;
+        p_end = input + sizeof(input) - 1;
+        REQUIRE_THROWS_AS(root = fkyaml::node::deserialize(p_begin, p_end), fkyaml::parse_error);
+    }
+
+    SUBCASE("invalid block sequence entry") {
+        const char input[] = "- 1\n"
+                             "- two\n"
+                             "- tru 1\n"
+                             "- two\n"
+                             "-e";
+        p_begin = input;
+        p_end = input + sizeof(input) - 1;
+        REQUIRE_THROWS_AS(root = fkyaml::node::deserialize(p_begin, p_end), fkyaml::parse_error);
+    }
+
+    SUBCASE("invalid flow sequence after scalar root") {
+        const char input[] = "ke\n[";
+        p_begin = input;
+        p_end = input + sizeof(input) - 1;
+        REQUIRE_THROWS_AS(root = fkyaml::node::deserialize(p_begin, p_end), fkyaml::parse_error);
+    }
+
+    SUBCASE("mismatched flow endings") {
+        const char input[] = "{a: 1,  [2 b:,3}\n";
+        p_begin = input;
+        p_end = input + sizeof(input) - 1;
+        REQUIRE_THROWS_AS(root = fkyaml::node::deserialize(p_begin, p_end), fkyaml::parse_error);
+    }
+
+    SUBCASE("invalid block scalar indentation") {
+        const char input[] = "root:\n"
+                             "  c]h:di     |- \n"
+                             " a  ) - b\n";
+        p_begin = input;
+        p_end = input + sizeof(input) - 1;
+        REQUIRE_THROWS_AS(root = fkyaml::node::deserialize(p_begin, p_end), fkyaml::parse_error);
+    }
+}

--- a/tests/unit_test/test_lexical_analyzer_class.cpp
+++ b/tests/unit_test/test_lexical_analyzer_class.cpp
@@ -1236,6 +1236,28 @@ TEST_CASE("LexicalAnalyzer_LiteralStringScalar") {
         fkyaml::detail::lexical_analyzer lexer(input);
         REQUIRE_THROWS_AS(token = lexer.get_next_token(), fkyaml::parse_error);
     }
+
+    SUBCASE("literal string scalar with invalid header position") {
+        const char input[] = "root:\n"
+                             "  c]h:di     |- \n"
+                             " a  ) - b\n";
+        fkyaml::detail::lexical_analyzer lexer(input);
+
+        REQUIRE_NOTHROW(token = lexer.get_next_token());
+        REQUIRE(token.type == fkyaml::detail::lexical_token_t::PLAIN_SCALAR);
+        REQUIRE(token.str.begin() == &input[0]); // "root"
+        REQUIRE(token.str.end() == &input[4]);
+
+        REQUIRE_NOTHROW(token = lexer.get_next_token());
+        REQUIRE(token.type == fkyaml::detail::lexical_token_t::KEY_SEPARATOR);
+
+        REQUIRE_NOTHROW(token = lexer.get_next_token());
+        REQUIRE(token.type == fkyaml::detail::lexical_token_t::PLAIN_SCALAR);
+        REQUIRE(token.str.begin() == &input[8]); // "c]h:di"
+        REQUIRE(token.str.end() == &input[14]);
+
+        REQUIRE_THROWS_AS(token = lexer.get_next_token(), fkyaml::parse_error);
+    }
 }
 
 TEST_CASE("LexicalAnalyzer_FoldedString") {


### PR DESCRIPTION
This PR fixes several parser/lexer issues which caused a crash or memory leak.
All of such cases are now covered in the test suite.

- Converted fuzz-reachable invariant failures on parsing malformed YAML into explicit `parse_error`s instead of assert-only over-assumption, for example:
  - ```yaml
    o- 1
    - trueot:
      ch
    i
    ```
  - ```yaml
    - 1
    - two
    - tru 1
    - two
    -e
    ```
  - ```yaml
    ke
    [
    ```
- Fix memory leak in edge cases where flow endings (`}` or `]`) do not have any corresponding flow beginnings (`{` or `[`), for example:
  - ```yaml
    {a: 1, [2 b:, 3}
    ```
- Replaced an assert-path in block scalar indentation handling with an explicit `parse_error` for malformed inputs, for example:
  - ```yaml
    root:
      c]h:di     |-
     a  ) - b
    ```

---

## Pull Request Checklist

Read the [CONTRIBUTING.md](https://github.com/fktn-k/fkYAML/blob/develop/.github/CONTRIBUTING.md) file for detailed information.  

- [x] Changes are described in the pull request or in a referenced [issue](https://github.com/fktn-k/fkYAML/issues).
- [x] The test suite compiles and runs without any error.
- [x] [The code coverage](https://coveralls.io/github/fktn-k/fkYAML) on your branch is 100%.
- [x] The documentation is updated if you added/changed a feature.

## Please don't

- The C++11 support varies between different **compilers** and versions. Please note the [list of supported compilers](https://github.com/fktn-k/fkYAML/blob/develop/README.md#supported-compilers). Some compilers like GCC 4.7 (and earlier), Clang 3.3 (and earlier), or Microsoft Visual Studio 13.0 and earlier are known not to work due to missing or incomplete C++11 support. Please refrain from proposing changes that work around these compiler's limitations with `#ifdef`s or other means.
- Please refrain from proposing changes that would **break [YAML](https://yaml.org/) specifications**. If you propose a conformant extension of YAML to be supported by the library, please motivate this extension.
- Please do not open pull requests that address **multiple issues**.
