### PR TITLE
Fix more crashes caused by fuzz test

### DIFF
--- a/include/fkYAML/detail/input/deserializer.hpp
+++ b/include/fkYAML/detail/input/deserializer.hpp
@@ -602,7 +602,9 @@ private:
                 }
 
                 // handle explicit mapping key separators.
-                FK_YAML_ASSERT(m_context_stack.back().state == context_state_t::BLOCK_MAPPING_EXPLICIT_KEY);
+                if FK_YAML_UNLIKELY (m_context_stack.back().state != context_state_t::BLOCK_MAPPING_EXPLICIT_KEY) {
+                    throw parse_error("Unexpected explicit mapping key separator is found.", line, indent);
+                }
 
                 basic_node_type key_node = std::move(*m_context_stack.back().p_node);
                 m_context_stack.pop_back();
@@ -1289,7 +1291,9 @@ private:
     /// @param indent The indentation level of the target parent block mapping.
     template <typename Pred>
     void pop_to_parent_node(uint32_t line, uint32_t indent, Pred&& pred) {
-        FK_YAML_ASSERT(!m_context_stack.empty());
+        if FK_YAML_UNLIKELY (m_context_stack.empty()) {
+            throw parse_error("No parent block mapping is found.", line, indent);
+        }
 
         // LCOV_EXCL_START
         auto itr = std::find_if(m_context_stack.rbegin(), m_context_stack.rend(), std::forward<Pred>(pred));

--- a/include/fkYAML/detail/input/lexical_analyzer.hpp
+++ b/include/fkYAML/detail/input/lexical_analyzer.hpp
@@ -242,7 +242,11 @@ public:
         case '>': {
             const str_view sv {m_token_begin_itr, m_end_itr};
             const std::size_t header_end_pos = sv.find('\n');
-            FK_YAML_ASSERT(header_end_pos != str_view::npos);
+            if FK_YAML_UNLIKELY (header_end_pos == str_view::npos) {
+                emit_error(
+                    "Invalid block scalar header found. The header must be followed by a line break and its content.");
+            }
+
             const uint32_t base_indent = get_current_indent_level(&sv[header_end_pos]);
 
             const lexical_token_t type = *m_token_begin_itr == '|' ? lexical_token_t::BLOCK_LITERAL_SCALAR

--- a/single_include/fkYAML/node.hpp
+++ b/single_include/fkYAML/node.hpp
@@ -3470,7 +3470,11 @@ public:
         case '>': {
             const str_view sv {m_token_begin_itr, m_end_itr};
             const std::size_t header_end_pos = sv.find('\n');
-            FK_YAML_ASSERT(header_end_pos != str_view::npos);
+            if FK_YAML_UNLIKELY (header_end_pos == str_view::npos) {
+                emit_error(
+                    "Invalid block scalar header found. The header must be followed by a line break and its content.");
+            }
+
             const uint32_t base_indent = get_current_indent_level(&sv[header_end_pos]);
 
             const lexical_token_t type = *m_token_begin_itr == '|' ? lexical_token_t::BLOCK_LITERAL_SCALAR
@@ -8021,7 +8025,9 @@ private:
                 }
 
                 // handle explicit mapping key separators.
-                FK_YAML_ASSERT(m_context_stack.back().state == context_state_t::BLOCK_MAPPING_EXPLICIT_KEY);
+                if FK_YAML_UNLIKELY (m_context_stack.back().state != context_state_t::BLOCK_MAPPING_EXPLICIT_KEY) {
+                    throw parse_error("Unexpected explicit mapping key separator is found.", line, indent);
+                }
 
                 basic_node_type key_node = std::move(*m_context_stack.back().p_node);
                 m_context_stack.pop_back();
@@ -8708,7 +8714,9 @@ private:
     /// @param indent The indentation level of the target parent block mapping.
     template <typename Pred>
     void pop_to_parent_node(uint32_t line, uint32_t indent, Pred&& pred) {
-        FK_YAML_ASSERT(!m_context_stack.empty());
+        if FK_YAML_UNLIKELY (m_context_stack.empty()) {
+            throw parse_error("No parent block mapping is found.", line, indent);
+        }
 
         // LCOV_EXCL_START
         auto itr = std::find_if(m_context_stack.rbegin(), m_context_stack.rend(), std::forward<Pred>(pred));

--- a/tests/unit_test/test_fuzz_regression.cpp
+++ b/tests/unit_test/test_fuzz_regression.cpp
@@ -64,4 +64,27 @@ TEST_CASE("FuzzRegression") {
         p_end = input + sizeof(input) - 1;
         REQUIRE_THROWS_AS(root = fkyaml::node::deserialize(p_begin, p_end), fkyaml::parse_error);
     }
+
+    SUBCASE("invalid block scalar header") {
+        auto input = GENERATE(std::string(">"), std::string("|"));
+        p_begin = input.data();
+        p_end = input.data() + input.size();
+        REQUIRE_THROWS_AS(root = fkyaml::node::deserialize(p_begin, p_end), fkyaml::parse_error);
+    }
+
+    SUBCASE("invalid colons") {
+        const char input[] = ":\n"
+                             ":";
+        p_begin = input;
+        p_end = input + sizeof(input) - 1;
+        REQUIRE_THROWS_AS(root = fkyaml::node::deserialize(p_begin, p_end), fkyaml::parse_error);
+    }
+
+    SUBCASE("invalid explicit key indicator") {
+        const char input[] = "a\n"
+                             "? ";
+        p_begin = input;
+        p_end = input + sizeof(input) - 1;
+        REQUIRE_THROWS_AS(root = fkyaml::node::deserialize(p_begin, p_end), fkyaml::parse_error);
+    }
 }


### PR DESCRIPTION
This PR fixes crashes found during fuzz test by converting assertions into explicit `parse_error`s.

- invalid block scalar header
  ```yaml
  > 
  ```
- invalid colons
  ```yaml
  :
  :
  ```
- invalid explicit key indicator
  ```yaml
  a
  ? 
  ```

All the above inputs are added to regression test cases.

---

## Pull Request Checklist

Read the [CONTRIBUTING.md](https://github.com/fktn-k/fkYAML/blob/develop/.github/CONTRIBUTING.md) file for detailed information.  

- [x] Changes are described in the pull request or in a referenced [issue](https://github.com/fktn-k/fkYAML/issues).
- [x] The test suite compiles and runs without any error.
- [x] [The code coverage](https://coveralls.io/github/fktn-k/fkYAML) on your branch is 100%.
- [x] The documentation is updated if you added/changed a feature.

## Please don't

- The C++11 support varies between different **compilers** and versions. Please note the [list of supported compilers](https://github.com/fktn-k/fkYAML/blob/develop/README.md#supported-compilers). Some compilers like GCC 4.7 (and earlier), Clang 3.3 (and earlier), or Microsoft Visual Studio 13.0 and earlier are known not to work due to missing or incomplete C++11 support. Please refrain from proposing changes that work around these compiler's limitations with `#ifdef`s or other means.
- Please refrain from proposing changes that would **break [YAML](https://yaml.org/) specifications**. If you propose a conformant extension of YAML to be supported by the library, please motivate this extension.
- Please do not open pull requests that address **multiple issues**.
