### PR TITLE
Complete explicit mapping keys which are not followed by a value on the same line

### DIFF
--- a/include/fkYAML/detail/input/deserializer.hpp
+++ b/include/fkYAML/detail/input/deserializer.hpp
@@ -587,19 +587,35 @@ private:
                     }
 
                     if (indent <= m_context_stack.back().indent) {
-                        FK_YAML_ASSERT(m_context_stack.back().state == context_state_t::MAPPING_VALUE);
+                        if (m_context_stack.back().state == context_state_t::BLOCK_MAPPING_EXPLICIT_KEY) {
+                            // An explicit key can omit its value as well, in which case the entry must still be
+                            // added to the parent mapping.
+                            // ```yaml
+                            // ? foo
+                            // :
+                            // bar: baz
+                            // # -> {foo: null, bar: baz}
+                            // ```
+                            basic_node_type key_node = std::move(*m_context_stack.back().p_node);
+                            m_context_stack.pop_back();
+                            m_context_stack.back().p_node->as_map().emplace(std::move(key_node), basic_node_type());
+                            mp_current_node = m_context_stack.back().p_node;
+                        }
+                        else {
+                            FK_YAML_ASSERT(m_context_stack.back().state == context_state_t::MAPPING_VALUE);
 
-                        // Mapping values can be omitted and are considered to be null.
-                        // ```yaml
-                        // foo:
-                        // bar:
-                        //   baz:
-                        // qux:
-                        // # -> {foo: null, bar: {baz: null}, qux: null}
-                        // ```
-                        pop_to_parent_node(line, indent, [indent](const parse_context& c) {
-                            return (c.state == context_state_t::BLOCK_MAPPING) && (indent == c.indent);
-                        });
+                            // Mapping values can be omitted and are considered to be null.
+                            // ```yaml
+                            // foo:
+                            // bar:
+                            //   baz:
+                            // qux:
+                            // # -> {foo: null, bar: {baz: null}, qux: null}
+                            // ```
+                            pop_to_parent_node(line, indent, [indent](const parse_context& c) {
+                                return (c.state == context_state_t::BLOCK_MAPPING) && (indent == c.indent);
+                            });
+                        }
                     }
 
                     // defer checking the existence of a key separator after the following scalar until the next

--- a/include/fkYAML/detail/input/deserializer.hpp
+++ b/include/fkYAML/detail/input/deserializer.hpp
@@ -624,7 +624,15 @@ private:
                         // # -> {foo: null, bar: baz}
                         // ```
                         if (!add_explicit_key_with_null_value()) {
-                            FK_YAML_ASSERT(m_context_stack.back().state == context_state_t::MAPPING_VALUE);
+                            if FK_YAML_UNLIKELY (m_context_stack.back().state != context_state_t::MAPPING_VALUE) {
+                                // The key separator does not follow a mapping key, for example:
+                                // ```yaml
+                                // ? foo
+                                // :
+                                // :
+                                // ```
+                                throw parse_error("A key separator is not allowed in this context.", line, indent);
+                            }
 
                             // Mapping values can be omitted and are considered to be null.
                             // ```yaml

--- a/include/fkYAML/detail/input/deserializer.hpp
+++ b/include/fkYAML/detail/input/deserializer.hpp
@@ -291,6 +291,13 @@ private:
             last_type == lexical_token_t::END_OF_BUFFER || last_type == lexical_token_t::END_OF_DIRECTIVES ||
             last_type == lexical_token_t::END_OF_DOCUMENT);
 
+        // An explicit key at the end of a document has no value either.
+        // ```yaml
+        // ? foo
+        // # -> {foo: null}
+        // ```
+        add_explicit_key_with_null_value();
+
         // reset parameters for the next call.
         mp_current_node = nullptr;
         mp_meta.reset();
@@ -411,6 +418,12 @@ private:
                 if FK_YAML_UNLIKELY (m_context_stack.empty()) {
                     throw parse_error("An explicit key is not allowed in this context.", line, indent);
                 }
+
+                if (indent == m_context_stack.back().indent) {
+                    // The preceding explicit key, if any, has no value at this point.
+                    add_explicit_key_with_null_value();
+                }
+
                 const bool needs_to_move_back = indent == 0 || indent < m_context_stack.back().indent;
                 if (needs_to_move_back) {
                     pop_to_parent_node(line, indent, [indent](const parse_context& c) {
@@ -515,6 +528,21 @@ private:
                 }
 
                 if (line > old_line) {
+                    const bool is_explicit_value_begin =
+                        m_context_stack.back().state == context_state_t::BLOCK_MAPPING_EXPLICIT_KEY &&
+                        (token.type == lexical_token_t::SEQUENCE_BLOCK_PREFIX ||
+                         indent > m_context_stack.back().indent);
+                    if (is_explicit_value_begin) {
+                        // The value of an explicit key can begin on a line after its key separator.
+                        // ```yaml
+                        // ? foo
+                        // :
+                        //   bar
+                        // # -> {foo: bar}
+                        // ```
+                        add_explicit_key_with_empty_value(old_line, old_indent);
+                    }
+
                     if (m_needs_tag_impl) {
                         const tag_t tag_type = tag_resolver_type::resolve_tag(m_tag_name, mp_meta);
                         if (tag_type == tag_t::MAPPING || tag_type == tag_t::CUSTOM_TAG) {
@@ -587,21 +615,15 @@ private:
                     }
 
                     if (indent <= m_context_stack.back().indent) {
-                        if (m_context_stack.back().state == context_state_t::BLOCK_MAPPING_EXPLICIT_KEY) {
-                            // An explicit key can omit its value as well, in which case the entry must still be
-                            // added to the parent mapping.
-                            // ```yaml
-                            // ? foo
-                            // :
-                            // bar: baz
-                            // # -> {foo: null, bar: baz}
-                            // ```
-                            basic_node_type key_node = std::move(*m_context_stack.back().p_node);
-                            m_context_stack.pop_back();
-                            m_context_stack.back().p_node->as_map().emplace(std::move(key_node), basic_node_type());
-                            mp_current_node = m_context_stack.back().p_node;
-                        }
-                        else {
+                        // An explicit key can omit its value as well, in which case the entry must still be
+                        // added to the parent mapping.
+                        // ```yaml
+                        // ? foo
+                        // :
+                        // bar: baz
+                        // # -> {foo: null, bar: baz}
+                        // ```
+                        if (!add_explicit_key_with_null_value()) {
                             FK_YAML_ASSERT(m_context_stack.back().state == context_state_t::MAPPING_VALUE);
 
                             // Mapping values can be omitted and are considered to be null.
@@ -628,13 +650,7 @@ private:
                     throw parse_error("Unexpected explicit mapping key separator is found.", line, indent);
                 }
 
-                basic_node_type key_node = std::move(*m_context_stack.back().p_node);
-                m_context_stack.pop_back();
-                basic_node_type* p_parent_node = current_context(line, indent).p_node;
-                p_parent_node->as_map().emplace(key_node, basic_node_type());
-                mp_current_node = &(p_parent_node->operator[](std::move(key_node)));
-                m_context_stack.emplace_back(
-                    old_line, old_indent, context_state_t::BLOCK_MAPPING_EXPLICIT_VALUE, mp_current_node);
+                add_explicit_key_with_empty_value(old_line, old_indent);
 
                 if (token.type == lexical_token_t::SEQUENCE_BLOCK_PREFIX) {
                     *mp_current_node = basic_node_type::sequence({basic_node_type()});
@@ -1256,6 +1272,22 @@ private:
                     parse_context& cur_context = m_context_stack.back();
                     switch (cur_context.state) {
                     case context_state_t::BLOCK_MAPPING_EXPLICIT_KEY:
+                        if (cur_context.indent == indent) {
+                            // A mapping entry which follows an explicit key without its value, for example:
+                            // ```yaml
+                            // ? foo
+                            // bar: 123
+                            // # -> {foo: null, bar: 123}
+                            // ```
+                            add_explicit_key_with_null_value();
+                            add_new_key(std::move(node), line, indent);
+                            indent = lexer.get_last_token_begin_pos();
+                            line = lexer.get_lines_processed();
+                            return;
+                        }
+
+                        m_context_stack.emplace_back(line, indent, context_state_t::BLOCK_MAPPING, mp_current_node);
+                        break;
                     case context_state_t::BLOCK_MAPPING_EXPLICIT_VALUE:
                         m_context_stack.emplace_back(line, indent, context_state_t::BLOCK_MAPPING, mp_current_node);
                         break;
@@ -1336,6 +1368,45 @@ private:
             throw parse_error("No parent context is found.", line, indent);
         }
         return m_context_stack.back();
+    }
+
+    /// @brief Adds an entry for an explicit key and makes its value node the current node.
+    /// @note The current context must be the context of the explicit key.
+    /// @param line The line where the value of the explicit key begins.
+    /// @param indent The indentation width where the value of the explicit key begins.
+    void add_explicit_key_with_empty_value(const uint32_t line, const uint32_t indent) {
+        FK_YAML_ASSERT(m_context_stack.back().state == context_state_t::BLOCK_MAPPING_EXPLICIT_KEY);
+
+        basic_node_type key_node = std::move(*m_context_stack.back().p_node);
+        m_context_stack.pop_back();
+        basic_node_type* p_parent_node = current_context(line, indent).p_node;
+        p_parent_node->as_map().emplace(key_node, basic_node_type());
+        mp_current_node = &(p_parent_node->operator[](std::move(key_node)));
+        m_context_stack.emplace_back(line, indent, context_state_t::BLOCK_MAPPING_EXPLICIT_VALUE, mp_current_node);
+    }
+
+    /// @brief Adds an entry with a null value for an explicit key which is not followed by its value.
+    /// @note
+    /// An explicit key is kept in its own context until its value is found. If no value follows the key, the
+    /// entry must still be added to the parent mapping since an omitted value is a null value.
+    /// ```yaml
+    /// ? foo
+    /// ? bar
+    /// # -> {foo: null, bar: null}
+    /// ```
+    /// @return true if an entry has been added, false if the current context is not an explicit key.
+    bool add_explicit_key_with_null_value() {
+        const bool is_explicit_key =
+            m_context_stack.size() > 1 && m_context_stack.back().state == context_state_t::BLOCK_MAPPING_EXPLICIT_KEY;
+        if (!is_explicit_key) {
+            return false;
+        }
+
+        basic_node_type key_node = std::move(*m_context_stack.back().p_node);
+        m_context_stack.pop_back();
+        m_context_stack.back().p_node->as_map().emplace(std::move(key_node), basic_node_type());
+        mp_current_node = m_context_stack.back().p_node;
+        return true;
     }
 
     /// @brief Pops parent contexts to a block mapping with the given indentation.

--- a/single_include/fkYAML/node.hpp
+++ b/single_include/fkYAML/node.hpp
@@ -8028,19 +8028,35 @@ private:
                     }
 
                     if (indent <= m_context_stack.back().indent) {
-                        FK_YAML_ASSERT(m_context_stack.back().state == context_state_t::MAPPING_VALUE);
+                        if (m_context_stack.back().state == context_state_t::BLOCK_MAPPING_EXPLICIT_KEY) {
+                            // An explicit key can omit its value as well, in which case the entry must still be
+                            // added to the parent mapping.
+                            // ```yaml
+                            // ? foo
+                            // :
+                            // bar: baz
+                            // # -> {foo: null, bar: baz}
+                            // ```
+                            basic_node_type key_node = std::move(*m_context_stack.back().p_node);
+                            m_context_stack.pop_back();
+                            m_context_stack.back().p_node->as_map().emplace(std::move(key_node), basic_node_type());
+                            mp_current_node = m_context_stack.back().p_node;
+                        }
+                        else {
+                            FK_YAML_ASSERT(m_context_stack.back().state == context_state_t::MAPPING_VALUE);
 
-                        // Mapping values can be omitted and are considered to be null.
-                        // ```yaml
-                        // foo:
-                        // bar:
-                        //   baz:
-                        // qux:
-                        // # -> {foo: null, bar: {baz: null}, qux: null}
-                        // ```
-                        pop_to_parent_node(line, indent, [indent](const parse_context& c) {
-                            return (c.state == context_state_t::BLOCK_MAPPING) && (indent == c.indent);
-                        });
+                            // Mapping values can be omitted and are considered to be null.
+                            // ```yaml
+                            // foo:
+                            // bar:
+                            //   baz:
+                            // qux:
+                            // # -> {foo: null, bar: {baz: null}, qux: null}
+                            // ```
+                            pop_to_parent_node(line, indent, [indent](const parse_context& c) {
+                                return (c.state == context_state_t::BLOCK_MAPPING) && (indent == c.indent);
+                            });
+                        }
                     }
 
                     // defer checking the existence of a key separator after the following scalar until the next

--- a/single_include/fkYAML/node.hpp
+++ b/single_include/fkYAML/node.hpp
@@ -8065,7 +8065,15 @@ private:
                         // # -> {foo: null, bar: baz}
                         // ```
                         if (!add_explicit_key_with_null_value()) {
-                            FK_YAML_ASSERT(m_context_stack.back().state == context_state_t::MAPPING_VALUE);
+                            if FK_YAML_UNLIKELY (m_context_stack.back().state != context_state_t::MAPPING_VALUE) {
+                                // The key separator does not follow a mapping key, for example:
+                                // ```yaml
+                                // ? foo
+                                // :
+                                // :
+                                // ```
+                                throw parse_error("A key separator is not allowed in this context.", line, indent);
+                            }
 
                             // Mapping values can be omitted and are considered to be null.
                             // ```yaml

--- a/single_include/fkYAML/node.hpp
+++ b/single_include/fkYAML/node.hpp
@@ -7732,6 +7732,13 @@ private:
             last_type == lexical_token_t::END_OF_BUFFER || last_type == lexical_token_t::END_OF_DIRECTIVES ||
             last_type == lexical_token_t::END_OF_DOCUMENT);
 
+        // An explicit key at the end of a document has no value either.
+        // ```yaml
+        // ? foo
+        // # -> {foo: null}
+        // ```
+        add_explicit_key_with_null_value();
+
         // reset parameters for the next call.
         mp_current_node = nullptr;
         mp_meta.reset();
@@ -7852,6 +7859,12 @@ private:
                 if FK_YAML_UNLIKELY (m_context_stack.empty()) {
                     throw parse_error("An explicit key is not allowed in this context.", line, indent);
                 }
+
+                if (indent == m_context_stack.back().indent) {
+                    // The preceding explicit key, if any, has no value at this point.
+                    add_explicit_key_with_null_value();
+                }
+
                 const bool needs_to_move_back = indent == 0 || indent < m_context_stack.back().indent;
                 if (needs_to_move_back) {
                     pop_to_parent_node(line, indent, [indent](const parse_context& c) {
@@ -7956,6 +7969,21 @@ private:
                 }
 
                 if (line > old_line) {
+                    const bool is_explicit_value_begin =
+                        m_context_stack.back().state == context_state_t::BLOCK_MAPPING_EXPLICIT_KEY &&
+                        (token.type == lexical_token_t::SEQUENCE_BLOCK_PREFIX ||
+                         indent > m_context_stack.back().indent);
+                    if (is_explicit_value_begin) {
+                        // The value of an explicit key can begin on a line after its key separator.
+                        // ```yaml
+                        // ? foo
+                        // :
+                        //   bar
+                        // # -> {foo: bar}
+                        // ```
+                        add_explicit_key_with_empty_value(old_line, old_indent);
+                    }
+
                     if (m_needs_tag_impl) {
                         const tag_t tag_type = tag_resolver_type::resolve_tag(m_tag_name, mp_meta);
                         if (tag_type == tag_t::MAPPING || tag_type == tag_t::CUSTOM_TAG) {
@@ -8028,21 +8056,15 @@ private:
                     }
 
                     if (indent <= m_context_stack.back().indent) {
-                        if (m_context_stack.back().state == context_state_t::BLOCK_MAPPING_EXPLICIT_KEY) {
-                            // An explicit key can omit its value as well, in which case the entry must still be
-                            // added to the parent mapping.
-                            // ```yaml
-                            // ? foo
-                            // :
-                            // bar: baz
-                            // # -> {foo: null, bar: baz}
-                            // ```
-                            basic_node_type key_node = std::move(*m_context_stack.back().p_node);
-                            m_context_stack.pop_back();
-                            m_context_stack.back().p_node->as_map().emplace(std::move(key_node), basic_node_type());
-                            mp_current_node = m_context_stack.back().p_node;
-                        }
-                        else {
+                        // An explicit key can omit its value as well, in which case the entry must still be
+                        // added to the parent mapping.
+                        // ```yaml
+                        // ? foo
+                        // :
+                        // bar: baz
+                        // # -> {foo: null, bar: baz}
+                        // ```
+                        if (!add_explicit_key_with_null_value()) {
                             FK_YAML_ASSERT(m_context_stack.back().state == context_state_t::MAPPING_VALUE);
 
                             // Mapping values can be omitted and are considered to be null.
@@ -8069,13 +8091,7 @@ private:
                     throw parse_error("Unexpected explicit mapping key separator is found.", line, indent);
                 }
 
-                basic_node_type key_node = std::move(*m_context_stack.back().p_node);
-                m_context_stack.pop_back();
-                basic_node_type* p_parent_node = current_context(line, indent).p_node;
-                p_parent_node->as_map().emplace(key_node, basic_node_type());
-                mp_current_node = &(p_parent_node->operator[](std::move(key_node)));
-                m_context_stack.emplace_back(
-                    old_line, old_indent, context_state_t::BLOCK_MAPPING_EXPLICIT_VALUE, mp_current_node);
+                add_explicit_key_with_empty_value(old_line, old_indent);
 
                 if (token.type == lexical_token_t::SEQUENCE_BLOCK_PREFIX) {
                     *mp_current_node = basic_node_type::sequence({basic_node_type()});
@@ -8697,6 +8713,22 @@ private:
                     parse_context& cur_context = m_context_stack.back();
                     switch (cur_context.state) {
                     case context_state_t::BLOCK_MAPPING_EXPLICIT_KEY:
+                        if (cur_context.indent == indent) {
+                            // A mapping entry which follows an explicit key without its value, for example:
+                            // ```yaml
+                            // ? foo
+                            // bar: 123
+                            // # -> {foo: null, bar: 123}
+                            // ```
+                            add_explicit_key_with_null_value();
+                            add_new_key(std::move(node), line, indent);
+                            indent = lexer.get_last_token_begin_pos();
+                            line = lexer.get_lines_processed();
+                            return;
+                        }
+
+                        m_context_stack.emplace_back(line, indent, context_state_t::BLOCK_MAPPING, mp_current_node);
+                        break;
                     case context_state_t::BLOCK_MAPPING_EXPLICIT_VALUE:
                         m_context_stack.emplace_back(line, indent, context_state_t::BLOCK_MAPPING, mp_current_node);
                         break;
@@ -8777,6 +8809,45 @@ private:
             throw parse_error("No parent context is found.", line, indent);
         }
         return m_context_stack.back();
+    }
+
+    /// @brief Adds an entry for an explicit key and makes its value node the current node.
+    /// @note The current context must be the context of the explicit key.
+    /// @param line The line where the value of the explicit key begins.
+    /// @param indent The indentation width where the value of the explicit key begins.
+    void add_explicit_key_with_empty_value(const uint32_t line, const uint32_t indent) {
+        FK_YAML_ASSERT(m_context_stack.back().state == context_state_t::BLOCK_MAPPING_EXPLICIT_KEY);
+
+        basic_node_type key_node = std::move(*m_context_stack.back().p_node);
+        m_context_stack.pop_back();
+        basic_node_type* p_parent_node = current_context(line, indent).p_node;
+        p_parent_node->as_map().emplace(key_node, basic_node_type());
+        mp_current_node = &(p_parent_node->operator[](std::move(key_node)));
+        m_context_stack.emplace_back(line, indent, context_state_t::BLOCK_MAPPING_EXPLICIT_VALUE, mp_current_node);
+    }
+
+    /// @brief Adds an entry with a null value for an explicit key which is not followed by its value.
+    /// @note
+    /// An explicit key is kept in its own context until its value is found. If no value follows the key, the
+    /// entry must still be added to the parent mapping since an omitted value is a null value.
+    /// ```yaml
+    /// ? foo
+    /// ? bar
+    /// # -> {foo: null, bar: null}
+    /// ```
+    /// @return true if an entry has been added, false if the current context is not an explicit key.
+    bool add_explicit_key_with_null_value() {
+        const bool is_explicit_key =
+            m_context_stack.size() > 1 && m_context_stack.back().state == context_state_t::BLOCK_MAPPING_EXPLICIT_KEY;
+        if (!is_explicit_key) {
+            return false;
+        }
+
+        basic_node_type key_node = std::move(*m_context_stack.back().p_node);
+        m_context_stack.pop_back();
+        m_context_stack.back().p_node->as_map().emplace(std::move(key_node), basic_node_type());
+        mp_current_node = m_context_stack.back().p_node;
+        return true;
     }
 
     /// @brief Pops parent contexts to a block mapping with the given indentation.

--- a/tests/unit_test/test_deserializer_class.cpp
+++ b/tests/unit_test/test_deserializer_class.cpp
@@ -63,6 +63,24 @@ TEST_CASE("Deserializer_KeySeparator") {
 
         REQUIRE(thrown);
     }
+
+    SUBCASE("key separator which does not follow a mapping key") {
+        const std::string input_str = "? foo\n"
+                                      ":\n"
+                                      ":\n";
+
+        bool thrown = false;
+        try {
+            root = deserializer.deserialize(fkyaml::detail::input_adapter(input_str));
+        }
+        catch (const fkyaml::parse_error& e) {
+            thrown = true;
+            const std::string msg(e.what());
+            REQUIRE(msg.find("A key separator is not allowed in this context.") != std::string::npos);
+        }
+
+        REQUIRE(thrown);
+    }
 }
 
 TEST_CASE("Deserializer_ValueSeparator") {

--- a/tests/unit_test/test_deserializer_class.cpp
+++ b/tests/unit_test/test_deserializer_class.cpp
@@ -1680,6 +1680,34 @@ TEST_CASE("Deserializer_ExplicitBlockMapping") {
         REQUIRE(key2_1_node.as_str() == "qux");
     }
 
+    SUBCASE("explicit mapping keys with omitted values") {
+        std::string input = "? foo\n"
+                            ":\n"
+                            "bar: baz\n"
+                            "qux:\n"
+                            "  ? corge\n"
+                            "  :\n";
+        REQUIRE_NOTHROW(root = deserializer.deserialize(fkyaml::detail::input_adapter(input)));
+
+        REQUIRE(root.is_mapping());
+        REQUIRE(root.size() == 3);
+
+        REQUIRE(root.contains("foo"));
+        REQUIRE(root["foo"].is_null());
+
+        REQUIRE(root.contains("bar"));
+        fkyaml::node& bar_node = root["bar"];
+        REQUIRE(bar_node.is_string());
+        REQUIRE(bar_node.as_str() == "baz");
+
+        REQUIRE(root.contains("qux"));
+        fkyaml::node& qux_node = root["qux"];
+        REQUIRE(qux_node.is_mapping());
+        REQUIRE(qux_node.size() == 1);
+        REQUIRE(qux_node.contains("corge"));
+        REQUIRE(qux_node["corge"].is_null());
+    }
+
     SUBCASE("Explicit block mapping as block sequence entry") {
         std::string input = "- ? foo: 123\n"
                             "  : true: 3.14\n"

--- a/tests/unit_test/test_deserializer_class.cpp
+++ b/tests/unit_test/test_deserializer_class.cpp
@@ -1708,6 +1708,80 @@ TEST_CASE("Deserializer_ExplicitBlockMapping") {
         REQUIRE(qux_node["corge"].is_null());
     }
 
+    SUBCASE("explicit mapping keys without values") {
+        std::string input = "? foo\n"
+                            "? bar\n"
+                            "baz: 123\n"
+                            "qux:\n"
+                            "  ? corge\n";
+        REQUIRE_NOTHROW(root = deserializer.deserialize(fkyaml::detail::input_adapter(input)));
+
+        REQUIRE(root.is_mapping());
+        REQUIRE(root.size() == 4);
+
+        REQUIRE(root.contains("foo"));
+        REQUIRE(root["foo"].is_null());
+
+        REQUIRE(root.contains("bar"));
+        REQUIRE(root["bar"].is_null());
+
+        REQUIRE(root.contains("baz"));
+        fkyaml::node& baz_node = root["baz"];
+        REQUIRE(baz_node.is_integer());
+        REQUIRE(baz_node.get_value<int>() == 123);
+
+        REQUIRE(root.contains("qux"));
+        fkyaml::node& qux_node = root["qux"];
+        REQUIRE(qux_node.is_mapping());
+        REQUIRE(qux_node.size() == 1);
+        REQUIRE(qux_node.contains("corge"));
+        REQUIRE(qux_node["corge"].is_null());
+    }
+
+    SUBCASE("explicit mapping keys whose values begin on the following lines") {
+        std::string input = "? foo\n"
+                            ":\n"
+                            "  bar\n"
+                            "? baz\n"
+                            ":\n"
+                            "  - 123\n"
+                            "? qux\n"
+                            ":\n"
+                            "- 456\n"
+                            "? corge\n"
+                            ":\n"
+                            "  ? grault\n"
+                            "  :\n";
+        REQUIRE_NOTHROW(root = deserializer.deserialize(fkyaml::detail::input_adapter(input)));
+
+        REQUIRE(root.is_mapping());
+        REQUIRE(root.size() == 4);
+
+        REQUIRE(root.contains("foo"));
+        fkyaml::node& foo_node = root["foo"];
+        REQUIRE(foo_node.is_string());
+        REQUIRE(foo_node.as_str() == "bar");
+
+        REQUIRE(root.contains("baz"));
+        fkyaml::node& baz_node = root["baz"];
+        REQUIRE(baz_node.is_sequence());
+        REQUIRE(baz_node.size() == 1);
+        REQUIRE(baz_node[0].get_value<int>() == 123);
+
+        REQUIRE(root.contains("qux"));
+        fkyaml::node& qux_node = root["qux"];
+        REQUIRE(qux_node.is_sequence());
+        REQUIRE(qux_node.size() == 1);
+        REQUIRE(qux_node[0].get_value<int>() == 456);
+
+        REQUIRE(root.contains("corge"));
+        fkyaml::node& corge_node = root["corge"];
+        REQUIRE(corge_node.is_mapping());
+        REQUIRE(corge_node.size() == 1);
+        REQUIRE(corge_node.contains("grault"));
+        REQUIRE(corge_node["grault"].is_null());
+    }
+
     SUBCASE("Explicit block mapping as block sequence entry") {
         std::string input = "- ? foo: 123\n"
                             "  : true: 3.14\n"


### PR DESCRIPTION
Fixes #553.

`basic_deserializer` keeps an explicit key (`? key`) in its own parse context until its value is
found, and only a `: value` on the same line ever completed the entry. Every other way of writing
the entry discarded the pending key node without an error, so the entry silently disappeared from
the result:

```yaml
? foo
? bar
baz: 123
# -> {baz: 123}, expected {foo: null, bar: null, baz: 123}

? qux
:
  corge
# -> {}, expected {qux: corge}
```

Two of these inputs also tripped `FK_YAML_ASSERT(m_context_stack.back().state == context_state_t::MAPPING_VALUE)`
in a debug build, since that branch assumed an omitted value can only happen for an implicit key.
With the entries completed properly they no longer reach that assertion.

## The change

There are two ways a pending explicit key entry gets completed, so this adds a helper for each and
calls them where the key used to be discarded:

- `add_explicit_key_with_null_value()` for a key with no value at all: at the end of a document,
  before another explicit key at the same indentation, before a mapping entry with an implicit key
  at the same indentation, and in the omitted-value branch of the key separator handling.
- `add_explicit_key_with_empty_value()` for a key whose value begins on a following line, which
  then parses into the value node as usual. The same-line path was already doing this inline, so it
  now shares the helper. Rebased onto the merged #552, it reads the parent context through
  `current_context()` so the empty-stack guard added there still applies after the key context is
  popped.

The third commit replaces the assertion in that same branch with a `parse_error`. It asserted that
the context reaching the omitted-value path is a mapping value context, which malformed input like
`? foo` / `:` / `:` violates: it aborts a debug build and, under `NDEBUG`, parses on from the
unexpected state. The only other contexts that reach it are `BLOCK_MAPPING` and
`BLOCK_MAPPING_EXPLICIT_VALUE`, and every document doing so in the corpus below is one PyYAML
rejects as malformed, so no valid document changes behavior.

Note that this error is consistent with how empty keys are handled today (`: a` / `: b` is already
rejected). If empty keys become supported the way you describe in #553, that input becomes valid
(`{foo: null, null: null}`) and this error will need revisiting. I would rather flag it now than
have it look like an oversight later.

## Verification

- The unit test suite passes: 371 test cases, 9525 assertions, with 4 new subcases in
  `test_deserializer_class.cpp` covering keys with omitted values, keys with no key separator at
  all, keys whose values begin on the following lines (scalar, block sequence at both
  indentations, nested explicit key), and the malformed key separator above.
- I also ran a differential test against PyYAML 6.0.3 over 16093 generated documents built from
  explicit-key line patterns, compared structurally: fkYAML's output is loaded back with PyYAML and
  checked against PyYAML's parse of the same input. Against `develop`, **1023 documents that were
  parsed incorrectly are now correct**, and nothing regressed except the class below.

## One behavior change worth pointing out 🤔

30 documents in that corpus now raise `parse_error: Detected duplication in mapping keys` where
they used to parse "successfully". These are documents where the same key appears twice, e.g.

```yaml
? foo
:
foo: 123
```

The explicit entry used to be dropped, so the duplicate never became visible; now both entries
reach the mapping and the duplicate is reported. That matches how fkYAML already treats
`foo: 1` / `foo: 2`, so I believe it is the correct outcome, but it is a visible change for anyone
whose input contains such a duplicate.

## Not in this PR!

Following your answer in #553 about empty keys, `"? :\n"` should end up as `{{null: null}: null}`
and `":\n"` as `{null: null}`. This PR moves `"? :\n"` from `{}` to `{null: null}`, which is closer
but not that, and it leaves `":\n"` as `{"": null}`, an empty **string** key, which is what fkYAML
does today and what an existing unit test asserts.

Getting to the behavior you described means supporting empty keys across block and flow, which is
currently missing in more places than this one: `: a` / `: b`, `{ : }` and `{ ? foo :, : bar }`
(spec example 7.3) are all rejected, and `[ : empty key ]` drops the key. That is a separate change
which also flips documented behavior (`""` to `null`), so I would rather do it in its own PR
against its own issue than widen this one. I did not lock `"? :\n"` into a test here, so nothing in
this PR stands in the way of that.

---

## Pull Request Checklist

Read the [CONTRIBUTING.md](https://github.com/fktn-k/fkYAML/blob/develop/.github/CONTRIBUTING.md) file for detailed information.  

- [x] Changes are described in the pull request or in a referenced [issue](https://github.com/fktn-k/fkYAML/issues).
- [x] The test suite compiles and runs without any error.
- [x] [The code coverage](https://coveralls.io/github/fktn-k/fkYAML) on your branch is 100%.
- [x] The documentation is updated if you added/changed a feature.

## Please don't

- The C++11 support varies between different **compilers** and versions. Please note the [list of supported compilers](https://github.com/fktn-k/fkYAML/blob/develop/README.md#supported-compilers). Some compilers like GCC 4.7 (and earlier), Clang 3.3 (and earlier), or Microsoft Visual Studio 13.0 and earlier are known not to work due to missing or incomplete C++11 support. Please refrain from proposing changes that work around these compiler's limitations with `#ifdef`s or other means.
- Please refrain from proposing changes that would **break [YAML](https://yaml.org/) specifications**. If you propose a conformant extension of YAML to be supported by the library, please motivate this extension.
- Please do not open pull requests that address **multiple issues**.
