### PR TITLE
Allow block scalars with only its header

### DIFF
--- a/include/fkYAML/detail/input/lexical_analyzer.hpp
+++ b/include/fkYAML/detail/input/lexical_analyzer.hpp
@@ -350,17 +350,21 @@ private:
         }
         case '|':
         case '>': {
+            const lexical_token_t type = *m_token_begin_itr == '|' ? lexical_token_t::BLOCK_LITERAL_SCALAR
+                                                                   : lexical_token_t::BLOCK_FOLDED_SCALAR;
             const str_view sv {m_token_begin_itr, m_end_itr};
             const std::size_t header_end_pos = sv.find('\n');
+
             if FK_YAML_UNLIKELY (header_end_pos == str_view::npos) {
-                emit_error(
-                    "Invalid block scalar header found. The header must be followed by a line break and its content.");
+                m_block_scalar_header = convert_to_block_scalar_header(sv.substr(1));
+                // If the block scalar header is not followed by a newline code, its content is empty.
+                m_cur_itr = m_token_begin_itr = m_end_itr;
+                info.token = {type, {m_token_begin_itr, 0}};
+                return info;
             }
 
             const uint32_t base_indent = get_current_indent_level(&sv[header_end_pos]);
 
-            const lexical_token_t type = *m_token_begin_itr == '|' ? lexical_token_t::BLOCK_LITERAL_SCALAR
-                                                                   : lexical_token_t::BLOCK_FOLDED_SCALAR;
             const str_view header_line = sv.substr(1, header_end_pos - 1);
             m_block_scalar_header = convert_to_block_scalar_header(header_line);
 

--- a/single_include/fkYAML/node.hpp
+++ b/single_include/fkYAML/node.hpp
@@ -3584,17 +3584,21 @@ private:
         }
         case '|':
         case '>': {
+            const lexical_token_t type = *m_token_begin_itr == '|' ? lexical_token_t::BLOCK_LITERAL_SCALAR
+                                                                   : lexical_token_t::BLOCK_FOLDED_SCALAR;
             const str_view sv {m_token_begin_itr, m_end_itr};
             const std::size_t header_end_pos = sv.find('\n');
+
             if FK_YAML_UNLIKELY (header_end_pos == str_view::npos) {
-                emit_error(
-                    "Invalid block scalar header found. The header must be followed by a line break and its content.");
+                m_block_scalar_header = convert_to_block_scalar_header(sv.substr(1));
+                // If the block scalar header is not followed by a newline code, its content is empty.
+                m_cur_itr = m_token_begin_itr = m_end_itr;
+                info.token = {type, {m_token_begin_itr, 0}};
+                return info;
             }
 
             const uint32_t base_indent = get_current_indent_level(&sv[header_end_pos]);
 
-            const lexical_token_t type = *m_token_begin_itr == '|' ? lexical_token_t::BLOCK_LITERAL_SCALAR
-                                                                   : lexical_token_t::BLOCK_FOLDED_SCALAR;
             const str_view header_line = sv.substr(1, header_end_pos - 1);
             m_block_scalar_header = convert_to_block_scalar_header(header_line);
 

--- a/tests/unit_test/test_fuzz_regression.cpp
+++ b/tests/unit_test/test_fuzz_regression.cpp
@@ -65,11 +65,13 @@ TEST_CASE("FuzzRegression") {
         REQUIRE_THROWS_AS(root = fkyaml::node::deserialize(p_begin, p_end), fkyaml::parse_error);
     }
 
-    SUBCASE("invalid block scalar header") {
+    SUBCASE("a block scalar with only a header and no content lines") {
         auto input = GENERATE(std::string(">"), std::string("|"));
         p_begin = input.data();
         p_end = input.data() + input.size();
-        REQUIRE_THROWS_AS(root = fkyaml::node::deserialize(p_begin, p_end), fkyaml::parse_error);
+        REQUIRE_NOTHROW(root = fkyaml::node::deserialize(p_begin, p_end));
+        REQUIRE(root.is_string());
+        REQUIRE(root.as_str().empty());
     }
 
     SUBCASE("invalid colons") {


### PR DESCRIPTION
This PR allows a block scalar with only its header, for example:

```yaml
>
```

According to the YAML test suite (e.g. `2G84/03/in.yaml`), such a scalar is parsed as an empty string scalar.  
So, I modified the lexer implementation accordingly.

---

## Pull Request Checklist

Read the [CONTRIBUTING.md](https://github.com/fktn-k/fkYAML/blob/develop/.github/CONTRIBUTING.md) file for detailed information.  

- [x] Changes are described in the pull request or in a referenced [issue](https://github.com/fktn-k/fkYAML/issues).
- [x] The test suite compiles and runs without any error.
- [x] [The code coverage](https://coveralls.io/github/fktn-k/fkYAML) on your branch is 100%.
- [x] The documentation is updated if you added/changed a feature.

## Please don't

- The C++11 support varies between different **compilers** and versions. Please note the [list of supported compilers](https://github.com/fktn-k/fkYAML/blob/develop/README.md#supported-compilers). Some compilers like GCC 4.7 (and earlier), Clang 3.3 (and earlier), or Microsoft Visual Studio 13.0 and earlier are known not to work due to missing or incomplete C++11 support. Please refrain from proposing changes that work around these compiler's limitations with `#ifdef`s or other means.
- Please refrain from proposing changes that would **break [YAML](https://yaml.org/) specifications**. If you propose a conformant extension of YAML to be supported by the library, please motivate this extension.
- Please do not open pull requests that address **multiple issues**.
