### PR TITLE
Treat only a single dash as a prefix for block sequence entries

### DIFF
--- a/include/fkYAML/detail/input/lexical_analyzer.hpp
+++ b/include/fkYAML/detail/input/lexical_analyzer.hpp
@@ -267,6 +267,11 @@ private:
             // See https://yaml.org/spec/1.2.2/#912-document-markers for more details.
             break;
         case '-': {
+            if (m_cur_itr + 1 == m_end_itr) {
+                ++m_cur_itr;
+                info.token.type = lexical_token_t::SEQUENCE_BLOCK_PREFIX;
+                return info;
+            }
             switch (*(m_cur_itr + 1)) {
             case ' ':
             case '\t':

--- a/single_include/fkYAML/node.hpp
+++ b/single_include/fkYAML/node.hpp
@@ -3540,6 +3540,11 @@ private:
             // See https://yaml.org/spec/1.2.2/#912-document-markers for more details.
             break;
         case '-': {
+            if (m_cur_itr + 1 == m_end_itr) {
+                ++m_cur_itr;
+                info.token.type = lexical_token_t::SEQUENCE_BLOCK_PREFIX;
+                return info;
+            }
             switch (*(m_cur_itr + 1)) {
             case ' ':
             case '\t':


### PR DESCRIPTION
This PR fixes the handling of only a single dash character in a document.  
Such a character is now treated as a prefix of block sequence entries.  

All unit tests pass.
This also fixes `SM9W/00` (Single character streams) in the YAML test suite.
As a result, 103 failing cases has decreased to 102 with no newly failing case.

---

## Pull Request Checklist

Read the [CONTRIBUTING.md](https://github.com/fktn-k/fkYAML/blob/develop/.github/CONTRIBUTING.md) file for detailed information.  

- [x] Changes are described in the pull request or in a referenced [issue](https://github.com/fktn-k/fkYAML/issues).
- [x] The test suite compiles and runs without any error.
- [x] [The code coverage](https://coveralls.io/github/fktn-k/fkYAML) on your branch is 100%.
- [x] The documentation is updated if you added/changed a feature.

## Please don't

- The C++11 support varies between different **compilers** and versions. Please note the [list of supported compilers](https://github.com/fktn-k/fkYAML/blob/develop/README.md#supported-compilers). Some compilers like GCC 4.7 (and earlier), Clang 3.3 (and earlier), or Microsoft Visual Studio 13.0 and earlier are known not to work due to missing or incomplete C++11 support. Please refrain from proposing changes that work around these compiler's limitations with `#ifdef`s or other means.
- Please refrain from proposing changes that would **break [YAML](https://yaml.org/) specifications**. If you propose a conformant extension of YAML to be supported by the library, please motivate this extension.
- Please do not open pull requests that address **multiple issues**.
