### PR TITLE
Support a line break between a flow mapping key and its value indicator

### DIFF
--- a/include/fkYAML/detail/input/deserializer.hpp
+++ b/include/fkYAML/detail/input/deserializer.hpp
@@ -332,6 +332,7 @@ private:
         m_needs_tag_impl = false;
         m_needs_anchor_impl = false;
         m_flow_context_depth = 0;
+        m_flow_base_indent = -1;
         m_flow_token_state = flow_token_state_t::NEEDS_VALUE_OR_SUFFIX;
         m_context_stack.clear();
 
@@ -441,6 +442,23 @@ private:
         uint32_t indent = first_indent;
 
         do {
+            if (m_flow_base_indent >= 0) {
+                // The contents of a flow context nested in a block context must be more indented than the block
+                // context it belongs to.
+                // ```yaml
+                // foo: [bar,
+                // baz]
+                // # ^ this line is not indented enough.
+                // ```
+                const auto token_indent = static_cast<int32_t>(lexer.get_last_token_begin_pos());
+                if FK_YAML_UNLIKELY (token_indent <= m_flow_base_indent) {
+                    throw parse_error(
+                        "Contents of a flow context must be more indented than its parent block context.",
+                        lexer.get_lines_processed(),
+                        lexer.get_last_token_begin_pos());
+                }
+            }
+
             switch (token.type) {
             case lexical_token_t::EXPLICIT_KEY_PREFIX: {
                 if FK_YAML_UNLIKELY (m_context_stack.empty()) {
@@ -838,6 +856,8 @@ private:
                             }
                         });
                     }
+
+                    m_flow_base_indent = static_cast<int32_t>(current_context(line, indent).indent);
                 }
                 else if FK_YAML_UNLIKELY (m_flow_token_state == flow_token_state_t::NEEDS_SEPARATOR_OR_SUFFIX) {
                     throw parse_error("Flow sequence beginning is found without separated with a comma.", line, indent);
@@ -884,6 +904,7 @@ private:
 
                 if (--m_flow_context_depth == 0) {
                     lexer.set_context_state(false);
+                    m_flow_base_indent = -1;
                 }
 
                 close_single_pair_mapping(line, indent);
@@ -959,6 +980,8 @@ private:
                             }
                         });
                     }
+
+                    m_flow_base_indent = static_cast<int32_t>(current_context(line, indent).indent);
                 }
                 else if FK_YAML_UNLIKELY (m_flow_token_state == flow_token_state_t::NEEDS_SEPARATOR_OR_SUFFIX) {
                     throw parse_error("Flow mapping beginning is found without separated with a comma.", line, indent);
@@ -1008,6 +1031,7 @@ private:
 
                 if (--m_flow_context_depth == 0) {
                     lexer.set_context_state(false);
+                    m_flow_base_indent = -1;
                 }
 
                 close_omitted_mapping_value(line, indent);
@@ -1336,8 +1360,14 @@ private:
         lexer_type& lexer, basic_node_type&& node, uint32_t& indent, uint32_t& line, lexical_token& token) {
         token = lexer.get_next_token();
         if (mp_current_node->is_mapping()) {
-            const bool is_key_sep_followed =
-                (token.type == lexical_token_t::KEY_SEPARATOR) && (line == lexer.get_lines_processed());
+            // An implicit key in the block context must be followed by the ":" indicator on the same line, while in
+            // the flow context the two can be separated by line breaks.
+            // ```yaml
+            // {"foo"
+            // : "bar"}
+            // ```
+            const bool is_key_sep_followed = (token.type == lexical_token_t::KEY_SEPARATOR) &&
+                                             (line == lexer.get_lines_processed() || m_flow_context_depth > 0);
             if FK_YAML_UNLIKELY (!is_key_sep_followed) {
                 throw parse_error(
                     "The \":\" mapping value indicator must be followed after a mapping key.",
@@ -1684,6 +1714,8 @@ private:
     std::deque<parse_context> m_context_stack {};
     /// The current depth of flow contexts.
     uint32_t m_flow_context_depth {0};
+    /// The indentation the contents of the outermost flow context must exceed, or -1 if unconstrained.
+    int32_t m_flow_base_indent {-1};
     /// The set of YAML directives.
     std::shared_ptr<doc_metainfo_type> mp_meta {};
     /// A flag to determine the need for YAML anchor node implementation.

--- a/single_include/fkYAML/node.hpp
+++ b/single_include/fkYAML/node.hpp
@@ -7882,6 +7882,7 @@ private:
         m_needs_tag_impl = false;
         m_needs_anchor_impl = false;
         m_flow_context_depth = 0;
+        m_flow_base_indent = -1;
         m_flow_token_state = flow_token_state_t::NEEDS_VALUE_OR_SUFFIX;
         m_context_stack.clear();
 
@@ -7991,6 +7992,23 @@ private:
         uint32_t indent = first_indent;
 
         do {
+            if (m_flow_base_indent >= 0) {
+                // The contents of a flow context nested in a block context must be more indented than the block
+                // context it belongs to.
+                // ```yaml
+                // foo: [bar,
+                // baz]
+                // # ^ this line is not indented enough.
+                // ```
+                const auto token_indent = static_cast<int32_t>(lexer.get_last_token_begin_pos());
+                if FK_YAML_UNLIKELY (token_indent <= m_flow_base_indent) {
+                    throw parse_error(
+                        "Contents of a flow context must be more indented than its parent block context.",
+                        lexer.get_lines_processed(),
+                        lexer.get_last_token_begin_pos());
+                }
+            }
+
             switch (token.type) {
             case lexical_token_t::EXPLICIT_KEY_PREFIX: {
                 if FK_YAML_UNLIKELY (m_context_stack.empty()) {
@@ -8388,6 +8406,8 @@ private:
                             }
                         });
                     }
+
+                    m_flow_base_indent = static_cast<int32_t>(current_context(line, indent).indent);
                 }
                 else if FK_YAML_UNLIKELY (m_flow_token_state == flow_token_state_t::NEEDS_SEPARATOR_OR_SUFFIX) {
                     throw parse_error("Flow sequence beginning is found without separated with a comma.", line, indent);
@@ -8434,6 +8454,7 @@ private:
 
                 if (--m_flow_context_depth == 0) {
                     lexer.set_context_state(false);
+                    m_flow_base_indent = -1;
                 }
 
                 close_single_pair_mapping(line, indent);
@@ -8509,6 +8530,8 @@ private:
                             }
                         });
                     }
+
+                    m_flow_base_indent = static_cast<int32_t>(current_context(line, indent).indent);
                 }
                 else if FK_YAML_UNLIKELY (m_flow_token_state == flow_token_state_t::NEEDS_SEPARATOR_OR_SUFFIX) {
                     throw parse_error("Flow mapping beginning is found without separated with a comma.", line, indent);
@@ -8558,6 +8581,7 @@ private:
 
                 if (--m_flow_context_depth == 0) {
                     lexer.set_context_state(false);
+                    m_flow_base_indent = -1;
                 }
 
                 close_omitted_mapping_value(line, indent);
@@ -8886,8 +8910,14 @@ private:
         lexer_type& lexer, basic_node_type&& node, uint32_t& indent, uint32_t& line, lexical_token& token) {
         token = lexer.get_next_token();
         if (mp_current_node->is_mapping()) {
-            const bool is_key_sep_followed =
-                (token.type == lexical_token_t::KEY_SEPARATOR) && (line == lexer.get_lines_processed());
+            // An implicit key in the block context must be followed by the ":" indicator on the same line, while in
+            // the flow context the two can be separated by line breaks.
+            // ```yaml
+            // {"foo"
+            // : "bar"}
+            // ```
+            const bool is_key_sep_followed = (token.type == lexical_token_t::KEY_SEPARATOR) &&
+                                             (line == lexer.get_lines_processed() || m_flow_context_depth > 0);
             if FK_YAML_UNLIKELY (!is_key_sep_followed) {
                 throw parse_error(
                     "The \":\" mapping value indicator must be followed after a mapping key.",
@@ -9234,6 +9264,8 @@ private:
     std::deque<parse_context> m_context_stack {};
     /// The current depth of flow contexts.
     uint32_t m_flow_context_depth {0};
+    /// The indentation the contents of the outermost flow context must exceed, or -1 if unconstrained.
+    int32_t m_flow_base_indent {-1};
     /// The set of YAML directives.
     std::shared_ptr<doc_metainfo_type> mp_meta {};
     /// A flag to determine the need for YAML anchor node implementation.

--- a/tests/unit_test/test_deserializer_class.cpp
+++ b/tests/unit_test/test_deserializer_class.cpp
@@ -2556,6 +2556,27 @@ TEST_CASE("Deserializer_FlowMapping") {
         REQUIRE(foo_node.is_mapping());
         REQUIRE(foo_node.empty());
     }
+
+    SUBCASE("key separator on the line after the key") {
+        auto input =
+            GENERATE(std::string("{\"foo\"\n: bar}"), std::string("{foo\n: bar}"), std::string("{foo\n:\nbar}"));
+        REQUIRE_NOTHROW(root = deserializer.deserialize(fkyaml::detail::input_adapter(input)));
+
+        REQUIRE(root.is_mapping());
+        REQUIRE(root.size() == 1);
+        REQUIRE(root.contains("foo"));
+        REQUIRE(root["foo"].as_str() == "bar");
+    }
+
+    SUBCASE("quoted key spanning multiple lines") {
+        auto input = GENERATE(std::string("{ \"multi\n  line\": value }"), std::string("{ 'multi\n  line': value }"));
+        REQUIRE_NOTHROW(root = deserializer.deserialize(fkyaml::detail::input_adapter(input)));
+
+        REQUIRE(root.is_mapping());
+        REQUIRE(root.size() == 1);
+        REQUIRE(root.contains("multi line"));
+        REQUIRE(root["multi line"].as_str() == "value");
+    }
 }
 
 TEST_CASE("Deserializer_UnclosedFlowCollection") {
@@ -2611,6 +2632,42 @@ TEST_CASE("Deserializer_OmittedFlowMappingValue") {
         auto input =
             GENERATE(std::string("{foo: 1,, bar: 2}"), std::string("{,}"), std::string("[a,,b]"), std::string("[,]"));
         REQUIRE_THROWS_AS(root = deserializer.deserialize(fkyaml::detail::input_adapter(input)), fkyaml::parse_error);
+    }
+}
+
+TEST_CASE("Deserializer_FlowContentIndentation") {
+    fkyaml::detail::basic_deserializer<fkyaml::node> deserializer;
+    fkyaml::node root;
+
+    SUBCASE("flow contents less indented than the parent block context") {
+        auto input =
+            GENERATE(std::string("foo: [bar,\nbaz]"), std::string("foo: {\nbar: baz\n}"), std::string("- [a,\nb]"));
+        REQUIRE_THROWS_AS(root = deserializer.deserialize(fkyaml::detail::input_adapter(input)), fkyaml::parse_error);
+    }
+
+    SUBCASE("flow contents more indented than the parent block context") {
+        std::string input = "foo: [bar,\n  baz]";
+        REQUIRE_NOTHROW(root = deserializer.deserialize(fkyaml::detail::input_adapter(input)));
+
+        REQUIRE(root.is_mapping());
+        REQUIRE(root.size() == 1);
+        REQUIRE(root.contains("foo"));
+
+        fkyaml::node& foo_node = root["foo"];
+        REQUIRE(foo_node.is_sequence());
+        REQUIRE(foo_node.size() == 2);
+        REQUIRE(foo_node[0].as_str() == "bar");
+        REQUIRE(foo_node[1].as_str() == "baz");
+    }
+
+    SUBCASE("flow contents at the document level are not constrained") {
+        std::string input = "[foo,\nbar]";
+        REQUIRE_NOTHROW(root = deserializer.deserialize(fkyaml::detail::input_adapter(input)));
+
+        REQUIRE(root.is_sequence());
+        REQUIRE(root.size() == 2);
+        REQUIRE(root[0].as_str() == "foo");
+        REQUIRE(root[1].as_str() == "bar");
     }
 }
 


### PR DESCRIPTION
In the flow context, YAML allows the `:` indicator to be separated from its key by a line break -
`ns-flow-map-yaml-key-entry` permits `s-separate` before `c-ns-flow-map-separate-value`. The
deserializer required both to be on the same line, which is only correct for implicit keys in the
block context:

```yaml
{"foo"
: "bar"}
```

Relaxing that on its own would accept under-indented flow contents, so this also adds the rule that
comes with it: the contents of a flow context nested in a block context must be more indented than
that block context, while a flow context beginning at the document level stays unconstrained. Without
it, `VJP3/00` from the test suite, which is an error case, would no longer be rejected.

## Effect on yaml-test-suite

Against `data-2022-01-17`, failing cases go from 110 to 103, with no regressions:

| case | |
|---|---|
| `4MUZ/00`, `4MUZ/01`, `4MUZ/02` | flow mapping colon on the line after the key |
| `NJ66`, `9SA2` | multiline flow mapping key |
| `VJP3/01` | flow collections over many lines |
| `9C9N` | wrong indented flow sequence, now rejected |

Three cases still fail with the same error message for unrelated reasons, and aren't addressed here:
`5MUD` and `K3WX` need `:` adjacent to a value after a JSON-like key, and `UT92` needs `%` to be
treated as plain content inside a flow context.

## What with tests?

`Deserializer_FlowMapping` gains cases for the separated indicator and for a key spanning two lines.
A new `Deserializer_FlowContentIndentation` covers under-indented contents, correctly indented
contents, and a document-level flow context whose contents start at column 0.

---

## Pull Request Checklist

Read the [CONTRIBUTING.md](https://github.com/fktn-k/fkYAML/blob/develop/.github/CONTRIBUTING.md) file for detailed information.  

- [x] Changes are described in the pull request or in a referenced [issue](https://github.com/fktn-k/fkYAML/issues).
- [x] The test suite compiles and runs without any error.
- [x] [The code coverage](https://coveralls.io/github/fktn-k/fkYAML) on your branch is 100%.
- [x] The documentation is updated if you added/changed a feature.

## Please don't

- The C++11 support varies between different **compilers** and versions. Please note the [list of supported compilers](https://github.com/fktn-k/fkYAML/blob/develop/README.md#supported-compilers). Some compilers like GCC 4.7 (and earlier), Clang 3.3 (and earlier), or Microsoft Visual Studio 13.0 and earlier are known not to work due to missing or incomplete C++11 support. Please refrain from proposing changes that work around these compiler's limitations with `#ifdef`s or other means.
- Please refrain from proposing changes that would **break [YAML](https://yaml.org/) specifications**. If you propose a conformant extension of YAML to be supported by the library, please motivate this extension.
- Please do not open pull requests that address **multiple issues**.
