### PR TITLE
Guard empty context stack in the key-separator and add_new_key paths

### DIFF
--- a/include/fkYAML/detail/input/deserializer.hpp
+++ b/include/fkYAML/detail/input/deserializer.hpp
@@ -475,6 +475,9 @@ private:
                 continue;
             }
             case lexical_token_t::KEY_SEPARATOR: {
+                if FK_YAML_UNLIKELY (m_context_stack.empty()) {
+                    throw parse_error("A key separator is not allowed in this context.", line, indent);
+                }
                 if FK_YAML_UNLIKELY (m_context_stack.back().state == context_state_t::BLOCK_SEQUENCE_ENTRY) {
                     // empty mapping keys are not supported.
                     // ```yaml
@@ -1096,6 +1099,9 @@ private:
     /// @param indent The indentation width in the current line where the key is found.
     void add_new_key(basic_node_type&& key, const uint32_t line, const uint32_t indent) {
         if (m_flow_context_depth == 0) {
+            if FK_YAML_UNLIKELY (m_context_stack.empty()) {
+                throw parse_error("A mapping key is not allowed in this context.", line, indent);
+            }
             if FK_YAML_UNLIKELY (m_context_stack.back().indent < indent) {
                 // bad indentation like the following YAML:
                 // ```yaml

--- a/single_include/fkYAML/node.hpp
+++ b/single_include/fkYAML/node.hpp
@@ -7898,6 +7898,9 @@ private:
                 continue;
             }
             case lexical_token_t::KEY_SEPARATOR: {
+                if FK_YAML_UNLIKELY (m_context_stack.empty()) {
+                    throw parse_error("A key separator is not allowed in this context.", line, indent);
+                }
                 if FK_YAML_UNLIKELY (m_context_stack.back().state == context_state_t::BLOCK_SEQUENCE_ENTRY) {
                     // empty mapping keys are not supported.
                     // ```yaml
@@ -8519,6 +8522,9 @@ private:
     /// @param indent The indentation width in the current line where the key is found.
     void add_new_key(basic_node_type&& key, const uint32_t line, const uint32_t indent) {
         if (m_flow_context_depth == 0) {
+            if FK_YAML_UNLIKELY (m_context_stack.empty()) {
+                throw parse_error("A mapping key is not allowed in this context.", line, indent);
+            }
             if FK_YAML_UNLIKELY (m_context_stack.back().indent < indent) {
                 // bad indentation like the following YAML:
                 // ```yaml

--- a/tests/unit_test/test_fuzz_regression.cpp
+++ b/tests/unit_test/test_fuzz_regression.cpp
@@ -94,4 +94,19 @@ TEST_CASE("FuzzRegression") {
         p_end = input + sizeof(input) - 1;
         REQUIRE_THROWS_AS(root = fkyaml::node::deserialize(p_begin, p_end), fkyaml::parse_error);
     }
+
+    SUBCASE("key separator without a parent context") {
+        uint8_t input[] = {0x0D, 0x3B, 0x00, 0x0A, 0x0A, 0x4A, 0x0A, 0x0A, 0x26, 0x7C, 0x0A, 0x3A};
+        p_begin = reinterpret_cast<const char*>(input);
+        p_end = p_begin + sizeof(input);
+        REQUIRE_THROWS_AS(root = fkyaml::node::deserialize(p_begin, p_end), fkyaml::parse_error);
+    }
+
+    SUBCASE("mapping key without a parent context") {
+        uint8_t input[] = {0x26, 0x78, 0x00, 0x61, 0x5B, 0x5D, 0x0A, 0x70, 0x72, 0x6F, 0x7B, 0x64, 0x2B,
+                           0x3A, 0x20, 0x3E, 0x72, 0x6F, 0x7B, 0x64, 0x2B, 0x3A, 0x7B, 0x32, 0x6A};
+        p_begin = reinterpret_cast<const char*>(input);
+        p_end = p_begin + sizeof(input);
+        REQUIRE_THROWS_AS(root = fkyaml::node::deserialize(p_begin, p_end), fkyaml::parse_error);
+    }
 }


### PR DESCRIPTION
Fuzzing `develop` after #540 surfaced two more crashes of the same class you fixed in #533/#538/#540 — an unguarded `m_context_stack.back()` when the context stack is empty (reported in #536).

- **`KEY_SEPARATOR` handler** — a `:` with no parent context (e.g. after a completed scalar root) reaches `m_context_stack.back().state` on an empty deque. Minimal input `0D 3B 00 0A 0A 4A 0A 0A 26 7C 0A 3A`.
- **`add_new_key()`** — a mapping key with no parent block-mapping context reaches `m_context_stack.back().indent` on an empty deque. Minimal input `26 78 00 61 5B 5D 0A 70 72 6F 7B 64 2B 3A 20 3E 72 6F 7B 64 2B 3A 7B 32 6A`.

Both dereference `back()` on an empty `std::deque` (UB; near-null read → SEGV in `-DNDEBUG` builds). Each is guarded with an `empty()` check that raises a `parse_error` for the misplaced token, mirroring the empty-stack handling added in #540. Two regression tests with the minimal inputs are added to `test_fuzz_regression.cpp`.

I confirmed both inputs crash before the change and return a `parse_error` after it (Debug and `-DNDEBUG -O2`), and that the full unit test suite passes under `-fsanitize=address,undefined`.

---

## Pull Request Checklist

- [x] Changes are described in the pull request or in a referenced [issue](https://github.com/fktn-k/fkYAML/issues/536).
- [x] The test suite compiles and runs without any error.
- [x] The code coverage on your branch is 100%.
- [ ] The documentation is updated if you added/changed a feature. (n/a — internal bug fix, no API or YAML-spec change)
