### PR TITLE
Add get_resolved_tag_name API to basic_node

### DIFF
--- a/.clang-tidy
+++ b/.clang-tidy
@@ -1,5 +1,6 @@
 ---
 Checks: '*,
+         -abseil-string-find-startswith,
          -altera-id-dependent-backward-branch,
          -altera-struct-pack-align,
          -altera-unroll-loops,

--- a/docs/docs/api/basic_node/get_resolved_tag_name.md
+++ b/docs/docs/api/basic_node/get_resolved_tag_name.md
@@ -1,0 +1,41 @@
+<small>Defined in header [`<fkYAML/node.hpp>`](https://github.com/fktn-k/fkYAML/blob/develop/include/fkYAML/node.hpp)</small>
+
+# <small>fkyaml::basic_node::</small>get_resolved_tag_name
+
+```cpp
+std::string get_resolved_tag_name() const;
+```
+
+Gets a resolved tag name associated to the YAML node.  
+Some tag name must be set before calling this API.  
+Call [`has_tag_name`](has_tag_name.md) to see if the node has any tag name beforehand.  
+If no tag name has been set, an [`fkyaml::exception`](../exception/index.md) will be thrown.  
+
+If the target node has a tag `!!str`, the returned value would be `tag:yaml.org,2002:str`.  
+This is because `!!` is the secondary tag handle and resolved to `tag:yaml.org,2002:` by default.  
+See https://yaml.org/spec/1.2.2/#6821-tag-handles for more details on the tag handles.  
+
+If the target node has a verbatim tag `!<...>`, this method returns the `...` part  
+as the YAML specification states at https://yaml.org/spec/1.2.2/#691-node-tags.
+
+## **Return Value**
+
+The tag name associated to the node.  
+
+## **Examples**
+
+??? Example
+
+    ```cpp
+    --8<-- "apis/basic_node/get_resolved_tag_name.cpp:9"
+    ```
+
+    output:
+    ```bash
+    --8<-- "apis/basic_node/get_resolved_tag_name.output"
+    ```
+
+## **See Also**
+
+* [basic_node](index.md)
+* [has_tag_name](has_tag_name.md)

--- a/docs/docs/api/basic_node/index.md
+++ b/docs/docs/api/basic_node/index.md
@@ -56,8 +56,8 @@ This class provides features to handle YAML nodes.
 | difference_type                               | [`std::ptrdiff_t`](https://en.cppreference.com/w/cpp/types/ptrdiff_t)                                     |
 | [iterator](iterator.md)                       | [LegacyBidirectionalIterator](https://en.cppreference.com/w/cpp/named_req/BidirectionalIterator)          |
 | [const_iterator](iterator.md)                 | constant [LegacyBidirectionalIterator](https://en.cppreference.com/w/cpp/named_req/BidirectionalIterator) |
-| [reverse_iterator](reverse_iterator.md)       | reverse iterator derived from `iterator`          |
-| [const_reverse_iterator](reverse_iterator.md) | reverse iterator derived from `const_iterator` |
+| [reverse_iterator](reverse_iterator.md)       | reverse iterator derived from `iterator`                                                                  |
+| [const_reverse_iterator](reverse_iterator.md) | reverse iterator derived from `const_iterator`                                                            |
 
 ### Miscellaneous
 | Name                                            | Description                                                         |
@@ -152,16 +152,17 @@ This class provides features to handle YAML nodes.
 | [operator>=](operator_ge.md) | comparison: greater than or equal |
 
 ### Manipulations for Node Properties
-| Name                                  | Description                                              |
-| ------------------------------------- | -------------------------------------------------------- |
-| [is_alias](is_alias.md)               | checks if a basic_node is an alias node.                 |
-| [is_anchor](is_anchor.md)             | checks if a basic_node is an anchor node.                |
-| [add_anchor_name](add_anchor_name.md) | registers an anchor name to a basic_node object.         |
-| [get_anchor_name](get_anchor_name.md) | gets an anchor name associated with a basic_node object. |
-| [has_anchor_name](has_anchor_name.md) | checks if a basic_node has any anchor name.              |
-| [add_tag_name](add_tag_name.md)       | registers a tag name to a basic_node object.             |
-| [get_tag_name](get_tag_name.md)       | gets a tag name associated with a basic_node object.     |
-| [has_tag_name](has_tag_name.md)       | checks if a basic_node has any tag name.                 |
+| Name                                              | Description                                                   |
+| ------------------------------------------------- | ------------------------------------------------------------- |
+| [is_alias](is_alias.md)                           | checks if a basic_node is an alias node.                      |
+| [is_anchor](is_anchor.md)                         | checks if a basic_node is an anchor node.                     |
+| [add_anchor_name](add_anchor_name.md)             | registers an anchor name to a basic_node object.              |
+| [get_anchor_name](get_anchor_name.md)             | gets an anchor name associated with a basic_node object.      |
+| [has_anchor_name](has_anchor_name.md)             | checks if a basic_node has any anchor name.                   |
+| [add_tag_name](add_tag_name.md)                   | registers a tag name to a basic_node object.                  |
+| [get_tag_name](get_tag_name.md)                   | gets a tag name associated with a basic_node object.          |
+| [get_resolved_tag_name](get_resolved_tag_name.md) | gets a resolved tag name associated with a basic_node object. |
+| [has_tag_name](has_tag_name.md)                   | checks if a basic_node has any tag name.                      |
 
 ### Manipulations for Document Properties
 | Name                                              | Description                                                               |

--- a/docs/docs/index.md
+++ b/docs/docs/index.md
@@ -206,7 +206,7 @@ Testing of the library with [the YAML test suite](https://github.com/yaml/yaml-t
 
 ## Benchmarking
 
-Though efficiency is not everything, speed and memory consumption are very important characteristics for C++ developers. Regarding speed, benchmarking scores are now available with [the dedicated benchmarking tool](./tool/benchmark/README.md) for the parsing.  
+Though efficiency is not everything, speed and memory consumption are very important characteristics for C++ developers. Regarding speed, benchmarking scores are now available with [the dedicated benchmarking tool](https://github.com/fktn-k/fkYAML/blob/develop/tools/benchmark/README.md) for the parsing.  
 The following tables are created from the benchmarking results in the following environment:  
 
 * CPU: AMD Ryzen 7 5800H @3.20GHz

--- a/docs/mkdocs.yml
+++ b/docs/mkdocs.yml
@@ -140,6 +140,7 @@ nav:
     - 'end, cend': api/basic_node/end.md
     - erase: api/basic_node/erase.md
     - get_anchor_name: api/basic_node/get_anchor_name.md
+    - get_resolved_tag_name: api/basic_node/get_resolved_tag_name.md
     - get_tag_name: api/basic_node/get_tag_name.md
     - get_type: api/basic_node/get_type.md
     - get_value: api/basic_node/get_value.md

--- a/examples/apis/basic_node/get_resolved_tag_name.cpp
+++ b/examples/apis/basic_node/get_resolved_tag_name.cpp
@@ -1,0 +1,41 @@
+//  _______   __ __   __  _____   __  __  __
+// |   __| |_/  |  \_/  |/  _  \ /  \/  \|  |     fkYAML: A C++ header-only YAML library (supporting code)
+// |   __|  _  < \_   _/|  ___  |    _   |  |___  version 0.4.3
+// |__|  |_| \__|  |_|  |_|   |_|___||___|______| https://github.com/fktn-k/fkYAML
+//
+// SPDX-FileCopyrightText: 2023-2026 Kensuke Fukutani <fktn.dev@gmail.com>
+// SPDX-License-Identifier: MIT
+
+#include <iostream>
+#include <fkYAML/node.hpp>
+
+int main() {
+    // create a YAML node.
+    fkyaml::node n = "foo";
+
+    // try to get a tag name before any tag name has been set.
+    try {
+        std::cout << n.get_resolved_tag_name() << std::endl;
+    }
+    catch (const fkyaml::exception& e) {
+        std::cout << e.what() << std::endl;
+    }
+
+    // The tag name (!!str) is set during deserialization.
+    n = fkyaml::node::deserialize("- !!str foo");
+    std::cout << n.at(0).get_resolved_tag_name() << std::endl;
+
+    // "%TAG" directive changes the prefix.
+    std::string input = "%TAG !! tag:example.com,2026:\n"
+                        "---\n"
+                        "- !!str foo\n";
+    n = fkyaml::node::deserialize(input);
+    std::cout << n.at(0).get_resolved_tag_name() << std::endl;
+
+    // You can also set a tag name manually.
+    n = "foo";
+    n.add_tag_name("!!str");
+    std::cout << n.get_resolved_tag_name() << std::endl;
+
+    return 0;
+}

--- a/examples/apis/basic_node/get_resolved_tag_name.output
+++ b/examples/apis/basic_node/get_resolved_tag_name.output
@@ -1,0 +1,4 @@
+No tag name has been set.
+tag:yaml.org,2002:str
+tag:example.com,2026:str
+tag:yaml.org,2002:str

--- a/examples/apis/macros/versions.output
+++ b/examples/apis/macros/versions.output
@@ -1,1 +1,1 @@
-fkYAML version 0.4.2
+fkYAML version 0.4.3

--- a/examples/apis/node_value_converter/to_node.output
+++ b/examples/apis/node_value_converter/to_node.output
@@ -1,4 +1,4 @@
-author: John Doe
-title: Noman's Journey
+author: "John Doe"
+title: "Noman's Journey"
 year: 2023
 

--- a/examples/tutorials/tutorial_1.output
+++ b/examples/tutorials/tutorial_1.output
@@ -1,22 +1,22 @@
 novels:
   -
-    author: Daniel Defoe
-    title: Robinson Crusoe
+    author: "Daniel Defoe"
+    title: "Robinson Crusoe"
     year: 1678
   -
-    author: Jane Austen
+    author: "Jane Austen"
     title: Frankenstein
     year: 1818
   -
-    author: Herman Melville
+    author: "Herman Melville"
     title: Moby-Dick
     year: 1851
   -
-    author: Aldous Huxley
-    title: Brave New World
+    author: "Aldous Huxley"
+    title: "Brave New World"
     year: 1932
   -
-    author: Kazuo Ishiguro
-    title: Never Let Me Go
+    author: "Kazuo Ishiguro"
+    title: "Never Let Me Go"
     year: 2005
 

--- a/examples/tutorials/tutorial_3.output
+++ b/examples/tutorials/tutorial_3.output
@@ -1,17 +1,17 @@
 recommends:
   -
-    author: Daniel Defoe
-    title: Robinson Crusoe
+    author: "Daniel Defoe"
+    title: "Robinson Crusoe"
   -
-    author: Jane Austen
+    author: "Jane Austen"
     title: Frankenstein
   -
-    author: Herman Melville
+    author: "Herman Melville"
     title: Moby-Dick
   -
-    author: Aldous Huxley
-    title: Brave New World
+    author: "Aldous Huxley"
+    title: "Brave New World"
   -
-    author: Kazuo Ishiguro
-    title: Never Let Me Go
+    author: "Kazuo Ishiguro"
+    title: "Never Let Me Go"
 

--- a/examples/tutorials/tutorial_4.output
+++ b/examples/tutorials/tutorial_4.output
@@ -1,17 +1,17 @@
 recommends:
   -
-    author: Daniel Defoe
-    title: Robinson Crusoe
+    author: "Daniel Defoe"
+    title: "Robinson Crusoe"
   -
-    author: Jane Austen
+    author: "Jane Austen"
     title: Frankenstein
   -
-    author: Herman Melville
+    author: "Herman Melville"
     title: Moby-Dick
   -
-    author: Aldous Huxley
-    title: Brave New World
+    author: "Aldous Huxley"
+    title: "Brave New World"
   -
-    author: Kazuo Ishiguro
-    title: Never Let Me Go
+    author: "Kazuo Ishiguro"
+    title: "Never Let Me Go"
 

--- a/include/fkYAML/detail/input/deserializer.hpp
+++ b/include/fkYAML/detail/input/deserializer.hpp
@@ -623,7 +623,8 @@ private:
                         // bar: baz
                         // # -> {foo: null, bar: baz}
                         // ```
-                        if (!add_explicit_key_with_null_value()) {
+                        const bool is_entry_added = add_explicit_key_with_null_value();
+                        if (!is_entry_added) {
                             if FK_YAML_UNLIKELY (m_context_stack.back().state != context_state_t::MAPPING_VALUE) {
                                 // The key separator does not follow a mapping key, for example:
                                 // ```yaml

--- a/include/fkYAML/node.hpp
+++ b/include/fkYAML/node.hpp
@@ -1281,13 +1281,61 @@ public:
     /// @brief Get the tag name associated with this basic_node object.
     /// @note Some tag name must be set before calling this method. Call has_tag_name() to see if this basic_node
     /// object has any tag name.
-    /// @return The tag name associated with the node. It may be empty.
+    /// @return The tag name associated with the node.
     /// @sa https://fktn-k.github.io/fkYAML/api/basic_node/get_tag_name/
     const std::string& get_tag_name() const {
         if FK_YAML_UNLIKELY (!has_tag_name()) {
             throw fkyaml::exception("No tag name has been set.");
         }
         return m_prop.tag;
+    }
+
+    /// @brief Get the resolved tag name associated with this basic_node object.
+    /// @note Some tag name must be set before calling this method. Call has_tag_name() to see if this basic_node object
+    /// has any tag name.
+    /// @return The resolved tag name associated with the node.
+    /// @sa https://fktn-k.github.io/fkYAML/api/basic_node/get_resolved_tag_name/
+    std::string get_resolved_tag_name() const {
+        if FK_YAML_UNLIKELY (!has_tag_name()) {
+            throw fkyaml::exception("No tag name has been set.");
+        }
+
+        const auto& tag = m_prop.tag;
+
+        // non-specific tag
+        if (tag == "!") {
+            return tag;
+        }
+
+        // secondary tag handle
+        if (tag.rfind("!!", 0) == 0) {
+            if (mp_meta->secondary_handle_prefix.empty()) {
+                return "tag:yaml.org,2002:" + tag.substr(2);
+            }
+            return mp_meta->secondary_handle_prefix + tag.substr(2);
+        }
+
+        // named handles
+        for (const auto& named_handle_itr : mp_meta->named_handle_map) {
+            if (tag.rfind(named_handle_itr.first, 0) == 0) {
+                return named_handle_itr.second + tag.substr(named_handle_itr.first.size());
+            }
+        }
+
+        // vertabim tags
+        const bool is_verbatim = tag.rfind("!<", 0) == 0 && tag.back() == '>';
+        if (is_verbatim) {
+            // Verbatim tags (!<...>) are not subject to tag resolution.
+            // Anything in ... must not be expanded.
+            // https://yaml.org/spec/1.2.2/#691-node-tags
+            return tag.substr(2, tag.size() - 3);
+        }
+
+        // primary tag handle
+        if (mp_meta->primary_handle_prefix.empty()) {
+            return "!" + tag.substr(1);
+        }
+        return mp_meta->primary_handle_prefix + tag.substr(1);
     }
 
     /// @brief Add a tag name to this basic_node object.

--- a/single_include/fkYAML/node.hpp
+++ b/single_include/fkYAML/node.hpp
@@ -8064,7 +8064,8 @@ private:
                         // bar: baz
                         // # -> {foo: null, bar: baz}
                         // ```
-                        if (!add_explicit_key_with_null_value()) {
+                        const bool is_entry_added = add_explicit_key_with_null_value();
+                        if (!is_entry_added) {
                             if FK_YAML_UNLIKELY (m_context_stack.back().state != context_state_t::MAPPING_VALUE) {
                                 // The key separator does not follow a mapping key, for example:
                                 // ```yaml
@@ -14312,13 +14313,61 @@ public:
     /// @brief Get the tag name associated with this basic_node object.
     /// @note Some tag name must be set before calling this method. Call has_tag_name() to see if this basic_node
     /// object has any tag name.
-    /// @return The tag name associated with the node. It may be empty.
+    /// @return The tag name associated with the node.
     /// @sa https://fktn-k.github.io/fkYAML/api/basic_node/get_tag_name/
     const std::string& get_tag_name() const {
         if FK_YAML_UNLIKELY (!has_tag_name()) {
             throw fkyaml::exception("No tag name has been set.");
         }
         return m_prop.tag;
+    }
+
+    /// @brief Get the resolved tag name associated with this basic_node object.
+    /// @note Some tag name must be set before calling this method. Call has_tag_name() to see if this basic_node object
+    /// has any tag name.
+    /// @return The resolved tag name associated with the node.
+    /// @sa https://fktn-k.github.io/fkYAML/api/basic_node/get_resolved_tag_name/
+    std::string get_resolved_tag_name() const {
+        if FK_YAML_UNLIKELY (!has_tag_name()) {
+            throw fkyaml::exception("No tag name has been set.");
+        }
+
+        const auto& tag = m_prop.tag;
+
+        // non-specific tag
+        if (tag == "!") {
+            return tag;
+        }
+
+        // secondary tag handle
+        if (tag.rfind("!!", 0) == 0) {
+            if (mp_meta->secondary_handle_prefix.empty()) {
+                return "tag:yaml.org,2002:" + tag.substr(2);
+            }
+            return mp_meta->secondary_handle_prefix + tag.substr(2);
+        }
+
+        // named handles
+        for (const auto& named_handle_itr : mp_meta->named_handle_map) {
+            if (tag.rfind(named_handle_itr.first, 0) == 0) {
+                return named_handle_itr.second + tag.substr(named_handle_itr.first.size());
+            }
+        }
+
+        // vertabim tags
+        const bool is_verbatim = tag.rfind("!<", 0) == 0 && tag.back() == '>';
+        if (is_verbatim) {
+            // Verbatim tags (!<...>) are not subject to tag resolution.
+            // Anything in ... must not be expanded.
+            // https://yaml.org/spec/1.2.2/#691-node-tags
+            return tag.substr(2, tag.size() - 3);
+        }
+
+        // primary tag handle
+        if (mp_meta->primary_handle_prefix.empty()) {
+            return "!" + tag.substr(1);
+        }
+        return mp_meta->primary_handle_prefix + tag.substr(1);
     }
 
     /// @brief Add a tag name to this basic_node object.

--- a/tests/unit_test/test_node_class.cpp
+++ b/tests/unit_test/test_node_class.cpp
@@ -2989,6 +2989,41 @@ TEST_CASE("Node_GetTagName") {
     }
 }
 
+TEST_CASE("Node_GetResolvedTagName") {
+    fkyaml::node node;
+
+    SUBCASE("node without tag name.") {
+        REQUIRE_THROWS_AS(node.get_resolved_tag_name(), fkyaml::exception);
+    }
+
+    SUBCASE("node with tag name.") {
+        std::string input = "- !!str foo\n"
+                            "- ! bar\n"
+                            "- !local baz\n"
+                            "- !<tag:example.com,2026:verbatim/str> qux\n";
+        node = fkyaml::node::deserialize(input);
+        REQUIRE(node.at(0).get_resolved_tag_name() == "tag:yaml.org,2002:str");
+        REQUIRE(node.at(1).get_resolved_tag_name() == "!");
+        REQUIRE(node.at(2).get_resolved_tag_name() == "!local");
+        REQUIRE(node.at(3).get_resolved_tag_name() == "tag:example.com,2026:verbatim/str");
+
+        std::string input2 = "%TAG ! tag:example.com,2026:primary/\n"
+                             "%TAG !! tag:example.com,2026:secondary/\n"
+                             "%TAG !a! tag:example.com,2026:named/a/\n"
+                             "%TAG !b! tag:example.com,2026:named/b/\n"
+                             "---\n"
+                             "- !!str foo\n"
+                             "- !str bar\n"
+                             "- !a!str baz\n"
+                             "- !b!str qux\n";
+        node = fkyaml::node::deserialize(input2);
+        REQUIRE(node.at(0).get_resolved_tag_name() == "tag:example.com,2026:secondary/str");
+        REQUIRE(node.at(1).get_resolved_tag_name() == "tag:example.com,2026:primary/str");
+        REQUIRE(node.at(2).get_resolved_tag_name() == "tag:example.com,2026:named/a/str");
+        REQUIRE(node.at(3).get_resolved_tag_name() == "tag:example.com,2026:named/b/str");
+    }
+}
+
 TEST_CASE("Node_AddTagName") {
     fkyaml::node node;
     std::string tag_name = "tag_name";


### PR DESCRIPTION
This PR adds a new basic_node API `get_resolved_tag_name()` which returns a resolved tag name, for examples:
- If a node has a tag `!!str` and no `%TAG` directive changes the secondary prefix `!!`, this method returns `tag:yaml.org,2002:str` as a resolved tag name.
- If a node has a verbatim tag `!<tag:example.com,2026:foo>`, this method returns `tag:example.com,2026:foo` since verbatim tags are not subject to tag resolutions.

For more details and examples, visit https://fktn-k.github.io/fkYAML/api/basic_node/get_tag_name/.

---

## Pull Request Checklist

Read the [CONTRIBUTING.md](https://github.com/fktn-k/fkYAML/blob/develop/.github/CONTRIBUTING.md) file for detailed information.  

- [x] Changes are described in the pull request or in a referenced [issue](https://github.com/fktn-k/fkYAML/issues).
- [x] The test suite compiles and runs without any error.
- [x] [The code coverage](https://coveralls.io/github/fktn-k/fkYAML) on your branch is 100%.
- [x] The documentation is updated if you added/changed a feature.

## Please don't

- The C++11 support varies between different **compilers** and versions. Please note the [list of supported compilers](https://github.com/fktn-k/fkYAML/blob/develop/README.md#supported-compilers). Some compilers like GCC 4.7 (and earlier), Clang 3.3 (and earlier), or Microsoft Visual Studio 13.0 and earlier are known not to work due to missing or incomplete C++11 support. Please refrain from proposing changes that work around these compiler's limitations with `#ifdef`s or other means.
- Please refrain from proposing changes that would **break [YAML](https://yaml.org/) specifications**. If you propose a conformant extension of YAML to be supported by the library, please motivate this extension.
- Please do not open pull requests that address **multiple issues**.
