### PR TITLE
Raise a parse error when a collection tag is applied to a scalar

### DIFF
--- a/include/fkYAML/detail/input/deserializer.hpp
+++ b/include/fkYAML/detail/input/deserializer.hpp
@@ -1114,10 +1114,7 @@ private:
             case lexical_token_t::PLAIN_SCALAR:
             case lexical_token_t::SINGLE_QUOTED_SCALAR:
             case lexical_token_t::DOUBLE_QUOTED_SCALAR: {
-                tag_t tag_type {tag_t::NONE};
-                if (m_needs_tag_impl) {
-                    tag_type = tag_resolver_type::resolve_tag(m_tag_name, mp_meta);
-                }
+                const tag_t tag_type = resolve_scalar_tag(line, indent);
 
                 basic_node_type node = scalar_parser_type(line, indent).parse_flow(token.type, tag_type, token.str);
                 apply_directive_set(node);
@@ -1128,10 +1125,7 @@ private:
             }
             case lexical_token_t::BLOCK_LITERAL_SCALAR:
             case lexical_token_t::BLOCK_FOLDED_SCALAR: {
-                tag_t tag_type {tag_t::NONE};
-                if (m_needs_tag_impl) {
-                    tag_type = tag_resolver_type::resolve_tag(m_tag_name, mp_meta);
-                }
+                const tag_t tag_type = resolve_scalar_tag(line, indent);
 
                 basic_node_type node =
                     scalar_parser_type(line, indent)
@@ -1635,6 +1629,26 @@ private:
             mp_current_node = current_context(line, indent).p_node;
             m_flow_token_state = flow_token_state_t::NEEDS_SEPARATOR_OR_SUFFIX;
         }
+    }
+
+    /// @brief Resolves the tag for a scalar node, if any is pending.
+    /// @param line Current line.
+    /// @param indent Current indentation.
+    /// @return The resolved tag type, or tag_t::NONE if no tag is pending.
+    tag_t resolve_scalar_tag(const uint32_t line, const uint32_t indent) const {
+        if (!m_needs_tag_impl) {
+            return tag_t::NONE;
+        }
+
+        const tag_t tag_type = tag_resolver_type::resolve_tag(m_tag_name, mp_meta);
+
+        // A collection tag denotes a sequence or a mapping, so it cannot apply to a scalar node.
+        // Such an input is a syntax error rather than an internal inconsistency.
+        if FK_YAML_UNLIKELY (tag_type == tag_t::SEQUENCE || tag_type == tag_t::MAPPING) {
+            throw parse_error("A sequence or mapping tag cannot be specified to a scalar node.", line, indent);
+        }
+
+        return tag_type;
     }
 
     /// @brief Set YAML node properties (anchor and/or tag names) to the given node.

--- a/single_include/fkYAML/node.hpp
+++ b/single_include/fkYAML/node.hpp
@@ -8651,10 +8651,7 @@ private:
             case lexical_token_t::PLAIN_SCALAR:
             case lexical_token_t::SINGLE_QUOTED_SCALAR:
             case lexical_token_t::DOUBLE_QUOTED_SCALAR: {
-                tag_t tag_type {tag_t::NONE};
-                if (m_needs_tag_impl) {
-                    tag_type = tag_resolver_type::resolve_tag(m_tag_name, mp_meta);
-                }
+                const tag_t tag_type = resolve_scalar_tag(line, indent);
 
                 basic_node_type node = scalar_parser_type(line, indent).parse_flow(token.type, tag_type, token.str);
                 apply_directive_set(node);
@@ -8665,10 +8662,7 @@ private:
             }
             case lexical_token_t::BLOCK_LITERAL_SCALAR:
             case lexical_token_t::BLOCK_FOLDED_SCALAR: {
-                tag_t tag_type {tag_t::NONE};
-                if (m_needs_tag_impl) {
-                    tag_type = tag_resolver_type::resolve_tag(m_tag_name, mp_meta);
-                }
+                const tag_t tag_type = resolve_scalar_tag(line, indent);
 
                 basic_node_type node =
                     scalar_parser_type(line, indent)
@@ -9172,6 +9166,26 @@ private:
             mp_current_node = current_context(line, indent).p_node;
             m_flow_token_state = flow_token_state_t::NEEDS_SEPARATOR_OR_SUFFIX;
         }
+    }
+
+    /// @brief Resolves the tag for a scalar node, if any is pending.
+    /// @param line Current line.
+    /// @param indent Current indentation.
+    /// @return The resolved tag type, or tag_t::NONE if no tag is pending.
+    tag_t resolve_scalar_tag(const uint32_t line, const uint32_t indent) const {
+        if (!m_needs_tag_impl) {
+            return tag_t::NONE;
+        }
+
+        const tag_t tag_type = tag_resolver_type::resolve_tag(m_tag_name, mp_meta);
+
+        // A collection tag denotes a sequence or a mapping, so it cannot apply to a scalar node.
+        // Such an input is a syntax error rather than an internal inconsistency.
+        if FK_YAML_UNLIKELY (tag_type == tag_t::SEQUENCE || tag_type == tag_t::MAPPING) {
+            throw parse_error("A sequence or mapping tag cannot be specified to a scalar node.", line, indent);
+        }
+
+        return tag_type;
     }
 
     /// @brief Set YAML node properties (anchor and/or tag names) to the given node.

--- a/tests/unit_test/test_deserializer_class.cpp
+++ b/tests/unit_test/test_deserializer_class.cpp
@@ -3491,6 +3491,19 @@ TEST_CASE("Deserializer_Tag") {
         auto input = GENERATE(std::string("foo: !!map !!map\n  bar: baz"), std::string("!!str !!bool true: 123"));
         REQUIRE_THROWS_AS(deserializer.deserialize(fkyaml::detail::input_adapter(input)), fkyaml::parse_error);
     }
+
+    SUBCASE("collection tag applied to a scalar node") {
+        // Only inputs where the tag really does apply to a scalar belong here. A `!!map` which precedes
+        // a block mapping, as in the `735Y` and `BU8L` suite cases, is valid YAML and must not be added.
+        auto input = GENERATE(
+            std::string("foo: !!seq bar"),
+            std::string("foo: !!seq \"bar\""),
+            std::string("foo: !!map 'bar'"),
+            std::string("foo: !!map |\n  bar"),
+            std::string("foo: !!seq >\n  bar"),
+            std::string("!!map foo"));
+        REQUIRE_THROWS_AS(deserializer.deserialize(fkyaml::detail::input_adapter(input)), fkyaml::parse_error);
+    }
 }
 
 TEST_CASE("Deserializer_NodeProperties") {


### PR DESCRIPTION
Fixes #576.

A pending `!!map` tag survives until the next scalar token and is handed to `scalar_parser`, which
asserts that it never receives a collection tag. A collection tag on a scalar is a syntax error in the
input, not an internal inconsistency, so the deserializer now rejects it with a `parse_error` before
it gets that far. The assertions in `scalar_parser` are left in place: they are no longer reachable
from the deserializer, which is where an assertion belongs.

Removing the assertion instead would not have worked. With `NDEBUG` the parse continues and fails with
`Detected invalid indentation`, so it's a correct tripwire rather than an over-strict one.

Both scalar dispatch sites resolved the pending tag with the same four lines, so they now share a
`resolve_scalar_tag()` helper that carries the check.

### Scope

This stops the crash, it does not close the underlying gap. Of the four affected YAML test suite
cases, only `H7J7` is marked as an error case and it now passes. `6JWB`, `735Y` and `BU8L` are valid
YAML that should parse; they still fail, but with a `parse_error` rather than taking the process down.
Happy to open a follow-up for that separately.

### Verified

YAML test suite on `develop` vs. this branch: aborting cases 4 to 0, failing cases 113 down to 112,
with no newly failing case. Unit tests pass.

---

## Pull Request Checklist

Read the [CONTRIBUTING.md](https://github.com/fktn-k/fkYAML/blob/develop/.github/CONTRIBUTING.md) file for detailed information.  

- [x] Changes are described in the pull request or in a referenced [issue](https://github.com/fktn-k/fkYAML/issues).
- [x] The test suite compiles and runs without any error.
- [x] [The code coverage](https://coveralls.io/github/fktn-k/fkYAML) on your branch is 100%.
- [x] The documentation is updated if you added/changed a feature.

## Please don't

- The C++11 support varies between different **compilers** and versions. Please note the [list of supported compilers](https://github.com/fktn-k/fkYAML/blob/develop/README.md#supported-compilers). Some compilers like GCC 4.7 (and earlier), Clang 3.3 (and earlier), or Microsoft Visual Studio 13.0 and earlier are known not to work due to missing or incomplete C++11 support. Please refrain from proposing changes that work around these compiler's limitations with `#ifdef`s or other means.
- Please refrain from proposing changes that would **break [YAML](https://yaml.org/) specifications**. If you propose a conformant extension of YAML to be supported by the library, please motivate this extension.
- Please do not open pull requests that address **multiple issues**.
