### PR TITLE
Prevent stack overflow by a self-referential alias

### DIFF
--- a/include/fkYAML/detail/input/deserializer.hpp
+++ b/include/fkYAML/detail/input/deserializer.hpp
@@ -947,22 +947,34 @@ private:
                     throw parse_error("Anchor cannot be specified to an alias node.", line, indent);
                 }
 
-                std::string token_str = std::string(token.str.begin(), token.str.end());
+                const std::string anchor_name = std::string(token.str.begin(), token.str.end());
 
-                const auto anchor_counts = static_cast<uint32_t>(mp_meta->anchor_table.count(token_str));
+                const auto anchor_counts = static_cast<uint32_t>(mp_meta->anchor_table.count(anchor_name));
                 if FK_YAML_UNLIKELY (anchor_counts == 0) {
                     throw parse_error("The given anchor name must appear prior to the alias node.", line, indent);
                 }
 
                 basic_node_type node {};
                 node.m_attrs |= detail::node_attr_bits::alias_bit;
-                node.m_prop.anchor = std::move(token_str);
+                node.m_prop.anchor = anchor_name;
                 detail::node_attr_bits::set_anchor_offset(anchor_counts - 1, node.m_attrs);
 
                 apply_directive_set(node);
                 apply_node_properties(node);
 
                 deserialize_scalar(lexer, std::move(node), indent, line, token);
+
+                // Check if the alias node is self-referential.
+                // If so, throw a parse error to avoid infinite recursion and stack overflow during deserialization.
+                auto itr = mp_meta->anchor_table.equal_range(anchor_name).first;
+                std::advance(itr, anchor_counts - 1);
+                const auto& anchor = itr->second;
+                const bool is_self_referential = anchor.contains_self_referential_alias(anchor_name, anchor_counts - 1);
+                if FK_YAML_UNLIKELY (is_self_referential) {
+                    const std::string msg = format("Self-referential alias (*%s) is found.", anchor_name.c_str());
+                    throw parse_error(msg.c_str(), line, indent);
+                }
+
                 continue;
             }
             case lexical_token_t::PLAIN_SCALAR:

--- a/include/fkYAML/node.hpp
+++ b/include/fkYAML/node.hpp
@@ -721,7 +721,7 @@ public:
     /// @param rhs A basic_node object to be compared with this basic_node object.
     /// @return true if both types and values are equal, false otherwise.
     /// @sa https://fktn-k.github.io/fkYAML/api/basic_node/operator_eq/
-    bool operator==(const basic_node& rhs) const noexcept {
+    bool operator==(const basic_node& rhs) const {
         const basic_node& lhs = resolve_reference();
         const basic_node& act_rhs = rhs.resolve_reference();
 
@@ -775,7 +775,7 @@ public:
     /// @param rhs A basic_node object to be compared with this basic_node object.
     /// @return true this basic_node object is less than `rhs`.
     /// @sa https://fktn-k.github.io/fkYAML/api/basic_node/operator_lt/
-    bool operator<(const basic_node& rhs) const noexcept {
+    bool operator<(const basic_node& rhs) const {
         if (operator==(rhs)) {
             return false;
         }
@@ -1800,7 +1800,8 @@ public:
 
         auto& map = *act_node.m_value.p_map;
         for (auto itr = map.begin(); itr != map.end(); ++itr) {
-            if (itr->first == key_node) {
+            bool key_found = itr->first == key_node;
+            if (key_found) {
                 map.erase(itr);
                 return size_type {1};
             }
@@ -1814,8 +1815,18 @@ private:
     basic_node& resolve_reference() {
         if FK_YAML_UNLIKELY (has_anchor_name()) {
             auto itr = mp_meta->anchor_table.equal_range(m_prop.anchor).first;
-            std::advance(itr, detail::node_attr_bits::get_anchor_offset(m_attrs));
-            return itr->second;
+            auto offset = detail::node_attr_bits::get_anchor_offset(m_attrs);
+            std::advance(itr, offset);
+            auto& anchor = itr->second;
+
+            // Checks for cyclic references in the child nodes of the anchor node.
+            // If it does, throws an exception to prevent infinite recursion and stack overflow.
+            const bool contains_self_ref = anchor.contains_self_referential_alias(m_prop.anchor, offset);
+            if FK_YAML_UNLIKELY (contains_self_ref) {
+                throw fkyaml::exception("Cyclic reference detected during anchor/alias resolving.");
+            }
+
+            return anchor;
         }
         return *this;
     }
@@ -1825,10 +1836,55 @@ private:
     const basic_node& resolve_reference() const {
         if FK_YAML_UNLIKELY (has_anchor_name()) {
             auto itr = mp_meta->anchor_table.equal_range(m_prop.anchor).first;
-            std::advance(itr, detail::node_attr_bits::get_anchor_offset(m_attrs));
-            return itr->second;
+            auto offset = detail::node_attr_bits::get_anchor_offset(m_attrs);
+            std::advance(itr, offset);
+            const auto& anchor = itr->second;
+
+            // Checks for cyclic references in the child nodes of the anchor node.
+            // If it does, throws an exception to prevent infinite recursion and stack overflow.
+            const bool contains_self_ref = anchor.contains_self_referential_alias(m_prop.anchor, offset);
+            if FK_YAML_UNLIKELY (contains_self_ref) {
+                throw fkyaml::exception("Cyclic reference detected during anchor/alias resolving.");
+            }
+
+            return anchor;
         }
         return *this;
+    }
+
+    /// @brief Checks if this node contains any alias node which references itself in its child nodes, which would cause
+    /// infinite recursion and then stack overflow.
+    ///
+    /// @param anchor_name The anchor name of the node to check.
+    /// @param anchor_offset The anchor offset of the node to check.
+    bool contains_self_referential_alias(const std::string& anchor_name, uint32_t anchor_offset) const {
+        std::vector<const basic_node*> stack {this};
+        while (!stack.empty()) {
+            const auto* node = stack.back();
+            stack.pop_back();
+            if (node->is_alias()) {
+                const auto& alias = *node;
+                const bool references_self =
+                    (alias.get_anchor_name() == anchor_name &&
+                     detail::node_attr_bits::get_anchor_offset(alias.m_attrs) == anchor_offset);
+                if (references_self) {
+                    return true;
+                }
+            }
+            else if (node->is_sequence()) {
+                for (const auto& child : node->as_seq()) {
+                    stack.push_back(&child);
+                }
+            }
+            else if (node->is_mapping()) {
+                for (const auto& entry : node->as_map()) {
+                    stack.push_back(&entry.first);
+                    stack.push_back(&entry.second);
+                }
+            }
+        }
+
+        return false;
     }
 
     bool is_sequence_impl() const noexcept {

--- a/single_include/fkYAML/node.hpp
+++ b/single_include/fkYAML/node.hpp
@@ -8388,22 +8388,34 @@ private:
                     throw parse_error("Anchor cannot be specified to an alias node.", line, indent);
                 }
 
-                std::string token_str = std::string(token.str.begin(), token.str.end());
+                const std::string anchor_name = std::string(token.str.begin(), token.str.end());
 
-                const auto anchor_counts = static_cast<uint32_t>(mp_meta->anchor_table.count(token_str));
+                const auto anchor_counts = static_cast<uint32_t>(mp_meta->anchor_table.count(anchor_name));
                 if FK_YAML_UNLIKELY (anchor_counts == 0) {
                     throw parse_error("The given anchor name must appear prior to the alias node.", line, indent);
                 }
 
                 basic_node_type node {};
                 node.m_attrs |= detail::node_attr_bits::alias_bit;
-                node.m_prop.anchor = std::move(token_str);
+                node.m_prop.anchor = anchor_name;
                 detail::node_attr_bits::set_anchor_offset(anchor_counts - 1, node.m_attrs);
 
                 apply_directive_set(node);
                 apply_node_properties(node);
 
                 deserialize_scalar(lexer, std::move(node), indent, line, token);
+
+                // Check if the alias node is self-referential.
+                // If so, throw a parse error to avoid infinite recursion and stack overflow during deserialization.
+                auto itr = mp_meta->anchor_table.equal_range(anchor_name).first;
+                std::advance(itr, anchor_counts - 1);
+                const auto& anchor = itr->second;
+                const bool is_self_referential = anchor.contains_self_referential_alias(anchor_name, anchor_counts - 1);
+                if FK_YAML_UNLIKELY (is_self_referential) {
+                    const std::string msg = format("Self-referential alias (*%s) is found.", anchor_name.c_str());
+                    throw parse_error(msg.c_str(), line, indent);
+                }
+
                 continue;
             }
             case lexical_token_t::PLAIN_SCALAR:
@@ -13629,7 +13641,7 @@ public:
     /// @param rhs A basic_node object to be compared with this basic_node object.
     /// @return true if both types and values are equal, false otherwise.
     /// @sa https://fktn-k.github.io/fkYAML/api/basic_node/operator_eq/
-    bool operator==(const basic_node& rhs) const noexcept {
+    bool operator==(const basic_node& rhs) const {
         const basic_node& lhs = resolve_reference();
         const basic_node& act_rhs = rhs.resolve_reference();
 
@@ -13683,7 +13695,7 @@ public:
     /// @param rhs A basic_node object to be compared with this basic_node object.
     /// @return true this basic_node object is less than `rhs`.
     /// @sa https://fktn-k.github.io/fkYAML/api/basic_node/operator_lt/
-    bool operator<(const basic_node& rhs) const noexcept {
+    bool operator<(const basic_node& rhs) const {
         if (operator==(rhs)) {
             return false;
         }
@@ -14708,7 +14720,8 @@ public:
 
         auto& map = *act_node.m_value.p_map;
         for (auto itr = map.begin(); itr != map.end(); ++itr) {
-            if (itr->first == key_node) {
+            bool key_found = itr->first == key_node;
+            if (key_found) {
                 map.erase(itr);
                 return size_type {1};
             }
@@ -14722,8 +14735,18 @@ private:
     basic_node& resolve_reference() {
         if FK_YAML_UNLIKELY (has_anchor_name()) {
             auto itr = mp_meta->anchor_table.equal_range(m_prop.anchor).first;
-            std::advance(itr, detail::node_attr_bits::get_anchor_offset(m_attrs));
-            return itr->second;
+            auto offset = detail::node_attr_bits::get_anchor_offset(m_attrs);
+            std::advance(itr, offset);
+            auto& anchor = itr->second;
+
+            // Checks for cyclic references in the child nodes of the anchor node.
+            // If it does, throws an exception to prevent infinite recursion and stack overflow.
+            const bool contains_self_ref = anchor.contains_self_referential_alias(m_prop.anchor, offset);
+            if FK_YAML_UNLIKELY (contains_self_ref) {
+                throw fkyaml::exception("Cyclic reference detected during anchor/alias resolving.");
+            }
+
+            return anchor;
         }
         return *this;
     }
@@ -14733,10 +14756,55 @@ private:
     const basic_node& resolve_reference() const {
         if FK_YAML_UNLIKELY (has_anchor_name()) {
             auto itr = mp_meta->anchor_table.equal_range(m_prop.anchor).first;
-            std::advance(itr, detail::node_attr_bits::get_anchor_offset(m_attrs));
-            return itr->second;
+            auto offset = detail::node_attr_bits::get_anchor_offset(m_attrs);
+            std::advance(itr, offset);
+            const auto& anchor = itr->second;
+
+            // Checks for cyclic references in the child nodes of the anchor node.
+            // If it does, throws an exception to prevent infinite recursion and stack overflow.
+            const bool contains_self_ref = anchor.contains_self_referential_alias(m_prop.anchor, offset);
+            if FK_YAML_UNLIKELY (contains_self_ref) {
+                throw fkyaml::exception("Cyclic reference detected during anchor/alias resolving.");
+            }
+
+            return anchor;
         }
         return *this;
+    }
+
+    /// @brief Checks if this node contains any alias node which references itself in its child nodes, which would cause
+    /// infinite recursion and then stack overflow.
+    ///
+    /// @param anchor_name The anchor name of the node to check.
+    /// @param anchor_offset The anchor offset of the node to check.
+    bool contains_self_referential_alias(const std::string& anchor_name, uint32_t anchor_offset) const {
+        std::vector<const basic_node*> stack {this};
+        while (!stack.empty()) {
+            const auto* node = stack.back();
+            stack.pop_back();
+            if (node->is_alias()) {
+                const auto& alias = *node;
+                const bool references_self =
+                    (alias.get_anchor_name() == anchor_name &&
+                     detail::node_attr_bits::get_anchor_offset(alias.m_attrs) == anchor_offset);
+                if (references_self) {
+                    return true;
+                }
+            }
+            else if (node->is_sequence()) {
+                for (const auto& child : node->as_seq()) {
+                    stack.push_back(&child);
+                }
+            }
+            else if (node->is_mapping()) {
+                for (const auto& entry : node->as_map()) {
+                    stack.push_back(&entry.first);
+                    stack.push_back(&entry.second);
+                }
+            }
+        }
+
+        return false;
     }
 
     bool is_sequence_impl() const noexcept {

--- a/tests/unit_test/test_deserializer_class.cpp
+++ b/tests/unit_test/test_deserializer_class.cpp
@@ -3330,6 +3330,16 @@ TEST_CASE("Deserializer_NodeProperties") {
         REQUIRE(foo_node.is_string());
         REQUIRE(foo_node.as_str() == "bar");
     }
+
+    SUBCASE("self referential alias") {
+        auto input = GENERATE(
+            std::string("&x [*x]"),
+            std::string("{&x [*x]: 0}"),
+            std::string("&x {a: *x}"),
+            std::string("{&x [*x]: 0, &y [*y]: 1}"),
+            std::string("&x {a: {b: *x}}"));
+        REQUIRE_THROWS_AS(root = deserializer.deserialize(fkyaml::detail::input_adapter(input)), fkyaml::parse_error);
+    }
 }
 
 TEST_CASE("Deserializer_NoMachingAnchor") {

--- a/tests/unit_test/test_node_class.cpp
+++ b/tests/unit_test/test_node_class.cpp
@@ -1353,6 +1353,31 @@ TEST_CASE("Node_AliasNodeFactory") {
         REQUIRE(alias.is_string());
         REQUIRE(alias.as_str().compare("alias_test") == 0);
     }
+
+    SUBCASE("anchor contains a self-referential alias in its children") {
+        anchor = fkyaml::node::sequence();
+        anchor.add_anchor_name("anchor_name");
+        fkyaml::node alias = fkyaml::node::alias_of(anchor);
+        REQUIRE(alias.is_alias());
+        // `anchor` now contains a self-referential alias in its children.
+        anchor.as_seq().emplace_back(std::move(alias));
+        // The anchor/alias resolving is performed inside `as_seq()`,
+        // which throws an exception against the cyclic reference.
+        REQUIRE_THROWS_AS(anchor.as_seq(), fkyaml::exception);
+        REQUIRE_THROWS_AS(anchor.size(), fkyaml::exception);
+    }
+
+    SUBCASE("anchor contains an alias which is not self-referential") {
+        anchor = fkyaml::node::sequence();
+        anchor.add_anchor_name("anchor_name");
+        fkyaml::node anchor2 = true;
+        anchor2.add_anchor_name("anchor_name_2");
+        fkyaml::node alias = fkyaml::node::alias_of(anchor2);
+        REQUIRE(alias.is_alias());
+        anchor.as_seq().emplace_back(std::move(alias));
+        REQUIRE_NOTHROW(anchor.as_seq());
+        REQUIRE_NOTHROW(anchor.size());
+    }
 }
 
 //


### PR DESCRIPTION
This PR fixes #548.
A `parse_errror` is now thrown in deserializing YAML documents like the followings where an anchor contains a self-referential alias in its direct/nested children.
This is because parsing such a YAML document caused infinite recursion and then stack overflow in the anchor/alias resolving.

- ```yaml
  # Parsing this mapping caused stack overflow while checking duplicate keys
  # since resolving `*x` caused infinite recursion.
  {&x [*x]: 0, &y [*y]: 1}
  ```
- ```yaml
  # Just parsing this did not cause stack overflow
  # but cyclic reference happened between the anchor (`&x [*x]`) and the alias (`*x`)
  # on accessing `*x` after deserialization completes.
  {&x [*x]: 0}
  {&y foo: {bar: [baz, [*y]]}}
  ```

Since fkYAML supports creating an alias by calling `basic_node::alias_of`, the cyclic reference detection is also added to the anchor/alias resolving process which is executed almost every `basic_node`'s method call. 

---

## Pull Request Checklist

Read the [CONTRIBUTING.md](https://github.com/fktn-k/fkYAML/blob/develop/.github/CONTRIBUTING.md) file for detailed information.  

- [x] Changes are described in the pull request or in a referenced [issue](https://github.com/fktn-k/fkYAML/issues).
- [x] The test suite compiles and runs without any error.
- [x] [The code coverage](https://coveralls.io/github/fktn-k/fkYAML) on your branch is 100%.
- [x] The documentation is updated if you added/changed a feature.

## Please don't

- The C++11 support varies between different **compilers** and versions. Please note the [list of supported compilers](https://github.com/fktn-k/fkYAML/blob/develop/README.md#supported-compilers). Some compilers like GCC 4.7 (and earlier), Clang 3.3 (and earlier), or Microsoft Visual Studio 13.0 and earlier are known not to work due to missing or incomplete C++11 support. Please refrain from proposing changes that work around these compiler's limitations with `#ifdef`s or other means.
- Please refrain from proposing changes that would **break [YAML](https://yaml.org/) specifications**. If you propose a conformant extension of YAML to be supported by the library, please motivate this extension.
- Please do not open pull requests that address **multiple issues**.
