### PR TITLE
Fix the indentation base of a document level block scalar

### DIFF
--- a/include/fkYAML/detail/input/lexical_analyzer.hpp
+++ b/include/fkYAML/detail/input/lexical_analyzer.hpp
@@ -382,6 +382,8 @@ private:
             }
 
             const uint32_t base_indent = get_current_indent_level(&sv[header_end_pos]);
+            // Must be checked before m_token_begin_itr is moved to the beginning of the contents below.
+            const bool is_document_root = begins_document_level_node();
 
             const str_view header_line = sv.substr(1, header_end_pos - 1);
             m_block_scalar_header = convert_to_block_scalar_header(header_line);
@@ -391,7 +393,7 @@ private:
             info.token = {
                 type,
                 determine_block_scalar_content_range(
-                    base_indent, m_block_scalar_header.indent, m_block_scalar_header.indent)};
+                    base_indent, m_block_scalar_header.indent, is_document_root, m_block_scalar_header.indent)};
             return info;
         }
         default:
@@ -400,6 +402,32 @@ private:
 
         info.token = {lexical_token_t::PLAIN_SCALAR, determine_plain_scalar_range()};
         return info;
+    }
+
+    /// @brief Checks if the token which begins at m_token_begin_itr is the root node of a document.
+    /// @note Such a node has no parent, so its contents may begin at the first column.
+    /// @return true if nothing but a document start marker precedes the token on its line, false otherwise.
+    bool begins_document_level_node() const {
+        const char* p_line_begin = m_token_begin_itr;
+        while (p_line_begin != m_begin_itr && *(p_line_begin - 1) != '\n') {
+            --p_line_begin;
+        }
+
+        if (p_line_begin == m_token_begin_itr) {
+            return true;
+        }
+
+        const char* cur_itr = p_line_begin;
+        if (m_token_begin_itr - cur_itr < 3 || !std::equal(cur_itr, cur_itr + 3, "---")) {
+            return false;
+        }
+
+        for (cur_itr += 3; cur_itr != m_token_begin_itr; ++cur_itr) {
+            if (*cur_itr != ' ') {
+                return false;
+            }
+        }
+        return true;
     }
 
     uint32_t get_current_indent_level(const char* p_line_end) {
@@ -1054,10 +1082,11 @@ private:
     /// @brief Scan a block style string token either in the literal or folded style.
     /// @param base_indent The base indent level of the block scalar.
     /// @param indicated_indent The indicated indent level in the block scalar header. 0 means it's not indicated.
+    /// @param is_document_root Whether the block scalar is the root node of a document.
     /// @param token Storage for the scanned block scalar range.
     /// @return The content indentation level of the block scalar.
     str_view determine_block_scalar_content_range(
-        uint32_t base_indent, uint32_t indicated_indent, uint32_t& content_indent) {
+        uint32_t base_indent, uint32_t indicated_indent, bool is_document_root, uint32_t& content_indent) {
         const str_view sv {m_token_begin_itr, m_end_itr};
         const std::size_t remain_input_len = sv.size();
 
@@ -1109,7 +1138,13 @@ private:
         }
 
         if (indicated_indent == 0) {
-            if FK_YAML_UNLIKELY (base_indent >= cur_indent) {
+            // A block scalar which is the root node of a document has no parent node to be more indented than, so
+            // its contents may begin at the first column.
+            // ```yaml
+            // --- >
+            // line1
+            // ```
+            if FK_YAML_UNLIKELY (!is_document_root && base_indent >= cur_indent) {
                 emit_error("The first non-empty line in the block scalar is less indented.");
             }
             indicated_indent = cur_indent - base_indent;

--- a/single_include/fkYAML/node.hpp
+++ b/single_include/fkYAML/node.hpp
@@ -3655,6 +3655,8 @@ private:
             }
 
             const uint32_t base_indent = get_current_indent_level(&sv[header_end_pos]);
+            // Must be checked before m_token_begin_itr is moved to the beginning of the contents below.
+            const bool is_document_root = begins_document_level_node();
 
             const str_view header_line = sv.substr(1, header_end_pos - 1);
             m_block_scalar_header = convert_to_block_scalar_header(header_line);
@@ -3664,7 +3666,7 @@ private:
             info.token = {
                 type,
                 determine_block_scalar_content_range(
-                    base_indent, m_block_scalar_header.indent, m_block_scalar_header.indent)};
+                    base_indent, m_block_scalar_header.indent, is_document_root, m_block_scalar_header.indent)};
             return info;
         }
         default:
@@ -3673,6 +3675,32 @@ private:
 
         info.token = {lexical_token_t::PLAIN_SCALAR, determine_plain_scalar_range()};
         return info;
+    }
+
+    /// @brief Checks if the token which begins at m_token_begin_itr is the root node of a document.
+    /// @note Such a node has no parent, so its contents may begin at the first column.
+    /// @return true if nothing but a document start marker precedes the token on its line, false otherwise.
+    bool begins_document_level_node() const {
+        const char* p_line_begin = m_token_begin_itr;
+        while (p_line_begin != m_begin_itr && *(p_line_begin - 1) != '\n') {
+            --p_line_begin;
+        }
+
+        if (p_line_begin == m_token_begin_itr) {
+            return true;
+        }
+
+        const char* cur_itr = p_line_begin;
+        if (m_token_begin_itr - cur_itr < 3 || !std::equal(cur_itr, cur_itr + 3, "---")) {
+            return false;
+        }
+
+        for (cur_itr += 3; cur_itr != m_token_begin_itr; ++cur_itr) {
+            if (*cur_itr != ' ') {
+                return false;
+            }
+        }
+        return true;
     }
 
     uint32_t get_current_indent_level(const char* p_line_end) {
@@ -4327,10 +4355,11 @@ private:
     /// @brief Scan a block style string token either in the literal or folded style.
     /// @param base_indent The base indent level of the block scalar.
     /// @param indicated_indent The indicated indent level in the block scalar header. 0 means it's not indicated.
+    /// @param is_document_root Whether the block scalar is the root node of a document.
     /// @param token Storage for the scanned block scalar range.
     /// @return The content indentation level of the block scalar.
     str_view determine_block_scalar_content_range(
-        uint32_t base_indent, uint32_t indicated_indent, uint32_t& content_indent) {
+        uint32_t base_indent, uint32_t indicated_indent, bool is_document_root, uint32_t& content_indent) {
         const str_view sv {m_token_begin_itr, m_end_itr};
         const std::size_t remain_input_len = sv.size();
 
@@ -4382,7 +4411,13 @@ private:
         }
 
         if (indicated_indent == 0) {
-            if FK_YAML_UNLIKELY (base_indent >= cur_indent) {
+            // A block scalar which is the root node of a document has no parent node to be more indented than, so
+            // its contents may begin at the first column.
+            // ```yaml
+            // --- >
+            // line1
+            // ```
+            if FK_YAML_UNLIKELY (!is_document_root && base_indent >= cur_indent) {
                 emit_error("The first non-empty line in the block scalar is less indented.");
             }
             indicated_indent = cur_indent - base_indent;

--- a/tests/unit_test/test_deserializer_class.cpp
+++ b/tests/unit_test/test_deserializer_class.cpp
@@ -437,6 +437,38 @@ TEST_CASE("Deserializer_BlockFoldedScalar") {
     }
 }
 
+TEST_CASE("Deserializer_DocumentLevelBlockScalar") {
+    fkyaml::detail::basic_deserializer<fkyaml::node> deserializer;
+    fkyaml::node root;
+
+    SUBCASE("contents of a root block scalar may begin at the first column") {
+        auto input = GENERATE(std::string("--- >\nline1\nline2\n"), std::string(">\nline1\nline2\n"));
+        REQUIRE_NOTHROW(root = deserializer.deserialize(fkyaml::detail::input_adapter(input)));
+
+        REQUIRE(root.is_string());
+        REQUIRE(root.as_str() == "line1 line2\n");
+    }
+
+    SUBCASE("a root block scalar may still be indented") {
+        std::string input = "--- |\n  line1\n  line2\n";
+        REQUIRE_NOTHROW(root = deserializer.deserialize(fkyaml::detail::input_adapter(input)));
+
+        REQUIRE(root.is_string());
+        REQUIRE(root.as_str() == "line1\nline2\n");
+    }
+
+    SUBCASE("contents of a nested block scalar must still be more indented than its parent") {
+        auto input = GENERATE(std::string("foo: >\nline1\n"), std::string("- |\nline1\n"));
+        REQUIRE_THROWS_AS(root = deserializer.deserialize(fkyaml::detail::input_adapter(input)), fkyaml::parse_error);
+    }
+
+    SUBCASE("a block scalar nested after the document start marker is not document-level") {
+        auto input = GENERATE(
+            std::string("--- foo: >\nline1\n"), std::string("--- -x: >\nline1\n"), std::string("--- --x: >\nline1\n"));
+        REQUIRE_THROWS_AS(root = deserializer.deserialize(fkyaml::detail::input_adapter(input)), fkyaml::parse_error);
+    }
+}
+
 TEST_CASE("Deserializer_ScalarConversionErrorHandling") {
     fkyaml::detail::basic_deserializer<fkyaml::node> deserializer;
     fkyaml::node root;


### PR DESCRIPTION
A block scalar which is the root node of a document has no parent, so per the spec its contents are
measured against `n = -1` and may begin at the first column:

```yaml
--- >
line1
line2
```

The lexer measured them against the indentation of the header line, which is `0` for both `--- >`
and a bare `>`, so `base_indent >= cur_indent` rejected any content starting at column 0.

A block scalar counts as a document root only when nothing but an optional `---` marker precedes its
header on the line, so a header sitting on an indented line of its own is still measured against its
parent.

## Tests

YAML test suite failing cases go from 102 to 100 with no regressions: `FP8R` and `DK3J` now pass. `M7A3` and `W4TN`
parse correctly now too, but still fail on the document count, which per @fktn-k's answer in #587
stays an allowed failure for now.

I also added `Deserializer_DocumentLevelBlockScalar`, which covers a root block scalar starting at the first column
(`--- >` and a bare `>`), an indented one, and the negative cases `foo: >` and `- |`.

---

## Pull Request Checklist

Read the [CONTRIBUTING.md](https://github.com/fktn-k/fkYAML/blob/develop/.github/CONTRIBUTING.md) file for detailed information.  

- [x] Changes are described in the pull request or in a referenced [issue](https://github.com/fktn-k/fkYAML/issues).
- [x] The test suite compiles and runs without any error.
- [x] [The code coverage](https://coveralls.io/github/fktn-k/fkYAML) on your branch is 100%.
- [x] The documentation is updated if you added/changed a feature.

## Please don't

- The C++11 support varies between different **compilers** and versions. Please note the [list of supported compilers](https://github.com/fktn-k/fkYAML/blob/develop/README.md#supported-compilers). Some compilers like GCC 4.7 (and earlier), Clang 3.3 (and earlier), or Microsoft Visual Studio 13.0 and earlier are known not to work due to missing or incomplete C++11 support. Please refrain from proposing changes that work around these compiler's limitations with `#ifdef`s or other means.
- Please refrain from proposing changes that would **break [YAML](https://yaml.org/) specifications**. If you propose a conformant extension of YAML to be supported by the library, please motivate this extension.
- Please do not open pull requests that address **multiple issues**.
