### PR TITLE
Fix four out-of-bounds reads in the lexer and tag URI validation

### DIFF
--- a/include/fkYAML/detail/encodings/uri_encoding.hpp
+++ b/include/fkYAML/detail/encodings/uri_encoding.hpp
@@ -37,6 +37,11 @@ public:
                     return false;
                 }
 
+                // validate_octets() advances `current` past the last octet it consumed. Without
+                // moving it back, the loop's own ++current skips the character which follows the
+                // escape sequence, and, when the escape ends the sequence, moves `current` one
+                // past `end` so that the loop condition never holds and reads out of bounds.
+                --current;
                 continue;
             }
 

--- a/include/fkYAML/detail/input/lexical_analyzer.hpp
+++ b/include/fkYAML/detail/input/lexical_analyzer.hpp
@@ -554,6 +554,11 @@ private:
         // extract a tag prefix.
         //
 
+        // skip_white_spaces() above may have consumed the rest of the input buffer.
+        if FK_YAML_UNLIKELY (m_cur_itr == m_end_itr) {
+            emit_error("invalid TAG directive is found.");
+        }
+
         m_token_begin_itr = m_cur_itr;
         const char* p_tag_prefix_begin = m_cur_itr;
         switch (*m_cur_itr) {
@@ -684,7 +689,9 @@ private:
         case '<':
             // Verbatim tags (!<TAG>)
             is_verbatim = true;
-            ++m_cur_itr;
+            if FK_YAML_UNLIKELY (++m_cur_itr == m_end_itr) {
+                emit_error("verbatim tag (!<TAG>) must be ended with \'>\'.");
+            }
             break;
         default:
             // Either local tags (!suffix) or named handles (!tag!suffix)
@@ -816,12 +823,18 @@ private:
                 // * even number of backslashes -> double quotation mark IS NOT escaped (e.g., "\\"")
                 uint32_t backslash_counts = 0;
                 const char* p = m_token_begin_itr + (pos - 1);
-                do {
-                    if (*p-- != '\\') {
+                for (;;) {
+                    if (*p != '\\') {
                         break;
                     }
                     ++backslash_counts;
-                } while (p != m_token_begin_itr);
+                    if (p == m_token_begin_itr) {
+                        // the first character of the token has just been counted. Stopping here
+                        // also keeps `p` from being decremented past the beginning of the token.
+                        break;
+                    }
+                    --p;
+                }
                 is_closed = ((backslash_counts & 1u) == 0); // true: even, false: odd
             }
 

--- a/single_include/fkYAML/node.hpp
+++ b/single_include/fkYAML/node.hpp
@@ -1310,6 +1310,11 @@ public:
                     return false;
                 }
 
+                // validate_octets() advances `current` past the last octet it consumed. Without
+                // moving it back, the loop's own ++current skips the character which follows the
+                // escape sequence, and, when the escape ends the sequence, moves `current` one
+                // past `end` so that the loop condition never holds and reads out of bounds.
+                --current;
                 continue;
             }
 
@@ -3782,6 +3787,11 @@ private:
         // extract a tag prefix.
         //
 
+        // skip_white_spaces() above may have consumed the rest of the input buffer.
+        if FK_YAML_UNLIKELY (m_cur_itr == m_end_itr) {
+            emit_error("invalid TAG directive is found.");
+        }
+
         m_token_begin_itr = m_cur_itr;
         const char* p_tag_prefix_begin = m_cur_itr;
         switch (*m_cur_itr) {
@@ -3912,7 +3922,9 @@ private:
         case '<':
             // Verbatim tags (!<TAG>)
             is_verbatim = true;
-            ++m_cur_itr;
+            if FK_YAML_UNLIKELY (++m_cur_itr == m_end_itr) {
+                emit_error("verbatim tag (!<TAG>) must be ended with \'>\'.");
+            }
             break;
         default:
             // Either local tags (!suffix) or named handles (!tag!suffix)
@@ -4044,12 +4056,18 @@ private:
                 // * even number of backslashes -> double quotation mark IS NOT escaped (e.g., "\\"")
                 uint32_t backslash_counts = 0;
                 const char* p = m_token_begin_itr + (pos - 1);
-                do {
-                    if (*p-- != '\\') {
+                for (;;) {
+                    if (*p != '\\') {
                         break;
                     }
                     ++backslash_counts;
-                } while (p != m_token_begin_itr);
+                    if (p == m_token_begin_itr) {
+                        // the first character of the token has just been counted. Stopping here
+                        // also keeps `p` from being decremented past the beginning of the token.
+                        break;
+                    }
+                    --p;
+                }
                 is_closed = ((backslash_counts & 1u) == 0); // true: even, false: odd
             }
 

--- a/tests/unit_test/test_fuzz_regression.cpp
+++ b/tests/unit_test/test_fuzz_regression.cpp
@@ -118,4 +118,39 @@ TEST_CASE("FuzzRegression") {
         p_end = p_begin + sizeof(input);
         REQUIRE_THROWS_AS(root = fkyaml::node::deserialize(p_begin, p_end), fkyaml::invalid_encoding);
     }
+
+    SUBCASE("verbatim tag which ends the input buffer") {
+        const char input[] = "!<";
+        p_begin = input;
+        p_end = input + sizeof(input) - 1;
+        REQUIRE_THROWS_AS(root = fkyaml::node::deserialize(p_begin, p_end), fkyaml::parse_error);
+    }
+
+    SUBCASE("TAG directive without a tag prefix") {
+        const char input[] = "%TAG !  ";
+        p_begin = input;
+        p_end = input + sizeof(input) - 1;
+        REQUIRE_THROWS_AS(root = fkyaml::node::deserialize(p_begin, p_end), fkyaml::parse_error);
+    }
+
+    SUBCASE("percent escape at the end of a tag URI") {
+        const char input[] = "!!a%41";
+        p_begin = input;
+        p_end = input + sizeof(input) - 1;
+        REQUIRE_NOTHROW(root = fkyaml::node::deserialize(p_begin, p_end));
+    }
+
+    SUBCASE("invalid URI character right after a percent escape") {
+        const char input[] = "!!a%41^";
+        p_begin = input;
+        p_end = input + sizeof(input) - 1;
+        REQUIRE_THROWS_AS(root = fkyaml::node::deserialize(p_begin, p_end), fkyaml::parse_error);
+    }
+
+    SUBCASE("double quoted scalar closed by an escaped quotation mark") {
+        const char input[] = "\"\\\\\\\"";
+        p_begin = input;
+        p_end = input + sizeof(input) - 1;
+        REQUIRE_THROWS_AS(root = fkyaml::node::deserialize(p_begin, p_end), fkyaml::parse_error);
+    }
 }


### PR DESCRIPTION
This PR fixes four out-of-bounds reads in the lexer and tag URI validation, all found by
running the existing `tests/fuzz_test` harness under `libFuzzer` + `AddressSanitizer`.

Each one reproduces on unmodified `develop` and is reachable from
`fkyaml::node::deserialize()` with a tiny input:

| Input | Where |
| --- | --- |
| `!<` | `extract_tag_name()` steps past `m_end_itr` before the loop's end test can fire |
| `!!a%41` | `uri_encoding::validate()` advances the iterator twice per percent escape |
| `%TAG !  ` | `scan_tag_directive()` dereferences after `skip_white_spaces()` drained the buffer |
| `"\\\"` | backslash counting misses the token's first character, so the scalar parser gets a short token and `remove_prefix()` underflows |

These are separate from #544 and #545, so no overlap with either patch. I found them after
applying both locally so the fuzzer could get past those crashes.

**Two results change for inputs that didn't crash before:** `!!a%41^` is now rejected, since
the character after a percent escape is finally validated, and `!!%41` is now accepted, since a
percent escape may legitimately end a tag URI.

Fixes #546.

---

## Pull Request Checklist

Read the [CONTRIBUTING.md](https://github.com/fktn-k/fkYAML/blob/develop/.github/CONTRIBUTING.md) file for detailed information.  

- [x] Changes are described in the pull request or in a referenced [issue](https://github.com/fktn-k/fkYAML/issues).
- [x] The test suite compiles and runs without any error.
- [ ] [The code coverage](https://coveralls.io/github/fktn-k/fkYAML) on your branch is 100%.
- [x] The documentation is updated if you added/changed a feature.

## Please don't

- The C++11 support varies between different **compilers** and versions. Please note the [list of supported compilers](https://github.com/fktn-k/fkYAML/blob/develop/README.md#supported-compilers). Some compilers like GCC 4.7 (and earlier), Clang 3.3 (and earlier), or Microsoft Visual Studio 13.0 and earlier are known not to work due to missing or incomplete C++11 support. Please refrain from proposing changes that work around these compiler's limitations with `#ifdef`s or other means.
- Please refrain from proposing changes that would **break [YAML](https://yaml.org/) specifications**. If you propose a conformant extension of YAML to be supported by the library, please motivate this extension.
- Please do not open pull requests that address **multiple issues**.
