### PR TITLE
Support single pair mappings in flow sequences

### DIFF
--- a/include/fkYAML/detail/input/deserializer.hpp
+++ b/include/fkYAML/detail/input/deserializer.hpp
@@ -882,6 +882,8 @@ private:
                     lexer.set_context_state(false);
                 }
 
+                close_single_pair_mapping(line, indent);
+
                 const bool has_valid_beginning =
                     !m_context_stack.empty() && (m_context_stack.back().state == context_state_t::FLOW_SEQUENCE ||
                                                  m_context_stack.back().state == context_state_t::FLOW_SEQUENCE_KEY);
@@ -1063,6 +1065,7 @@ private:
                 if FK_YAML_UNLIKELY (m_flow_token_state != flow_token_state_t::NEEDS_SEPARATOR_OR_SUFFIX) {
                     throw parse_error("invalid value separator is found.", line, indent);
                 }
+                close_single_pair_mapping(line, indent);
                 m_flow_token_state = flow_token_state_t::NEEDS_VALUE_OR_SUFFIX;
                 break;
             case lexical_token_t::ALIAS_PREFIX: {
@@ -1585,6 +1588,28 @@ private:
     /// @param node A basic_node_type object to be set YAML directive properties.
     void apply_directive_set(basic_node_type& node) noexcept {
         node.mp_meta = mp_meta;
+    }
+
+    /// @brief Closes the implicit single pair mapping wrapping a flow sequence entry, if one is open.
+    /// @note
+    /// A flow sequence entry may be a mapping entry written without braces, e.g. `[foo: 1]` meaning
+    /// `[{foo: 1}]`. Such an entry is wrapped in a mapping when its key separator is found, and that
+    /// wrapper must be closed once the entry ends, either at a separator or at the sequence suffix.
+    /// Block content cannot appear inside a flow collection, so a block mapping context found here can
+    /// only be that wrapper.
+    /// @param line Current line.
+    /// @param indent Current indentation.
+    void close_single_pair_mapping(const uint32_t line, const uint32_t indent) {
+        // LCOV_EXCL_START
+        if FK_YAML_UNLIKELY (m_context_stack.empty()) {
+            return;
+        }
+        // LCOV_EXCL_STOP
+
+        if (m_context_stack.back().state == context_state_t::BLOCK_MAPPING) {
+            m_context_stack.pop_back();
+            mp_current_node = current_context(line, indent).p_node;
+        }
     }
 
     /// @brief Set YAML node properties (anchor and/or tag names) to the given node.

--- a/include/fkYAML/detail/input/deserializer.hpp
+++ b/include/fkYAML/detail/input/deserializer.hpp
@@ -1602,7 +1602,7 @@ private:
     void close_single_pair_mapping(const uint32_t line, const uint32_t indent) {
         // LCOV_EXCL_START
         if FK_YAML_UNLIKELY (m_context_stack.empty()) {
-            return;
+            throw parse_error("No parent flow collection is found.", line, indent);
         }
         // LCOV_EXCL_STOP
 

--- a/single_include/fkYAML/node.hpp
+++ b/single_include/fkYAML/node.hpp
@@ -8386,6 +8386,8 @@ private:
                     lexer.set_context_state(false);
                 }
 
+                close_single_pair_mapping(line, indent);
+
                 const bool has_valid_beginning =
                     !m_context_stack.empty() && (m_context_stack.back().state == context_state_t::FLOW_SEQUENCE ||
                                                  m_context_stack.back().state == context_state_t::FLOW_SEQUENCE_KEY);
@@ -8567,6 +8569,7 @@ private:
                 if FK_YAML_UNLIKELY (m_flow_token_state != flow_token_state_t::NEEDS_SEPARATOR_OR_SUFFIX) {
                     throw parse_error("invalid value separator is found.", line, indent);
                 }
+                close_single_pair_mapping(line, indent);
                 m_flow_token_state = flow_token_state_t::NEEDS_VALUE_OR_SUFFIX;
                 break;
             case lexical_token_t::ALIAS_PREFIX: {
@@ -9089,6 +9092,28 @@ private:
     /// @param node A basic_node_type object to be set YAML directive properties.
     void apply_directive_set(basic_node_type& node) noexcept {
         node.mp_meta = mp_meta;
+    }
+
+    /// @brief Closes the implicit single pair mapping wrapping a flow sequence entry, if one is open.
+    /// @note
+    /// A flow sequence entry may be a mapping entry written without braces, e.g. `[foo: 1]` meaning
+    /// `[{foo: 1}]`. Such an entry is wrapped in a mapping when its key separator is found, and that
+    /// wrapper must be closed once the entry ends, either at a separator or at the sequence suffix.
+    /// Block content cannot appear inside a flow collection, so a block mapping context found here can
+    /// only be that wrapper.
+    /// @param line Current line.
+    /// @param indent Current indentation.
+    void close_single_pair_mapping(const uint32_t line, const uint32_t indent) {
+        // LCOV_EXCL_START
+        if FK_YAML_UNLIKELY (m_context_stack.empty()) {
+            return;
+        }
+        // LCOV_EXCL_STOP
+
+        if (m_context_stack.back().state == context_state_t::BLOCK_MAPPING) {
+            m_context_stack.pop_back();
+            mp_current_node = current_context(line, indent).p_node;
+        }
     }
 
     /// @brief Set YAML node properties (anchor and/or tag names) to the given node.

--- a/single_include/fkYAML/node.hpp
+++ b/single_include/fkYAML/node.hpp
@@ -9106,7 +9106,7 @@ private:
     void close_single_pair_mapping(const uint32_t line, const uint32_t indent) {
         // LCOV_EXCL_START
         if FK_YAML_UNLIKELY (m_context_stack.empty()) {
-            return;
+            throw parse_error("No parent flow collection is found.", line, indent);
         }
         // LCOV_EXCL_STOP
 

--- a/tests/unit_test/test_deserializer_class.cpp
+++ b/tests/unit_test/test_deserializer_class.cpp
@@ -2189,6 +2189,54 @@ TEST_CASE("Deserializer_FlowSequence") {
     }
 }
 
+TEST_CASE("Deserializer_SinglePairMappingInFlowSequence") {
+    fkyaml::detail::basic_deserializer<fkyaml::node> deserializer;
+    fkyaml::node root;
+
+    SUBCASE("a single entry without braces") {
+        std::string input = "[foo: 1]";
+        REQUIRE_NOTHROW(root = deserializer.deserialize(fkyaml::detail::input_adapter(input)));
+
+        REQUIRE(root.is_sequence());
+        REQUIRE(root.size() == 1);
+        REQUIRE(root[0].is_mapping());
+        REQUIRE(root[0].size() == 1);
+        REQUIRE(root[0].contains("foo"));
+        REQUIRE(root[0]["foo"].get_value<int>() == 1);
+    }
+
+    SUBCASE("each entry becomes its own mapping") {
+        std::string input = "[foo: 1, bar: 2]";
+        REQUIRE_NOTHROW(root = deserializer.deserialize(fkyaml::detail::input_adapter(input)));
+
+        REQUIRE(root.is_sequence());
+        REQUIRE(root.size() == 2);
+        REQUIRE(root[0].is_mapping());
+        REQUIRE(root[0].size() == 1);
+        REQUIRE(root[0]["foo"].get_value<int>() == 1);
+        REQUIRE(root[1].is_mapping());
+        REQUIRE(root[1].size() == 1);
+        REQUIRE(root[1]["bar"].get_value<int>() == 2);
+    }
+
+    SUBCASE("nested in a flow mapping value") {
+        std::string input = "{a: [b: 1]}";
+        REQUIRE_NOTHROW(root = deserializer.deserialize(fkyaml::detail::input_adapter(input)));
+
+        REQUIRE(root.is_mapping());
+        REQUIRE(root["a"].is_sequence());
+        REQUIRE(root["a"].size() == 1);
+        REQUIRE(root["a"][0].is_mapping());
+        REQUIRE(root["a"][0]["b"].get_value<int>() == 1);
+    }
+
+    SUBCASE("the explicit brace form is unaffected") {
+        auto input = GENERATE(std::string("[{foo: 1}]"), std::string("[a, b]"));
+        REQUIRE_NOTHROW(root = deserializer.deserialize(fkyaml::detail::input_adapter(input)));
+        REQUIRE(root.is_sequence());
+    }
+}
+
 TEST_CASE("Deserializer_FlowMapping") {
     fkyaml::detail::basic_deserializer<fkyaml::node> deserializer;
     fkyaml::node root;


### PR DESCRIPTION
Fixes #561.

The wrapping itself was already there: when a key separator is found while the current node is a
sequence, `add_new_key` wraps the entry in a mapping and pushes a context for it. Nothing ever closed
that context, so `]` saw a block mapping on top of the stack instead of the flow sequence and reported
`No corresponding flow sequence beginning is found`. The comma had the same problem from the other
side (it did not close the wrapper either, so `[foo: 1, bar: 2]` would have collected both keys into
one mapping rather than two).

`close_single_pair_mapping()` is called at both points. Block content cannot appear inside a flow
collection, so a block mapping context found there can only be that wrapper.

I verified YAML test suite: 125 failing cases down to 116, with no newly failing case. Nine cases fixed:
`9MMW`, `CFD4`, `4FJ6`, `CN3R` and Spec Examples 7.4 (`LQZ7`), 7.8 (`87E4`), 7.11 (`L9U5`),
7.14 (`8UDB`) and 7.19 (`QF4Y`).

`CFD4` needed the empty key support from #558 as well, which is why it passes in full now.

Unit tests also pass.

---

## Pull Request Checklist

Read the [CONTRIBUTING.md](https://github.com/fktn-k/fkYAML/blob/develop/.github/CONTRIBUTING.md) file for detailed information.  

- [x] Changes are described in the pull request or in a referenced [issue](https://github.com/fktn-k/fkYAML/issues).
- [x] The test suite compiles and runs without any error.
- [x] [The code coverage](https://coveralls.io/github/fktn-k/fkYAML) on your branch is 100%.
- [x] The documentation is updated if you added/changed a feature.

## Please don't

- The C++11 support varies between different **compilers** and versions. Please note the [list of supported compilers](https://github.com/fktn-k/fkYAML/blob/develop/README.md#supported-compilers). Some compilers like GCC 4.7 (and earlier), Clang 3.3 (and earlier), or Microsoft Visual Studio 13.0 and earlier are known not to work due to missing or incomplete C++11 support. Please refrain from proposing changes that work around these compiler's limitations with `#ifdef`s or other means.
- Please refrain from proposing changes that would **break [YAML](https://yaml.org/) specifications**. If you propose a conformant extension of YAML to be supported by the library, please motivate this extension.
- Please do not open pull requests that address **multiple issues**.
