### PR TITLE
Change the way to generate test_data.hpp for unit tests

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -6,5 +6,8 @@
 /docs/site/
 /docs/venv/
 
+# test data
+/tests/unit_test/test_data.hpp
+
 # natvis generator
 /tools/natvis_generator/venv/

--- a/tests/unit_test/CMakeLists.txt
+++ b/tests/unit_test/CMakeLists.txt
@@ -45,12 +45,12 @@ include(${doctest_SOURCE_DIR}/scripts/cmake/doctest.cmake)
 ######################################
 
 # While executing CTest on Windows, just specifying a relative path seems not working.
-# This is a workaround to resolve the issue. (Delete it when a better solution is found.)
-set(TEST_DATA_HEADER "${CMAKE_CURRENT_BINARY_DIR}/include/test_data.hpp")
-file(WRITE  ${TEST_DATA_HEADER} "#ifndef FK_YAML_TEST_TEST_DATA_HPP_\n")
-file(APPEND ${TEST_DATA_HEADER} "#define FK_YAML_TEST_TEST_DATA_HPP_\n\n")
-file(APPEND ${TEST_DATA_HEADER} "#define FK_YAML_TEST_DATA_DIR \"${CMAKE_CURRENT_SOURCE_DIR}/test_data\"\n\n")
-file(APPEND ${TEST_DATA_HEADER} "#endif /* FK_YAML_TEST_TEST_DATA_HPP_ */\n")
+# So, define the absolute path in this file to open test data files.
+configure_file(
+  "${CMAKE_CURRENT_SOURCE_DIR}/test_data.hpp.in"
+  "${CMAKE_CURRENT_SOURCE_DIR}/test_data.hpp"
+  @ONLY
+)
 
 #################################
 #   Configure compile options   #
@@ -60,7 +60,7 @@ add_library(unit_test_config INTERFACE)
 target_include_directories(
   unit_test_config
   INTERFACE
-    "${CMAKE_CURRENT_BINARY_DIR}/include"
+    "${CMAKE_CURRENT_SOURCE_DIR}"
     "${doctest_SOURCE_DIR}"
 )
 

--- a/tests/unit_test/test_data.hpp.in
+++ b/tests/unit_test/test_data.hpp.in
@@ -1,0 +1,14 @@
+//  _______   __ __   __  _____   __  __  __
+// |   __| |_/  |  \_/  |/  _  \ /  \/  \|  |     fkYAML: A C++ header-only YAML library (supporting code)
+// |   __|  _  < \_   _/|  ___  |    _   |  |___  version 0.4.3
+// |__|  |_| \__|  |_|  |_|   |_|___||___|______| https://github.com/fktn-k/fkYAML
+//
+// SPDX-FileCopyrightText: 2023-2026 Kensuke Fukutani <fktn.dev@gmail.com>
+// SPDX-License-Identifier: MIT
+
+#ifndef FK_YAML_TEST_TEST_DATA_HPP
+#define FK_YAML_TEST_TEST_DATA_HPP
+
+#define FK_YAML_TEST_DATA_DIR "@CMAKE_CURRENT_SOURCE_DIR@/test_data"
+
+#endif /* FK_YAML_TEST_TEST_DATA_HPP */


### PR DESCRIPTION
This PR changes the way of generating test_data.hpp for unit tests to be able to open test data files.  
Previously, it is generated by CMake's `file()` commands.  
From this PR on, the generation depends on CMake's `configure_file()` command.  
No functional changes have been made.

---

## Pull Request Checklist

Read the [CONTRIBUTING.md](https://github.com/fktn-k/fkYAML/blob/develop/.github/CONTRIBUTING.md) file for detailed information.  

- [x] Changes are described in the pull request or in a referenced [issue](https://github.com/fktn-k/fkYAML/issues).
- [x] The test suite compiles and runs without any error.
- [x] [The code coverage](https://coveralls.io/github/fktn-k/fkYAML) on your branch is 100%.
- [x] The documentation is updated if you added/changed a feature.

## Please don't

- The C++11 support varies between different **compilers** and versions. Please note the [list of supported compilers](https://github.com/fktn-k/fkYAML/blob/develop/README.md#supported-compilers). Some compilers like GCC 4.7 (and earlier), Clang 3.3 (and earlier), or Microsoft Visual Studio 13.0 and earlier are known not to work due to missing or incomplete C++11 support. Please refrain from proposing changes that work around these compiler's limitations with `#ifdef`s or other means.
- Please refrain from proposing changes that would **break [YAML](https://yaml.org/) specifications**. If you propose a conformant extension of YAML to be supported by the library, please motivate this extension.
- Please do not open pull requests that address **multiple issues**.
