### PR TITLE
Make UBSan findings fail the fuzz test

### DIFF
--- a/tests/fuzz_test/CMakeLists.txt
+++ b/tests/fuzz_test/CMakeLists.txt
@@ -27,6 +27,11 @@ target_compile_options(
   fuzz_test
   PRIVATE
     -fsanitize=fuzzer,address,undefined
+    # UBSan checks are recoverable by default: without this they print a diagnostic and the
+    # run continues, so libFuzzer never sees a crash and never saves the offending input.
+    -fno-sanitize-recover=all
+    # Excluded for the same reason the unit test configuration excludes it.
+    -fno-sanitize=signed-integer-overflow
     -g
     -O1
 )


### PR DESCRIPTION
UBSan checks are recoverable by default, so a finding in the fuzz target prints a `runtime error:`
line and the run continues. libFuzzer never sees a crash, never saves the offending input, and
`make fuzz-test` still exits 0. `-fno-sanitize-recover=all` makes those findings abort instead.

`signed-integer-overflow` is excluded to stay in step with the clang sanitizer flags for the unit
tests, which have excluded it since #391. `implicit-conversion` is excluded there too but is not part
of `-fsanitize=undefined`, so it isn't repeated here.

Only `target_compile_options` changes: recover mode is a codegen decision (the compiler emits
`__ubsan_handle_*_abort` rather than `__ubsan_handle_*`), so the flag is a no-op on the link line.

Two notes:

- I couldn't build this locally, and no workflow builds the fuzz target, so `make fuzz-test` on Linux
  is the first real check. The unit test job already runs a superset of these checks fatally with the
  same exclusion and is green, so the combination is at least viable on this codebase. If something
  does fire, it is most likely a finding rather than a regression of this change.
- This touches the same `target_compile_options` block as #571, so whichever merges second will need a
  trivial conflict resolution.

---

## Pull Request Checklist

Read the [CONTRIBUTING.md](https://github.com/fktn-k/fkYAML/blob/develop/.github/CONTRIBUTING.md) file for detailed information.  

- [x] Changes are described in the pull request or in a referenced [issue](https://github.com/fktn-k/fkYAML/issues).
- [x] The test suite compiles and runs without any error.
- [x] [The code coverage](https://coveralls.io/github/fktn-k/fkYAML) on your branch is 100%.
- [x] The documentation is updated if you added/changed a feature.

## Please don't

- The C++11 support varies between different **compilers** and versions. Please note the [list of supported compilers](https://github.com/fktn-k/fkYAML/blob/develop/README.md#supported-compilers). Some compilers like GCC 4.7 (and earlier), Clang 3.3 (and earlier), or Microsoft Visual Studio 13.0 and earlier are known not to work due to missing or incomplete C++11 support. Please refrain from proposing changes that work around these compiler's limitations with `#ifdef`s or other means.
- Please refrain from proposing changes that would **break [YAML](https://yaml.org/) specifications**. If you propose a conformant extension of YAML to be supported by the library, please motivate this extension.
- Please do not open pull requests that address **multiple issues**.
