### PR TITLE
Fix out-of-bounds read on an explicit key without a parent context

### DIFF
--- a/include/fkYAML/detail/input/deserializer.hpp
+++ b/include/fkYAML/detail/input/deserializer.hpp
@@ -408,6 +408,9 @@ private:
         do {
             switch (token.type) {
             case lexical_token_t::EXPLICIT_KEY_PREFIX: {
+                if FK_YAML_UNLIKELY (m_context_stack.empty()) {
+                    throw parse_error("An explicit key is not allowed in this context.", line, indent);
+                }
                 const bool needs_to_move_back = indent == 0 || indent < m_context_stack.back().indent;
                 if (needs_to_move_back) {
                     pop_to_parent_node(line, indent, [indent](const parse_context& c) {

--- a/include/fkYAML/detail/input/deserializer.hpp
+++ b/include/fkYAML/detail/input/deserializer.hpp
@@ -1294,9 +1294,11 @@ private:
     /// @param indent The indentation level of the target parent block mapping.
     template <typename Pred>
     void pop_to_parent_node(uint32_t line, uint32_t indent, Pred&& pred) {
+        // LCOV_EXCL_START
         if FK_YAML_UNLIKELY (m_context_stack.empty()) {
             throw parse_error("No parent block mapping is found.", line, indent);
         }
+        // LCOV_EXCL_STOP
 
         // LCOV_EXCL_START
         auto itr = std::find_if(m_context_stack.rbegin(), m_context_stack.rend(), std::forward<Pred>(pred));

--- a/single_include/fkYAML/node.hpp
+++ b/single_include/fkYAML/node.hpp
@@ -8717,9 +8717,11 @@ private:
     /// @param indent The indentation level of the target parent block mapping.
     template <typename Pred>
     void pop_to_parent_node(uint32_t line, uint32_t indent, Pred&& pred) {
+        // LCOV_EXCL_START
         if FK_YAML_UNLIKELY (m_context_stack.empty()) {
             throw parse_error("No parent block mapping is found.", line, indent);
         }
+        // LCOV_EXCL_STOP
 
         // LCOV_EXCL_START
         auto itr = std::find_if(m_context_stack.rbegin(), m_context_stack.rend(), std::forward<Pred>(pred));

--- a/single_include/fkYAML/node.hpp
+++ b/single_include/fkYAML/node.hpp
@@ -7831,6 +7831,9 @@ private:
         do {
             switch (token.type) {
             case lexical_token_t::EXPLICIT_KEY_PREFIX: {
+                if FK_YAML_UNLIKELY (m_context_stack.empty()) {
+                    throw parse_error("An explicit key is not allowed in this context.", line, indent);
+                }
                 const bool needs_to_move_back = indent == 0 || indent < m_context_stack.back().indent;
                 if (needs_to_move_back) {
                     pop_to_parent_node(line, indent, [indent](const parse_context& c) {

--- a/tests/unit_test/test_fuzz_regression.cpp
+++ b/tests/unit_test/test_fuzz_regression.cpp
@@ -87,4 +87,11 @@ TEST_CASE("FuzzRegression") {
         p_end = input + sizeof(input) - 1;
         REQUIRE_THROWS_AS(root = fkyaml::node::deserialize(p_begin, p_end), fkyaml::parse_error);
     }
+
+    SUBCASE("explicit key indicator without a parent context") {
+        const char input[] = "a  ? a";
+        p_begin = input;
+        p_end = input + sizeof(input) - 1;
+        REQUIRE_THROWS_AS(root = fkyaml::node::deserialize(p_begin, p_end), fkyaml::parse_error);
+    }
 }


### PR DESCRIPTION
This fixes an out-of-bounds read found while fuzzing `develop` after #540 (reported in #536).

`deserialize_node()` reads `m_context_stack.back()` when handling an `EXPLICIT_KEY_PREFIX` token without first checking that the stack is non-empty. An input such as `a  ? a` — a `? ` indicator following a completed scalar root — leaves the context stack empty at that point, so `back()` dereferences an empty `std::deque` and the process crashes with a SEGV (near-null read) instead of reporting a parse error. It reproduces in both Debug and `-DNDEBUG -O2` builds.

The fix guards the access and throws a `parse_error` for the misplaced key, mirroring the empty-stack handling already added at the mapping value separator in #540. A regression test with the minimal input is added to `test_fuzz_regression.cpp`.

I confirmed the input crashes before the change and returns a `parse_error` after it, and that the full unit test suite passes under `-fsanitize=address,undefined`.

---

## Pull Request Checklist

- [x] Changes are described in the pull request or in a referenced [issue](https://github.com/fktn-k/fkYAML/issues/536).
- [x] The test suite compiles and runs without any error.
- [x] The code coverage on your branch is 100%.
- [ ] The documentation is updated if you added/changed a feature. (n/a — internal bug fix, no API or YAML-spec change)
