### PR TITLE
Add trace info by running the YAML test suite into the test coverage

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -27,8 +27,12 @@ if(FK_YAML_CODE_COVERAGE OR FK_YAML_RUN_VALGRIND OR FK_YAML_RUN_CLANG_SANITIZERS
     message(FATAL_ERROR "Compiler must be clang when FK_YAML_RUN_CLANG_SANITIZERS is enabled.")
   endif()
 
-  # Generating code coverage depends on the unit test app. So force build it.
-  set(FK_YAML_BUILD_TEST ON)
+  # Generating code coverage depends on the unit tests and the YAML test suite.
+  # So force build them.
+  if(FK_YAML_CODE_COVERAGE)
+    set(FK_YAML_BUILD_TEST ON)
+    set(FK_YAML_USE_YAML_TEST_SUITE ON)
+  endif()
 endif()
 
 if(FK_YAML_BUILD_ALL_TEST)

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -256,14 +256,34 @@ if(FK_YAML_CODE_COVERAGE)
   file(GLOB_RECURSE SRC_FILES ${PROJECT_SOURCE_DIR}/include/fkYAML/*.hpp)
 
   add_custom_target(
-    generate_test_coverage
-    COMMAND ${CMAKE_CTEST_COMMAND} -C ${CMAKE_BUILD_TYPE} --output-on-failure
+    generate_unit_test_coverage
+    COMMAND ${CMAKE_CTEST_COMMAND} -C ${CMAKE_BUILD_TYPE} --output-on-failure -E validation_compositor -E yaml_test_suite
     COMMAND cd ${PROJECT_BINARY_DIR}/tests/unit_test/CMakeFiles/unit_test.dir
     COMMAND ${LCOV_TOOL} --directory . --capture --output-file ${PROJECT_NAME}.info --rc branch_coverage=1 --rc geninfo_unexecuted_blocks=1 --ignore-errors mismatch,mismatch
     COMMAND ${LCOV_TOOL} -e ${PROJECT_NAME}.info ${SRC_FILES} --output-file ${PROJECT_NAME}.info.filtered --rc branch_coverage=1 --ignore-errors unused,unused
     COMMAND ${PROJECT_SOURCE_DIR}/thirdparty/imapdl/filterbr.py ${PROJECT_NAME}.info.filtered > ${PROJECT_NAME}.info.filtered.noexcept
-    COMMAND ${CMAKE_COMMAND} -E copy ${PROJECT_NAME}.info.filtered.noexcept ${PROJECT_BINARY_DIR}/coverage/fkYAML.info
+    COMMAND ${CMAKE_COMMAND} -E copy ${PROJECT_NAME}.info.filtered.noexcept ${PROJECT_BINARY_DIR}/coverage/fkYAML_unit_test.info
     DEPENDS unit_test
     COMMENT "Execute unit test app with code coverage."
+  )
+
+  add_custom_target(
+    generate_yaml_test_suite_coverage
+    # Some cases in the YAML test suite fail, so we ignore the return code of the test suite runner app for now to generate coverage data.
+    COMMAND ${CMAKE_CTEST_COMMAND} -C ${CMAKE_BUILD_TYPE} --output-on-failure -R yaml_test_suite || true
+    COMMAND cd ${PROJECT_BINARY_DIR}/tests/yaml_test_suite_runner/CMakeFiles/yaml_test_suite.dir
+    COMMAND ${LCOV_TOOL} --directory . --capture --output-file ${PROJECT_NAME}.info --rc branch_coverage=1 --rc geninfo_unexecuted_blocks=1 --ignore-errors mismatch,mismatch
+    COMMAND ${LCOV_TOOL} -e ${PROJECT_NAME}.info ${SRC_FILES} --output-file ${PROJECT_NAME}.info.filtered --rc branch_coverage=1 --ignore-errors unused,unused
+    COMMAND ${PROJECT_SOURCE_DIR}/thirdparty/imapdl/filterbr.py ${PROJECT_NAME}.info.filtered > ${PROJECT_NAME}.info.filtered.noexcept
+    COMMAND ${CMAKE_COMMAND} -E copy ${PROJECT_NAME}.info.filtered.noexcept ${PROJECT_BINARY_DIR}/coverage/fkYAML_yaml_test_suite.info
+    DEPENDS yaml_test_suite
+    COMMENT "Execute YAML test suite runner app with code coverage."
+  )
+
+  add_custom_target(
+    generate_test_coverage
+    COMMAND ${LCOV_TOOL} --add-tracefile ${PROJECT_BINARY_DIR}/coverage/fkYAML_unit_test.info --add-tracefile ${PROJECT_BINARY_DIR}/coverage/fkYAML_yaml_test_suite.info --output-file ${PROJECT_BINARY_DIR}/coverage/fkYAML.info --rc branch_coverage=1
+    DEPENDS generate_unit_test_coverage generate_yaml_test_suite_coverage
+    COMMENT "Generate code coverage data for unit test and YAML test suite."
   )
 endif()


### PR DESCRIPTION
This PR adds the trace info by running the YAML test suite into the test coverage.  

**CAVEAT**:  
The result code of running the YAML test suite is currently ignored since a number of the cases fail at this moment. The ignorance will be removed when this library passes all the cases like the unit tests.  

---

## Pull Request Checklist

Read the [CONTRIBUTING.md](https://github.com/fktn-k/fkYAML/blob/develop/.github/CONTRIBUTING.md) file for detailed information.  

- [x] Changes are described in the pull request or in a referenced [issue](https://github.com/fktn-k/fkYAML/issues).
- [x] The test suite compiles and runs without any error.
- [x] [The code coverage](https://coveralls.io/github/fktn-k/fkYAML) on your branch is 100%.
- [x] The documentation is updated if you added/changed a feature.

## Please don't

- The C++11 support varies between different **compilers** and versions. Please note the [list of supported compilers](https://github.com/fktn-k/fkYAML/blob/develop/README.md#supported-compilers). Some compilers like GCC 4.7 (and earlier), Clang 3.3 (and earlier), or Microsoft Visual Studio 13.0 and earlier are known not to work due to missing or incomplete C++11 support. Please refrain from proposing changes that work around these compiler's limitations with `#ifdef`s or other means.
- Please refrain from proposing changes that would **break [YAML](https://yaml.org/) specifications**. If you propose a conformant extension of YAML to be supported by the library, please motivate this extension.
- Please do not open pull requests that address **multiple issues**.
