### PR TITLE
Guard the context stack access behind a checked accessor

### DIFF
--- a/include/fkYAML/detail/input/deserializer.hpp
+++ b/include/fkYAML/detail/input/deserializer.hpp
@@ -614,8 +614,9 @@ private:
 
                 basic_node_type key_node = std::move(*m_context_stack.back().p_node);
                 m_context_stack.pop_back();
-                m_context_stack.back().p_node->as_map().emplace(key_node, basic_node_type());
-                mp_current_node = &(m_context_stack.back().p_node->operator[](std::move(key_node)));
+                basic_node_type* p_parent_node = current_context(line, indent).p_node;
+                p_parent_node->as_map().emplace(key_node, basic_node_type());
+                mp_current_node = &(p_parent_node->operator[](std::move(key_node)));
                 m_context_stack.emplace_back(
                     old_line, old_indent, context_state_t::BLOCK_MAPPING_EXPLICIT_VALUE, mp_current_node);
 
@@ -721,7 +722,7 @@ private:
 
                 ++m_flow_context_depth;
 
-                switch (m_context_stack.back().state) {
+                switch (current_context(line, indent).state) {
                 case context_state_t::BLOCK_SEQUENCE:
                 case context_state_t::FLOW_SEQUENCE:
                     mp_current_node->as_seq().emplace_back(basic_node_type::sequence());
@@ -836,7 +837,7 @@ private:
 
                 ++m_flow_context_depth;
 
-                switch (m_context_stack.back().state) {
+                switch (current_context(line, indent).state) {
                 case context_state_t::BLOCK_SEQUENCE:
                 case context_state_t::FLOW_SEQUENCE:
                     mp_current_node->as_seq().emplace_back(basic_node_type::mapping());
@@ -1146,7 +1147,7 @@ private:
         }
 
         mp_current_node = &(itr.first->second);
-        const parse_context& key_context = m_context_stack.back();
+        const parse_context& key_context = current_context(line, indent);
         m_context_stack.emplace_back(
             key_context.line, key_context.indent, context_state_t::MAPPING_VALUE, mp_current_node);
     }
@@ -1181,7 +1182,7 @@ private:
 
         if FK_YAML_LIKELY (m_context_stack.back().state != context_state_t::BLOCK_MAPPING_EXPLICIT_KEY) {
             m_context_stack.pop_back();
-            mp_current_node = m_context_stack.back().p_node;
+            mp_current_node = current_context(line, indent).p_node;
 
             if (m_flow_context_depth > 0) {
                 m_flow_token_state = flow_token_state_t::NEEDS_SEPARATOR_OR_SUFFIX;
@@ -1304,6 +1305,21 @@ private:
 
         indent = lexer.get_last_token_begin_pos();
         line = lexer.get_lines_processed();
+    }
+
+    /// @brief Returns the parse context on the top of the context stack.
+    /// @note
+    /// Accessing an empty context stack is undefined behavior. Malformed input can empty the stack in the middle of
+    /// deserialization, so the emptiness must be checked before the access. This function throws a parse_error for
+    /// such input instead of letting the callers dereference an invalid iterator.
+    /// @param line The current line count.
+    /// @param indent The current indentation width.
+    /// @return The parse context on the top of the context stack.
+    parse_context& current_context(const uint32_t line, const uint32_t indent) {
+        if FK_YAML_UNLIKELY (m_context_stack.empty()) {
+            throw parse_error("No parent context is found.", line, indent);
+        }
+        return m_context_stack.back();
     }
 
     /// @brief Pops parent contexts to a block mapping with the given indentation.

--- a/single_include/fkYAML/node.hpp
+++ b/single_include/fkYAML/node.hpp
@@ -8055,8 +8055,9 @@ private:
 
                 basic_node_type key_node = std::move(*m_context_stack.back().p_node);
                 m_context_stack.pop_back();
-                m_context_stack.back().p_node->as_map().emplace(key_node, basic_node_type());
-                mp_current_node = &(m_context_stack.back().p_node->operator[](std::move(key_node)));
+                basic_node_type* p_parent_node = current_context(line, indent).p_node;
+                p_parent_node->as_map().emplace(key_node, basic_node_type());
+                mp_current_node = &(p_parent_node->operator[](std::move(key_node)));
                 m_context_stack.emplace_back(
                     old_line, old_indent, context_state_t::BLOCK_MAPPING_EXPLICIT_VALUE, mp_current_node);
 
@@ -8162,7 +8163,7 @@ private:
 
                 ++m_flow_context_depth;
 
-                switch (m_context_stack.back().state) {
+                switch (current_context(line, indent).state) {
                 case context_state_t::BLOCK_SEQUENCE:
                 case context_state_t::FLOW_SEQUENCE:
                     mp_current_node->as_seq().emplace_back(basic_node_type::sequence());
@@ -8277,7 +8278,7 @@ private:
 
                 ++m_flow_context_depth;
 
-                switch (m_context_stack.back().state) {
+                switch (current_context(line, indent).state) {
                 case context_state_t::BLOCK_SEQUENCE:
                 case context_state_t::FLOW_SEQUENCE:
                     mp_current_node->as_seq().emplace_back(basic_node_type::mapping());
@@ -8587,7 +8588,7 @@ private:
         }
 
         mp_current_node = &(itr.first->second);
-        const parse_context& key_context = m_context_stack.back();
+        const parse_context& key_context = current_context(line, indent);
         m_context_stack.emplace_back(
             key_context.line, key_context.indent, context_state_t::MAPPING_VALUE, mp_current_node);
     }
@@ -8622,7 +8623,7 @@ private:
 
         if FK_YAML_LIKELY (m_context_stack.back().state != context_state_t::BLOCK_MAPPING_EXPLICIT_KEY) {
             m_context_stack.pop_back();
-            mp_current_node = m_context_stack.back().p_node;
+            mp_current_node = current_context(line, indent).p_node;
 
             if (m_flow_context_depth > 0) {
                 m_flow_token_state = flow_token_state_t::NEEDS_SEPARATOR_OR_SUFFIX;
@@ -8745,6 +8746,21 @@ private:
 
         indent = lexer.get_last_token_begin_pos();
         line = lexer.get_lines_processed();
+    }
+
+    /// @brief Returns the parse context on the top of the context stack.
+    /// @note
+    /// Accessing an empty context stack is undefined behavior. Malformed input can empty the stack in the middle of
+    /// deserialization, so the emptiness must be checked before the access. This function throws a parse_error for
+    /// such input instead of letting the callers dereference an invalid iterator.
+    /// @param line The current line count.
+    /// @param indent The current indentation width.
+    /// @return The parse context on the top of the context stack.
+    parse_context& current_context(const uint32_t line, const uint32_t indent) {
+        if FK_YAML_UNLIKELY (m_context_stack.empty()) {
+            throw parse_error("No parent context is found.", line, indent);
+        }
+        return m_context_stack.back();
     }
 
     /// @brief Pops parent contexts to a block mapping with the given indentation.

--- a/tests/unit_test/test_fuzz_regression.cpp
+++ b/tests/unit_test/test_fuzz_regression.cpp
@@ -153,4 +153,22 @@ TEST_CASE("FuzzRegression") {
         p_end = input + sizeof(input) - 1;
         REQUIRE_THROWS_AS(root = fkyaml::node::deserialize(p_begin, p_end), fkyaml::parse_error);
     }
+
+    SUBCASE("flow mapping beginning without a parent context") {
+        // The third "{" is processed in the default branch of the flow mapping beginning handler, which
+        // increments the flow context depth without pushing a parse context. The following "}"s then pop
+        // the context stack empty while the depth is still positive, so the last "{" is processed with no
+        // parent context left.
+        const char input[] = "{{{}},{";
+        p_begin = input;
+        p_end = input + sizeof(input) - 1;
+        REQUIRE_THROWS_AS(root = fkyaml::node::deserialize(p_begin, p_end), fkyaml::parse_error);
+    }
+
+    SUBCASE("flow sequence beginning without a parent context") {
+        const char input[] = "{{{}},[";
+        p_begin = input;
+        p_end = input + sizeof(input) - 1;
+        REQUIRE_THROWS_AS(root = fkyaml::node::deserialize(p_begin, p_end), fkyaml::parse_error);
+    }
 }


### PR DESCRIPTION
Follow-up to #536, and the accessor cleanup @fktn-k asked for [here](https://github.com/fktn-k/fkYAML/issues/536#issuecomment-5255927271). Sorry it took me a while to get to it.

`basic_deserializer` reads `m_context_stack.back()` in a number of places where the stack has not
been proven non-empty at that point. `std::deque::back()` on an empty deque is undefined behavior,
so this is the same class as the crashes fixed by #540 / #543 / #544, just at the remaining sites.

## The reachable case
Both flow-begin handlers dereference the stack without a check whenever `m_flow_context_depth > 0`,
the existing empty-stack guard only runs on the `m_flow_context_depth == 0` path. Two 7-byte
inputs reach it:

```cpp
fkyaml::node::deserialize(std::string("{{{}},{"));   // 7B 7B 7B 7D 7D 2C 7B
fkyaml::node::deserialize(std::string("{{{}},["));   // 7B 7B 7B 7D 7D 2C 5B
```

The mechanism is an imbalance between the flow depth counter and the context stack. The `default:`
branch of the flow-begin handlers increments `m_flow_context_depth` but does **not** push a parse
context - it rewrites the existing one. The matching flow endings then pop one context each, so the
stack empties while the depth is still positive, and the next `{` or `[` lands on `back()` with
nothing left:

```
{        push FLOW_MAPPING          depth 1, stack 1
 {       push FLOW_MAPPING_KEY      depth 2, stack 2
  {      default: no push           depth 3, stack 2   <-- imbalance
   }     pop                        depth 2, stack 1
    }    pop                        depth 1, stack 0
     ,{  back() on an empty stack   depth 1, stack 0   <-- boom
```

This is not debug-only: built with `-DNDEBUG -O2` both inputs crash (verified with MSVC STL
hardening, which reports `back() called on empty deque` and traps).

## The change
A single checked accessor, and the unguarded reads routed through it:

```cpp
parse_context& current_context(const uint32_t line, const uint32_t indent) {
    if FK_YAML_UNLIKELY (m_context_stack.empty()) {
        throw parse_error("No parent context is found.", line, indent);
    }
    return m_context_stack.back();
}
```

Five call sites: both flow-begin handlers, the explicit-key path of `KEY_SEPARATOR` after its
`pop_back()`, `add_new_key()`, and `assign_node_value()` after its `pop_back()`.

I deliberately did **not** convert every `m_context_stack.back()` in the file. The rest fall into
three groups that are already correct, and routing them through the accessor would only make the
diff bigger and the error messages worse:

- sites that already throw a case-specific `parse_error` a few lines above (their messages are more
  useful than a generic one, and the unit tests assert on them),
- sites that treat an empty stack as a legitimate state and short-circuit on it
  (`m_context_stack.empty() || ...`, `!m_context_stack.empty() && ...`),
- reads immediately after an `emplace_back()`.

To be upfront about it: of the five converted sites, **two have repros** (the flow-begin ones, both
in the tests below). The other three are the reads right after a `pop_back()`, where non-emptiness
simply is not established by anything - I have no input that reaches them, so they are hardening
rather than demonstrated bugs.

## Verification

- Two regression cases added to `test_fuzz_regression.cpp`. On current `develop` they do not just
  fail, they abort the test binary with `back() called on empty deque`. On this branch they pass.
- The new `throw` is exercised by both added tests; Coveralls reports the patch fully covered
  (11 of 11 lines) with overall coverage unchanged at 100%.
- To check that the five sites are the whole story, I instrumented **all 40** `m_context_stack.back()`
  reads on `develop` with a probe that throws when the stack is empty (sites that short-circuit on
  `empty()` never reach it, so every report is a genuine empty-stack read) and swept ~45M short
  inputs over three alphabets - `{}[],:?-a` up to 7 bytes, the same plus newline and space up to
  7 bytes, and one including anchors, aliases, tags, a block scalar indicator and a quote up to
  6 bytes. Exactly two distinct sites ever fired, both fixed here. That is evidence over the
  searched space, not a proof, but no other site showed up.

## Not in this PR!

- The `{{{` / `? [` / `? []` leak family (@AlexandrKhromov2005 is taking that one, and it needs the
  ownership rework rather than a guard).
- While sweeping I also hit a bug that is a different invariant (stack state, not emptiness) and
  turned out not to be fuzz-only: mapping entries written with an explicit key are silently dropped
  unless a value follows on the same line. It reproduces on `develop` independently of this change,
  so it is filed separately as #553 with a fix in its own PR.

---

## Pull Request Checklist

Read the [CONTRIBUTING.md](https://github.com/fktn-k/fkYAML/blob/develop/.github/CONTRIBUTING.md) file for detailed information.  

- [x] Changes are described in the pull request or in a referenced [issue](https://github.com/fktn-k/fkYAML/issues).
- [x] The test suite compiles and runs without any error.
- [x] [The code coverage](https://coveralls.io/github/fktn-k/fkYAML) on your branch is 100%.
- [x] The documentation is updated if you added/changed a feature.

## Please don't

- The C++11 support varies between different **compilers** and versions. Please note the [list of supported compilers](https://github.com/fktn-k/fkYAML/blob/develop/README.md#supported-compilers). Some compilers like GCC 4.7 (and earlier), Clang 3.3 (and earlier), or Microsoft Visual Studio 13.0 and earlier are known not to work due to missing or incomplete C++11 support. Please refrain from proposing changes that work around these compiler's limitations with `#ifdef`s or other means.
- Please refrain from proposing changes that would **break [YAML](https://yaml.org/) specifications**. If you propose a conformant extension of YAML to be supported by the library, please motivate this extension.
- Please do not open pull requests that address **multiple issues**.