### PR TITLE
Fix out-of-bounds read from a truncated BOM in the char encoding detector

### DIFF
--- a/include/fkYAML/detail/encodings/utf_encode_detector.hpp
+++ b/include/fkYAML/detail/encodings/utf_encode_detector.hpp
@@ -104,27 +104,40 @@ struct utf_encode_detector<ItrType, enable_if_t<is_iterator_of<ItrType, char>::v
         std::array<uint8_t, 4> bytes {{}};
         bytes.fill(0xFFu);
         auto current = begin;
+        int num_read = 0;
         for (int i = 0; i < 4 && current != end; i++, ++current) {
             bytes[i] = static_cast<uint8_t>(*current); // NOLINT(cppcoreguidelines-pro-bounds-constant-array-index)
+            ++num_read;
         }
 
         bool has_bom = false;
         const utf_encode_t encode_type = detect_encoding_type(bytes, has_bom);
 
         if (has_bom) {
-            // skip reading the BOM.
+            // Skip reading the BOM, but only when it is fully present in the input. The probe above pads
+            // unread positions with 0xFF, so an input shorter than the BOM (e.g. a lone 0xFE) can spuriously
+            // match a BOM pattern; advancing past the bytes actually read would move `begin` past `end`.
+            int bom_size = 0;
             switch (encode_type) {
             case utf_encode_t::UTF_8:
-                std::advance(begin, 3);
+                bom_size = 3;
                 break;
             case utf_encode_t::UTF_16BE:
             case utf_encode_t::UTF_16LE:
-                std::advance(begin, 2);
+                bom_size = 2;
                 break;
             case utf_encode_t::UTF_32BE:
             case utf_encode_t::UTF_32LE:
-                std::advance(begin, 4);
+                bom_size = 4;
                 break;
+            }
+            if (num_read >= bom_size) {
+                std::advance(begin, bom_size);
+            }
+            else {
+                // The match was against the padding, not a real BOM; treat the input as UTF-8 so the
+                // spurious encoding is not propagated.
+                return utf_encode_t::UTF_8;
             }
         }
 

--- a/single_include/fkYAML/node.hpp
+++ b/single_include/fkYAML/node.hpp
@@ -8970,27 +8970,40 @@ struct utf_encode_detector<ItrType, enable_if_t<is_iterator_of<ItrType, char>::v
         std::array<uint8_t, 4> bytes {{}};
         bytes.fill(0xFFu);
         auto current = begin;
+        int num_read = 0;
         for (int i = 0; i < 4 && current != end; i++, ++current) {
             bytes[i] = static_cast<uint8_t>(*current); // NOLINT(cppcoreguidelines-pro-bounds-constant-array-index)
+            ++num_read;
         }
 
         bool has_bom = false;
         const utf_encode_t encode_type = detect_encoding_type(bytes, has_bom);
 
         if (has_bom) {
-            // skip reading the BOM.
+            // Skip reading the BOM, but only when it is fully present in the input. The probe above pads
+            // unread positions with 0xFF, so an input shorter than the BOM (e.g. a lone 0xFE) can spuriously
+            // match a BOM pattern; advancing past the bytes actually read would move `begin` past `end`.
+            int bom_size = 0;
             switch (encode_type) {
             case utf_encode_t::UTF_8:
-                std::advance(begin, 3);
+                bom_size = 3;
                 break;
             case utf_encode_t::UTF_16BE:
             case utf_encode_t::UTF_16LE:
-                std::advance(begin, 2);
+                bom_size = 2;
                 break;
             case utf_encode_t::UTF_32BE:
             case utf_encode_t::UTF_32LE:
-                std::advance(begin, 4);
+                bom_size = 4;
                 break;
+            }
+            if (num_read >= bom_size) {
+                std::advance(begin, bom_size);
+            }
+            else {
+                // The match was against the padding, not a real BOM; treat the input as UTF-8 so the
+                // spurious encoding is not propagated.
+                return utf_encode_t::UTF_8;
             }
         }
 

--- a/tests/unit_test/test_fuzz_regression.cpp
+++ b/tests/unit_test/test_fuzz_regression.cpp
@@ -109,4 +109,13 @@ TEST_CASE("FuzzRegression") {
         p_end = p_begin + sizeof(input);
         REQUIRE_THROWS_AS(root = fkyaml::node::deserialize(p_begin, p_end), fkyaml::parse_error);
     }
+
+    SUBCASE("truncated UTF-16 BOM") {
+        // A lone 0xFE spuriously matched the UTF-16BE BOM against the detector's padding bytes,
+        // then advancing past the BOM moved the read position past the end of the input.
+        uint8_t input[] = {0xFE};
+        p_begin = reinterpret_cast<const char*>(input);
+        p_end = p_begin + sizeof(input);
+        REQUIRE_THROWS_AS(root = fkyaml::node::deserialize(p_begin, p_end), fkyaml::invalid_encoding);
+    }
 }


### PR DESCRIPTION
Fuzzing `develop` (reported in #536) found an out-of-bounds read reachable from ordinary `char`/`std::string` input.

`utf_encode_detector<char>::detect()` probes up to 4 leading bytes into an array padded with `0xFF`, then infers the encoding and a BOM. When the input is shorter than the BOM, the unread `0xFF` padding can spuriously complete a BOM pattern:

- a lone `0xFE` matches the UTF-16BE BOM (`FE FF`), and
- `00 00 FE` matches the UTF-32BE BOM (`00 00 FE FF`).

`detect()` then advanced `begin` by the full BOM length (2 or 4), moving it **past `end`**. The following read in `get_buffer_view_utf16()` / `get_buffer_view_utf32()` was an out-of-bounds read on the input buffer:

```
AddressSanitizer: heap-buffer-overflow ... READ of size 1
  in iterator_input_adapter<char*>::get_buffer_view_utf16() input_adapter.hpp:197
```

The fix tracks how many bytes were actually read and only skips a BOM that is fully present. Short inputs fall through to normal decoding, which reports a clean `invalid_encoding` instead of reading past the end — so valid BOMs behave exactly as before. A regression test with the 1-byte `0xFE` input is added.

I confirmed the input reads out of bounds before the change (heap-backed buffer, ASan) and throws `invalid_encoding` after it, in Debug and `-DNDEBUG -O2`, and that the full unit test suite (including the BOM/encoding tests) passes under `-fsanitize=address,undefined`.

The sibling `char8_t`/`char16_t`/`char32_t` detectors don't have this exposure: `char8_t` throws before advancing on any non-UTF-8 result, and the `char16_t`/`char32_t` BOM checks only use bytes from real code units.

---

## Pull Request Checklist

- [x] Changes are described in the pull request or in a referenced [issue](https://github.com/fktn-k/fkYAML/issues/536).
- [x] The test suite compiles and runs without any error.
- [x] The code coverage on your branch is 100%.
- [ ] The documentation is updated if you added/changed a feature. (n/a — internal bug fix, no API or YAML-spec change)
