### PR TITLE
Reject an input which leaves a flow collection unclosed

### DIFF
--- a/include/fkYAML/detail/input/deserializer.hpp
+++ b/include/fkYAML/detail/input/deserializer.hpp
@@ -1160,6 +1160,10 @@ private:
             line = lexer.get_lines_processed();
         } while (token.type != lexical_token_t::END_OF_BUFFER);
 
+        if FK_YAML_UNLIKELY (m_flow_context_depth > 0) {
+            throw parse_error("An unclosed flow collection found at the end of input", line, indent);
+        }
+
         last_type = token.type;
     }
 

--- a/single_include/fkYAML/node.hpp
+++ b/single_include/fkYAML/node.hpp
@@ -8664,6 +8664,10 @@ private:
             line = lexer.get_lines_processed();
         } while (token.type != lexical_token_t::END_OF_BUFFER);
 
+        if FK_YAML_UNLIKELY (m_flow_context_depth > 0) {
+            throw parse_error("An unclosed flow collection found at the end of input", line, indent);
+        }
+
         last_type = token.type;
     }
 

--- a/tests/unit_test/test_deserializer_class.cpp
+++ b/tests/unit_test/test_deserializer_class.cpp
@@ -2505,6 +2505,21 @@ TEST_CASE("Deserializer_FlowMapping") {
     }
 }
 
+TEST_CASE("Deserializer_UnclosedFlowCollection") {
+    fkyaml::detail::basic_deserializer<fkyaml::node> deserializer;
+    fkyaml::node root;
+
+    SUBCASE("flow collection left unclosed at the end of input") {
+        auto input = GENERATE(
+            std::string("{{{"),
+            std::string("? ["),
+            std::string("[foo, bar"),
+            std::string("{foo: bar"),
+            std::string("---\n[ [ a, b, c ]"));
+        REQUIRE_THROWS_AS(root = deserializer.deserialize(fkyaml::detail::input_adapter(input)), fkyaml::parse_error);
+    }
+}
+
 TEST_CASE("Deserializer_BadIndentation") {
     fkyaml::detail::basic_deserializer<fkyaml::node> deserializer;
     fkyaml::node root;

--- a/tests/unit_test/test_fuzz_regression.cpp
+++ b/tests/unit_test/test_fuzz_regression.cpp
@@ -159,9 +159,10 @@ TEST_CASE("FuzzRegression") {
     SUBCASE("key nodes owned by a parse context are released") {
         // These inputs leave a key node owned by its parse context on a path where the context state is
         // later rewritten, which used to leak the node. They are kept here so the sanitizer builds cover
-        // that ownership, the parse results themselves are secondary.
+        // that ownership. Both leave a flow collection unclosed, so the parse is rejected at the end of
+        // input, which happens after the contexts have been built and rewritten.
         auto input = GENERATE(std::string("{{{"), std::string("? ["));
-        REQUIRE_NOTHROW(root = fkyaml::node::deserialize(input));
+        REQUIRE_THROWS_AS(root = fkyaml::node::deserialize(input), fkyaml::parse_error);
     }
 
     SUBCASE("key node owned by a parse context is released on an error path") {


### PR DESCRIPTION
Fixes #564.

`END_OF_DIRECTIVES` and `END_OF_DOCUMENT` already reject a document marker found inside a flow
collection, but nothing checked the flow context depth at the end of input, so `{{{` and `? []`
completed with a wrong result instead of an error. The `END_OF_BUFFER` case in the token switch only
handles an empty input: a non-empty document leaves the parse loop through its `while` condition,
so the check goes after the loop.

Note the change to `test_fuzz_regression.cpp`: that subcase was added in #563 to keep the sanitizer
builds covering the parse context ownership path, and it happened to pin the old behaviour with
`REQUIRE_NOTHROW`. Both of its inputs leave a flow collection unclosed, so they are now rejected. The
subcase keeps its original purpose, since the error is raised at the end of input, after the contexts
have been built and rewritten.

Unit tests pass, in the YAML test suite this also fixes `6JTT` (Flow sequence without closing bracket),
125 failing cases down to 124, with no newly failing case.

---

## Pull Request Checklist

Read the [CONTRIBUTING.md](https://github.com/fktn-k/fkYAML/blob/develop/.github/CONTRIBUTING.md) file for detailed information.  

- [x] Changes are described in the pull request or in a referenced [issue](https://github.com/fktn-k/fkYAML/issues).
- [x] The test suite compiles and runs without any error.
- [x] [The code coverage](https://coveralls.io/github/fktn-k/fkYAML) on your branch is 100%.
- [x] The documentation is updated if you added/changed a feature.

## Please don't

- The C++11 support varies between different **compilers** and versions. Please note the [list of supported compilers](https://github.com/fktn-k/fkYAML/blob/develop/README.md#supported-compilers). Some compilers like GCC 4.7 (and earlier), Clang 3.3 (and earlier), or Microsoft Visual Studio 13.0 and earlier are known not to work due to missing or incomplete C++11 support. Please refrain from proposing changes that work around these compiler's limitations with `#ifdef`s or other means.
- Please refrain from proposing changes that would **break [YAML](https://yaml.org/) specifications**. If you propose a conformant extension of YAML to be supported by the library, please motivate this extension.
- Please do not open pull requests that address **multiple issues**.
