### PR TITLE
Fix comment posting failures to the PRs from forks

### DIFF
--- a/.github/workflows/coverage.yml
+++ b/.github/workflows/coverage.yml
@@ -25,13 +25,12 @@ jobs:
     runs-on: ubuntu-24.04
     permissions:
       contents: read
-      pull-requests: write
 
     steps:
     - uses: actions/checkout@v7
       with:
-        repository: ${{github.event.pull_request.head.repo.full_name}}
-        ref: ${{github.event.pull_request.head.sha}}
+        repository: ${{github.event.pull_request.head.repo.full_name || github.repository}}
+        ref: ${{github.event.pull_request.head.sha || github.sha}}
         persist-credentials: false
 
     - name: Install lcov
@@ -69,17 +68,3 @@ jobs:
           ${{github.workspace}}/build_coverage/html/**
         overwrite: true
 
-    - name: Notify the artifact URL
-      if: github.event_name == 'pull_request' && steps.upload_artifact_step.conclusion == 'success'
-      uses: thollander/actions-comment-pull-request@v3
-      with:
-        message: |
-          ## :octocat: Upload Coverage Event Notification
-          Coverage data has been uploaded for the commit [${{github.event.pull_request.head.sha}}](https://github.com/${{github.repository}}/commit/${{github.event.pull_request.head.sha}}).
-          You can download the artifact which contains the same file uploaded to the Coveralls and its HTML version.
-
-          | Name | ${{steps.create_zip.outputs.artifact_name}}.zip      |
-          |:-----|:-----------------------------------------------------|
-          | ID   | ${{steps.upload_artifact_step.outputs.artifact-id}}  |
-          | URL  | ${{steps.upload_artifact_step.outputs.artifact-url}} |
-        comment-tag: coverage_notification

--- a/.github/workflows/coverage_notify.yml
+++ b/.github/workflows/coverage_notify.yml
@@ -1,0 +1,75 @@
+name: Coverage Notification
+
+on:
+  workflow_run:
+    workflows:
+      - Coverage
+    types:
+      - completed
+
+jobs:
+  notify:
+    if: github.event.workflow_run.conclusion == 'success' && github.event.workflow_run.event == 'pull_request'
+    runs-on: ubuntu-24.04
+    permissions:
+      actions: read
+      contents: read
+      issues: write
+      pull-requests: write
+
+    steps:
+    - name: Resolve PR and artifact metadata
+      id: resolve
+      env:
+        GITHUB_TOKEN: ${{secrets.GITHUB_TOKEN}}
+        REPOSITORY: ${{github.repository}}
+        RUN_ID: ${{github.event.workflow_run.id}}
+      run: |
+        set -eu
+
+        PR_NUMBER=$(jq -r '.workflow_run.pull_requests[0].number // empty' "$GITHUB_EVENT_PATH")
+
+        if [[ -z "${PR_NUMBER}" ]]; then
+          echo "found=false" >> "$GITHUB_OUTPUT"
+          exit 0
+        fi
+
+        echo "pr_number=${PR_NUMBER}" >> "$GITHUB_OUTPUT"
+
+        api_url="https://api.github.com/repos/${REPOSITORY}/actions/runs/${RUN_ID}/artifacts"
+        artifact_json=$(curl -fsSL \
+          -H "Authorization: Bearer ${GITHUB_TOKEN}" \
+          -H "Accept: application/vnd.github+json" \
+          "$api_url")
+
+        artifact_name=$(printf '%s' "$artifact_json" | jq -r --arg prefix "fkYAML_coverage.pr${PR_NUMBER}" '.artifacts[] | select(.name | startswith($prefix)) | .name' | head -n1)
+        artifact_id=$(printf '%s' "$artifact_json" | jq -r --arg prefix "fkYAML_coverage.pr${PR_NUMBER}" '.artifacts[] | select(.name | startswith($prefix)) | .id' | head -n1)
+
+        if [[ -z "${artifact_name}" || -z "${artifact_id}" || "${artifact_name}" == "null" || "${artifact_id}" == "null" ]]; then
+          echo "found=false" >> "$GITHUB_OUTPUT"
+          exit 0
+        fi
+
+        artifact_url="https://github.com/${REPOSITORY}/actions/runs/${RUN_ID}/artifacts/${artifact_id}"
+
+        echo "artifact_name=${artifact_name}" >> "$GITHUB_OUTPUT"
+        echo "artifact_id=${artifact_id}" >> "$GITHUB_OUTPUT"
+        echo "artifact_url=${artifact_url}" >> "$GITHUB_OUTPUT"
+        echo "found=true" >> "$GITHUB_OUTPUT"
+
+    - name: Notify the artifact URL
+      if: steps.resolve.outputs.found == 'true'
+      uses: thollander/actions-comment-pull-request@v3
+      with:
+        pr-number: ${{steps.resolve.outputs.pr_number}}
+        comment-tag: coverage_notification
+        mode: upsert
+        message: |
+          ## :octocat: Upload Coverage Event Notification
+          Coverage data has been uploaded for the commit [${{github.event.workflow_run.head_sha}}](https://github.com/${{github.repository}}/commit/${{github.event.workflow_run.head_sha}}).
+          You can download the artifact which contains the same file uploaded to Coveralls and its HTML version.
+
+          | Name | ${{steps.resolve.outputs.artifact_name}}.zip |
+          |:-----|:---------------------------------------------|
+          | ID   | ${{steps.resolve.outputs.artifact_id}}       |
+          | URL  | ${{steps.resolve.outputs.artifact_url}}      |

--- a/.github/workflows/format_check.yml
+++ b/.github/workflows/format_check.yml
@@ -37,13 +37,12 @@ jobs:
     runs-on: ubuntu-latest
     permissions:
       contents: read
-      pull-requests: write
 
     steps:
     - uses: actions/checkout@v7
       with:
-        repository: ${{github.event.pull_request.head.repo.full_name}}
-        ref: ${{github.event.pull_request.head.sha}}
+        repository: ${{github.event.pull_request.head.repo.full_name || github.repository}}
+        ref: ${{github.event.pull_request.head.sha || github.sha}}
         persist-credentials: false
 
     - name: Run clang-format style check
@@ -55,7 +54,7 @@ jobs:
     - name: Detect diffs caused by formatting scripts
       id: format_diff
       env:
-        PR_NUMBER: ${{github.event.number}}
+        PR_NUMBER: ${{github.event.number || github.run_number}}
       run: |
         git diff --patch --no-color > ${{github.workspace}}/format_diff_pr${{env.PR_NUMBER}}.patch
         if [ -s ${{github.workspace}}/format_diff_pr${{env.PR_NUMBER}}.patch ]; then
@@ -72,24 +71,9 @@ jobs:
 
     - name: Upload patch
       id: upload_artifact_step
-      if: steps.format_diff.outputs.has_diff == 'true'
+      if: always() && steps.format_diff.outputs.has_diff == 'true'
       uses: actions/upload-artifact@v7
       with:
         name: ${{steps.format_diff.outputs.patch_file_name}}
         path: ${{steps.format_diff.outputs.patch_file_name}}
         overwrite: true
-
-    - name: Notify the artifact URL
-      if: steps.upload_artifact_step.conclusion == 'success'
-      uses: thollander/actions-comment-pull-request@v3
-      with:
-        message: |
-          ## :octocat: Format/Amalgamation Check Failed
-          The source code has not been formatted/amalgamated correctly in the commit [${{github.event.pull_request.head.sha}}](https://github.com/${{github.repository}}/commit/${{github.event.pull_request.head.sha}}).
-          Please download and apply the patch to fix it.
-
-          | Name | ${{steps.format_diff.outputs.patch_file_name}}.zip           |
-          |:-----|:-----------------------------------------------------|
-          | ID   | ${{steps.upload_artifact_step.outputs.artifact-id}}  |
-          | URL  | ${{steps.upload_artifact_step.outputs.artifact-url}} |
-        comment-tag: format_notification

--- a/.github/workflows/format_check_notify.yml
+++ b/.github/workflows/format_check_notify.yml
@@ -1,0 +1,75 @@
+name: Format Check Notification
+
+on:
+  workflow_run:
+    workflows:
+      - Format_Check
+    types:
+      - completed
+
+jobs:
+  notify:
+    if: github.event.workflow_run.event == 'pull_request'
+    runs-on: ubuntu-latest
+    permissions:
+      actions: read
+      contents: read
+      issues: write
+      pull-requests: write
+
+    steps:
+    - name: Resolve PR and artifact metadata
+      id: resolve
+      env:
+        GITHUB_TOKEN: ${{secrets.GITHUB_TOKEN}}
+        REPOSITORY: ${{github.repository}}
+        RUN_ID: ${{github.event.workflow_run.id}}
+      run: |
+        set -eu
+
+        PR_NUMBER=$(jq -r '.workflow_run.pull_requests[0].number // empty' "$GITHUB_EVENT_PATH")
+
+        if [[ -z "${PR_NUMBER}" ]]; then
+          echo "found=false" >> "$GITHUB_OUTPUT"
+          exit 0
+        fi
+
+        echo "pr_number=${PR_NUMBER}" >> "$GITHUB_OUTPUT"
+
+        api_url="https://api.github.com/repos/${REPOSITORY}/actions/runs/${RUN_ID}/artifacts"
+        artifact_json=$(curl -fsSL \
+          -H "Authorization: Bearer ${GITHUB_TOKEN}" \
+          -H "Accept: application/vnd.github+json" \
+          "$api_url")
+
+        artifact_name=$(printf '%s' "$artifact_json" | jq -r --arg prefix "format_diff_pr${PR_NUMBER}.patch" '.artifacts[] | select(.name == $prefix) | .name' | head -n1)
+        artifact_id=$(printf '%s' "$artifact_json" | jq -r --arg prefix "format_diff_pr${PR_NUMBER}.patch" '.artifacts[] | select(.name == $prefix) | .id' | head -n1)
+
+        if [[ -z "${artifact_name}" || -z "${artifact_id}" || "${artifact_name}" == "null" || "${artifact_id}" == "null" ]]; then
+          echo "found=false" >> "$GITHUB_OUTPUT"
+          exit 0
+        fi
+
+        artifact_url="https://github.com/${REPOSITORY}/actions/runs/${RUN_ID}/artifacts/${artifact_id}"
+
+        echo "artifact_name=${artifact_name}" >> "$GITHUB_OUTPUT"
+        echo "artifact_id=${artifact_id}" >> "$GITHUB_OUTPUT"
+        echo "artifact_url=${artifact_url}" >> "$GITHUB_OUTPUT"
+        echo "found=true" >> "$GITHUB_OUTPUT"
+
+    - name: Notify the artifact URL
+      if: steps.resolve.outputs.found == 'true'
+      uses: thollander/actions-comment-pull-request@v3
+      with:
+        pr-number: ${{steps.resolve.outputs.pr_number}}
+        comment-tag: format_notification
+        mode: upsert
+        message: |
+          ## :octocat: Format/Amalgamation Check Failed
+          The source code has not been formatted/amalgamated correctly in the commit [${{github.event.workflow_run.head_sha}}](https://github.com/${{github.repository}}/commit/${{github.event.workflow_run.head_sha}}).
+          Please download and apply the patch to fix it.
+
+          | Name | ${{steps.resolve.outputs.artifact_name}}.zip |
+          |:-----|:----------------------------------------------|
+          | ID   | ${{steps.resolve.outputs.artifact_id}}        |
+          | URL  | ${{steps.resolve.outputs.artifact_url}}       |


### PR DESCRIPTION
This PR fixes comment-posting failures on pull requests from forks.  
The notification flow was redesigned so that write operations happen in a separate privileged workflow.  

**detailed changes:**
- PR comments were removed from the original coverage/format check workflows.
- New `workflow_run`-based notification workflows were introduced to run after those workflows complete.

---

## Pull Request Checklist

Read the [CONTRIBUTING.md](https://github.com/fktn-k/fkYAML/blob/develop/.github/CONTRIBUTING.md) file for detailed information.  

- [x] Changes are described in the pull request or in a referenced [issue](https://github.com/fktn-k/fkYAML/issues).
- [x] The test suite compiles and runs without any error.
- [x] [The code coverage](https://coveralls.io/github/fktn-k/fkYAML) on your branch is 100%.
- [x] The documentation is updated if you added/changed a feature.

## Please don't

- The C++11 support varies between different **compilers** and versions. Please note the [list of supported compilers](https://github.com/fktn-k/fkYAML/blob/develop/README.md#supported-compilers). Some compilers like GCC 4.7 (and earlier), Clang 3.3 (and earlier), or Microsoft Visual Studio 13.0 and earlier are known not to work due to missing or incomplete C++11 support. Please refrain from proposing changes that work around these compiler's limitations with `#ifdef`s or other means.
- Please refrain from proposing changes that would **break [YAML](https://yaml.org/) specifications**. If you propose a conformant extension of YAML to be supported by the library, please motivate this extension.
- Please do not open pull requests that address **multiple issues**.
