### PR TITLE
Avoid passing a negative char to cctype functions

### DIFF
--- a/include/fkYAML/detail/char_class.hpp
+++ b/include/fkYAML/detail/char_class.hpp
@@ -1,0 +1,45 @@
+//  _______   __ __   __  _____   __  __  __
+// |   __| |_/  |  \_/  |/  _  \ /  \/  \|  |     fkYAML: A C++ header-only YAML library
+// |   __|  _  < \_   _/|  ___  |    _   |  |___  version 0.4.4
+// |__|  |_| \__|  |_|  |_|   |_|___||___|______| https://github.com/fktn-k/fkYAML
+//
+// SPDX-FileCopyrightText: 2023-2026 Kensuke Fukutani <fktn.dev@gmail.com>
+// SPDX-License-Identifier: MIT
+
+#ifndef FK_YAML_DETAIL_CHAR_CLASS_HPP
+#define FK_YAML_DETAIL_CHAR_CLASS_HPP
+
+#include <fkYAML/detail/macros/define_macros.hpp>
+
+FK_YAML_DETAIL_NAMESPACE_BEGIN
+
+// The functions below replace their <cctype> counterparts, which must not be used on the characters of
+// an input buffer. Those take an int whose value has to be representable as an unsigned char or equal
+// to EOF, so passing a char is undefined behavior for any byte of a multi-byte UTF-8 sequence on a
+// platform where char is signed. They also depend on the current locale, while both YAML syntax and
+// URI syntax allow exactly the ASCII ranges spelled out here.
+
+/// @brief Check if the given character is a digit.
+/// @param c A character to be checked.
+/// @return true if the given character is a digit, false otherwise.
+inline bool is_digit(char c) noexcept {
+    return ('0' <= c && c <= '9');
+}
+
+/// @brief Check if the given character is a hex-digit.
+/// @param c A character to be checked.
+/// @return true if the given character is a hex-digit, false otherwise.
+inline bool is_xdigit(char c) noexcept {
+    return is_digit(c) || ('A' <= c && c <= 'F') || ('a' <= c && c <= 'f');
+}
+
+/// @brief Check if the given character is an alphabet or a digit.
+/// @param c A character to be checked.
+/// @return true if the given character is an alphabet or a digit, false otherwise.
+inline bool is_alnum(char c) noexcept {
+    return is_digit(c) || ('A' <= c && c <= 'Z') || ('a' <= c && c <= 'z');
+}
+
+FK_YAML_DETAIL_NAMESPACE_END
+
+#endif /* FK_YAML_DETAIL_CHAR_CLASS_HPP */

--- a/include/fkYAML/detail/encodings/uri_encoding.hpp
+++ b/include/fkYAML/detail/encodings/uri_encoding.hpp
@@ -9,8 +9,8 @@
 #ifndef FK_YAML_DETAIL_ENCODINGS_URI_ENCODING_HPP
 #define FK_YAML_DETAIL_ENCODINGS_URI_ENCODING_HPP
 
-#include <cctype>
 #include <string>
+#include <fkYAML/detail/char_class.hpp>
 
 #include <fkYAML/detail/macros/define_macros.hpp>
 
@@ -65,18 +65,9 @@ private:
                 return false;
             }
 
-            // Normalize a character for a-f/A-F comparison
-            const int octet = std::tolower(*begin);
-
-            if ('0' <= octet && octet <= '9') {
-                continue;
+            if (!is_xdigit(*begin)) {
+                return false;
             }
-
-            if ('a' <= octet && octet <= 'f') {
-                continue;
-            }
-
-            return false;
         }
 
         return true;
@@ -120,7 +111,7 @@ private:
             return true;
         default:
             // alphabets and numbers are also allowed.
-            return static_cast<bool>(std::isalnum(c));
+            return is_alnum(c);
         }
     }
 };

--- a/include/fkYAML/detail/input/lexical_analyzer.hpp
+++ b/include/fkYAML/detail/input/lexical_analyzer.hpp
@@ -10,12 +10,12 @@
 #define FK_YAML_DETAIL_INPUT_LEXICAL_ANALYZER_HPP
 
 #include <algorithm>
-#include <cctype>
 #include <cstdlib>
 #include <deque>
 
 #include <fkYAML/detail/macros/define_macros.hpp>
 #include <fkYAML/detail/assert.hpp>
+#include <fkYAML/detail/char_class.hpp>
 #include <fkYAML/detail/encodings/uri_encoding.hpp>
 #include <fkYAML/detail/encodings/utf_encodings.hpp>
 #include <fkYAML/detail/input/block_scalar_header.hpp>
@@ -592,7 +592,7 @@ private:
                 case '-':
                     break;
                 default:
-                    if FK_YAML_UNLIKELY (!isalnum(*m_cur_itr)) {
+                    if FK_YAML_UNLIKELY (!is_alnum(*m_cur_itr)) {
                         // See https://yaml.org/spec/1.2.2/#rule-c-named-tag-handle for more details.
                         emit_error("named handle can contain only numbers(0-9), alphabets(A-Z,a-z) and hyphens(-).");
                     }

--- a/include/fkYAML/detail/input/scalar_scanner.hpp
+++ b/include/fkYAML/detail/input/scalar_scanner.hpp
@@ -14,6 +14,7 @@
 
 #include <fkYAML/detail/macros/define_macros.hpp>
 #include <fkYAML/detail/assert.hpp>
+#include <fkYAML/detail/char_class.hpp>
 #include <fkYAML/node_type.hpp>
 
 FK_YAML_DETAIL_NAMESPACE_BEGIN
@@ -305,24 +306,6 @@ private:
             return (len > 1) ? scan_hexadecimal_number(++itr, --len) : node_type::INTEGER;
         }
         return node_type::STRING;
-    }
-
-    /// @brief Check if the given character is a digit.
-    /// @note This function is needed to avoid assertion failures in `std::isdigit()` especially when compiled with
-    /// MSVC.
-    /// @param c A character to be checked.
-    /// @return true if the given character is a digit, false otherwise.
-    static bool is_digit(char c) {
-        return ('0' <= c && c <= '9');
-    }
-
-    /// @brief Check if the given character is a hex-digit.
-    /// @note This function is needed to avoid assertion failures in `std::isxdigit()` especially when compiled with
-    /// MSVC.
-    /// @param c A character to be checked.
-    /// @return true if the given character is a hex-digit, false otherwise.
-    static bool is_xdigit(char c) {
-        return (('0' <= c && c <= '9') || ('A' <= c && c <= 'F') || ('a' <= c && c <= 'f'));
     }
 };
 

--- a/single_include/fkYAML/node.hpp
+++ b/single_include/fkYAML/node.hpp
@@ -1263,13 +1263,60 @@ FK_YAML_DETAIL_NAMESPACE_END
 #define FK_YAML_DETAIL_INPUT_LEXICAL_ANALYZER_HPP
 
 #include <algorithm>
-#include <cctype>
 #include <cstdlib>
 #include <deque>
 
 // #include <fkYAML/detail/macros/define_macros.hpp>
 
 // #include <fkYAML/detail/assert.hpp>
+
+// #include <fkYAML/detail/char_class.hpp>
+//  _______   __ __   __  _____   __  __  __
+// |   __| |_/  |  \_/  |/  _  \ /  \/  \|  |     fkYAML: A C++ header-only YAML library
+// |   __|  _  < \_   _/|  ___  |    _   |  |___  version 0.4.4
+// |__|  |_| \__|  |_|  |_|   |_|___||___|______| https://github.com/fktn-k/fkYAML
+//
+// SPDX-FileCopyrightText: 2023-2026 Kensuke Fukutani <fktn.dev@gmail.com>
+// SPDX-License-Identifier: MIT
+
+#ifndef FK_YAML_DETAIL_CHAR_CLASS_HPP
+#define FK_YAML_DETAIL_CHAR_CLASS_HPP
+
+// #include <fkYAML/detail/macros/define_macros.hpp>
+
+
+FK_YAML_DETAIL_NAMESPACE_BEGIN
+
+// The functions below replace their <cctype> counterparts, which must not be used on the characters of
+// an input buffer. Those take an int whose value has to be representable as an unsigned char or equal
+// to EOF, so passing a char is undefined behavior for any byte of a multi-byte UTF-8 sequence on a
+// platform where char is signed. They also depend on the current locale, while both YAML syntax and
+// URI syntax allow exactly the ASCII ranges spelled out here.
+
+/// @brief Check if the given character is a digit.
+/// @param c A character to be checked.
+/// @return true if the given character is a digit, false otherwise.
+inline bool is_digit(char c) noexcept {
+    return ('0' <= c && c <= '9');
+}
+
+/// @brief Check if the given character is a hex-digit.
+/// @param c A character to be checked.
+/// @return true if the given character is a hex-digit, false otherwise.
+inline bool is_xdigit(char c) noexcept {
+    return is_digit(c) || ('A' <= c && c <= 'F') || ('a' <= c && c <= 'f');
+}
+
+/// @brief Check if the given character is an alphabet or a digit.
+/// @param c A character to be checked.
+/// @return true if the given character is an alphabet or a digit, false otherwise.
+inline bool is_alnum(char c) noexcept {
+    return is_digit(c) || ('A' <= c && c <= 'Z') || ('a' <= c && c <= 'z');
+}
+
+FK_YAML_DETAIL_NAMESPACE_END
+
+#endif /* FK_YAML_DETAIL_CHAR_CLASS_HPP */
 
 // #include <fkYAML/detail/encodings/uri_encoding.hpp>
 //  _______   __ __   __  _____   __  __  __
@@ -1283,8 +1330,9 @@ FK_YAML_DETAIL_NAMESPACE_END
 #ifndef FK_YAML_DETAIL_ENCODINGS_URI_ENCODING_HPP
 #define FK_YAML_DETAIL_ENCODINGS_URI_ENCODING_HPP
 
-#include <cctype>
 #include <string>
+// #include <fkYAML/detail/char_class.hpp>
+
 
 // #include <fkYAML/detail/macros/define_macros.hpp>
 
@@ -1340,18 +1388,9 @@ private:
                 return false;
             }
 
-            // Normalize a character for a-f/A-F comparison
-            const int octet = std::tolower(*begin);
-
-            if ('0' <= octet && octet <= '9') {
-                continue;
+            if (!is_xdigit(*begin)) {
+                return false;
             }
-
-            if ('a' <= octet && octet <= 'f') {
-                continue;
-            }
-
-            return false;
         }
 
         return true;
@@ -1395,7 +1434,7 @@ private:
             return true;
         default:
             // alphabets and numbers are also allowed.
-            return static_cast<bool>(std::isalnum(c));
+            return is_alnum(c);
         }
     }
 };
@@ -3826,7 +3865,7 @@ private:
                 case '-':
                     break;
                 default:
-                    if FK_YAML_UNLIKELY (!isalnum(*m_cur_itr)) {
+                    if FK_YAML_UNLIKELY (!is_alnum(*m_cur_itr)) {
                         // See https://yaml.org/spec/1.2.2/#rule-c-named-tag-handle for more details.
                         emit_error("named handle can contain only numbers(0-9), alphabets(A-Z,a-z) and hyphens(-).");
                     }
@@ -6295,6 +6334,8 @@ FK_YAML_DETAIL_NAMESPACE_END
 
 // #include <fkYAML/detail/assert.hpp>
 
+// #include <fkYAML/detail/char_class.hpp>
+
 // #include <fkYAML/node_type.hpp>
 
 
@@ -6587,24 +6628,6 @@ private:
             return (len > 1) ? scan_hexadecimal_number(++itr, --len) : node_type::INTEGER;
         }
         return node_type::STRING;
-    }
-
-    /// @brief Check if the given character is a digit.
-    /// @note This function is needed to avoid assertion failures in `std::isdigit()` especially when compiled with
-    /// MSVC.
-    /// @param c A character to be checked.
-    /// @return true if the given character is a digit, false otherwise.
-    static bool is_digit(char c) {
-        return ('0' <= c && c <= '9');
-    }
-
-    /// @brief Check if the given character is a hex-digit.
-    /// @note This function is needed to avoid assertion failures in `std::isxdigit()` especially when compiled with
-    /// MSVC.
-    /// @param c A character to be checked.
-    /// @return true if the given character is a hex-digit, false otherwise.
-    static bool is_xdigit(char c) {
-        return (('0' <= c && c <= '9') || ('A' <= c && c <= 'F') || ('a' <= c && c <= 'f'));
     }
 };
 

--- a/tests/unit_test/test_lexical_analyzer_class.cpp
+++ b/tests/unit_test/test_lexical_analyzer_class.cpp
@@ -137,7 +137,11 @@ TEST_CASE("LexicalAnalyzer_TagDirective") {
             fkyaml::detail::str_view("%TAG !invalid\tbar"),
             fkyaml::detail::str_view("%TAG !inv@lid! bar"),
             fkyaml::detail::str_view("%TAG !invalid!tag bar"),
-            fkyaml::detail::str_view("%TAG !invalid"));
+            fkyaml::detail::str_view("%TAG !invalid"),
+            // A byte outside the ASCII range is a negative char where char is signed, which used to be
+            // passed to <cctype> as-is. A named handle allows only [0-9A-Za-z-].
+            fkyaml::detail::str_view("%TAG !\xC3\xA9! bar"),
+            fkyaml::detail::str_view("%TAG !a\xFF! bar"));
 
         fkyaml::detail::lexical_analyzer lexer(input);
         lexer.set_document_state(true);

--- a/tests/unit_test/test_uri_encoding_class.cpp
+++ b/tests/unit_test/test_uri_encoding_class.cpp
@@ -75,7 +75,15 @@ TEST_CASE("URIEncoding_Validate") {
             std::string("^"),
             std::string("`"),
             std::string("|"),
-            std::string("\x7F"));
+            std::string("\x7F"),
+            // Bytes outside the ASCII range, i.e. any byte of a multi-byte UTF-8 sequence. These are a
+            // negative char where char is signed, which used to be passed to <cctype> functions.
+            std::string("\x80"),
+            std::string("\xC3"),
+            std::string("\xC3\xA9"),
+            std::string("\xFF"),
+            std::string("%\xC3\xA9"),
+            std::string("%0\xC3"));
         REQUIRE_FALSE(fkyaml::detail::uri_encoding::validate(input.c_str(), input.c_str() + input.size()));
     }
 }


### PR DESCRIPTION
Fixes #578.

The three `cctype` calls are replaced with explicit ASCII range checks. Rather than spelling those out
at each site, they move into a new `detail/char_class.hpp` with `is_digit()`, `is_xdigit()` and
`is_alnum()`, and `scalar_scanner` now delegates to it instead of keeping its own two copies.

The shared header is the point rather than a tidy-up. The reason not to use `cctype` here had to be
written three times in my first attempt, and the two existing helpers were already a copy of each other,
which is how the bug arose in the first place: reaching for `std::isalnum` was the shortest path
because nothing local said otherwise. Now there is one place that says it.

As a side effect `validate_octets()` loses its `std::tolower` normalisation and the two range branches
that followed it, since `is_xdigit()` covers `A-F` directly.

### Verified

Behaviour is unchanged: the YAML test suite reports the same 115 failing cases as `develop`, with none
fixed and none newly failing. That is the intended result - this is an undefined behaviour fix, not
conformance one, so any movement there would mean I had altered parsing by accident.
Unit tests pass and the CRT reports nothing on the inputs that previously triggered two assertions each.

`test_uri_encoding_class.cpp` already covered `%AF%af`, so the octet change is guarded for case folding.
It had no byte above `0x7F` at all, so six were added, and two named tag handles with high bytes were
added to `test_lexical_analyzer_class.cpp`, which had no coverage of that validation.

---

## Pull Request Checklist

Read the [CONTRIBUTING.md](https://github.com/fktn-k/fkYAML/blob/develop/.github/CONTRIBUTING.md) file for detailed information.  

- [x] Changes are described in the pull request or in a referenced [issue](https://github.com/fktn-k/fkYAML/issues).
- [x] The test suite compiles and runs without any error.
- [x] [The code coverage](https://coveralls.io/github/fktn-k/fkYAML) on your branch is 100%.
- [x] The documentation is updated if you added/changed a feature.

## Please don't

- The C++11 support varies between different **compilers** and versions. Please note the [list of supported compilers](https://github.com/fktn-k/fkYAML/blob/develop/README.md#supported-compilers). Some compilers like GCC 4.7 (and earlier), Clang 3.3 (and earlier), or Microsoft Visual Studio 13.0 and earlier are known not to work due to missing or incomplete C++11 support. Please refrain from proposing changes that work around these compiler's limitations with `#ifdef`s or other means.
- Please refrain from proposing changes that would **break [YAML](https://yaml.org/) specifications**. If you propose a conformant extension of YAML to be supported by the library, please motivate this extension.
- Please do not open pull requests that address **multiple issues**.
