### PR TITLE
Fix the in-place benchmark parsing an empty buffer

### DIFF
--- a/README.md
+++ b/README.md
@@ -224,31 +224,31 @@ The following tables are created from the benchmarking results in the following 
 
 | Benchmark                          | processed bytes per second (Release) |
 | ---------------------------------- | ------------------------------------ |
-| fkYAML                             | 62.5049Mi/s                          |
-| libfyaml                           | 39.235Mi/s                           |
-| rapidyaml<br>(with mutable buff)   | 22.007Gi/s                           |
-| rapidyaml<br>(with immutable buff) | 133.311Mi/s                          |
-| yaml-cpp                           | 9.07876Mi/s                          |
+| fkYAML                             | 60.6026Mi/s                          |
+| libfyaml                           | 35.4699Mi/s                          |
+| rapidyaml<br>(with mutable buff)   | 152.795Mi/s                          |
+| rapidyaml<br>(with immutable buff) | 136.538Mi/s                          |
+| yaml-cpp                           | 10.3192Mi/s                          |
 
 ### Parsing [citm_catalog.json](https://github.com/fktn-k/fkYAML/blob/develop/tools/benchmark/cases/citm_catalog.json)
 
 | Benchmark                          | processed bytes per second (Release) |
 | ---------------------------------- | ------------------------------------ |
-| fkYAML                             | 97.216Mi/s                           |
-| libfyaml                           | 57.3021Mi/s                          |
-| rapidyaml<br>(with mutable buff)   | 37.9026Gi/s                          |
-| rapidyaml<br>(with immutable buff) | 140.375Mi/s                          |
-| yaml-cpp                           | 14.3192Mi/s                          |
+| fkYAML                             | 97.4616Mi/s                          |
+| libfyaml                           | 50.3768Mi/s                          |
+| rapidyaml<br>(with mutable buff)   | 120.381Mi/s                          |
+| rapidyaml<br>(with immutable buff) | 119.205Mi/s                          |
+| yaml-cpp                           | 16.7686Mi/s                          |
 
 ### Parsing [citm_catalog.yml](https://github.com/fktn-k/fkYAML/blob/develop/tools/benchmark/cases/citm_catalog.yml)
 
 | Benchmark                          | processed bytes per second (Release) |
 | ---------------------------------- | ------------------------------------ |
-| fkYAML                             | 38.7563Mi/s                          |
-| libfyaml                           | 24.7526Mi/s                          |
-| rapidyaml<br>(with mutable buff)   | 37.9676Gi/s                          |
-| rapidyaml<br>(with immutable buff) | 68.4245Mi/s                          |
-| yaml-cpp                           | 6.47003Mi/s                          |
+| fkYAML                             | 41.4116Mi/s                          |
+| libfyaml                           | 22.3071Mi/s                          |
+| rapidyaml<br>(with mutable buff)   | 54.1632Mi/s                          |
+| rapidyaml<br>(with immutable buff) | 53.6708Mi/s                          |
+| yaml-cpp                           | 7.4989Mi/s                           |
 
 Although [rapidyaml](https://github.com/biojppm/rapidyaml) is about 2x faster than fkYAML as it focuses on high performance, fkYAML is in general 70% faster than [libfyaml](https://github.com/pantoniou/libfyaml) and also about 6.5x faster than [yaml-cpp](https://github.com/jbeder/yaml-cpp).  
 Note that, since fkYAML deserializes scalars into native booleans or integers during the parsing, the performance could be more faster in some use cases since there is no need for string manipulations upon data queries.  

--- a/README.md
+++ b/README.md
@@ -250,7 +250,7 @@ The following tables are created from the benchmarking results in the following 
 | rapidyaml<br>(with immutable buff) | 68.4245Mi/s                          |
 | yaml-cpp                           | 6.47003Mi/s                          |
 
-Although [rapidyaml](https://github.com/biojppm/rapidyaml) is about 2x faster with immutable buffers and far faster with mutable buffers than fkYAML as it focuses on high performance, fkYAML is in general 70% faster than [libfyaml](https://github.com/pantoniou/libfyaml) and also about 6.5x faster than [yaml-cpp](https://github.com/jbeder/yaml-cpp).  
+Although [rapidyaml](https://github.com/biojppm/rapidyaml) is about 2x faster than fkYAML as it focuses on high performance, fkYAML is in general 70% faster than [libfyaml](https://github.com/pantoniou/libfyaml) and also about 6.5x faster than [yaml-cpp](https://github.com/jbeder/yaml-cpp).  
 Note that, since fkYAML deserializes scalars into native booleans or integers during the parsing, the performance could be more faster in some use cases since there is no need for string manipulations upon data queries.  
 
 ## Community Support

--- a/README.md
+++ b/README.md
@@ -250,7 +250,7 @@ The following tables are created from the benchmarking results in the following 
 | rapidyaml<br>(with immutable buff) | 53.6708Mi/s                          |
 | yaml-cpp                           | 7.4989Mi/s                           |
 
-Although [rapidyaml](https://github.com/biojppm/rapidyaml) is about 2x faster than fkYAML as it focuses on high performance, fkYAML is in general 70% faster than [libfyaml](https://github.com/pantoniou/libfyaml) and also about 6.5x faster than [yaml-cpp](https://github.com/jbeder/yaml-cpp).  
+Although [rapidyaml](https://github.com/biojppm/rapidyaml) is 1.2x to 2.5x faster than fkYAML as it focuses on high performance, fkYAML is in general 70-90% faster than [libfyaml](https://github.com/pantoniou/libfyaml) and also more than 5x faster than [yaml-cpp](https://github.com/jbeder/yaml-cpp).  
 Note that, since fkYAML deserializes scalars into native booleans or integers during the parsing, the performance could be more faster in some use cases since there is no need for string manipulations upon data queries.  
 
 ## Community Support

--- a/tools/benchmark/main.cpp
+++ b/tools/benchmark/main.cpp
@@ -103,8 +103,11 @@ void bm_rapidyaml_parse_inplace(benchmark::State& st) {
     for (auto _ : st) {
         // ryml::parse_in_place() modifies the contents of `in_place_buff` during parsing.
         // Without the following copy, the second (and subsequent) parsing would fail.
+        // The timer is paused around the copy so that only the parsing is measured.
+        st.PauseTiming();
         assert(in_place_buff.size() == test_src.size());
         std::memcpy(&in_place_buff[0], &test_src[0], in_place_buff.size());
+        st.ResumeTiming();
 
         ryml::Tree tree = ryml::parse_in_place(c4_test_src);
     }

--- a/tools/benchmark/main.cpp
+++ b/tools/benchmark/main.cpp
@@ -94,7 +94,10 @@ void bm_libfyaml_parse(benchmark::State& st) {
 
 // rapidyaml (in place)
 void bm_rapidyaml_parse_inplace(benchmark::State& st) {
-    std::string in_place_buff(test_src.size(), '\0');
+    // Initialize from the source so the view below spans the real contents. Constructing the buffer
+    // filled with '\0' instead would make trimr('\0') strip all of it, leaving an empty view and
+    // making the benchmark parse nothing.
+    std::string in_place_buff(test_src);
     c4::substr c4_test_src = c4::to_substr(in_place_buff).trimr('\0');
 
     for (auto _ : st) {

--- a/tools/benchmark/results/result_debug_citm_catalog_json.txt
+++ b/tools/benchmark/results/result_debug_citm_catalog_json.txt
@@ -1,4 +1,4 @@
-2025-01-22T01:24:56+09:00
+2026-08-24T10:07:15+09:00
 Running ./build_bm_debug/tools/benchmark/benchmarker
 Run on (16 X 3193.92 MHz CPU s)
 CPU Caches:
@@ -6,13 +6,13 @@ CPU Caches:
   L1 Instruction 32 KiB (x8)
   L2 Unified 512 KiB (x8)
   L3 Unified 16384 KiB (x1)
-Load Average: 0.41, 0.48, 0.37
+Load Average: 0.36, 0.29, 0.27
 ***WARNING*** Library was built as DEBUG. Timings may be affected.
 -------------------------------------------------------------------------------------
 Benchmark                           Time             CPU   Iterations UserCounters...
 -------------------------------------------------------------------------------------
-bm_fkyaml_parse              19655126 ns     19654672 ns           36 bytes_per_second=83.8065Mi/s items_per_second=50.8785/s
-bm_yamlcpp_parse            785616717 ns    785615000 ns            1 bytes_per_second=2.09669Mi/s items_per_second=1.27289/s
-bm_libfyaml_parse           116035673 ns    116034750 ns            6 bytes_per_second=14.1957Mi/s items_per_second=8.61811/s
-bm_rapidyaml_parse_inplace      46239 ns        46239 ns        16289 bytes_per_second=34.7886Gi/s items_per_second=21.6268k/s
-bm_rapidyaml_parse_arena     40129454 ns     40128400 ns           17 bytes_per_second=41.048Mi/s items_per_second=24.92/s
+bm_fkyaml_parse              17980714 ns     17975240 ns           39 bytes_per_second=91.6366Mi/s items_per_second=55.6321/s
+bm_yamlcpp_parse            768683936 ns    768468593 ns            1 bytes_per_second=2.14347Mi/s items_per_second=1.30129/s
+bm_libfyaml_parse           116010801 ns    115996771 ns            6 bytes_per_second=14.2003Mi/s items_per_second=8.62093/s
+bm_rapidyaml_parse_inplace   41376645 ns     41372796 ns           17 bytes_per_second=39.8134Mi/s items_per_second=24.1705/s
+bm_rapidyaml_parse_arena     42405496 ns     42400848 ns           16 bytes_per_second=38.848Mi/s items_per_second=23.5844/s

--- a/tools/benchmark/results/result_debug_citm_catalog_yml.txt
+++ b/tools/benchmark/results/result_debug_citm_catalog_yml.txt
@@ -1,4 +1,4 @@
-2025-01-22T01:25:01+09:00
+2026-08-24T10:07:20+09:00
 Running ./build_bm_debug/tools/benchmark/benchmarker
 Run on (16 X 3193.92 MHz CPU s)
 CPU Caches:
@@ -6,13 +6,13 @@ CPU Caches:
   L1 Instruction 32 KiB (x8)
   L2 Unified 512 KiB (x8)
   L3 Unified 16384 KiB (x1)
-Load Average: 0.45, 0.49, 0.38
+Load Average: 0.42, 0.30, 0.27
 ***WARNING*** Library was built as DEBUG. Timings may be affected.
 -------------------------------------------------------------------------------------
 Benchmark                           Time             CPU   Iterations UserCounters...
 -------------------------------------------------------------------------------------
-bm_fkyaml_parse              19937878 ns     19937994 ns           36 bytes_per_second=34.3161Mi/s items_per_second=50.1555/s
-bm_yamlcpp_parse            797608026 ns    797605100 ns            1 bytes_per_second=878.397Ki/s items_per_second=1.25375/s
-bm_libfyaml_parse           109612610 ns    109613300 ns            7 bytes_per_second=6.24188Mi/s items_per_second=9.12298/s
-bm_rapidyaml_parse_inplace      20804 ns        20804 ns        33092 bytes_per_second=32.1165Gi/s items_per_second=48.0672k/s
-bm_rapidyaml_parse_arena     35513217 ns     35513440 ns           20 bytes_per_second=19.2658Mi/s items_per_second=28.1584/s
+bm_fkyaml_parse              18225572 ns     18222512 ns           38 bytes_per_second=37.5466Mi/s items_per_second=54.8772/s
+bm_yamlcpp_parse            795819555 ns    795722256 ns            1 bytes_per_second=880.476Ki/s items_per_second=1.25672/s
+bm_libfyaml_parse           107639987 ns    107630675 ns            8 bytes_per_second=6.35686Mi/s items_per_second=9.29103/s
+bm_rapidyaml_parse_inplace   36385415 ns     36381838 ns           19 bytes_per_second=18.8059Mi/s items_per_second=27.4862/s
+bm_rapidyaml_parse_arena     36487670 ns     36483246 ns           19 bytes_per_second=18.7536Mi/s items_per_second=27.4098/s

--- a/tools/benchmark/results/result_debug_ubuntu_yml.txt
+++ b/tools/benchmark/results/result_debug_ubuntu_yml.txt
@@ -1,4 +1,4 @@
-2025-01-22T01:24:52+09:00
+2026-08-24T10:07:11+09:00
 Running ./build_bm_debug/tools/benchmark/benchmarker
 Run on (16 X 3193.92 MHz CPU s)
 CPU Caches:
@@ -6,13 +6,13 @@ CPU Caches:
   L1 Instruction 32 KiB (x8)
   L2 Unified 512 KiB (x8)
   L3 Unified 16384 KiB (x1)
-Load Average: 0.35, 0.47, 0.37
+Load Average: 0.31, 0.27, 0.26
 ***WARNING*** Library was built as DEBUG. Timings may be affected.
 -------------------------------------------------------------------------------------
 Benchmark                           Time             CPU   Iterations UserCounters...
 -------------------------------------------------------------------------------------
-bm_fkyaml_parse                154761 ns       154758 ns         4522 bytes_per_second=54.3336Mi/s items_per_second=6.46171k/s
-bm_yamlcpp_parse              7625752 ns      7625710 ns           89 bytes_per_second=1.10266Mi/s items_per_second=131.135/s
-bm_libfyaml_parse              994492 ns       994476 ns          687 bytes_per_second=8.45525Mi/s items_per_second=1.00555k/s
-bm_rapidyaml_parse_inplace        925 ns          925 ns       755134 bytes_per_second=8.88146Gi/s items_per_second=1.08159M/s
-bm_rapidyaml_parse_arena       282340 ns       282339 ns         2503 bytes_per_second=29.7818Mi/s items_per_second=3.54185k/s
+bm_fkyaml_parse                152518 ns       152500 ns         4568 bytes_per_second=55.1504Mi/s items_per_second=6.55736k/s
+bm_yamlcpp_parse              7631117 ns      7630600 ns           92 bytes_per_second=1.1022Mi/s items_per_second=131.051/s
+bm_libfyaml_parse              998811 ns       998695 ns          702 bytes_per_second=8.42144Mi/s items_per_second=1.00131k/s
+bm_rapidyaml_parse_inplace     267363 ns       267460 ns         2617 bytes_per_second=31.4457Mi/s items_per_second=3.73888k/s
+bm_rapidyaml_parse_arena       274256 ns       274232 ns         2554 bytes_per_second=30.6691Mi/s items_per_second=3.64654k/s

--- a/tools/benchmark/results/result_release_citm_catalog_json.txt
+++ b/tools/benchmark/results/result_release_citm_catalog_json.txt
@@ -1,4 +1,4 @@
-2025-01-22T01:18:38+09:00
+2026-08-24T10:03:12+09:00
 Running ./build_bm_release/tools/benchmark/benchmarker
 Run on (16 X 3193.92 MHz CPU s)
 CPU Caches:
@@ -6,12 +6,12 @@ CPU Caches:
   L1 Instruction 32 KiB (x8)
   L2 Unified 512 KiB (x8)
   L3 Unified 16384 KiB (x1)
-Load Average: 0.49, 0.32, 0.30
+Load Average: 0.26, 0.32, 0.27
 -------------------------------------------------------------------------------------
 Benchmark                           Time             CPU   Iterations UserCounters...
 -------------------------------------------------------------------------------------
-bm_fkyaml_parse              16943687 ns     16943618 ns           40 bytes_per_second=97.216Mi/s items_per_second=59.0193/s
-bm_yamlcpp_parse            115034348 ns    115033614 ns            7 bytes_per_second=14.3192Mi/s items_per_second=8.69311/s
-bm_libfyaml_parse            28745831 ns     28745712 ns           25 bytes_per_second=57.3021Mi/s items_per_second=34.7878/s
-bm_rapidyaml_parse_inplace      42440 ns        42440 ns        16161 bytes_per_second=37.9026Gi/s items_per_second=23.5627k/s
-bm_rapidyaml_parse_arena     11734386 ns     11734217 ns           58 bytes_per_second=140.375Mi/s items_per_second=85.2209/s
+bm_fkyaml_parse              16903246 ns     16900908 ns           40 bytes_per_second=97.4616Mi/s items_per_second=59.1684/s
+bm_yamlcpp_parse             98245719 ns     98230351 ns            7 bytes_per_second=16.7686Mi/s items_per_second=10.1802/s
+bm_libfyaml_parse            32700983 ns     32697421 ns           21 bytes_per_second=50.3768Mi/s items_per_second=30.5835/s
+bm_rapidyaml_parse_inplace   13684824 ns     13683128 ns           52 bytes_per_second=120.381Mi/s items_per_second=73.0827/s
+bm_rapidyaml_parse_arena     13819764 ns     13818114 ns           51 bytes_per_second=119.205Mi/s items_per_second=72.3688/s

--- a/tools/benchmark/results/result_release_citm_catalog_yml.txt
+++ b/tools/benchmark/results/result_release_citm_catalog_yml.txt
@@ -1,4 +1,4 @@
-2025-01-22T01:18:43+09:00
+2026-08-24T10:03:16+09:00
 Running ./build_bm_release/tools/benchmark/benchmarker
 Run on (16 X 3193.92 MHz CPU s)
 CPU Caches:
@@ -6,12 +6,12 @@ CPU Caches:
   L1 Instruction 32 KiB (x8)
   L2 Unified 512 KiB (x8)
   L3 Unified 16384 KiB (x1)
-Load Average: 0.53, 0.33, 0.30
+Load Average: 0.26, 0.32, 0.27
 -------------------------------------------------------------------------------------
 Benchmark                           Time             CPU   Iterations UserCounters...
 -------------------------------------------------------------------------------------
-bm_fkyaml_parse              17653677 ns     17653735 ns           40 bytes_per_second=38.7563Mi/s items_per_second=56.6452/s
-bm_yamlcpp_parse            105749049 ns    105748129 ns            7 bytes_per_second=6.47003Mi/s items_per_second=9.45643/s
-bm_libfyaml_parse            27641204 ns     27641304 ns           26 bytes_per_second=24.7526Mi/s items_per_second=36.1777/s
-bm_rapidyaml_parse_inplace      17598 ns        17598 ns        39483 bytes_per_second=37.9676Gi/s items_per_second=56.8242k/s
-bm_rapidyaml_parse_arena      9999307 ns      9999242 ns           67 bytes_per_second=68.4245Mi/s items_per_second=100.008/s
+bm_fkyaml_parse              16523539 ns     16521799 ns           42 bytes_per_second=41.4116Mi/s items_per_second=60.5261/s
+bm_yamlcpp_parse             91251370 ns     91239235 ns            7 bytes_per_second=7.4989Mi/s items_per_second=10.9602/s
+bm_libfyaml_parse            30673186 ns     30671549 ns           23 bytes_per_second=22.3071Mi/s items_per_second=32.6035/s
+bm_rapidyaml_parse_inplace   12633220 ns     12632065 ns           55 bytes_per_second=54.1632Mi/s items_per_second=79.1636/s
+bm_rapidyaml_parse_arena     12750275 ns     12747973 ns           55 bytes_per_second=53.6708Mi/s items_per_second=78.4438/s

--- a/tools/benchmark/results/result_release_ubuntu_yml.txt
+++ b/tools/benchmark/results/result_release_ubuntu_yml.txt
@@ -1,4 +1,4 @@
-2025-01-22T01:18:33+09:00
+2026-08-24T10:03:07+09:00
 Running ./build_bm_release/tools/benchmark/benchmarker
 Run on (16 X 3193.92 MHz CPU s)
 CPU Caches:
@@ -6,12 +6,12 @@ CPU Caches:
   L1 Instruction 32 KiB (x8)
   L2 Unified 512 KiB (x8)
   L3 Unified 16384 KiB (x1)
-Load Average: 0.44, 0.31, 0.30
+Load Average: 0.19, 0.31, 0.27
 -------------------------------------------------------------------------------------
 Benchmark                           Time             CPU   Iterations UserCounters...
 -------------------------------------------------------------------------------------
-bm_fkyaml_parse                134527 ns       134526 ns         5131 bytes_per_second=62.5049Mi/s items_per_second=7.4335k/s
-bm_yamlcpp_parse               926173 ns       926178 ns          744 bytes_per_second=9.07876Mi/s items_per_second=1.07971k/s
-bm_libfyaml_parse              214311 ns       214312 ns         3261 bytes_per_second=39.235Mi/s items_per_second=4.66609k/s
-bm_rapidyaml_parse_inplace        373 ns          373 ns      1879323 bytes_per_second=22.007Gi/s items_per_second=2.68003M/s
-bm_rapidyaml_parse_arena        63075 ns        63074 ns        11031 bytes_per_second=133.311Mi/s items_per_second=15.8543k/s
+bm_fkyaml_parse                138799 ns       138781 ns         5057 bytes_per_second=60.6026Mi/s items_per_second=7.20562k/s
+bm_yamlcpp_parse               815083 ns       815030 ns          859 bytes_per_second=10.3192Mi/s items_per_second=1.22695k/s
+bm_libfyaml_parse              237163 ns       237116 ns         2948 bytes_per_second=35.4699Mi/s items_per_second=4.21735k/s
+bm_rapidyaml_parse_inplace      54993 ns        55044 ns        12700 bytes_per_second=152.795Mi/s items_per_second=18.1673k/s
+bm_rapidyaml_parse_arena        61606 ns        61598 ns        11344 bytes_per_second=136.538Mi/s items_per_second=16.2344k/s


### PR DESCRIPTION
`bm_rapidyaml_parse_inplace` has been measuring nothing:

```cpp
std::string in_place_buff(test_src.size(), '\0');
c4::substr c4_test_src = c4::to_substr(in_place_buff).trimr('\0');
```

The view is taken before the loop, from a buffer that at that point consists entirely of `'\0'`, so
`trimr('\0')` strips all of it and leaves an empty view. The `memcpy` inside the loop fills the buffer,
but `c4_test_src` still spans zero bytes, so every iteration parses an empty input. Confirmed with a
temporary probe:

```
[PROBE] test_src=9119  c4_test_src=0
```

`SetBytesProcessed` credits each iteration with the full file size regardless, which is where the
implausible throughput comes from. On my machine, `ubuntu.yml` before and after:

| | before | after |
|---|---|---|
| `bm_rapidyaml_parse_inplace` | 216 ns, 40 GiB/s | 32153 ns, 293 MiB/s |
| `bm_rapidyaml_parse_arena` | 30567 ns, 283 MiB/s | 30731 ns, 282 MiB/s |

The two now land close together, which is what you would expect: parsing in place only saves one copy
of the source, which is small next to building the tree.

Initializing the buffer from `test_src` rather than from `'\0'` is enough - the `memcpy` in the loop
still restores it before each iteration, so the intent of the benchmark is unchanged.

The README claim that rapidyaml is "far faster with mutable buffers" rested entirely on this, so it is
removed. The rest of that sentence still holds: against `parse_in_arena` the ratio is about 2x in your
own numbers.

Two things I could not fix here, since they are measurements from your environment rather than mine:
the `rapidyaml (with mutable buff)` row in all three README tables, and the
`bm_rapidyaml_parse_inplace` lines in `tools/benchmark/results/`. Both would need regenerating.

---

## Pull Request Checklist

Read the [CONTRIBUTING.md](https://github.com/fktn-k/fkYAML/blob/develop/.github/CONTRIBUTING.md) file for detailed information.  

- [x] Changes are described in the pull request or in a referenced [issue](https://github.com/fktn-k/fkYAML/issues).
- [x] The test suite compiles and runs without any error.
- [x] [The code coverage](https://coveralls.io/github/fktn-k/fkYAML) on your branch is 100%.
- [x] The documentation is updated if you added/changed a feature.

## Please don't

- The C++11 support varies between different **compilers** and versions. Please note the [list of supported compilers](https://github.com/fktn-k/fkYAML/blob/develop/README.md#supported-compilers). Some compilers like GCC 4.7 (and earlier), Clang 3.3 (and earlier), or Microsoft Visual Studio 13.0 and earlier are known not to work due to missing or incomplete C++11 support. Please refrain from proposing changes that work around these compiler's limitations with `#ifdef`s or other means.
- Please refrain from proposing changes that would **break [YAML](https://yaml.org/) specifications**. If you propose a conformant extension of YAML to be supported by the library, please motivate this extension.
- Please do not open pull requests that address **multiple issues**.
