### PR TITLE
Allocate node properties and document metainfo only when needed

### DIFF
--- a/README.md
+++ b/README.md
@@ -224,33 +224,33 @@ The following tables are created from the benchmarking results in the following 
 
 | Benchmark                          | processed bytes per second (Release) |
 | ---------------------------------- | ------------------------------------ |
-| fkYAML                             | 60.6026Mi/s                          |
-| libfyaml                           | 35.4699Mi/s                          |
-| rapidyaml<br>(with mutable buff)   | 152.795Mi/s                          |
-| rapidyaml<br>(with immutable buff) | 136.538Mi/s                          |
-| yaml-cpp                           | 10.3192Mi/s                          |
+| fkYAML                             | 77.8628Mi/s                          |
+| libfyaml                           | 34.7381Mi/s                          |
+| rapidyaml<br>(with mutable buff)   | 150.988Mi/s                          |
+| rapidyaml<br>(with immutable buff) | 135.589Mi/s                          |
+| yaml-cpp                           | 10.1239Mi/s                          |
 
 ### Parsing [citm_catalog.json](https://github.com/fktn-k/fkYAML/blob/develop/tools/benchmark/cases/citm_catalog.json)
 
 | Benchmark                          | processed bytes per second (Release) |
 | ---------------------------------- | ------------------------------------ |
-| fkYAML                             | 97.4616Mi/s                          |
-| libfyaml                           | 50.3768Mi/s                          |
-| rapidyaml<br>(with mutable buff)   | 120.381Mi/s                          |
-| rapidyaml<br>(with immutable buff) | 119.205Mi/s                          |
-| yaml-cpp                           | 16.7686Mi/s                          |
+| fkYAML                             | 126.783Mi/s                          |
+| libfyaml                           | 49.9466Mi/s                          |
+| rapidyaml<br>(with mutable buff)   | 120.681Mi/s                          |
+| rapidyaml<br>(with immutable buff) | 118.728Mi/s                          |
+| yaml-cpp                           | 16.5976Mi/s                          |
 
 ### Parsing [citm_catalog.yml](https://github.com/fktn-k/fkYAML/blob/develop/tools/benchmark/cases/citm_catalog.yml)
 
 | Benchmark                          | processed bytes per second (Release) |
 | ---------------------------------- | ------------------------------------ |
-| fkYAML                             | 41.4116Mi/s                          |
-| libfyaml                           | 22.3071Mi/s                          |
-| rapidyaml<br>(with mutable buff)   | 54.1632Mi/s                          |
-| rapidyaml<br>(with immutable buff) | 53.6708Mi/s                          |
-| yaml-cpp                           | 7.4989Mi/s                           |
+| fkYAML                             | 55.9384Mi/s                          |
+| libfyaml                           | 21.6074Mi/s                          |
+| rapidyaml<br>(with mutable buff)   | 54.2151Mi/s                          |
+| rapidyaml<br>(with immutable buff) | 53.7195Mi/s                          |
+| yaml-cpp                           | 7.0331Mi/s                           |
 
-Although [rapidyaml](https://github.com/biojppm/rapidyaml) is 1.2x to 2.5x faster than fkYAML as it focuses on high performance, fkYAML is in general 70-90% faster than [libfyaml](https://github.com/pantoniou/libfyaml) and also more than 5x faster than [yaml-cpp](https://github.com/jbeder/yaml-cpp).  
+Although [rapidyaml](https://github.com/biojppm/rapidyaml) focuses on high performance and can be up to about 1.9x faster than fkYAML depending on the input, fkYAML is in general 2.2x to 2.6x faster than [libfyaml](https://github.com/pantoniou/libfyaml) and also more than 7x faster than [yaml-cpp](https://github.com/jbeder/yaml-cpp).  
 Note that, since fkYAML deserializes scalars into native booleans or integers during the parsing, the performance could be more faster in some use cases since there is no need for string manipulations upon data queries.  
 
 ## Community Support

--- a/docs/docs/api/basic_node/set_yaml_version.md
+++ b/docs/docs/api/basic_node/set_yaml_version.md
@@ -3,7 +3,7 @@
 # <small>fkyaml::basic_node::</small>set_yaml_version
 
 ```cpp
-void set_yaml_version(const yaml_version_t version) noexcept;
+void set_yaml_version(const yaml_version_t version);
 ```
 
 !!! warning "Deprecation"

--- a/docs/docs/api/basic_node/set_yaml_version_type.md
+++ b/docs/docs/api/basic_node/set_yaml_version_type.md
@@ -3,7 +3,7 @@
 # <small>fkyaml::basic_node::</small>set_yaml_version_type
 
 ```cpp
-void set_yaml_version_type(const yaml_version_type version) noexcept;
+void set_yaml_version_type(const yaml_version_type version);
 ```
 
 Sets a target YAML specification version to the `basic_node` object.  

--- a/include/fkYAML/detail/input/deserializer.hpp
+++ b/include/fkYAML/detail/input/deserializer.hpp
@@ -191,7 +191,9 @@ private:
 
         basic_node_type root;
         mp_current_node = &root;
-        mp_meta = root.mp_meta;
+        // One metainfo object is created per document and shared by all of its nodes.
+        mp_meta = std::make_shared<doc_metainfo_type>();
+        root.mp_meta = mp_meta;
 
         // parse directives first.
         deserialize_directives(lexer, token);

--- a/include/fkYAML/detail/input/deserializer.hpp
+++ b/include/fkYAML/detail/input/deserializer.hpp
@@ -1096,7 +1096,7 @@ private:
 
                 basic_node_type node {};
                 node.m_attrs |= detail::node_attr_bits::alias_bit;
-                node.m_prop.anchor = anchor_name;
+                node.prop().anchor = anchor_name;
                 detail::node_attr_bits::set_anchor_offset(anchor_counts - 1, node.m_attrs);
 
                 apply_directive_set(node);

--- a/include/fkYAML/detail/output/serializer.hpp
+++ b/include/fkYAML/detail/output/serializer.hpp
@@ -83,6 +83,11 @@ private:
     /// @return bool true if any directive is serialized, false otherwise.
     bool serialize_directives(const BasicNodeType& node, std::string& str) {
         const auto& p_meta = node.mp_meta;
+        if (!p_meta) {
+            // A node which was never part of a parsed document carries no directives.
+            return false;
+        }
+
         bool needs_directive_end = false;
 
         if (p_meta->is_version_specified) {

--- a/include/fkYAML/node.hpp
+++ b/include/fkYAML/node.hpp
@@ -1166,15 +1166,16 @@ public:
     /// @return The YAML version if already set, `yaml_version_type::VERSION_1_2` otherwise.
     /// @sa https://fktn-k.github.io/fkYAML/api/basic_node/get_yaml_version_type/
     yaml_version_type get_yaml_version_type() const noexcept {
-        return mp_meta->is_version_specified ? mp_meta->version : yaml_version_type::VERSION_1_2;
+        return (mp_meta && mp_meta->is_version_specified) ? mp_meta->version : yaml_version_type::VERSION_1_2;
     }
 
     /// @brief Set the YAML version for this basic_node object.
     /// @param[in] version The target YAML version.
     /// @sa https://fktn-k.github.io/fkYAML/api/basic_node/set_yaml_version_type/
     void set_yaml_version_type(const yaml_version_type version) noexcept {
-        mp_meta->version = version;
-        mp_meta->is_version_specified = true;
+        auto& directives = *meta();
+        directives.version = version;
+        directives.is_version_specified = true;
     }
 
     /// @brief Get the YAML version for this basic_node object.
@@ -1229,7 +1230,7 @@ public:
             mp_meta->anchor_table.erase(itr);
         }
 
-        auto p_meta = mp_meta;
+        auto p_meta = meta();
 
         basic_node node;
         node.swap(*this);
@@ -1257,7 +1258,7 @@ public:
             mp_meta->anchor_table.erase(itr);
         }
 
-        auto p_meta = mp_meta;
+        auto p_meta = meta();
 
         basic_node node;
         node.swap(*this);
@@ -1307,16 +1308,19 @@ public:
             return tag;
         }
 
+        static const detail::document_metainfo<basic_node> NO_DIRECTIVES {};
+        const auto& directives = mp_meta ? *mp_meta : NO_DIRECTIVES;
+
         // secondary tag handle
         if (tag.rfind("!!", 0) == 0) {
-            if (mp_meta->secondary_handle_prefix.empty()) {
+            if (directives.secondary_handle_prefix.empty()) {
                 return "tag:yaml.org,2002:" + tag.substr(2);
             }
-            return mp_meta->secondary_handle_prefix + tag.substr(2);
+            return directives.secondary_handle_prefix + tag.substr(2);
         }
 
         // named handles
-        for (const auto& named_handle_itr : mp_meta->named_handle_map) {
+        for (const auto& named_handle_itr : directives.named_handle_map) {
             if (tag.rfind(named_handle_itr.first, 0) == 0) {
                 return named_handle_itr.second + tag.substr(named_handle_itr.first.size());
             }
@@ -1332,10 +1336,10 @@ public:
         }
 
         // primary tag handle
-        if (mp_meta->primary_handle_prefix.empty()) {
+        if (directives.primary_handle_prefix.empty()) {
             return "!" + tag.substr(1);
         }
-        return mp_meta->primary_handle_prefix + tag.substr(1);
+        return directives.primary_handle_prefix + tag.substr(1);
     }
 
     /// @brief Add a tag name to this basic_node object.
@@ -1935,6 +1939,15 @@ private:
         return false;
     }
 
+    /// @brief Returns the metainfo of the document this node belongs to, creating it on first use.
+    /// @return The shared document metainfo.
+    const std::shared_ptr<detail::document_metainfo<basic_node>>& meta() const {
+        if (!mp_meta) {
+            mp_meta = std::make_shared<detail::document_metainfo<basic_node>>();
+        }
+        return mp_meta;
+    }
+
     bool is_sequence_impl() const noexcept {
         return m_attrs & detail::node_attr_bits::seq_bit;
     }
@@ -2072,9 +2085,8 @@ private:
     /// The current node attributes.
     detail::node_attr_t m_attrs {detail::node_attr_bits::default_bits};
     /// The shared set of YAML directives applied to this node.
-    mutable std::shared_ptr<detail::document_metainfo<basic_node>> mp_meta {
-        // NOLINTNEXTLINE(bugprone-unhandled-exception-at-new)
-        std::shared_ptr<detail::document_metainfo<basic_node>>(new detail::document_metainfo<basic_node>())};
+    /// It is created on first use, since most nodes never need it, and then shared by the nodes of a document.
+    mutable std::shared_ptr<detail::document_metainfo<basic_node>> mp_meta {};
     /// The current node value.
     node_value m_value {};
     /// The property set of this node.

--- a/include/fkYAML/node.hpp
+++ b/include/fkYAML/node.hpp
@@ -262,7 +262,7 @@ public:
     basic_node(const basic_node& rhs)
         : m_attrs(rhs.m_attrs),
           mp_meta(rhs.mp_meta),
-          m_prop(rhs.m_prop) {
+          mp_prop(rhs.mp_prop ? new detail::node_property(*rhs.mp_prop) : nullptr) {
         if FK_YAML_LIKELY (!has_anchor_name()) {
             switch (m_attrs & detail::node_attr_mask::value) {
             case detail::node_attr_bits::seq_bit:
@@ -298,7 +298,7 @@ public:
     basic_node(basic_node&& rhs) noexcept
         : m_attrs(rhs.m_attrs),
           mp_meta(std::move(rhs.mp_meta)),
-          m_prop(std::move(rhs.m_prop)) {
+          mp_prop(std::move(rhs.mp_prop)) {
         if FK_YAML_LIKELY (!has_anchor_name()) {
             switch (m_attrs & detail::node_attr_mask::value) {
             case detail::node_attr_bits::seq_bit:
@@ -418,7 +418,7 @@ public:
     {
         if (m_attrs & detail::node_attr_mask::anchoring) {
             if (m_attrs & detail::node_attr_bits::anchor_bit) {
-                auto itr = mp_meta->anchor_table.equal_range(m_prop.anchor).first;
+                auto itr = mp_meta->anchor_table.equal_range(anchor_prop()).first;
                 std::advance(itr, detail::node_attr_bits::get_anchor_offset(m_attrs));
                 itr->second.m_value.destroy(itr->second.m_attrs & detail::node_attr_mask::value);
                 itr->second.m_attrs = detail::node_attr_bits::default_bits;
@@ -1201,7 +1201,7 @@ public:
     /// @return true if ths basic_node has an anchor name, false otherwise.
     /// @sa https://fktn-k.github.io/fkYAML/api/basic_node/has_anchor_name/
     bool has_anchor_name() const noexcept {
-        return (m_attrs & detail::node_attr_mask::anchoring) && !m_prop.anchor.empty();
+        return (m_attrs & detail::node_attr_mask::anchoring) && mp_prop && !mp_prop->anchor.empty();
     }
 
     /// @brief Get the anchor name associated with this basic_node object.
@@ -1213,7 +1213,7 @@ public:
         if FK_YAML_UNLIKELY (!has_anchor_name()) {
             throw fkyaml::exception("No anchor name has been set.");
         }
-        return m_prop.anchor;
+        return mp_prop->anchor;
     }
 
     /// @brief Add an anchor name to this basic_node object.
@@ -1223,7 +1223,7 @@ public:
     void add_anchor_name(const std::string& anchor_name) {
         if (is_anchor()) {
             m_attrs &= ~detail::node_attr_mask::anchoring;
-            auto itr = mp_meta->anchor_table.equal_range(m_prop.anchor).first;
+            auto itr = mp_meta->anchor_table.equal_range(anchor_prop()).first;
             std::advance(itr, detail::node_attr_bits::get_anchor_offset(m_attrs));
             mp_meta.reset();
             itr->second.swap(*this);
@@ -1241,7 +1241,7 @@ public:
         mp_meta = p_meta;
         const auto offset = static_cast<uint32_t>(mp_meta->anchor_table.count(anchor_name) - 1);
         detail::node_attr_bits::set_anchor_offset(offset, m_attrs);
-        m_prop.anchor = anchor_name;
+        prop().anchor = anchor_name;
     }
 
     /// @brief Add an anchor name to this basic_node object.
@@ -1251,7 +1251,7 @@ public:
     void add_anchor_name(std::string&& anchor_name) {
         if (is_anchor()) {
             m_attrs &= ~detail::node_attr_mask::anchoring;
-            auto itr = mp_meta->anchor_table.equal_range(m_prop.anchor).first;
+            auto itr = mp_meta->anchor_table.equal_range(anchor_prop()).first;
             std::advance(itr, detail::node_attr_bits::get_anchor_offset(m_attrs));
             mp_meta.reset();
             itr->second.swap(*this);
@@ -1269,14 +1269,14 @@ public:
         mp_meta = p_meta;
         auto offset = static_cast<uint32_t>(mp_meta->anchor_table.count(anchor_name) - 1);
         detail::node_attr_bits::set_anchor_offset(offset, m_attrs);
-        m_prop.anchor = std::move(anchor_name);
+        prop().anchor = std::move(anchor_name);
     }
 
     /// @brief Check whether this basic_node object has already had any tag name.
     /// @return true if ths basic_node has a tag name, false otherwise.
     /// @sa https://fktn-k.github.io/fkYAML/api/basic_node/has_tag_name/
     bool has_tag_name() const noexcept {
-        return !m_prop.tag.empty();
+        return mp_prop && !mp_prop->tag.empty();
     }
 
     /// @brief Get the tag name associated with this basic_node object.
@@ -1288,7 +1288,7 @@ public:
         if FK_YAML_UNLIKELY (!has_tag_name()) {
             throw fkyaml::exception("No tag name has been set.");
         }
-        return m_prop.tag;
+        return mp_prop->tag;
     }
 
     /// @brief Get the resolved tag name associated with this basic_node object.
@@ -1301,7 +1301,7 @@ public:
             throw fkyaml::exception("No tag name has been set.");
         }
 
-        const auto& tag = m_prop.tag;
+        const auto& tag = mp_prop->tag;
 
         // non-specific tag
         if (tag == "!") {
@@ -1347,7 +1347,7 @@ public:
     /// @param[in] tag_name A tag name to get associated with this basic_node object.
     /// @sa https://fktn-k.github.io/fkYAML/api/basic_node/add_tag_name/
     void add_tag_name(const std::string& tag_name) {
-        m_prop.tag = tag_name;
+        prop().tag = tag_name;
     }
 
     /// @brief Add a tag name to this basic_node object.
@@ -1355,7 +1355,7 @@ public:
     /// @param[in] tag_name A tag name to get associated with this basic_node object.
     /// @sa https://fktn-k.github.io/fkYAML/api/basic_node/add_tag_name/
     void add_tag_name(std::string&& tag_name) {
-        m_prop.tag = std::move(tag_name);
+        prop().tag = std::move(tag_name);
     }
 
     /// @brief Get the node value object converted into a given type.
@@ -1670,8 +1670,7 @@ public:
         std::memcpy(&m_value, &rhs.m_value, sizeof(node_value));
         std::memcpy(&rhs.m_value, &tmp, sizeof(node_value));
 
-        swap(m_prop.tag, rhs.m_prop.tag);
-        swap(m_prop.anchor, rhs.m_prop.anchor);
+        swap(mp_prop, rhs.mp_prop);
     }
 
     /// @brief Returns an iterator to the first element of a container node (sequence or mapping).
@@ -1866,14 +1865,14 @@ private:
     /// @return Reference to an actual value node.
     basic_node& resolve_reference() {
         if FK_YAML_UNLIKELY (has_anchor_name()) {
-            auto itr = mp_meta->anchor_table.equal_range(m_prop.anchor).first;
+            auto itr = mp_meta->anchor_table.equal_range(anchor_prop()).first;
             auto offset = detail::node_attr_bits::get_anchor_offset(m_attrs);
             std::advance(itr, offset);
             auto& anchor = itr->second;
 
             // Checks for cyclic references in the child nodes of the anchor node.
             // If it does, throws an exception to prevent infinite recursion and stack overflow.
-            const bool contains_self_ref = anchor.contains_self_referential_alias(m_prop.anchor, offset);
+            const bool contains_self_ref = anchor.contains_self_referential_alias(anchor_prop(), offset);
             if FK_YAML_UNLIKELY (contains_self_ref) {
                 throw fkyaml::exception("Cyclic reference detected during anchor/alias resolving.");
             }
@@ -1887,14 +1886,14 @@ private:
     /// @return Const reference to an actual value node.
     const basic_node& resolve_reference() const {
         if FK_YAML_UNLIKELY (has_anchor_name()) {
-            auto itr = mp_meta->anchor_table.equal_range(m_prop.anchor).first;
+            auto itr = mp_meta->anchor_table.equal_range(anchor_prop()).first;
             auto offset = detail::node_attr_bits::get_anchor_offset(m_attrs);
             std::advance(itr, offset);
             const auto& anchor = itr->second;
 
             // Checks for cyclic references in the child nodes of the anchor node.
             // If it does, throws an exception to prevent infinite recursion and stack overflow.
-            const bool contains_self_ref = anchor.contains_self_referential_alias(m_prop.anchor, offset);
+            const bool contains_self_ref = anchor.contains_self_referential_alias(anchor_prop(), offset);
             if FK_YAML_UNLIKELY (contains_self_ref) {
                 throw fkyaml::exception("Cyclic reference detected during anchor/alias resolving.");
             }
@@ -1946,6 +1945,24 @@ private:
             mp_meta = std::make_shared<detail::document_metainfo<basic_node>>();
         }
         return mp_meta;
+    }
+
+    /// @brief Returns the properties of this node, creating them on first use.
+    /// @return The node properties.
+    detail::node_property& prop() {
+        if (!mp_prop) {
+            // std::make_unique is C++14, while this library targets C++11.
+            // NOLINTNEXTLINE(modernize-make-unique)
+            mp_prop.reset(new detail::node_property());
+        }
+        return *mp_prop;
+    }
+
+    /// @brief Returns the anchor name of this node, which must have one.
+    /// @return The anchor name.
+    const std::string& anchor_prop() const noexcept {
+        FK_YAML_ASSERT(mp_prop != nullptr);
+        return mp_prop->anchor;
     }
 
     bool is_sequence_impl() const noexcept {
@@ -2089,8 +2106,9 @@ private:
     mutable std::shared_ptr<detail::document_metainfo<basic_node>> mp_meta {};
     /// The current node value.
     node_value m_value {};
-    /// The property set of this node.
-    detail::node_property m_prop {};
+    /// The property set of this node. It is created on first use since most nodes have neither an
+    /// anchor name nor a tag name.
+    std::unique_ptr<detail::node_property> mp_prop;
 };
 
 /// @brief Swap function for basic_node objects.

--- a/include/fkYAML/node.hpp
+++ b/include/fkYAML/node.hpp
@@ -1172,7 +1172,7 @@ public:
     /// @brief Set the YAML version for this basic_node object.
     /// @param[in] version The target YAML version.
     /// @sa https://fktn-k.github.io/fkYAML/api/basic_node/set_yaml_version_type/
-    void set_yaml_version_type(const yaml_version_type version) noexcept {
+    void set_yaml_version_type(const yaml_version_type version) {
         auto& directives = *meta();
         directives.version = version;
         directives.is_version_specified = true;
@@ -1193,7 +1193,7 @@ public:
     /// @param[in] version The target YAML version.
     /// @sa https://fktn-k.github.io/fkYAML/api/basic_node/set_yaml_version/
     FK_YAML_DEPRECATED("Since 0.3.12; Use set_yaml_version_type(const yaml_version_type)")
-    void set_yaml_version(const yaml_version_t version) noexcept {
+    void set_yaml_version(const yaml_version_t version) {
         set_yaml_version_type(detail::convert_to_yaml_version_type(version));
     }
 

--- a/single_include/fkYAML/node.hpp
+++ b/single_include/fkYAML/node.hpp
@@ -14522,7 +14522,7 @@ public:
     /// @brief Set the YAML version for this basic_node object.
     /// @param[in] version The target YAML version.
     /// @sa https://fktn-k.github.io/fkYAML/api/basic_node/set_yaml_version_type/
-    void set_yaml_version_type(const yaml_version_type version) noexcept {
+    void set_yaml_version_type(const yaml_version_type version) {
         auto& directives = *meta();
         directives.version = version;
         directives.is_version_specified = true;
@@ -14543,7 +14543,7 @@ public:
     /// @param[in] version The target YAML version.
     /// @sa https://fktn-k.github.io/fkYAML/api/basic_node/set_yaml_version/
     FK_YAML_DEPRECATED("Since 0.3.12; Use set_yaml_version_type(const yaml_version_type)")
-    void set_yaml_version(const yaml_version_t version) noexcept {
+    void set_yaml_version(const yaml_version_t version) {
         set_yaml_version_type(detail::convert_to_yaml_version_type(version));
     }
 

--- a/single_include/fkYAML/node.hpp
+++ b/single_include/fkYAML/node.hpp
@@ -8646,7 +8646,7 @@ private:
 
                 basic_node_type node {};
                 node.m_attrs |= detail::node_attr_bits::alias_bit;
-                node.m_prop.anchor = anchor_name;
+                node.prop().anchor = anchor_name;
                 detail::node_attr_bits::set_anchor_offset(anchor_counts - 1, node.m_attrs);
 
                 apply_directive_set(node);
@@ -13612,7 +13612,7 @@ public:
     basic_node(const basic_node& rhs)
         : m_attrs(rhs.m_attrs),
           mp_meta(rhs.mp_meta),
-          m_prop(rhs.m_prop) {
+          mp_prop(rhs.mp_prop ? new detail::node_property(*rhs.mp_prop) : nullptr) {
         if FK_YAML_LIKELY (!has_anchor_name()) {
             switch (m_attrs & detail::node_attr_mask::value) {
             case detail::node_attr_bits::seq_bit:
@@ -13648,7 +13648,7 @@ public:
     basic_node(basic_node&& rhs) noexcept
         : m_attrs(rhs.m_attrs),
           mp_meta(std::move(rhs.mp_meta)),
-          m_prop(std::move(rhs.m_prop)) {
+          mp_prop(std::move(rhs.mp_prop)) {
         if FK_YAML_LIKELY (!has_anchor_name()) {
             switch (m_attrs & detail::node_attr_mask::value) {
             case detail::node_attr_bits::seq_bit:
@@ -13768,7 +13768,7 @@ public:
     {
         if (m_attrs & detail::node_attr_mask::anchoring) {
             if (m_attrs & detail::node_attr_bits::anchor_bit) {
-                auto itr = mp_meta->anchor_table.equal_range(m_prop.anchor).first;
+                auto itr = mp_meta->anchor_table.equal_range(anchor_prop()).first;
                 std::advance(itr, detail::node_attr_bits::get_anchor_offset(m_attrs));
                 itr->second.m_value.destroy(itr->second.m_attrs & detail::node_attr_mask::value);
                 itr->second.m_attrs = detail::node_attr_bits::default_bits;
@@ -14551,7 +14551,7 @@ public:
     /// @return true if ths basic_node has an anchor name, false otherwise.
     /// @sa https://fktn-k.github.io/fkYAML/api/basic_node/has_anchor_name/
     bool has_anchor_name() const noexcept {
-        return (m_attrs & detail::node_attr_mask::anchoring) && !m_prop.anchor.empty();
+        return (m_attrs & detail::node_attr_mask::anchoring) && mp_prop && !mp_prop->anchor.empty();
     }
 
     /// @brief Get the anchor name associated with this basic_node object.
@@ -14563,7 +14563,7 @@ public:
         if FK_YAML_UNLIKELY (!has_anchor_name()) {
             throw fkyaml::exception("No anchor name has been set.");
         }
-        return m_prop.anchor;
+        return mp_prop->anchor;
     }
 
     /// @brief Add an anchor name to this basic_node object.
@@ -14573,7 +14573,7 @@ public:
     void add_anchor_name(const std::string& anchor_name) {
         if (is_anchor()) {
             m_attrs &= ~detail::node_attr_mask::anchoring;
-            auto itr = mp_meta->anchor_table.equal_range(m_prop.anchor).first;
+            auto itr = mp_meta->anchor_table.equal_range(anchor_prop()).first;
             std::advance(itr, detail::node_attr_bits::get_anchor_offset(m_attrs));
             mp_meta.reset();
             itr->second.swap(*this);
@@ -14591,7 +14591,7 @@ public:
         mp_meta = p_meta;
         const auto offset = static_cast<uint32_t>(mp_meta->anchor_table.count(anchor_name) - 1);
         detail::node_attr_bits::set_anchor_offset(offset, m_attrs);
-        m_prop.anchor = anchor_name;
+        prop().anchor = anchor_name;
     }
 
     /// @brief Add an anchor name to this basic_node object.
@@ -14601,7 +14601,7 @@ public:
     void add_anchor_name(std::string&& anchor_name) {
         if (is_anchor()) {
             m_attrs &= ~detail::node_attr_mask::anchoring;
-            auto itr = mp_meta->anchor_table.equal_range(m_prop.anchor).first;
+            auto itr = mp_meta->anchor_table.equal_range(anchor_prop()).first;
             std::advance(itr, detail::node_attr_bits::get_anchor_offset(m_attrs));
             mp_meta.reset();
             itr->second.swap(*this);
@@ -14619,14 +14619,14 @@ public:
         mp_meta = p_meta;
         auto offset = static_cast<uint32_t>(mp_meta->anchor_table.count(anchor_name) - 1);
         detail::node_attr_bits::set_anchor_offset(offset, m_attrs);
-        m_prop.anchor = std::move(anchor_name);
+        prop().anchor = std::move(anchor_name);
     }
 
     /// @brief Check whether this basic_node object has already had any tag name.
     /// @return true if ths basic_node has a tag name, false otherwise.
     /// @sa https://fktn-k.github.io/fkYAML/api/basic_node/has_tag_name/
     bool has_tag_name() const noexcept {
-        return !m_prop.tag.empty();
+        return mp_prop && !mp_prop->tag.empty();
     }
 
     /// @brief Get the tag name associated with this basic_node object.
@@ -14638,7 +14638,7 @@ public:
         if FK_YAML_UNLIKELY (!has_tag_name()) {
             throw fkyaml::exception("No tag name has been set.");
         }
-        return m_prop.tag;
+        return mp_prop->tag;
     }
 
     /// @brief Get the resolved tag name associated with this basic_node object.
@@ -14651,7 +14651,7 @@ public:
             throw fkyaml::exception("No tag name has been set.");
         }
 
-        const auto& tag = m_prop.tag;
+        const auto& tag = mp_prop->tag;
 
         // non-specific tag
         if (tag == "!") {
@@ -14697,7 +14697,7 @@ public:
     /// @param[in] tag_name A tag name to get associated with this basic_node object.
     /// @sa https://fktn-k.github.io/fkYAML/api/basic_node/add_tag_name/
     void add_tag_name(const std::string& tag_name) {
-        m_prop.tag = tag_name;
+        prop().tag = tag_name;
     }
 
     /// @brief Add a tag name to this basic_node object.
@@ -14705,7 +14705,7 @@ public:
     /// @param[in] tag_name A tag name to get associated with this basic_node object.
     /// @sa https://fktn-k.github.io/fkYAML/api/basic_node/add_tag_name/
     void add_tag_name(std::string&& tag_name) {
-        m_prop.tag = std::move(tag_name);
+        prop().tag = std::move(tag_name);
     }
 
     /// @brief Get the node value object converted into a given type.
@@ -15020,8 +15020,7 @@ public:
         std::memcpy(&m_value, &rhs.m_value, sizeof(node_value));
         std::memcpy(&rhs.m_value, &tmp, sizeof(node_value));
 
-        swap(m_prop.tag, rhs.m_prop.tag);
-        swap(m_prop.anchor, rhs.m_prop.anchor);
+        swap(mp_prop, rhs.mp_prop);
     }
 
     /// @brief Returns an iterator to the first element of a container node (sequence or mapping).
@@ -15216,14 +15215,14 @@ private:
     /// @return Reference to an actual value node.
     basic_node& resolve_reference() {
         if FK_YAML_UNLIKELY (has_anchor_name()) {
-            auto itr = mp_meta->anchor_table.equal_range(m_prop.anchor).first;
+            auto itr = mp_meta->anchor_table.equal_range(anchor_prop()).first;
             auto offset = detail::node_attr_bits::get_anchor_offset(m_attrs);
             std::advance(itr, offset);
             auto& anchor = itr->second;
 
             // Checks for cyclic references in the child nodes of the anchor node.
             // If it does, throws an exception to prevent infinite recursion and stack overflow.
-            const bool contains_self_ref = anchor.contains_self_referential_alias(m_prop.anchor, offset);
+            const bool contains_self_ref = anchor.contains_self_referential_alias(anchor_prop(), offset);
             if FK_YAML_UNLIKELY (contains_self_ref) {
                 throw fkyaml::exception("Cyclic reference detected during anchor/alias resolving.");
             }
@@ -15237,14 +15236,14 @@ private:
     /// @return Const reference to an actual value node.
     const basic_node& resolve_reference() const {
         if FK_YAML_UNLIKELY (has_anchor_name()) {
-            auto itr = mp_meta->anchor_table.equal_range(m_prop.anchor).first;
+            auto itr = mp_meta->anchor_table.equal_range(anchor_prop()).first;
             auto offset = detail::node_attr_bits::get_anchor_offset(m_attrs);
             std::advance(itr, offset);
             const auto& anchor = itr->second;
 
             // Checks for cyclic references in the child nodes of the anchor node.
             // If it does, throws an exception to prevent infinite recursion and stack overflow.
-            const bool contains_self_ref = anchor.contains_self_referential_alias(m_prop.anchor, offset);
+            const bool contains_self_ref = anchor.contains_self_referential_alias(anchor_prop(), offset);
             if FK_YAML_UNLIKELY (contains_self_ref) {
                 throw fkyaml::exception("Cyclic reference detected during anchor/alias resolving.");
             }
@@ -15296,6 +15295,24 @@ private:
             mp_meta = std::make_shared<detail::document_metainfo<basic_node>>();
         }
         return mp_meta;
+    }
+
+    /// @brief Returns the properties of this node, creating them on first use.
+    /// @return The node properties.
+    detail::node_property& prop() {
+        if (!mp_prop) {
+            // std::make_unique is C++14, while this library targets C++11.
+            // NOLINTNEXTLINE(modernize-make-unique)
+            mp_prop.reset(new detail::node_property());
+        }
+        return *mp_prop;
+    }
+
+    /// @brief Returns the anchor name of this node, which must have one.
+    /// @return The anchor name.
+    const std::string& anchor_prop() const noexcept {
+        FK_YAML_ASSERT(mp_prop != nullptr);
+        return mp_prop->anchor;
     }
 
     bool is_sequence_impl() const noexcept {
@@ -15439,8 +15456,9 @@ private:
     mutable std::shared_ptr<detail::document_metainfo<basic_node>> mp_meta {};
     /// The current node value.
     node_value m_value {};
-    /// The property set of this node.
-    detail::node_property m_prop {};
+    /// The property set of this node. It is created on first use since most nodes have neither an
+    /// anchor name nor a tag name.
+    std::unique_ptr<detail::node_property> mp_prop;
 };
 
 /// @brief Swap function for basic_node objects.

--- a/single_include/fkYAML/node.hpp
+++ b/single_include/fkYAML/node.hpp
@@ -7741,7 +7741,9 @@ private:
 
         basic_node_type root;
         mp_current_node = &root;
-        mp_meta = root.mp_meta;
+        // One metainfo object is created per document and shared by all of its nodes.
+        mp_meta = std::make_shared<doc_metainfo_type>();
+        root.mp_meta = mp_meta;
 
         // parse directives first.
         deserialize_directives(lexer, token);
@@ -11793,6 +11795,11 @@ private:
     /// @return bool true if any directive is serialized, false otherwise.
     bool serialize_directives(const BasicNodeType& node, std::string& str) {
         const auto& p_meta = node.mp_meta;
+        if (!p_meta) {
+            // A node which was never part of a parsed document carries no directives.
+            return false;
+        }
+
         bool needs_directive_end = false;
 
         if (p_meta->is_version_specified) {
@@ -14509,15 +14516,16 @@ public:
     /// @return The YAML version if already set, `yaml_version_type::VERSION_1_2` otherwise.
     /// @sa https://fktn-k.github.io/fkYAML/api/basic_node/get_yaml_version_type/
     yaml_version_type get_yaml_version_type() const noexcept {
-        return mp_meta->is_version_specified ? mp_meta->version : yaml_version_type::VERSION_1_2;
+        return (mp_meta && mp_meta->is_version_specified) ? mp_meta->version : yaml_version_type::VERSION_1_2;
     }
 
     /// @brief Set the YAML version for this basic_node object.
     /// @param[in] version The target YAML version.
     /// @sa https://fktn-k.github.io/fkYAML/api/basic_node/set_yaml_version_type/
     void set_yaml_version_type(const yaml_version_type version) noexcept {
-        mp_meta->version = version;
-        mp_meta->is_version_specified = true;
+        auto& directives = *meta();
+        directives.version = version;
+        directives.is_version_specified = true;
     }
 
     /// @brief Get the YAML version for this basic_node object.
@@ -14572,7 +14580,7 @@ public:
             mp_meta->anchor_table.erase(itr);
         }
 
-        auto p_meta = mp_meta;
+        auto p_meta = meta();
 
         basic_node node;
         node.swap(*this);
@@ -14600,7 +14608,7 @@ public:
             mp_meta->anchor_table.erase(itr);
         }
 
-        auto p_meta = mp_meta;
+        auto p_meta = meta();
 
         basic_node node;
         node.swap(*this);
@@ -14650,16 +14658,19 @@ public:
             return tag;
         }
 
+        static const detail::document_metainfo<basic_node> NO_DIRECTIVES {};
+        const auto& directives = mp_meta ? *mp_meta : NO_DIRECTIVES;
+
         // secondary tag handle
         if (tag.rfind("!!", 0) == 0) {
-            if (mp_meta->secondary_handle_prefix.empty()) {
+            if (directives.secondary_handle_prefix.empty()) {
                 return "tag:yaml.org,2002:" + tag.substr(2);
             }
-            return mp_meta->secondary_handle_prefix + tag.substr(2);
+            return directives.secondary_handle_prefix + tag.substr(2);
         }
 
         // named handles
-        for (const auto& named_handle_itr : mp_meta->named_handle_map) {
+        for (const auto& named_handle_itr : directives.named_handle_map) {
             if (tag.rfind(named_handle_itr.first, 0) == 0) {
                 return named_handle_itr.second + tag.substr(named_handle_itr.first.size());
             }
@@ -14675,10 +14686,10 @@ public:
         }
 
         // primary tag handle
-        if (mp_meta->primary_handle_prefix.empty()) {
+        if (directives.primary_handle_prefix.empty()) {
             return "!" + tag.substr(1);
         }
-        return mp_meta->primary_handle_prefix + tag.substr(1);
+        return directives.primary_handle_prefix + tag.substr(1);
     }
 
     /// @brief Add a tag name to this basic_node object.
@@ -15278,6 +15289,15 @@ private:
         return false;
     }
 
+    /// @brief Returns the metainfo of the document this node belongs to, creating it on first use.
+    /// @return The shared document metainfo.
+    const std::shared_ptr<detail::document_metainfo<basic_node>>& meta() const {
+        if (!mp_meta) {
+            mp_meta = std::make_shared<detail::document_metainfo<basic_node>>();
+        }
+        return mp_meta;
+    }
+
     bool is_sequence_impl() const noexcept {
         return m_attrs & detail::node_attr_bits::seq_bit;
     }
@@ -15415,9 +15435,8 @@ private:
     /// The current node attributes.
     detail::node_attr_t m_attrs {detail::node_attr_bits::default_bits};
     /// The shared set of YAML directives applied to this node.
-    mutable std::shared_ptr<detail::document_metainfo<basic_node>> mp_meta {
-        // NOLINTNEXTLINE(bugprone-unhandled-exception-at-new)
-        std::shared_ptr<detail::document_metainfo<basic_node>>(new detail::document_metainfo<basic_node>())};
+    /// It is created on first use, since most nodes never need it, and then shared by the nodes of a document.
+    mutable std::shared_ptr<detail::document_metainfo<basic_node>> mp_meta {};
     /// The current node value.
     node_value m_value {};
     /// The property set of this node.

--- a/tests/unit_test/test_node_class.cpp
+++ b/tests/unit_test/test_node_class.cpp
@@ -690,6 +690,17 @@ TEST_CASE("Node_AliasCopyCtor") {
     REQUIRE(alias.as_bool() == true);
 }
 
+TEST_CASE("Node_TaggedCopyCtor") {
+    fkyaml::node copied = "test";
+    copied.add_tag_name("!!str");
+    fkyaml::node node(copied);
+    REQUIRE(node.has_tag_name());
+    REQUIRE(node.get_tag_name() == "!!str");
+
+    copied.add_tag_name("!overwritten");
+    REQUIRE(node.get_tag_name() == "!!str");
+}
+
 TEST_CASE("Node_SequenceMoveCtor") {
     fkyaml::node moved = {true, "test"};
     fkyaml::node node(std::move(moved));

--- a/tests/unit_test/test_node_class.cpp
+++ b/tests/unit_test/test_node_class.cpp
@@ -3022,6 +3022,24 @@ TEST_CASE("Node_GetResolvedTagName") {
         REQUIRE(node.at(2).get_resolved_tag_name() == "tag:example.com,2026:named/a/str");
         REQUIRE(node.at(3).get_resolved_tag_name() == "tag:example.com,2026:named/b/str");
     }
+
+    SUBCASE("node with tag name but without document metainfo.") {
+        fkyaml::node secondary(std::string("foo"));
+        secondary.add_tag_name("!!str");
+        REQUIRE(secondary.get_resolved_tag_name() == "tag:yaml.org,2002:str");
+
+        fkyaml::node non_specific(std::string("bar"));
+        non_specific.add_tag_name("!");
+        REQUIRE(non_specific.get_resolved_tag_name() == "!");
+
+        fkyaml::node primary(std::string("baz"));
+        primary.add_tag_name("!local");
+        REQUIRE(primary.get_resolved_tag_name() == "!local");
+
+        fkyaml::node verbatim(std::string("qux"));
+        verbatim.add_tag_name("!<tag:example.com,2026:verbatim/str>");
+        REQUIRE(verbatim.get_resolved_tag_name() == "tag:example.com,2026:verbatim/str");
+    }
 }
 
 TEST_CASE("Node_AddTagName") {

--- a/tools/benchmark/results/result_debug_citm_catalog_json.txt
+++ b/tools/benchmark/results/result_debug_citm_catalog_json.txt
@@ -1,4 +1,4 @@
-2026-08-24T10:07:15+09:00
+2026-08-24T22:44:32+09:00
 Running ./build_bm_debug/tools/benchmark/benchmarker
 Run on (16 X 3193.92 MHz CPU s)
 CPU Caches:
@@ -6,13 +6,13 @@ CPU Caches:
   L1 Instruction 32 KiB (x8)
   L2 Unified 512 KiB (x8)
   L3 Unified 16384 KiB (x1)
-Load Average: 0.36, 0.29, 0.27
+Load Average: 0.40, 0.34, 0.28
 ***WARNING*** Library was built as DEBUG. Timings may be affected.
 -------------------------------------------------------------------------------------
 Benchmark                           Time             CPU   Iterations UserCounters...
 -------------------------------------------------------------------------------------
-bm_fkyaml_parse              17980714 ns     17975240 ns           39 bytes_per_second=91.6366Mi/s items_per_second=55.6321/s
-bm_yamlcpp_parse            768683936 ns    768468593 ns            1 bytes_per_second=2.14347Mi/s items_per_second=1.30129/s
-bm_libfyaml_parse           116010801 ns    115996771 ns            6 bytes_per_second=14.2003Mi/s items_per_second=8.62093/s
-bm_rapidyaml_parse_inplace   41376645 ns     41372796 ns           17 bytes_per_second=39.8134Mi/s items_per_second=24.1705/s
-bm_rapidyaml_parse_arena     42405496 ns     42400848 ns           16 bytes_per_second=38.848Mi/s items_per_second=23.5844/s
+bm_fkyaml_parse              13400686 ns     13399506 ns           51 bytes_per_second=122.929Mi/s items_per_second=74.6296/s
+bm_yamlcpp_parse            778784708 ns    778724867 ns            1 bytes_per_second=2.11524Mi/s items_per_second=1.28415/s
+bm_libfyaml_parse           114571220 ns    114557764 ns            7 bytes_per_second=14.3787Mi/s items_per_second=8.72922/s
+bm_rapidyaml_parse_inplace   42024214 ns     42020532 ns           17 bytes_per_second=39.1996Mi/s items_per_second=23.7979/s
+bm_rapidyaml_parse_arena     42989432 ns     42985133 ns           16 bytes_per_second=38.32Mi/s items_per_second=23.2639/s

--- a/tools/benchmark/results/result_debug_citm_catalog_yml.txt
+++ b/tools/benchmark/results/result_debug_citm_catalog_yml.txt
@@ -1,4 +1,4 @@
-2026-08-24T10:07:20+09:00
+2026-08-24T22:44:37+09:00
 Running ./build_bm_debug/tools/benchmark/benchmarker
 Run on (16 X 3193.92 MHz CPU s)
 CPU Caches:
@@ -6,13 +6,13 @@ CPU Caches:
   L1 Instruction 32 KiB (x8)
   L2 Unified 512 KiB (x8)
   L3 Unified 16384 KiB (x1)
-Load Average: 0.42, 0.30, 0.27
+Load Average: 0.45, 0.35, 0.28
 ***WARNING*** Library was built as DEBUG. Timings may be affected.
 -------------------------------------------------------------------------------------
 Benchmark                           Time             CPU   Iterations UserCounters...
 -------------------------------------------------------------------------------------
-bm_fkyaml_parse              18225572 ns     18222512 ns           38 bytes_per_second=37.5466Mi/s items_per_second=54.8772/s
-bm_yamlcpp_parse            795819555 ns    795722256 ns            1 bytes_per_second=880.476Ki/s items_per_second=1.25672/s
-bm_libfyaml_parse           107639987 ns    107630675 ns            8 bytes_per_second=6.35686Mi/s items_per_second=9.29103/s
-bm_rapidyaml_parse_inplace   36385415 ns     36381838 ns           19 bytes_per_second=18.8059Mi/s items_per_second=27.4862/s
-bm_rapidyaml_parse_arena     36487670 ns     36483246 ns           19 bytes_per_second=18.7536Mi/s items_per_second=27.4098/s
+bm_fkyaml_parse              12875783 ns     12874828 ns           54 bytes_per_second=53.142Mi/s items_per_second=77.6709/s
+bm_yamlcpp_parse            790313133 ns    790237532 ns            1 bytes_per_second=886.587Ki/s items_per_second=1.26544/s
+bm_libfyaml_parse           107533176 ns    107524523 ns            8 bytes_per_second=6.36314Mi/s items_per_second=9.3002/s
+bm_rapidyaml_parse_inplace   36668917 ns     36666063 ns           19 bytes_per_second=18.6601Mi/s items_per_second=27.2732/s
+bm_rapidyaml_parse_arena     36726880 ns     36723818 ns           19 bytes_per_second=18.6308Mi/s items_per_second=27.2303/s

--- a/tools/benchmark/results/result_debug_ubuntu_yml.txt
+++ b/tools/benchmark/results/result_debug_ubuntu_yml.txt
@@ -1,4 +1,4 @@
-2026-08-24T10:07:11+09:00
+2026-08-24T22:44:28+09:00
 Running ./build_bm_debug/tools/benchmark/benchmarker
 Run on (16 X 3193.92 MHz CPU s)
 CPU Caches:
@@ -6,13 +6,13 @@ CPU Caches:
   L1 Instruction 32 KiB (x8)
   L2 Unified 512 KiB (x8)
   L3 Unified 16384 KiB (x1)
-Load Average: 0.31, 0.27, 0.26
+Load Average: 0.35, 0.33, 0.27
 ***WARNING*** Library was built as DEBUG. Timings may be affected.
 -------------------------------------------------------------------------------------
 Benchmark                           Time             CPU   Iterations UserCounters...
 -------------------------------------------------------------------------------------
-bm_fkyaml_parse                152518 ns       152500 ns         4568 bytes_per_second=55.1504Mi/s items_per_second=6.55736k/s
-bm_yamlcpp_parse              7631117 ns      7630600 ns           92 bytes_per_second=1.1022Mi/s items_per_second=131.051/s
-bm_libfyaml_parse              998811 ns       998695 ns          702 bytes_per_second=8.42144Mi/s items_per_second=1.00131k/s
-bm_rapidyaml_parse_inplace     267363 ns       267460 ns         2617 bytes_per_second=31.4457Mi/s items_per_second=3.73888k/s
-bm_rapidyaml_parse_arena       274256 ns       274232 ns         2554 bytes_per_second=30.6691Mi/s items_per_second=3.64654k/s
+bm_fkyaml_parse                113503 ns       113496 ns         6183 bytes_per_second=74.1033Mi/s items_per_second=8.81086k/s
+bm_yamlcpp_parse              7613398 ns      7612853 ns           92 bytes_per_second=1.10477Mi/s items_per_second=131.357/s
+bm_libfyaml_parse              991501 ns       991383 ns          706 bytes_per_second=8.48355Mi/s items_per_second=1.00869k/s
+bm_rapidyaml_parse_inplace     274196 ns       274300 ns         2542 bytes_per_second=30.6615Mi/s items_per_second=3.64564k/s
+bm_rapidyaml_parse_arena       279563 ns       279539 ns         2503 bytes_per_second=30.0869Mi/s items_per_second=3.57732k/s

--- a/tools/benchmark/results/result_release_citm_catalog_json.txt
+++ b/tools/benchmark/results/result_release_citm_catalog_json.txt
@@ -1,4 +1,4 @@
-2026-08-24T10:03:12+09:00
+2026-08-24T22:42:26+09:00
 Running ./build_bm_release/tools/benchmark/benchmarker
 Run on (16 X 3193.92 MHz CPU s)
 CPU Caches:
@@ -6,12 +6,12 @@ CPU Caches:
   L1 Instruction 32 KiB (x8)
   L2 Unified 512 KiB (x8)
   L3 Unified 16384 KiB (x1)
-Load Average: 0.26, 0.32, 0.27
+Load Average: 0.15, 0.29, 0.25
 -------------------------------------------------------------------------------------
 Benchmark                           Time             CPU   Iterations UserCounters...
 -------------------------------------------------------------------------------------
-bm_fkyaml_parse              16903246 ns     16900908 ns           40 bytes_per_second=97.4616Mi/s items_per_second=59.1684/s
-bm_yamlcpp_parse             98245719 ns     98230351 ns            7 bytes_per_second=16.7686Mi/s items_per_second=10.1802/s
-bm_libfyaml_parse            32700983 ns     32697421 ns           21 bytes_per_second=50.3768Mi/s items_per_second=30.5835/s
-bm_rapidyaml_parse_inplace   13684824 ns     13683128 ns           52 bytes_per_second=120.381Mi/s items_per_second=73.0827/s
-bm_rapidyaml_parse_arena     13819764 ns     13818114 ns           51 bytes_per_second=119.205Mi/s items_per_second=72.3688/s
+bm_fkyaml_parse              12993470 ns     12992218 ns           53 bytes_per_second=126.783Mi/s items_per_second=76.9691/s
+bm_yamlcpp_parse             99251969 ns     99242492 ns            7 bytes_per_second=16.5976Mi/s items_per_second=10.0763/s
+bm_libfyaml_parse            32983392 ns     32978992 ns           21 bytes_per_second=49.9466Mi/s items_per_second=30.3223/s
+bm_rapidyaml_parse_inplace   13650212 ns     13649138 ns           51 bytes_per_second=120.681Mi/s items_per_second=73.2647/s
+bm_rapidyaml_parse_arena     13874457 ns     13873671 ns           50 bytes_per_second=118.728Mi/s items_per_second=72.079/s

--- a/tools/benchmark/results/result_release_citm_catalog_yml.txt
+++ b/tools/benchmark/results/result_release_citm_catalog_yml.txt
@@ -1,4 +1,4 @@
-2026-08-24T10:03:16+09:00
+2026-08-24T22:42:30+09:00
 Running ./build_bm_release/tools/benchmark/benchmarker
 Run on (16 X 3193.92 MHz CPU s)
 CPU Caches:
@@ -6,12 +6,12 @@ CPU Caches:
   L1 Instruction 32 KiB (x8)
   L2 Unified 512 KiB (x8)
   L3 Unified 16384 KiB (x1)
-Load Average: 0.26, 0.32, 0.27
+Load Average: 0.15, 0.29, 0.25
 -------------------------------------------------------------------------------------
 Benchmark                           Time             CPU   Iterations UserCounters...
 -------------------------------------------------------------------------------------
-bm_fkyaml_parse              16523539 ns     16521799 ns           42 bytes_per_second=41.4116Mi/s items_per_second=60.5261/s
-bm_yamlcpp_parse             91251370 ns     91239235 ns            7 bytes_per_second=7.4989Mi/s items_per_second=10.9602/s
-bm_libfyaml_parse            30673186 ns     30671549 ns           23 bytes_per_second=22.3071Mi/s items_per_second=32.6035/s
-bm_rapidyaml_parse_inplace   12633220 ns     12632065 ns           55 bytes_per_second=54.1632Mi/s items_per_second=79.1636/s
-bm_rapidyaml_parse_arena     12750275 ns     12747973 ns           55 bytes_per_second=53.6708Mi/s items_per_second=78.4438/s
+bm_fkyaml_parse              12234863 ns     12231206 ns           57 bytes_per_second=55.9384Mi/s items_per_second=81.7581/s
+bm_yamlcpp_parse             97293420 ns     97281934 ns            6 bytes_per_second=7.0331Mi/s items_per_second=10.2794/s
+bm_libfyaml_parse            31668190 ns     31664814 ns           22 bytes_per_second=21.6074Mi/s items_per_second=31.5808/s
+bm_rapidyaml_parse_inplace   12620463 ns     12619981 ns           55 bytes_per_second=54.2151Mi/s items_per_second=79.2394/s
+bm_rapidyaml_parse_arena     12737953 ns     12736422 ns           55 bytes_per_second=53.7195Mi/s items_per_second=78.515/s

--- a/tools/benchmark/results/result_release_ubuntu_yml.txt
+++ b/tools/benchmark/results/result_release_ubuntu_yml.txt
@@ -1,17 +1,17 @@
-2026-08-24T10:03:07+09:00
+2026-08-24T22:42:22+09:00
 Running ./build_bm_release/tools/benchmark/benchmarker
-Run on (16 X 3193.92 MHz CPU s)
+Run on (12 X 3711.75 MHz CPU s)
 CPU Caches:
-  L1 Data 32 KiB (x8)
-  L1 Instruction 32 KiB (x8)
-  L2 Unified 512 KiB (x8)
+  L1 Data 32 KiB (x6)
+  L1 Instruction 32 KiB (x6)
+  L2 Unified 512 KiB (x6)
   L3 Unified 16384 KiB (x1)
-Load Average: 0.19, 0.31, 0.27
+Load Average: 0.07, 0.28, 0.25
 -------------------------------------------------------------------------------------
 Benchmark                           Time             CPU   Iterations UserCounters...
 -------------------------------------------------------------------------------------
-bm_fkyaml_parse                138799 ns       138781 ns         5057 bytes_per_second=60.6026Mi/s items_per_second=7.20562k/s
-bm_yamlcpp_parse               815083 ns       815030 ns          859 bytes_per_second=10.3192Mi/s items_per_second=1.22695k/s
-bm_libfyaml_parse              237163 ns       237116 ns         2948 bytes_per_second=35.4699Mi/s items_per_second=4.21735k/s
-bm_rapidyaml_parse_inplace      54993 ns        55044 ns        12700 bytes_per_second=152.795Mi/s items_per_second=18.1673k/s
-bm_rapidyaml_parse_arena        61606 ns        61598 ns        11344 bytes_per_second=136.538Mi/s items_per_second=16.2344k/s
+bm_fkyaml_parse                108029 ns       108016 ns         6491 bytes_per_second=77.8628Mi/s items_per_second=9.25786k/s
+bm_yamlcpp_parse               830822 ns       830749 ns          844 bytes_per_second=10.1239Mi/s items_per_second=1.20373k/s
+bm_libfyaml_parse              242131 ns       242110 ns         2871 bytes_per_second=34.7381Mi/s items_per_second=4.13035k/s
+bm_rapidyaml_parse_inplace      55647 ns        55703 ns        12635 bytes_per_second=150.988Mi/s items_per_second=17.9524k/s
+bm_rapidyaml_parse_arena        62033 ns        62029 ns        11310 bytes_per_second=135.589Mi/s items_per_second=16.1215k/s


### PR DESCRIPTION
This started as a question rather than a plan. While reading through the deserializer I noticed that
`node_property` - the anchor and the tag, so two `std::string`s - sits inline in every `basic_node`,
whether or not anything is ever set on it. Almost no node in a real document carries either. Same for
`document_metainfo`, which was being created per node instead of once.

So I wondered what would happen if those were separated out and allocated only when something actually
needs them. Both now live behind a pointer created on first use.

I expected a few percent:

| | before | after | |
|---|---|---|---|
| `ubuntu.yml` | 46.9 MiB/s | **86.5 MiB/s** | 1.8x |
| `citm_catalog.yml` | 26.2 MiB/s | **55.5 MiB/s** | 2.1x |

I did not expect that 😮

10 repetitions per side, same binary and same machine, differing only in the fkYAML headers; the
medians agree with the means. This is MSVC on Windows, so the absolute figures will not match your
Ubuntu results, but the effect is a matter of allocation counts rather than of the compiler.

### Where the factor comes from

The speedup is not a cleverer algorithm - it is the parser no longer allocating. Counting every
`operator new` across a single parse:

| | allocations | peak heap |
|---|---|---|
| `ubuntu.yml` | 3 897 -> **1 068** (-73%) | 98 KiB -> **61 KiB** (-37%) |
| `citm_catalog.yml` | 514 061 -> **108 364** (-79%) | 11.04 MiB -> **6.39 MiB** (-42%) |

These counts are deterministic, so they need no repetitions. The absolute numbers depend on the
standard library's small-string threshold; the ratio does not.

`sizeof(fkyaml::node)` goes from 96 to 40 bytes, and a node with no anchor and no tag no longer
constructs and destroys two strings. On `citm_catalog.yml` that multiplies across hundreds of
thousands of nodes, which is where the factor comes from.

### Behaviour is unchanged

A parser which is faster because it quietly does less work would be an easy mistake to make here, so
that is the check I care about most: YAML test suite reports the same 113 failing cases as
`develop`, identical case for case. Unit tests also pass.

Anchor and tag semantics are unaffected. The copy constructor deep-copies the property, so value
semantics are preserved, and neither `node_property` nor `document_metainfo` appears in a public
signature. Since the metainfo is now created on first use, a node built outside a parsed document has
none, so tag resolution falls back to the default handle prefixes rather than assuming a metainfo
exists.

A node which does carry an anchor or a tag now pays one extra allocation and one indirection - the
rare case gets slightly slower so that the common one gets much faster.

---

## Pull Request Checklist

Read the [CONTRIBUTING.md](https://github.com/fktn-k/fkYAML/blob/develop/.github/CONTRIBUTING.md) file for detailed information.  

- [x] Changes are described in the pull request or in a referenced [issue](https://github.com/fktn-k/fkYAML/issues).
- [x] The test suite compiles and runs without any error.
- [x] [The code coverage](https://coveralls.io/github/fktn-k/fkYAML) on your branch is 100%.
- [x] The documentation is updated if you added/changed a feature.

## Please don't

- The C++11 support varies between different **compilers** and versions. Please note the [list of supported compilers](https://github.com/fktn-k/fkYAML/blob/develop/README.md#supported-compilers). Some compilers like GCC 4.7 (and earlier), Clang 3.3 (and earlier), or Microsoft Visual Studio 13.0 and earlier are known not to work due to missing or incomplete C++11 support. Please refrain from proposing changes that work around these compiler's limitations with `#ifdef`s or other means.
- Please refrain from proposing changes that would **break [YAML](https://yaml.org/) specifications**. If you propose a conformant extension of YAML to be supported by the library, please motivate this extension.
- Please do not open pull requests that address **multiple issues**.
