### PR TITLE
Support empty keys in block and flow mappings

### DIFF
--- a/include/fkYAML/detail/input/deserializer.hpp
+++ b/include/fkYAML/detail/input/deserializer.hpp
@@ -253,10 +253,7 @@ private:
             apply_node_properties(root);
             m_context_stack.emplace_back(
                 lexer.get_lines_processed(), lexer.get_last_token_begin_pos(), context_state_t::BLOCK_MAPPING, &root);
-            add_new_key(basic_node_type(""), line, indent);
-            token = lexer.get_next_token();
-            line = lexer.get_lines_processed();
-            indent = lexer.get_last_token_begin_pos();
+            add_empty_key_entry(lexer, token, line, indent);
             break;
         case lexical_token_t::BLOCK_LITERAL_SCALAR:
         case lexical_token_t::BLOCK_FOLDED_SCALAR:
@@ -500,15 +497,32 @@ private:
                 if FK_YAML_UNLIKELY (m_context_stack.empty()) {
                     throw parse_error("A key separator is not allowed in this context.", line, indent);
                 }
-                if FK_YAML_UNLIKELY (m_context_stack.back().state == context_state_t::BLOCK_SEQUENCE_ENTRY) {
-                    // empty mapping keys are not supported.
+                if (m_context_stack.back().state == context_state_t::BLOCK_SEQUENCE_ENTRY) {
+                    // The entry is a mapping whose first key is empty.
                     // ```yaml
                     // - : foo
+                    // # -> [{null: foo}]
                     // ```
-                    throw parse_error("mapping key should not be empty.", line, indent);
+                    *mp_current_node = basic_node_type::mapping();
+                    apply_directive_set(*mp_current_node);
+                    m_context_stack.emplace_back(line, indent, context_state_t::BLOCK_MAPPING, mp_current_node);
+                    add_new_key(basic_node_type(), line, indent);
+
+                    token = lexer.get_next_token();
+                    indent = lexer.get_last_token_begin_pos();
+                    line = lexer.get_lines_processed();
+                    continue;
                 }
 
                 if (m_flow_context_depth > 0) {
+                    if (m_context_stack.back().state != context_state_t::MAPPING_VALUE) {
+                        // No key precedes this separator, so the entry has an empty key.
+                        // ```yaml
+                        // { : foo }
+                        // # -> {null: foo}
+                        // ```
+                        add_new_key(basic_node_type(), line, indent);
+                    }
                     break;
                 }
 
@@ -1281,6 +1295,18 @@ private:
                 }
 
                 if (m_context_stack.back().state != context_state_t::BLOCK_MAPPING_EXPLICIT_KEY) {
+                    const parse_context& cur_context = m_context_stack.back();
+                    if (cur_context.state == context_state_t::BLOCK_MAPPING && cur_context.indent == indent) {
+                        // A key separator which begins a line belongs to an entry with an empty key.
+                        // ```yaml
+                        // foo: bar
+                        // : baz
+                        // # -> {foo: bar, null: baz}
+                        // ```
+                        add_empty_key_entry(lexer, token, line, indent);
+                        return;
+                    }
+
                     pop_to_parent_node(line, indent, [indent](const parse_context& c) {
                         return c.state == context_state_t::BLOCK_MAPPING_EXPLICIT_KEY && indent == c.indent;
                     });
@@ -1392,6 +1418,35 @@ private:
         }
         // LCOV_EXCL_STOP
         return m_context_stack.back();
+    }
+
+    /// @brief Adds a mapping entry whose key is empty and moves to the token which follows it.
+    /// @note
+    /// An empty key is a null node. Its value can be omitted as well, in which case the following token
+    /// belongs to the parent mapping rather than to this entry.
+    /// ```yaml
+    /// :
+    /// foo: bar
+    /// # -> {null: null, foo: bar}
+    /// ```
+    /// @param lexer The lexical analyzer to be used.
+    /// @param token The storage for the token which follows the key separator.
+    /// @param line The line of the key separator. Updated to the line of the following token.
+    /// @param indent The indentation width of the key separator. Updated for the following token.
+    void add_empty_key_entry(lexer_type& lexer, lexical_token& token, uint32_t& line, uint32_t& indent) {
+        const uint32_t key_line = line;
+        const uint32_t key_indent = indent;
+        add_new_key(basic_node_type(), line, indent);
+
+        token = lexer.get_next_token();
+        line = lexer.get_lines_processed();
+        indent = lexer.get_last_token_begin_pos();
+
+        if (line > key_line && indent <= key_indent) {
+            pop_to_parent_node(line, indent, [key_indent](const parse_context& c) {
+                return c.state == context_state_t::BLOCK_MAPPING && key_indent == c.indent;
+            });
+        }
     }
 
     /// @brief Adds an entry for an explicit key and makes its value node the current node.

--- a/include/fkYAML/detail/input/deserializer.hpp
+++ b/include/fkYAML/detail/input/deserializer.hpp
@@ -296,12 +296,20 @@ private:
             last_type == lexical_token_t::END_OF_BUFFER || last_type == lexical_token_t::END_OF_DIRECTIVES ||
             last_type == lexical_token_t::END_OF_DOCUMENT);
 
-        // An explicit key at the end of a document has no value either.
+        // An explicit key at the end of a document has no value either. Its own contents may have left
+        // more contexts on the stack, so those are unwound first.
         // ```yaml
         // ? foo
-        // # -> {foo: null}
+        // ? bar: baz
+        // # -> {foo: null, {bar: baz}: null}
         // ```
-        add_explicit_key_with_null_value();
+        while (!m_context_stack.empty()) {
+            if (m_context_stack.back().state == context_state_t::BLOCK_MAPPING_EXPLICIT_KEY) {
+                add_explicit_key_with_null_value();
+                continue;
+            }
+            m_context_stack.pop_back();
+        }
 
         // reset parameters for the next call.
         mp_current_node = nullptr;
@@ -514,6 +522,26 @@ private:
                     continue;
                 }
 
+                {
+                    const parse_context& cur_context = m_context_stack.back();
+                    const bool is_explicit_key_content =
+                        cur_context.state == context_state_t::BLOCK_MAPPING_EXPLICIT_KEY && cur_context.line == line;
+                    if (is_explicit_key_content) {
+                        // The contents of an explicit key begin with a key separator, so the key is a mapping
+                        // whose first entry has an empty key. Whether that entry has a value, and whether the
+                        // explicit key itself has one, is not known yet.
+                        // ```yaml
+                        // ? : foo
+                        // #  ^ this key separator begins the contents of the explicit key
+                        // ```
+                        *mp_current_node = basic_node_type::mapping();
+                        apply_directive_set(*mp_current_node);
+                        m_context_stack.emplace_back(line, indent, context_state_t::BLOCK_MAPPING, mp_current_node);
+                        add_empty_key_entry(lexer, token, line, indent);
+                        continue;
+                    }
+                }
+
                 if (m_flow_context_depth > 0) {
                     if (m_context_stack.back().state != context_state_t::MAPPING_VALUE) {
                         // No key precedes this separator, so the entry has an empty key.
@@ -676,8 +704,25 @@ private:
                 }
 
                 // handle explicit mapping key separators.
-                if FK_YAML_UNLIKELY (m_context_stack.back().state != context_state_t::BLOCK_MAPPING_EXPLICIT_KEY) {
-                    throw parse_error("Unexpected explicit mapping key separator is found.", line, indent);
+                if (m_context_stack.back().state != context_state_t::BLOCK_MAPPING_EXPLICIT_KEY) {
+                    // The contents of the explicit key may have left their own contexts on the stack.
+                    // ```yaml
+                    // ? :
+                    // : v
+                    // # -> {{null: null}: v}
+                    // ```
+                    // old_indent is the position of this key separator, while indent already refers to the
+                    // token which follows it.
+                    const auto is_key_context = [old_indent](const parse_context& c) {
+                        return c.state == context_state_t::BLOCK_MAPPING_EXPLICIT_KEY && old_indent == c.indent;
+                    };
+                    const bool has_key_context =
+                        std::any_of(m_context_stack.rbegin(), m_context_stack.rend(), is_key_context);
+                    if FK_YAML_UNLIKELY (!has_key_context) {
+                        throw parse_error("Unexpected explicit mapping key separator is found.", line, indent);
+                    }
+
+                    pop_to_parent_node(old_line, old_indent, is_key_context);
                 }
 
                 add_explicit_key_with_empty_value(old_line, old_indent);

--- a/single_include/fkYAML/node.hpp
+++ b/single_include/fkYAML/node.hpp
@@ -7737,12 +7737,20 @@ private:
             last_type == lexical_token_t::END_OF_BUFFER || last_type == lexical_token_t::END_OF_DIRECTIVES ||
             last_type == lexical_token_t::END_OF_DOCUMENT);
 
-        // An explicit key at the end of a document has no value either.
+        // An explicit key at the end of a document has no value either. Its own contents may have left
+        // more contexts on the stack, so those are unwound first.
         // ```yaml
         // ? foo
-        // # -> {foo: null}
+        // ? bar: baz
+        // # -> {foo: null, {bar: baz}: null}
         // ```
-        add_explicit_key_with_null_value();
+        while (!m_context_stack.empty()) {
+            if (m_context_stack.back().state == context_state_t::BLOCK_MAPPING_EXPLICIT_KEY) {
+                add_explicit_key_with_null_value();
+                continue;
+            }
+            m_context_stack.pop_back();
+        }
 
         // reset parameters for the next call.
         mp_current_node = nullptr;
@@ -7955,6 +7963,26 @@ private:
                     continue;
                 }
 
+                {
+                    const parse_context& cur_context = m_context_stack.back();
+                    const bool is_explicit_key_content =
+                        cur_context.state == context_state_t::BLOCK_MAPPING_EXPLICIT_KEY && cur_context.line == line;
+                    if (is_explicit_key_content) {
+                        // The contents of an explicit key begin with a key separator, so the key is a mapping
+                        // whose first entry has an empty key. Whether that entry has a value, and whether the
+                        // explicit key itself has one, is not known yet.
+                        // ```yaml
+                        // ? : foo
+                        // #  ^ this key separator begins the contents of the explicit key
+                        // ```
+                        *mp_current_node = basic_node_type::mapping();
+                        apply_directive_set(*mp_current_node);
+                        m_context_stack.emplace_back(line, indent, context_state_t::BLOCK_MAPPING, mp_current_node);
+                        add_empty_key_entry(lexer, token, line, indent);
+                        continue;
+                    }
+                }
+
                 if (m_flow_context_depth > 0) {
                     if (m_context_stack.back().state != context_state_t::MAPPING_VALUE) {
                         // No key precedes this separator, so the entry has an empty key.
@@ -8117,8 +8145,25 @@ private:
                 }
 
                 // handle explicit mapping key separators.
-                if FK_YAML_UNLIKELY (m_context_stack.back().state != context_state_t::BLOCK_MAPPING_EXPLICIT_KEY) {
-                    throw parse_error("Unexpected explicit mapping key separator is found.", line, indent);
+                if (m_context_stack.back().state != context_state_t::BLOCK_MAPPING_EXPLICIT_KEY) {
+                    // The contents of the explicit key may have left their own contexts on the stack.
+                    // ```yaml
+                    // ? :
+                    // : v
+                    // # -> {{null: null}: v}
+                    // ```
+                    // old_indent is the position of this key separator, while indent already refers to the
+                    // token which follows it.
+                    const auto is_key_context = [old_indent](const parse_context& c) {
+                        return c.state == context_state_t::BLOCK_MAPPING_EXPLICIT_KEY && old_indent == c.indent;
+                    };
+                    const bool has_key_context =
+                        std::any_of(m_context_stack.rbegin(), m_context_stack.rend(), is_key_context);
+                    if FK_YAML_UNLIKELY (!has_key_context) {
+                        throw parse_error("Unexpected explicit mapping key separator is found.", line, indent);
+                    }
+
+                    pop_to_parent_node(old_line, old_indent, is_key_context);
                 }
 
                 add_explicit_key_with_empty_value(old_line, old_indent);

--- a/single_include/fkYAML/node.hpp
+++ b/single_include/fkYAML/node.hpp
@@ -7694,10 +7694,7 @@ private:
             apply_node_properties(root);
             m_context_stack.emplace_back(
                 lexer.get_lines_processed(), lexer.get_last_token_begin_pos(), context_state_t::BLOCK_MAPPING, &root);
-            add_new_key(basic_node_type(""), line, indent);
-            token = lexer.get_next_token();
-            line = lexer.get_lines_processed();
-            indent = lexer.get_last_token_begin_pos();
+            add_empty_key_entry(lexer, token, line, indent);
             break;
         case lexical_token_t::BLOCK_LITERAL_SCALAR:
         case lexical_token_t::BLOCK_FOLDED_SCALAR:
@@ -7941,15 +7938,32 @@ private:
                 if FK_YAML_UNLIKELY (m_context_stack.empty()) {
                     throw parse_error("A key separator is not allowed in this context.", line, indent);
                 }
-                if FK_YAML_UNLIKELY (m_context_stack.back().state == context_state_t::BLOCK_SEQUENCE_ENTRY) {
-                    // empty mapping keys are not supported.
+                if (m_context_stack.back().state == context_state_t::BLOCK_SEQUENCE_ENTRY) {
+                    // The entry is a mapping whose first key is empty.
                     // ```yaml
                     // - : foo
+                    // # -> [{null: foo}]
                     // ```
-                    throw parse_error("mapping key should not be empty.", line, indent);
+                    *mp_current_node = basic_node_type::mapping();
+                    apply_directive_set(*mp_current_node);
+                    m_context_stack.emplace_back(line, indent, context_state_t::BLOCK_MAPPING, mp_current_node);
+                    add_new_key(basic_node_type(), line, indent);
+
+                    token = lexer.get_next_token();
+                    indent = lexer.get_last_token_begin_pos();
+                    line = lexer.get_lines_processed();
+                    continue;
                 }
 
                 if (m_flow_context_depth > 0) {
+                    if (m_context_stack.back().state != context_state_t::MAPPING_VALUE) {
+                        // No key precedes this separator, so the entry has an empty key.
+                        // ```yaml
+                        // { : foo }
+                        // # -> {null: foo}
+                        // ```
+                        add_new_key(basic_node_type(), line, indent);
+                    }
                     break;
                 }
 
@@ -8722,6 +8736,18 @@ private:
                 }
 
                 if (m_context_stack.back().state != context_state_t::BLOCK_MAPPING_EXPLICIT_KEY) {
+                    const parse_context& cur_context = m_context_stack.back();
+                    if (cur_context.state == context_state_t::BLOCK_MAPPING && cur_context.indent == indent) {
+                        // A key separator which begins a line belongs to an entry with an empty key.
+                        // ```yaml
+                        // foo: bar
+                        // : baz
+                        // # -> {foo: bar, null: baz}
+                        // ```
+                        add_empty_key_entry(lexer, token, line, indent);
+                        return;
+                    }
+
                     pop_to_parent_node(line, indent, [indent](const parse_context& c) {
                         return c.state == context_state_t::BLOCK_MAPPING_EXPLICIT_KEY && indent == c.indent;
                     });
@@ -8833,6 +8859,35 @@ private:
         }
         // LCOV_EXCL_STOP
         return m_context_stack.back();
+    }
+
+    /// @brief Adds a mapping entry whose key is empty and moves to the token which follows it.
+    /// @note
+    /// An empty key is a null node. Its value can be omitted as well, in which case the following token
+    /// belongs to the parent mapping rather than to this entry.
+    /// ```yaml
+    /// :
+    /// foo: bar
+    /// # -> {null: null, foo: bar}
+    /// ```
+    /// @param lexer The lexical analyzer to be used.
+    /// @param token The storage for the token which follows the key separator.
+    /// @param line The line of the key separator. Updated to the line of the following token.
+    /// @param indent The indentation width of the key separator. Updated for the following token.
+    void add_empty_key_entry(lexer_type& lexer, lexical_token& token, uint32_t& line, uint32_t& indent) {
+        const uint32_t key_line = line;
+        const uint32_t key_indent = indent;
+        add_new_key(basic_node_type(), line, indent);
+
+        token = lexer.get_next_token();
+        line = lexer.get_lines_processed();
+        indent = lexer.get_last_token_begin_pos();
+
+        if (line > key_line && indent <= key_indent) {
+            pop_to_parent_node(line, indent, [key_indent](const parse_context& c) {
+                return c.state == context_state_t::BLOCK_MAPPING && key_indent == c.indent;
+            });
+        }
     }
 
     /// @brief Adds an entry for an explicit key and makes its value node the current node.

--- a/tests/unit_test/test_deserializer_class.cpp
+++ b/tests/unit_test/test_deserializer_class.cpp
@@ -79,6 +79,37 @@ TEST_CASE("Deserializer_KeySeparator") {
         REQUIRE(root[nullptr].as_str() == "empty key");
     }
 
+    SUBCASE("empty mapping key whose value is omitted") {
+        std::string input = ":\n"
+                            "bar: baz\n";
+        REQUIRE_NOTHROW(root = deserializer.deserialize(fkyaml::detail::input_adapter(input)));
+
+        REQUIRE(root.is_mapping());
+        REQUIRE(root.size() == 2);
+
+        REQUIRE(root.contains(nullptr));
+        REQUIRE(root[nullptr].is_null());
+
+        REQUIRE(root.contains("bar"));
+        REQUIRE(root["bar"].as_str() == "baz");
+    }
+
+    SUBCASE("empty mapping key whose value begins on the following line") {
+        std::string input = ":\n"
+                            "  bar: baz\n";
+        REQUIRE_NOTHROW(root = deserializer.deserialize(fkyaml::detail::input_adapter(input)));
+
+        REQUIRE(root.is_mapping());
+        REQUIRE(root.size() == 1);
+        REQUIRE(root.contains(nullptr));
+
+        fkyaml::node& value_node = root[nullptr];
+        REQUIRE(value_node.is_mapping());
+        REQUIRE(value_node.size() == 1);
+        REQUIRE(value_node.contains("bar"));
+        REQUIRE(value_node["bar"].as_str() == "baz");
+    }
+
     SUBCASE("empty mapping key in a flow mapping") {
         REQUIRE_NOTHROW(root = deserializer.deserialize(fkyaml::detail::input_adapter("{key: value, : empty key}")));
         REQUIRE(root.is_mapping());

--- a/tests/unit_test/test_deserializer_class.cpp
+++ b/tests/unit_test/test_deserializer_class.cpp
@@ -1797,6 +1797,54 @@ TEST_CASE("Deserializer_ExplicitBlockMapping") {
         REQUIRE(qux_node["corge"].is_null());
     }
 
+    SUBCASE("explicit mapping key whose contents begin with a key separator") {
+        // The contents of the explicit key are a mapping entry with an empty key.
+        REQUIRE_NOTHROW(root = deserializer.deserialize(fkyaml::detail::input_adapter("? :")));
+
+        REQUIRE(root.is_mapping());
+        REQUIRE(root.size() == 1);
+
+        fkyaml::node key = {{nullptr, nullptr}};
+        REQUIRE(root.contains(key));
+        REQUIRE(root[key].is_null());
+    }
+
+    SUBCASE("explicit mapping key with an empty key and a value") {
+        REQUIRE_NOTHROW(root = deserializer.deserialize(fkyaml::detail::input_adapter("? : foo")));
+
+        REQUIRE(root.is_mapping());
+        REQUIRE(root.size() == 1);
+
+        fkyaml::node key = {{nullptr, "foo"}};
+        REQUIRE(root.contains(key));
+        REQUIRE(root[key].is_null());
+    }
+
+    SUBCASE("explicit mapping key which is a mapping without a value") {
+        REQUIRE_NOTHROW(root = deserializer.deserialize(fkyaml::detail::input_adapter("? foo: bar")));
+
+        REQUIRE(root.is_mapping());
+        REQUIRE(root.size() == 1);
+
+        fkyaml::node key = {{"foo", "bar"}};
+        REQUIRE(root.contains(key));
+        REQUIRE(root[key].is_null());
+    }
+
+    SUBCASE("explicit mapping key with an empty key and its own value") {
+        std::string input = "? :\n"
+                            ": baz\n";
+        REQUIRE_NOTHROW(root = deserializer.deserialize(fkyaml::detail::input_adapter(input)));
+
+        REQUIRE(root.is_mapping());
+        REQUIRE(root.size() == 1);
+
+        fkyaml::node key = {{nullptr, nullptr}};
+        REQUIRE(root.contains(key));
+        REQUIRE(root[key].is_string());
+        REQUIRE(root[key].as_str() == "baz");
+    }
+
     SUBCASE("explicit mapping keys whose values begin on the following lines") {
         std::string input = "? foo\n"
                             ":\n"

--- a/tests/unit_test/test_deserializer_class.cpp
+++ b/tests/unit_test/test_deserializer_class.cpp
@@ -33,19 +33,60 @@ TEST_CASE("Deserializer_KeySeparator") {
         REQUIRE(root.size() == 1);
     }
 
-    SUBCASE("empty mapping key in block sequences is unsupported") {
-        auto input_str = GENERATE(std::string("- : foo"), std::string("- - : foo"));
-        REQUIRE_THROWS_AS(
-            root = deserializer.deserialize(fkyaml::detail::input_adapter(input_str)), fkyaml::parse_error);
+    SUBCASE("empty mapping key in a block sequence entry") {
+        REQUIRE_NOTHROW(root = deserializer.deserialize(fkyaml::detail::input_adapter("- : foo")));
+        REQUIRE(root.is_sequence());
+        REQUIRE(root.size() == 1);
+
+        fkyaml::node& entry_node = root[0];
+        REQUIRE(entry_node.is_mapping());
+        REQUIRE(entry_node.size() == 1);
+        REQUIRE(entry_node.contains(nullptr));
+        REQUIRE(entry_node[nullptr].as_str() == "foo");
+    }
+
+    SUBCASE("empty mapping key in a nested block sequence entry") {
+        REQUIRE_NOTHROW(root = deserializer.deserialize(fkyaml::detail::input_adapter("- - : foo")));
+        REQUIRE(root.is_sequence());
+        REQUIRE(root.size() == 1);
+        REQUIRE(root[0].is_sequence());
+        REQUIRE(root[0].size() == 1);
+
+        fkyaml::node& entry_node = root[0][0];
+        REQUIRE(entry_node.is_mapping());
+        REQUIRE(entry_node.contains(nullptr));
+        REQUIRE(entry_node[nullptr].as_str() == "foo");
     }
 
     SUBCASE("empty root mapping key") {
         REQUIRE_NOTHROW(root = deserializer.deserialize(fkyaml::detail::input_adapter(": foo")));
         REQUIRE(root.is_mapping());
         REQUIRE(root.size() == 1);
-        REQUIRE(root.contains(""));
-        REQUIRE(root[""].is_string());
-        REQUIRE(root[""].as_str() == "foo");
+        REQUIRE(root.contains(nullptr));
+        REQUIRE(root[nullptr].is_string());
+        REQUIRE(root[nullptr].as_str() == "foo");
+    }
+
+    SUBCASE("empty mapping key after a normal entry") {
+        std::string input = "key: value\n"
+                            ": empty key\n";
+        REQUIRE_NOTHROW(root = deserializer.deserialize(fkyaml::detail::input_adapter(input)));
+        REQUIRE(root.is_mapping());
+        REQUIRE(root.size() == 2);
+        REQUIRE(root.contains("key"));
+        REQUIRE(root["key"].as_str() == "value");
+        REQUIRE(root.contains(nullptr));
+        REQUIRE(root[nullptr].as_str() == "empty key");
+    }
+
+    SUBCASE("empty mapping key in a flow mapping") {
+        REQUIRE_NOTHROW(root = deserializer.deserialize(fkyaml::detail::input_adapter("{key: value, : empty key}")));
+        REQUIRE(root.is_mapping());
+        REQUIRE(root.size() == 2);
+        REQUIRE(root.contains("key"));
+        REQUIRE(root["key"].as_str() == "value");
+        REQUIRE(root.contains(nullptr));
+        REQUIRE(root[nullptr].as_str() == "empty key");
     }
 
     SUBCASE("invalid explicit mapping key separator after root scalar") {


### PR DESCRIPTION
This PR fixes #557.

An empty key was only handled at the very start of a document, and it produced an entry whose key
is an empty **string**. Everywhere else the key separator was rejected, and inside a flow mapping it
was ignored, which dropped the entry:

```yaml
key: value
: empty key                  # parse_error: Detected invalid indentation
- : foo                      # parse_error: mapping key should not be empty
{ key: value, : empty key }  # parse_error: The ":" mapping value indicator must be
                             # followed after a mapping key
```

## The change

`add_empty_key_entry()` adds an entry with a null key and moves to the token after the separator.
It is called wherever a key separator turns up with no key before it: at the document root, at the
start of a line in a block mapping, in a block sequence entry, and in a flow mapping. The
deliberate `mapping key should not be empty` rejection for block sequence entries is gone.

The value of an empty key can be omitted too, so the helper also moves back to the parent mapping
when the following token is not indented deeper - the same rule a normal key already follows:

```yaml
:
foo: bar
# -> {null: null, foo: bar}

:
  foo: bar
# -> {null: {foo: bar}}
```

| input | before | after |
|---|---|---|
| `": foo"` | `{"": foo}` | `{null: foo}` |
| `":"` | `{"": null}` | `{null: null}` |
| `"key: value\n: empty key"` | `parse_error` | `{key: value, null: 'empty key'}` |
| `":\nb: 1"` | `parse_error` | `{null: null, b: 1}` |
| `"- : foo"` | `parse_error` | `[{null: foo}]` |
| `"{key: value, : empty key}"` | `parse_error` | `{key: value, null: 'empty key'}` |
| `"\"\": foo"` | `{"": foo}` | unchanged, a quoted key stays a string |

## Breaking change

As you noted in #553, an empty key is now a null node rather than an empty string, so code reading
such an entry as `node[""]` has to read `node[nullptr]` instead. Two existing subcases in
`test_deserializer_class.cpp` asserted the old behavior and are updated here. I did not touch any
version macro, assuming the v0.5.0 bump happens at release time as usual.

---

## Pull Request Checklist

Read the [CONTRIBUTING.md](https://github.com/fktn-k/fkYAML/blob/develop/.github/CONTRIBUTING.md) file for detailed information.  

- [x] Changes are described in the pull request or in a referenced [issue](https://github.com/fktn-k/fkYAML/issues).
- [x] The test suite compiles and runs without any error.
- [ ] [The code coverage](https://coveralls.io/github/fktn-k/fkYAML) on your branch is 100%.
- [x] The documentation is updated if you added/changed a feature.

## Please don't

- The C++11 support varies between different **compilers** and versions. Please note the [list of supported compilers](https://github.com/fktn-k/fkYAML/blob/develop/README.md#supported-compilers). Some compilers like GCC 4.7 (and earlier), Clang 3.3 (and earlier), or Microsoft Visual Studio 13.0 and earlier are known not to work due to missing or incomplete C++11 support. Please refrain from proposing changes that work around these compiler's limitations with `#ifdef`s or other means.
- Please refrain from proposing changes that would **break [YAML](https://yaml.org/) specifications**. If you propose a conformant extension of YAML to be supported by the library, please motivate this extension.
- Please do not open pull requests that address **multiple issues**.
