### PR TITLE
Support an omitted value in a flow mapping entry

### DIFF
--- a/include/fkYAML/detail/input/deserializer.hpp
+++ b/include/fkYAML/detail/input/deserializer.hpp
@@ -1006,6 +1006,8 @@ private:
                     lexer.set_context_state(false);
                 }
 
+                close_omitted_mapping_value(line, indent);
+
                 const bool has_valid_beginning =
                     !m_context_stack.empty() && (m_context_stack.back().state == context_state_t::FLOW_MAPPING ||
                                                  m_context_stack.back().state == context_state_t::FLOW_MAPPING_KEY);
@@ -1062,6 +1064,7 @@ private:
                 if FK_YAML_UNLIKELY (m_flow_context_depth == 0) {
                     throw parse_error("invalid value separator is found.", line, indent);
                 }
+                close_omitted_mapping_value(line, indent);
                 if FK_YAML_UNLIKELY (m_flow_token_state != flow_token_state_t::NEEDS_SEPARATOR_OR_SUFFIX) {
                     throw parse_error("invalid value separator is found.", line, indent);
                 }
@@ -1609,6 +1612,28 @@ private:
         if (m_context_stack.back().state == context_state_t::BLOCK_MAPPING) {
             m_context_stack.pop_back();
             mp_current_node = current_context(line, indent).p_node;
+        }
+    }
+
+    /// @brief Completes a flow mapping entry whose value was omitted, if one is pending.
+    /// @note
+    /// A flow mapping entry may leave its value empty, in which case the value is null, e.g. `{foo: }`
+    /// meaning `{foo: null}`. The value node is already null since `add_new_key` default constructs it,
+    /// so the entry only needs its context closed once it ends, either at a separator or at the mapping
+    /// suffix.
+    /// @param line Current line.
+    /// @param indent Current indentation.
+    void close_omitted_mapping_value(const uint32_t line, const uint32_t indent) {
+        // LCOV_EXCL_START
+        if FK_YAML_UNLIKELY (m_context_stack.empty()) {
+            throw parse_error("No parent flow collection is found.", line, indent);
+        }
+        // LCOV_EXCL_STOP
+
+        if (m_context_stack.back().state == context_state_t::MAPPING_VALUE) {
+            m_context_stack.pop_back();
+            mp_current_node = current_context(line, indent).p_node;
+            m_flow_token_state = flow_token_state_t::NEEDS_SEPARATOR_OR_SUFFIX;
         }
     }
 

--- a/include/fkYAML/detail/input/lexical_analyzer.hpp
+++ b/include/fkYAML/detail/input/lexical_analyzer.hpp
@@ -993,6 +993,16 @@ private:
                     case '\n':
                         ends_loop = true;
                         break;
+                    case ',':
+                    case '[':
+                    case ']':
+                    case '{':
+                    case '}':
+                        // A flow indicator is not "safe" to follow a ":" in a flow context, so the ":" ends
+                        // the plain scalar and becomes a mapping value indicator instead.
+                        // See https://yaml.org/spec/1.2.2/#733-plain-style for more details.
+                        ends_loop = ((m_state & flow_context_bit) != 0);
+                        break;
                     default:
                         break;
                     }

--- a/single_include/fkYAML/node.hpp
+++ b/single_include/fkYAML/node.hpp
@@ -4227,6 +4227,16 @@ private:
                     case '\n':
                         ends_loop = true;
                         break;
+                    case ',':
+                    case '[':
+                    case ']':
+                    case '{':
+                    case '}':
+                        // A flow indicator is not "safe" to follow a ":" in a flow context, so the ":" ends
+                        // the plain scalar and becomes a mapping value indicator instead.
+                        // See https://yaml.org/spec/1.2.2/#733-plain-style for more details.
+                        ends_loop = ((m_state & flow_context_bit) != 0);
+                        break;
                     default:
                         break;
                     }
@@ -8510,6 +8520,8 @@ private:
                     lexer.set_context_state(false);
                 }
 
+                close_omitted_mapping_value(line, indent);
+
                 const bool has_valid_beginning =
                     !m_context_stack.empty() && (m_context_stack.back().state == context_state_t::FLOW_MAPPING ||
                                                  m_context_stack.back().state == context_state_t::FLOW_MAPPING_KEY);
@@ -8566,6 +8578,7 @@ private:
                 if FK_YAML_UNLIKELY (m_flow_context_depth == 0) {
                     throw parse_error("invalid value separator is found.", line, indent);
                 }
+                close_omitted_mapping_value(line, indent);
                 if FK_YAML_UNLIKELY (m_flow_token_state != flow_token_state_t::NEEDS_SEPARATOR_OR_SUFFIX) {
                     throw parse_error("invalid value separator is found.", line, indent);
                 }
@@ -9113,6 +9126,28 @@ private:
         if (m_context_stack.back().state == context_state_t::BLOCK_MAPPING) {
             m_context_stack.pop_back();
             mp_current_node = current_context(line, indent).p_node;
+        }
+    }
+
+    /// @brief Completes a flow mapping entry whose value was omitted, if one is pending.
+    /// @note
+    /// A flow mapping entry may leave its value empty, in which case the value is null, e.g. `{foo: }`
+    /// meaning `{foo: null}`. The value node is already null since `add_new_key` default constructs it,
+    /// so the entry only needs its context closed once it ends, either at a separator or at the mapping
+    /// suffix.
+    /// @param line Current line.
+    /// @param indent Current indentation.
+    void close_omitted_mapping_value(const uint32_t line, const uint32_t indent) {
+        // LCOV_EXCL_START
+        if FK_YAML_UNLIKELY (m_context_stack.empty()) {
+            throw parse_error("No parent flow collection is found.", line, indent);
+        }
+        // LCOV_EXCL_STOP
+
+        if (m_context_stack.back().state == context_state_t::MAPPING_VALUE) {
+            m_context_stack.pop_back();
+            mp_current_node = current_context(line, indent).p_node;
+            m_flow_token_state = flow_token_state_t::NEEDS_SEPARATOR_OR_SUFFIX;
         }
     }
 

--- a/tests/unit_test/test_deserializer_class.cpp
+++ b/tests/unit_test/test_deserializer_class.cpp
@@ -2568,6 +2568,47 @@ TEST_CASE("Deserializer_UnclosedFlowCollection") {
     }
 }
 
+TEST_CASE("Deserializer_OmittedFlowMappingValue") {
+    fkyaml::detail::basic_deserializer<fkyaml::node> deserializer;
+    fkyaml::node root;
+
+    SUBCASE("the only entry has no value") {
+        auto input = GENERATE(std::string("{foo: }"), std::string("{foo:}"), std::string("{\"foo\": }"));
+        REQUIRE_NOTHROW(root = deserializer.deserialize(fkyaml::detail::input_adapter(input)));
+
+        REQUIRE(root.is_mapping());
+        REQUIRE(root.size() == 1);
+        REQUIRE(root.contains("foo"));
+        REQUIRE(root["foo"].is_null());
+    }
+
+    SUBCASE("the first entry has no value") {
+        std::string input = "{foo: , bar: 1}";
+        REQUIRE_NOTHROW(root = deserializer.deserialize(fkyaml::detail::input_adapter(input)));
+
+        REQUIRE(root.is_mapping());
+        REQUIRE(root.size() == 2);
+        REQUIRE(root["foo"].is_null());
+        REQUIRE(root["bar"].get_value<int>() == 1);
+    }
+
+    SUBCASE("the last entry has no value") {
+        std::string input = "{foo: 1, bar: }";
+        REQUIRE_NOTHROW(root = deserializer.deserialize(fkyaml::detail::input_adapter(input)));
+
+        REQUIRE(root.is_mapping());
+        REQUIRE(root.size() == 2);
+        REQUIRE(root["foo"].get_value<int>() == 1);
+        REQUIRE(root["bar"].is_null());
+    }
+
+    SUBCASE("an empty entry is still rejected") {
+        auto input =
+            GENERATE(std::string("{foo: 1,, bar: 2}"), std::string("{,}"), std::string("[a,,b]"), std::string("[,]"));
+        REQUIRE_THROWS_AS(root = deserializer.deserialize(fkyaml::detail::input_adapter(input)), fkyaml::parse_error);
+    }
+}
+
 TEST_CASE("Deserializer_BadIndentation") {
     fkyaml::detail::basic_deserializer<fkyaml::node> deserializer;
     fkyaml::node root;


### PR DESCRIPTION
Fixes #560.

Two layers were involved.

In the deserializer, a flow mapping entry whose value never arrives leaves its `MAPPING_VALUE`
context on the stack, and `}` requires the flow context to be on top, hence
`No corresponding flow mapping beginning is found`. The value node is already null, since
`add_new_key` default constructs it, so the entry only needs its context closed. That happens at both
`,` and `}`; at the separator it has to run before the token state check, otherwise
`{foo: , bar: 1}` is rejected first.

In the lexer, `{foo:}` is a separate problem: `determine_plain_scalar_range()` ended a plain scalar at
`:` only before a space, tab or newline, so `foo:` was scanned as one scalar. A `:` followed by a flow
indicator is not `ns-plain-safe` in a flow context, so it now ends the scalar there too, using the
same set of indicators the lexer already checks for a standalone colon.

I verified: unit tests pass, YAML test suite: 115 failing cases down to 113, fixing
`C2DT` (Spec Example 7.18) and `NKF9`, with no newly failing case. I also checked that empty
entries are still rejected: `{foo: 1,, bar: 2}`, `{,}`, `[a,,b]` and `[,]` all still throw.

Two cases named in the issue still fail, for reasons outside this change. `FRK4` also needs an
*explicit* key with an omitted value (`? foo :,`), which is a different context state. `4ABK` fails on
`http://foo.com` - a flow mapping entry with no value indicator at all, which should be
`{http://foo.com: null}`. `{a, b}` reproduces that on its own, and it is a separate gap from this one.

---

## Pull Request Checklist

Read the [CONTRIBUTING.md](https://github.com/fktn-k/fkYAML/blob/develop/.github/CONTRIBUTING.md) file for detailed information.  

- [x] Changes are described in the pull request or in a referenced [issue](https://github.com/fktn-k/fkYAML/issues).
- [x] The test suite compiles and runs without any error.
- [x] [The code coverage](https://coveralls.io/github/fktn-k/fkYAML) on your branch is 100%.
- [x] The documentation is updated if you added/changed a feature.

## Please don't

- The C++11 support varies between different **compilers** and versions. Please note the [list of supported compilers](https://github.com/fktn-k/fkYAML/blob/develop/README.md#supported-compilers). Some compilers like GCC 4.7 (and earlier), Clang 3.3 (and earlier), or Microsoft Visual Studio 13.0 and earlier are known not to work due to missing or incomplete C++11 support. Please refrain from proposing changes that work around these compiler's limitations with `#ifdef`s or other means.
- Please refrain from proposing changes that would **break [YAML](https://yaml.org/) specifications**. If you propose a conformant extension of YAML to be supported by the library, please motivate this extension.
- Please do not open pull requests that address **multiple issues**.
