### PR TITLE
Continue a multiline plain scalar across equally indented lines

### DIFF
--- a/include/fkYAML/detail/input/lexical_analyzer.hpp
+++ b/include/fkYAML/detail/input/lexical_analyzer.hpp
@@ -430,6 +430,48 @@ private:
         return true;
     }
 
+    /// @brief Checks if the given position is a white space, a line break or the end of the buffer.
+    /// @note Tabs count as white space here, as in the definition of c-forbidden.
+    /// https://yaml.org/spec/1.2.2/#912-document-markers
+    /// @param sv The buffer contents being scanned.
+    /// @param pos The position to inspect.
+    /// @return true if nothing, a white space or a line break follows, false otherwise.
+    static bool is_followed_by_white_space(str_view sv, std::size_t pos) noexcept {
+        return (pos == sv.size()) || (sv[pos] == ' ') || (sv[pos] == '\t') || (sv[pos] == '\n');
+    }
+
+    /// @brief Checks if the given position begins something a plain scalar cannot continue into.
+    /// @param sv The buffer contents being scanned.
+    /// @param pos The position of the first non-space character in a line.
+    /// @param is_first_column Whether the position is at the beginning of its line.
+    /// @return true if a document marker or a block structure indicator begins there.
+    static bool begins_non_scalar_content(str_view sv, std::size_t pos, bool is_first_column) noexcept {
+        switch (sv[pos]) {
+        case ':':
+        case '?':
+            // These can never appear in a plain scalar, whatever their indentation. Others such as
+            // "- " can, when they are indented deeply enough to be content.
+            // See https://yaml.org/spec/1.2.2/#733-plain-style for more details.
+            return is_followed_by_white_space(sv, pos + 1);
+        case '[':
+        case ']':
+        case '{':
+        case '}':
+            // A flow collection beginning a line starts a node of its own.
+            return true;
+        default:
+            break;
+        }
+
+        // Document markers are only recognized at the beginning of a line.
+        if (!is_first_column) {
+            return false;
+        }
+
+        const bool begins_marker = (sv.compare(pos, 3, "---") == 0) || (sv.compare(pos, 3, "...") == 0);
+        return begins_marker && is_followed_by_white_space(sv, pos + 3);
+    }
+
     uint32_t get_current_indent_level(const char* p_line_end) {
         // get the beginning position of the current line.
         std::size_t line_begin_pos = str_view(m_begin_itr, p_line_end - 1).find_last_of('\n');
@@ -976,12 +1018,18 @@ private:
 
         bool ends_loop = false;
         uint32_t indent = std::numeric_limits<uint32_t>::max();
+        bool begins_own_line = false;
         do {
             FK_YAML_ASSERT(pos < sv.size());
             switch (sv[pos]) {
             case '\n': {
                 if (indent == std::numeric_limits<uint32_t>::max()) {
                     indent = get_current_indent_level(&sv[pos]);
+                    // The scalar begins a line of its own if its column is the indentation of that line.
+                    // Only meaningful in a block context: in a flow context the surrounding collection
+                    // owns the following lines, so a scalar must not extend into them.
+                    begins_own_line =
+                        ((m_state & flow_context_bit) == 0) && (m_pos_tracker.get_cur_pos_in_line() == indent);
                 }
 
                 constexpr str_view space_filter {" \t\n"};
@@ -989,7 +1037,25 @@ private:
                 const std::size_t last_newline_pos = sv.find_last_of('\n', non_space_pos);
                 FK_YAML_ASSERT(last_newline_pos != str_view::npos);
 
-                if (non_space_pos == str_view::npos || non_space_pos - last_newline_pos - 1 <= indent) {
+                // A plain scalar which begins a line of its own can be continued by lines at the same
+                // indentation, since nothing else on that line owns it:
+                // ```yaml
+                // foo:
+                //   first line
+                //   second line
+                // ```
+                // One which follows a key on the same line must be continued by more indented lines,
+                // because a line at the key's indentation belongs to the parent mapping instead.
+                const uint32_t min_continuation_indent = begins_own_line ? indent : indent + 1;
+
+                if (non_space_pos == str_view::npos) {
+                    ends_loop = true;
+                    break;
+                }
+
+                const std::size_t cur_line_indent = non_space_pos - last_newline_pos - 1;
+                const bool ends_scalar = begins_non_scalar_content(sv, non_space_pos, cur_line_indent == 0);
+                if (cur_line_indent < min_continuation_indent || ends_scalar) {
                     ends_loop = true;
                     break;
                 }

--- a/single_include/fkYAML/node.hpp
+++ b/single_include/fkYAML/node.hpp
@@ -3703,6 +3703,48 @@ private:
         return true;
     }
 
+    /// @brief Checks if the given position is a white space, a line break or the end of the buffer.
+    /// @note Tabs count as white space here, as in the definition of c-forbidden.
+    /// https://yaml.org/spec/1.2.2/#912-document-markers
+    /// @param sv The buffer contents being scanned.
+    /// @param pos The position to inspect.
+    /// @return true if nothing, a white space or a line break follows, false otherwise.
+    static bool is_followed_by_white_space(str_view sv, std::size_t pos) noexcept {
+        return (pos == sv.size()) || (sv[pos] == ' ') || (sv[pos] == '\t') || (sv[pos] == '\n');
+    }
+
+    /// @brief Checks if the given position begins something a plain scalar cannot continue into.
+    /// @param sv The buffer contents being scanned.
+    /// @param pos The position of the first non-space character in a line.
+    /// @param is_first_column Whether the position is at the beginning of its line.
+    /// @return true if a document marker or a block structure indicator begins there.
+    static bool begins_non_scalar_content(str_view sv, std::size_t pos, bool is_first_column) noexcept {
+        switch (sv[pos]) {
+        case ':':
+        case '?':
+            // These can never appear in a plain scalar, whatever their indentation. Others such as
+            // "- " can, when they are indented deeply enough to be content.
+            // See https://yaml.org/spec/1.2.2/#733-plain-style for more details.
+            return is_followed_by_white_space(sv, pos + 1);
+        case '[':
+        case ']':
+        case '{':
+        case '}':
+            // A flow collection beginning a line starts a node of its own.
+            return true;
+        default:
+            break;
+        }
+
+        // Document markers are only recognized at the beginning of a line.
+        if (!is_first_column) {
+            return false;
+        }
+
+        const bool begins_marker = (sv.compare(pos, 3, "---") == 0) || (sv.compare(pos, 3, "...") == 0);
+        return begins_marker && is_followed_by_white_space(sv, pos + 3);
+    }
+
     uint32_t get_current_indent_level(const char* p_line_end) {
         // get the beginning position of the current line.
         std::size_t line_begin_pos = str_view(m_begin_itr, p_line_end - 1).find_last_of('\n');
@@ -4249,12 +4291,18 @@ private:
 
         bool ends_loop = false;
         uint32_t indent = std::numeric_limits<uint32_t>::max();
+        bool begins_own_line = false;
         do {
             FK_YAML_ASSERT(pos < sv.size());
             switch (sv[pos]) {
             case '\n': {
                 if (indent == std::numeric_limits<uint32_t>::max()) {
                     indent = get_current_indent_level(&sv[pos]);
+                    // The scalar begins a line of its own if its column is the indentation of that line.
+                    // Only meaningful in a block context: in a flow context the surrounding collection
+                    // owns the following lines, so a scalar must not extend into them.
+                    begins_own_line =
+                        ((m_state & flow_context_bit) == 0) && (m_pos_tracker.get_cur_pos_in_line() == indent);
                 }
 
                 constexpr str_view space_filter {" \t\n"};
@@ -4262,7 +4310,25 @@ private:
                 const std::size_t last_newline_pos = sv.find_last_of('\n', non_space_pos);
                 FK_YAML_ASSERT(last_newline_pos != str_view::npos);
 
-                if (non_space_pos == str_view::npos || non_space_pos - last_newline_pos - 1 <= indent) {
+                // A plain scalar which begins a line of its own can be continued by lines at the same
+                // indentation, since nothing else on that line owns it:
+                // ```yaml
+                // foo:
+                //   first line
+                //   second line
+                // ```
+                // One which follows a key on the same line must be continued by more indented lines,
+                // because a line at the key's indentation belongs to the parent mapping instead.
+                const uint32_t min_continuation_indent = begins_own_line ? indent : indent + 1;
+
+                if (non_space_pos == str_view::npos) {
+                    ends_loop = true;
+                    break;
+                }
+
+                const std::size_t cur_line_indent = non_space_pos - last_newline_pos - 1;
+                const bool ends_scalar = begins_non_scalar_content(sv, non_space_pos, cur_line_indent == 0);
+                if (cur_line_indent < min_continuation_indent || ends_scalar) {
                     ends_loop = true;
                     break;
                 }

--- a/tests/unit_test/test_deserializer_class.cpp
+++ b/tests/unit_test/test_deserializer_class.cpp
@@ -469,6 +469,60 @@ TEST_CASE("Deserializer_DocumentLevelBlockScalar") {
     }
 }
 
+TEST_CASE("Deserializer_MultilinePlainScalarInBlockContext") {
+    fkyaml::detail::basic_deserializer<fkyaml::node> deserializer;
+    fkyaml::node root;
+
+    SUBCASE("a scalar on its own line is continued by equally indented lines") {
+        std::string input = "foo:\n  first line\n  second line\nbar: baz";
+        REQUIRE_NOTHROW(root = deserializer.deserialize(fkyaml::detail::input_adapter(input)));
+
+        REQUIRE(root.is_mapping());
+        REQUIRE(root.size() == 2);
+        REQUIRE(root["foo"].as_str() == "first line second line");
+        REQUIRE(root["bar"].as_str() == "baz");
+    }
+
+    SUBCASE("a scalar following its key needs more indented lines") {
+        std::string input = "foo: first line\n  second line\nbar: baz";
+        REQUIRE_NOTHROW(root = deserializer.deserialize(fkyaml::detail::input_adapter(input)));
+
+        REQUIRE(root.is_mapping());
+        REQUIRE(root.size() == 2);
+        REQUIRE(root["foo"].as_str() == "first line second line");
+        REQUIRE(root["bar"].as_str() == "baz");
+    }
+
+    SUBCASE("a document marker ends the scalar") {
+        // The marker may be followed by a space, a tab or a line break alike.
+        auto input = GENERATE(
+            std::string("foo:\n  first line\n  second line\n---\nbar"),
+            std::string("foo:\n  first line\n  second line\n--- bar"),
+            std::string("foo:\n  first line\n  second line\n---\tbar"));
+        std::vector<fkyaml::node> docs;
+        REQUIRE_NOTHROW(docs = fkyaml::node::deserialize_docs(input));
+
+        REQUIRE(docs.size() == 2);
+        REQUIRE(docs[0]["foo"].as_str() == "first line second line");
+        REQUIRE(docs[1].as_str() == "bar");
+    }
+
+    SUBCASE("a document end marker ends the scalar") {
+        std::string input = "foo:\n  first line\n  second line\n...\n";
+        std::vector<fkyaml::node> docs;
+        REQUIRE_NOTHROW(docs = fkyaml::node::deserialize_docs(input));
+
+        REQUIRE(docs.size() == 1);
+        REQUIRE(docs[0]["foo"].as_str() == "first line second line");
+    }
+
+    SUBCASE("a mapping value indicator ends the scalar") {
+        auto input = GENERATE(
+            std::string("foo\n: bar"), std::string("foo\n:\tbar"), std::string("foo\n:"), std::string("foo\n:\n"));
+        REQUIRE_THROWS_AS(root = deserializer.deserialize(fkyaml::detail::input_adapter(input)), fkyaml::parse_error);
+    }
+}
+
 TEST_CASE("Deserializer_ScalarConversionErrorHandling") {
     fkyaml::detail::basic_deserializer<fkyaml::node> deserializer;
     fkyaml::node root;

--- a/tests/unit_test/test_fuzz_regression.cpp
+++ b/tests/unit_test/test_fuzz_regression.cpp
@@ -42,6 +42,13 @@ TEST_CASE("FuzzRegression") {
         REQUIRE_THROWS_AS(root = fkyaml::node::deserialize(p_begin, p_end), fkyaml::parse_error);
     }
 
+    SUBCASE("block sequence entry after a scalar root") {
+        const char input[] = "'a'-";
+        p_begin = input;
+        p_end = input + sizeof(input) - 1;
+        REQUIRE_THROWS_AS(root = fkyaml::node::deserialize(p_begin, p_end), fkyaml::parse_error);
+    }
+
     SUBCASE("invalid flow sequence after scalar root") {
         const char input[] = "ke\n[";
         p_begin = input;
@@ -101,6 +108,15 @@ TEST_CASE("FuzzRegression") {
         uint8_t input[] = {0x0D, 0x3B, 0x00, 0x0A, 0x0A, 0x4A, 0x0A, 0x0A, 0x26, 0x7C, 0x0A, 0x3A};
         p_begin = reinterpret_cast<const char*>(input);
         p_end = p_begin + sizeof(input);
+        REQUIRE_THROWS_AS(root = fkyaml::node::deserialize(p_begin, p_end), fkyaml::parse_error);
+    }
+
+    SUBCASE("key separator after node properties without a parent context") {
+        const char input[] = "!\n"
+                             "!\n"
+                             ":";
+        p_begin = input;
+        p_end = input + sizeof(input) - 1;
         REQUIRE_THROWS_AS(root = fkyaml::node::deserialize(p_begin, p_end), fkyaml::parse_error);
     }
 

--- a/tests/unit_test/test_lexical_analyzer_class.cpp
+++ b/tests/unit_test/test_lexical_analyzer_class.cpp
@@ -692,16 +692,17 @@ TEST_CASE("LexicalAnalyzer_PlainScalar") {
         REQUIRE(token.str.end() == input.end() - 5);
     }
 
-    SUBCASE("multiline with equally indented line") {
+    SUBCASE("multiline continued by an equally indented line") {
         fkyaml::detail::str_view input = "  foo\n"
                                          "   bar\n"
                                          "  baz";
         fkyaml::detail::lexical_analyzer lexer(input);
 
+        // The scalar begins a line of its own, so a line at the same indentation continues it.
         REQUIRE_NOTHROW(token = lexer.get_next_token());
         REQUIRE(token.type == fkyaml::detail::lexical_token_t::PLAIN_SCALAR);
         REQUIRE(token.str.begin() == input.begin() + 2);
-        REQUIRE(token.str.end() == input.end() - 6);
+        REQUIRE(token.str.end() == input.end());
     }
 
     SUBCASE("multiline with empty line") {


### PR DESCRIPTION
A plain scalar which begins a line of its own can be continued by lines at the same indentation,
since nothing else on that line owns it:

```yaml
Warning:
  This is an error message
  for the log file
```

The continuation was measured against the indentation of the scalar's own first line, so a line at
that same indentation ended it. The scalar then broke into one token per line, and the deserializer
reported a misleading `The ":" mapping value indicator must be followed after a mapping key.`

A scalar which follows a key on the same line still requires more indented lines, because a line at
the key's indentation belongs to the parent mapping instead. The two cases are told apart by
comparing the scalar's column with the indentation of its line.

Lowering the bar also required naming the things which end a plain scalar explicitly, since the old
rule had been stopping scalars at column 0 as a side effect: a document marker, a `:` or `?`
followed by a space, and a flow collection. `- ` is deliberately not among them, because an indented
one is legitimate content (`AB8U`).

I ran tests and the YAML test suite failing cases go from 100 to 95 with no regressions: `4CQQ`, `NB6Z`, `RZT7` and
`XLQ9` now parse, and `DK4H` is now correctly rejected.

I also added `Deserializer_MultilinePlainScalarInBlockContext`, covering a scalar continued at the same
indentation, one following its key which needs deeper indentation, a document marker ending the
scalar, and `foo\n: bar` still being rejected. One existing expectation in
`LexicalAnalyzer_PlainScalar` changed: `"  foo\n   bar\n  baz"` is now a single token, which is the
same shape the suite requires in `4CQQ`.

---

## Pull Request Checklist

Read the [CONTRIBUTING.md](https://github.com/fktn-k/fkYAML/blob/develop/.github/CONTRIBUTING.md) file for detailed information.  

- [x] Changes are described in the pull request or in a referenced [issue](https://github.com/fktn-k/fkYAML/issues).
- [x] The test suite compiles and runs without any error.
- [x] [The code coverage](https://coveralls.io/github/fktn-k/fkYAML) on your branch is 100%.
- [x] The documentation is updated if you added/changed a feature.

## Please don't

- The C++11 support varies between different **compilers** and versions. Please note the [list of supported compilers](https://github.com/fktn-k/fkYAML/blob/develop/README.md#supported-compilers). Some compilers like GCC 4.7 (and earlier), Clang 3.3 (and earlier), or Microsoft Visual Studio 13.0 and earlier are known not to work due to missing or incomplete C++11 support. Please refrain from proposing changes that work around these compiler's limitations with `#ifdef`s or other means.
- Please refrain from proposing changes that would **break [YAML](https://yaml.org/) specifications**. If you propose a conformant extension of YAML to be supported by the library, please motivate this extension.
- Please do not open pull requests that address **multiple issues**.
