### PR TITLE
Fix anchor/alias ordering during serialization

### DIFF
--- a/include/fkYAML/detail/output/serializer.hpp
+++ b/include/fkYAML/detail/output/serializer.hpp
@@ -360,7 +360,9 @@ private:
     static bool has_prior_anchor_definition(
         const std::vector<anchor_reference>& anchors, const anchor_reference& target) {
         for (const auto& anchor : anchors) {
-            if (anchor.position < target.position && is_same_anchor(anchor, target)) {
+            const bool is_anchor_defined_prior_to_target =
+                anchor.position < target.position && is_same_anchor(anchor, target);
+            if (is_anchor_defined_prior_to_target) {
                 return true;
             }
         }
@@ -430,18 +432,15 @@ private:
     /// @param items The mapping items to reorder.
     /// @param item_anchors The anchor references grouped by mapping item.
     /// @param item_aliases The alias references grouped by mapping item.
+    /// @param anchors_in_mapping The anchor references defined in the mapping.
     /// @return The mapping items in dependency-respecting serialization order.
     std::vector<map_iterator> reorder_mapping_items_by_dependencies(
         const std::vector<map_iterator>& items, const std::vector<std::vector<anchor_reference>>& item_anchors,
-        const std::vector<std::vector<anchor_reference>>& item_aliases) const {
+        const std::vector<std::vector<anchor_reference>>& item_aliases,
+        std::vector<anchor_reference> anchors_in_mapping) const {
         std::vector<bool> emitted(items.size(), false);
         std::vector<map_iterator> ordered_items;
         ordered_items.reserve(items.size());
-
-        std::vector<anchor_reference> anchors_in_mapping;
-        for (const auto& anchors : item_anchors) {
-            anchors_in_mapping.insert(anchors_in_mapping.end(), anchors.begin(), anchors.end());
-        }
 
         std::size_t emitted_count = 0;
         while (emitted_count < items.size()) {
@@ -459,21 +458,10 @@ private:
                 }
             }
 
-            if (ready_item_index == items.size()) {
-                break;
-            }
-
             emitted[ready_item_index] = true;
             ordered_items.emplace_back(items[ready_item_index]);
             remove_anchors(item_anchors[ready_item_index], anchors_in_mapping);
             ++emitted_count;
-        }
-
-        for (std::size_t i = 0; i < items.size(); ++i) {
-            const bool is_item_emitted = emitted[i];
-            if (!is_item_emitted) {
-                ordered_items.emplace_back(items[i]);
-            }
         }
 
         return ordered_items;
@@ -499,11 +487,29 @@ private:
 
         // If there are no anchors (no resolving needed) or aliases (no anchor is referenced), return the items in the
         // order `node.map_items()` returns them.
-        if (!has_any_anchor || !has_any_alias) {
+        const bool needs_reordering = has_any_anchor && has_any_alias;
+        if (!needs_reordering) {
             return items;
         }
 
-        return reorder_mapping_items_by_dependencies(items, item_anchors, item_aliases);
+        std::vector<anchor_reference> anchors_in_mapping;
+        for (const auto& anchors : item_anchors) {
+            anchors_in_mapping.insert(anchors_in_mapping.end(), anchors.begin(), anchors.end());
+        }
+
+        for (std::size_t i = 0; i < items.size(); ++i) {
+            for (const auto& alias : item_aliases[i]) {
+                const bool is_anchor_defined_in_different_item =
+                    has_anchor(anchors_in_mapping, alias) && !has_anchor(item_anchors[i], alias);
+                if (is_anchor_defined_in_different_item) {
+                    return reorder_mapping_items_by_dependencies(
+                        items, item_anchors, item_aliases, std::move(anchors_in_mapping));
+                }
+            }
+        }
+
+        // Reordering is only needed when an alias refers to an anchor in another mapping item.
+        return items;
     }
 
     void collect_anchor_alias_names(

--- a/include/fkYAML/detail/output/serializer.hpp
+++ b/include/fkYAML/detail/output/serializer.hpp
@@ -543,7 +543,8 @@ private:
     /// @return true if the mapping was serialized here, false if it needs no reordering.
     bool serialize_reordered_mapping(const BasicNodeType& node, const uint32_t cur_indent, std::string& str) {
         std::vector<map_iterator> ordered_items;
-        if (!get_mapping_items_in_serialization_order(node, ordered_items)) {
+        const bool is_reordered = get_mapping_items_in_serialization_order(node, ordered_items);
+        if (!is_reordered) {
             return false;
         }
 

--- a/include/fkYAML/detail/output/serializer.hpp
+++ b/include/fkYAML/detail/output/serializer.hpp
@@ -207,7 +207,9 @@ private:
                 return;
             }
 
-            if (m_has_anchor_table) {
+            // If there is any anchor defined for this document and the mapping has more than one entry,
+            // reorder the mapping entries so the anchor resolution order is preserved.
+            if (m_has_anchor_table && node.size() > 1) {
                 for (const auto& itr : get_mapping_items_in_serialization_order(node)) {
                     serialize_mapping_entry(itr, cur_indent, str);
                 }

--- a/include/fkYAML/detail/output/serializer.hpp
+++ b/include/fkYAML/detail/output/serializer.hpp
@@ -248,14 +248,9 @@ private:
 
             // If there is any anchor defined for this document and the mapping has more than one entry,
             // reorder the mapping entries so the anchor resolution order is preserved.
-            if (m_has_anchor_table && node.size() > 1) {
-                std::vector<map_iterator> ordered_items;
-                if (get_mapping_items_in_serialization_order(node, ordered_items)) {
-                    for (const auto& itr : ordered_items) {
-                        serialize_mapping_entry(itr, cur_indent, str);
-                    }
-                    break;
-                }
+            // Only a document which defines an anchor can ever need its mapping entries reordered.
+            if (m_has_anchor_table && node.size() > 1 && serialize_reordered_mapping(node, cur_indent, str)) {
+                break;
             }
 
             for (const auto& itr : node.map_items()) {
@@ -541,6 +536,22 @@ private:
         return ordered_items;
     }
 
+    /// @brief Serialize a mapping whose entries have to be reordered for anchor resolution.
+    /// @param node The mapping to serialize.
+    /// @param cur_indent The current indent width.
+    /// @param str A string to hold the serialization result.
+    /// @return true if the mapping was serialized here, false if it needs no reordering.
+    bool serialize_reordered_mapping(const BasicNodeType& node, const uint32_t cur_indent, std::string& str) {
+        std::vector<map_iterator> ordered_items;
+        if (!get_mapping_items_in_serialization_order(node, ordered_items)) {
+            return false;
+        }
+
+        for (const auto& itr : ordered_items) {
+            serialize_mapping_entry(itr, cur_indent, str);
+        }
+        return true;
+    }
     /// @brief Collect the mapping items in the order they have to be serialized in.
     /// @param node The mapping to serialize.
     /// @param ordered_items Receives the reordered items, untouched unless reordering is needed.

--- a/include/fkYAML/detail/output/serializer.hpp
+++ b/include/fkYAML/detail/output/serializer.hpp
@@ -11,8 +11,10 @@
 
 #include <algorithm>
 #include <cmath>
+#include <deque>
 #include <sstream>
 #include <string>
+#include <unordered_map>
 #include <vector>
 
 #include <fkYAML/detail/macros/define_macros.hpp>
@@ -35,16 +37,42 @@ class basic_serializer {
 
     using map_iterator = typename BasicNodeType::const_map_range::const_iterator;
 
-    struct anchor_reference {
-        anchor_reference(std::string name, const uint32_t offset, const std::size_t position)
+    struct anchor_reference_event {
+        anchor_reference_event(std::string name, const uint32_t offset, const std::size_t position, bool is_anchor)
             : name(std::move(name)),
               offset(offset),
-              position(position) {
+              position(position),
+              is_anchor(is_anchor) {
         }
 
         std::string name;
         uint32_t offset {0};
         std::size_t position {0};
+        bool is_anchor {false};
+    };
+
+    struct anchor_reference_span {
+        anchor_reference_span() = default;
+
+        anchor_reference_span(uint32_t first_index, uint32_t count)
+            : first_index(first_index),
+              count(count) {
+        }
+
+        uint32_t first_index {0};
+        uint32_t count {0};
+    };
+
+    struct mapping_item_span {
+        mapping_item_span() = default;
+
+        mapping_item_span(uint32_t first_item_reference_index, uint32_t item_count)
+            : first_item_reference_index(first_item_reference_index),
+              item_count(item_count) {
+        }
+
+        uint32_t first_item_reference_index {0};
+        uint32_t item_count {0};
     };
 
 public:
@@ -78,6 +106,10 @@ public:
 private:
     void serialize_document(const BasicNodeType& node, std::string& str) {
         m_has_anchor_table = (node.mp_meta && !node.mp_meta->anchor_table.empty());
+
+        m_anchor_reference_events.clear();
+        m_mapping_item_references.clear();
+        m_anchor_reference_cache.clear();
 
         const bool dirs_serialized = serialize_directives(node, str);
 
@@ -336,7 +368,7 @@ private:
     /// @param lhs The first anchor reference.
     /// @param rhs The second anchor reference.
     /// @return true if both references identify the same anchor, false otherwise.
-    static bool is_same_anchor(const anchor_reference& lhs, const anchor_reference& rhs) noexcept {
+    static bool is_same_anchor(const anchor_reference_event& lhs, const anchor_reference_event& rhs) noexcept {
         return lhs.name == rhs.name && lhs.offset == rhs.offset;
     }
 
@@ -344,9 +376,20 @@ private:
     /// @param anchors The collection of anchor references.
     /// @param target The anchor reference to find.
     /// @return true if the target is present, false otherwise.
-    static bool has_anchor(const std::vector<anchor_reference>& anchors, const anchor_reference& target) {
-        for (const auto& anchor : anchors) {
-            if (is_same_anchor(anchor, target)) {
+    bool has_anchor(const anchor_reference_span& anchors, const anchor_reference_event& target) const {
+        const auto last_event_index = anchors.first_index + anchors.count;
+        for (uint32_t i = anchors.first_index; i < last_event_index; ++i) {
+            const auto& anchor = m_anchor_reference_events[i];
+            if (anchor.is_anchor && is_same_anchor(anchor, target)) {
+                return true;
+            }
+        }
+        return false;
+    }
+
+    bool has_anchor(const std::vector<uint32_t>& anchor_indices, const anchor_reference_event& target) const {
+        for (const auto anchor_index : anchor_indices) {
+            if (is_same_anchor(m_anchor_reference_events[anchor_index], target)) {
                 return true;
             }
         }
@@ -357,11 +400,13 @@ private:
     /// @param anchors The anchor references in the mapping item.
     /// @param target The anchor reference whose preceding definition is checked.
     /// @return true if a preceding definition exists, false otherwise.
-    static bool has_prior_anchor_definition(
-        const std::vector<anchor_reference>& anchors, const anchor_reference& target) {
-        for (const auto& anchor : anchors) {
+    bool has_prior_anchor_definition(
+        const anchor_reference_span& item_reference, const anchor_reference_event& target) const {
+        const auto last_event_index = item_reference.first_index + item_reference.count;
+        for (uint32_t i = item_reference.first_index; i < last_event_index; ++i) {
+            const auto& anchor = m_anchor_reference_events[i];
             const bool is_anchor_defined_prior_to_target =
-                anchor.position < target.position && is_same_anchor(anchor, target);
+                anchor.is_anchor && anchor.position < target.position && is_same_anchor(anchor, target);
             if (is_anchor_defined_prior_to_target) {
                 return true;
             }
@@ -374,9 +419,15 @@ private:
     /// @param anchors_in_mapping The anchor references that have not been emitted.
     /// @return true if an earlier anchor definition remains unemitted, false otherwise.
     bool has_unemitted_prior_anchor_definition(
-        const std::vector<anchor_reference>& anchors, const std::vector<anchor_reference>& anchors_in_mapping) const {
-        for (const auto& anchor : anchors) {
-            for (const auto& mapping_anchor : anchors_in_mapping) {
+        const anchor_reference_span& item_reference, const std::vector<uint32_t>& anchor_indices) const {
+        const auto last_event_index = item_reference.first_index + item_reference.count;
+        for (uint32_t i = item_reference.first_index; i < last_event_index; ++i) {
+            const auto& anchor = m_anchor_reference_events[i];
+            if (!anchor.is_anchor) {
+                continue;
+            }
+            for (const auto anchor_index : anchor_indices) {
+                const auto& mapping_anchor = m_anchor_reference_events[anchor_index];
                 if (mapping_anchor.name == anchor.name && mapping_anchor.offset < anchor.offset) {
                     return true;
                 }
@@ -391,10 +442,14 @@ private:
     /// @param anchors_in_mapping The anchor references that have not been emitted.
     /// @return true if an aliased anchor remains unemitted, false otherwise.
     bool has_unemitted_anchor_definition(
-        const std::vector<anchor_reference>& anchors, const std::vector<anchor_reference>& aliases,
-        const std::vector<anchor_reference>& anchors_in_mapping) const {
-        for (const auto& alias : aliases) {
-            if (!has_prior_anchor_definition(anchors, alias) && has_anchor(anchors_in_mapping, alias)) {
+        const anchor_reference_span& item_reference, const std::vector<uint32_t>& anchor_indices) const {
+        const auto last_event_index = item_reference.first_index + item_reference.count;
+        for (uint32_t i = item_reference.first_index; i < last_event_index; ++i) {
+            const auto& alias = m_anchor_reference_events[i];
+            if (alias.is_anchor) {
+                continue;
+            }
+            if (!has_prior_anchor_definition(item_reference, alias) && has_anchor(anchor_indices, alias)) {
                 return true;
             }
         }
@@ -407,21 +462,25 @@ private:
     /// @param anchors_in_mapping The anchor references that have not been emitted.
     /// @return true if the mapping item is ready to be emitted, false otherwise.
     bool is_ready_to_emit(
-        const std::vector<anchor_reference>& anchors, const std::vector<anchor_reference>& aliases,
-        const std::vector<anchor_reference>& anchors_in_mapping) const {
-        return !has_unemitted_prior_anchor_definition(anchors, anchors_in_mapping) &&
-               !has_unemitted_anchor_definition(anchors, aliases, anchors_in_mapping);
+        const anchor_reference_span& item_reference, const std::vector<uint32_t>& anchor_indices) const {
+        return !has_unemitted_prior_anchor_definition(item_reference, anchor_indices) &&
+               !has_unemitted_anchor_definition(item_reference, anchor_indices);
     }
 
     /// @brief Remove the anchors defined by an emitted mapping item.
     /// @param anchors The anchor references defined by the emitted mapping item.
     /// @param anchors_in_mapping The anchor references that have not been emitted.
-    static void remove_anchors(
-        const std::vector<anchor_reference>& anchors, std::vector<anchor_reference>& anchors_in_mapping) {
-        for (const auto& anchor : anchors) {
-            auto itr = anchors_in_mapping.begin();
-            while (itr != anchors_in_mapping.end()) {
-                itr = is_same_anchor(*itr, anchor) ? anchors_in_mapping.erase(itr) : std::next(itr);
+    void remove_anchors(const anchor_reference_span& anchors, std::vector<uint32_t>& anchor_indices) const {
+        const auto last_event_index = anchors.first_index + anchors.count;
+        for (uint32_t i = anchors.first_index; i < last_event_index; ++i) {
+            const auto& anchor = m_anchor_reference_events[i];
+            if (!anchor.is_anchor) {
+                continue;
+            }
+            auto itr = anchor_indices.begin();
+            while (itr != anchor_indices.end()) {
+                const auto& mapping_anchor = m_anchor_reference_events[*itr];
+                itr = is_same_anchor(mapping_anchor, anchor) ? anchor_indices.erase(itr) : std::next(itr);
             }
         }
     }
@@ -435,9 +494,8 @@ private:
     /// @param anchors_in_mapping The anchor references defined in the mapping.
     /// @return The mapping items in dependency-respecting serialization order.
     std::vector<map_iterator> reorder_mapping_items_by_dependencies(
-        const std::vector<map_iterator>& items, const std::vector<std::vector<anchor_reference>>& item_anchors,
-        const std::vector<std::vector<anchor_reference>>& item_aliases,
-        std::vector<anchor_reference> anchors_in_mapping) const {
+        const std::vector<map_iterator>& items, const std::vector<anchor_reference_span>& item_references,
+        std::vector<uint32_t> anchor_indices) const {
         std::vector<bool> emitted(items.size(), false);
         std::vector<map_iterator> ordered_items;
         ordered_items.reserve(items.size());
@@ -451,7 +509,7 @@ private:
                     continue;
                 }
 
-                const bool is_item_ready = is_ready_to_emit(item_anchors[i], item_aliases[i], anchors_in_mapping);
+                const bool is_item_ready = is_ready_to_emit(item_references[i], anchor_indices);
                 if (is_item_ready) {
                     ready_item_index = i;
                     break;
@@ -460,50 +518,83 @@ private:
 
             emitted[ready_item_index] = true;
             ordered_items.emplace_back(items[ready_item_index]);
-            remove_anchors(item_anchors[ready_item_index], anchors_in_mapping);
+            remove_anchors(item_references[ready_item_index], anchor_indices);
             ++emitted_count;
         }
 
         return ordered_items;
     }
 
-    std::vector<map_iterator> get_mapping_items_in_serialization_order(const BasicNodeType& node) const {
-        std::vector<map_iterator> items;
-        std::vector<std::vector<anchor_reference>> item_anchors;
-        std::vector<std::vector<anchor_reference>> item_aliases;
+    std::vector<map_iterator> get_mapping_items_in_serialization_order(const BasicNodeType& node) {
+        mapping_item_span mapping_reference {};
+        anchor_reference_span mapping_event_reference {};
+        const auto mapping_reference_itr = m_anchor_reference_cache.find(&node);
+        if (mapping_reference_itr == m_anchor_reference_cache.end()) {
+            std::size_t position = 0;
+            mapping_event_reference = collect_anchor_alias_names(node, position, false, &mapping_reference);
+        }
+        else {
+            mapping_reference = mapping_reference_itr->second;
+            const auto& first_item_reference = m_mapping_item_references[mapping_reference.first_item_reference_index];
+            const auto& last_item_reference = m_mapping_item_references
+                [mapping_reference.first_item_reference_index + mapping_reference.item_count - 1];
+            mapping_event_reference = anchor_reference_span {
+                first_item_reference.first_index,
+                last_item_reference.first_index + last_item_reference.count - first_item_reference.first_index};
+        }
+
         bool has_any_anchor = false;
         bool has_any_alias = false;
-
-        for (auto itr : node.map_items()) {
-            items.emplace_back(itr);
-            item_anchors.emplace_back();
-            item_aliases.emplace_back();
-            std::size_t position = 0;
-            collect_anchor_alias_names(itr.key(), item_anchors.back(), item_aliases.back(), position);
-            collect_anchor_alias_names(itr.value(), item_anchors.back(), item_aliases.back(), position);
-            has_any_anchor = has_any_anchor || !item_anchors.back().empty();
-            has_any_alias = has_any_alias || !item_aliases.back().empty();
+        const auto last_index = mapping_event_reference.first_index + mapping_event_reference.count;
+        for (uint32_t event_index = mapping_event_reference.first_index; event_index < last_index; ++event_index) {
+            has_any_anchor = has_any_anchor || m_anchor_reference_events[event_index].is_anchor;
+            has_any_alias = has_any_alias || !m_anchor_reference_events[event_index].is_anchor;
         }
 
         // If there are no anchors (no resolving needed) or aliases (no anchor is referenced), return the items in the
         // order `node.map_items()` returns them.
         const bool needs_reordering = has_any_anchor && has_any_alias;
         if (!needs_reordering) {
+            std::vector<map_iterator> items;
+            items.reserve(mapping_reference.item_count);
+            for (auto itr : node.map_items()) {
+                items.emplace_back(itr);
+            }
             return items;
         }
 
-        std::vector<anchor_reference> anchors_in_mapping;
-        for (const auto& anchors : item_anchors) {
-            anchors_in_mapping.insert(anchors_in_mapping.end(), anchors.begin(), anchors.end());
+        std::vector<map_iterator> items;
+        std::vector<anchor_reference_span> item_references;
+        items.reserve(mapping_reference.item_count);
+        item_references.reserve(mapping_reference.item_count);
+        std::vector<uint32_t> anchor_indices;
+
+        auto itr = node.map_items().begin();
+        for (uint32_t i = 0; i < mapping_reference.item_count; ++i, ++itr) {
+            items.emplace_back(itr);
+            const auto& item_reference = m_mapping_item_references[mapping_reference.first_item_reference_index + i];
+            item_references.emplace_back(item_reference);
+
+            const auto last_event_index = item_reference.first_index + item_reference.count;
+            for (uint32_t event_index = item_reference.first_index; event_index < last_event_index; ++event_index) {
+                if (m_anchor_reference_events[event_index].is_anchor) {
+                    anchor_indices.emplace_back(event_index);
+                }
+            }
         }
 
         for (std::size_t i = 0; i < items.size(); ++i) {
-            for (const auto& alias : item_aliases[i]) {
+            const auto& item_reference = item_references[i];
+            const auto last_event_index = item_reference.first_index + item_reference.count;
+            for (uint32_t event_index = item_reference.first_index; event_index < last_event_index; ++event_index) {
+                const auto& alias = m_anchor_reference_events[event_index];
+                if (alias.is_anchor) {
+                    continue;
+                }
                 const bool is_anchor_defined_in_different_item =
-                    has_anchor(anchors_in_mapping, alias) && !has_anchor(item_anchors[i], alias);
+                    has_anchor(anchor_indices, alias) && !has_anchor(item_reference, alias);
                 if (is_anchor_defined_in_different_item) {
-                    return reorder_mapping_items_by_dependencies(
-                        items, item_anchors, item_aliases, std::move(anchors_in_mapping));
+                    return reorder_mapping_items_by_dependencies(items, item_references, std::move(anchor_indices));
                 }
             }
         }
@@ -512,36 +603,62 @@ private:
         return items;
     }
 
-    void collect_anchor_alias_names(
-        const BasicNodeType& node, std::vector<anchor_reference>& anchors, std::vector<anchor_reference>& aliases,
-        std::size_t& position) const {
+    anchor_reference_span collect_anchor_alias_names(
+        const BasicNodeType& node, std::size_t& position, const bool cache_mapping = true,
+        mapping_item_span* p_mapping_reference = nullptr) {
+        const auto first_event_index = static_cast<uint32_t>(m_anchor_reference_events.size());
         if (node.is_alias()) {
-            anchor_reference alias_ref(
-                node.get_anchor_name(), detail::node_attr_bits::get_anchor_offset(node.m_attrs), position++);
-            aliases.emplace_back(std::move(alias_ref));
-            return;
+            anchor_reference_event alias_event(
+                node.get_anchor_name(), detail::node_attr_bits::get_anchor_offset(node.m_attrs), position++, false);
+            m_anchor_reference_events.emplace_back(std::move(alias_event));
         }
-        if (node.is_anchor()) {
-            anchor_reference anchor_ref(
-                node.get_anchor_name(), detail::node_attr_bits::get_anchor_offset(node.m_attrs), position++);
-            anchors.emplace_back(std::move(anchor_ref));
+        else if (node.is_anchor()) {
+            anchor_reference_event anchor_event(
+                node.get_anchor_name(), detail::node_attr_bits::get_anchor_offset(node.m_attrs), position++, true);
+            m_anchor_reference_events.emplace_back(std::move(anchor_event));
         }
 
-        switch (node.get_type()) {
-        case node_type::SEQUENCE:
-            for (const auto& item : node) {
-                collect_anchor_alias_names(item, anchors, aliases, position);
+        if (!node.is_alias()) {
+            switch (node.get_type()) {
+            case node_type::SEQUENCE:
+                for (const auto& item : node) {
+                    collect_anchor_alias_names(item, position);
+                }
+                break;
+            case node_type::MAPPING: {
+                std::vector<anchor_reference_span> item_references;
+                item_references.reserve(node.size());
+                for (auto itr : node.map_items()) {
+                    const auto key_reference = collect_anchor_alias_names(itr.key(), position);
+                    const auto value_reference = collect_anchor_alias_names(itr.value(), position);
+                    const auto event_count =
+                        value_reference.first_index + value_reference.count - key_reference.first_index;
+                    item_references.emplace_back(anchor_reference_span {key_reference.first_index, event_count});
+                }
+                const auto first_item_reference_index = static_cast<uint32_t>(m_mapping_item_references.size());
+                m_mapping_item_references.insert(
+                    m_mapping_item_references.end(), item_references.begin(), item_references.end());
+                const mapping_item_span reference {
+                    first_item_reference_index, static_cast<uint32_t>(item_references.size())};
+                if (cache_mapping) {
+                    m_anchor_reference_cache.emplace(&node, reference);
+                }
+                if (p_mapping_reference != nullptr) {
+                    *p_mapping_reference = reference;
+                }
+                break;
             }
-            break;
-        case node_type::MAPPING:
-            for (auto itr : node.map_items()) {
-                collect_anchor_alias_names(itr.key(), anchors, aliases, position);
-                collect_anchor_alias_names(itr.value(), anchors, aliases, position);
+            default:
+                break;
             }
-            break;
-        default:
-            break;
         }
+
+        if (node.is_mapping()) {
+            const auto event_count = static_cast<uint32_t>(m_anchor_reference_events.size()) - first_event_index;
+            return anchor_reference_span {first_event_index, event_count};
+        }
+        return anchor_reference_span {
+            first_event_index, static_cast<uint32_t>(m_anchor_reference_events.size()) - first_event_index};
     }
 
     /// @brief Get the current indentation width.
@@ -662,7 +779,14 @@ private:
 private:
     /// Indicates whether any anchor is present in the YAML document.
     bool m_has_anchor_table {false};
-
+    /// A queue to hold anchor reference events.
+    std::deque<anchor_reference_event> m_anchor_reference_events;
+    /// Anchor reference spans for mapping items.
+    /// Each entry represents an anchor reference span for a mapping item.
+    std::vector<anchor_reference_span> m_mapping_item_references;
+    /// Anchor reference cache for quick lookup of mapping reference spans.
+    /// Each entry maps a YAML node to its corresponding mapping reference span.
+    std::unordered_map<const BasicNodeType*, mapping_item_span> m_anchor_reference_cache;
     /// A temporal buffer for conversion from a scalar to a string.
     std::string m_tmp_str_buff;
 };

--- a/include/fkYAML/detail/output/serializer.hpp
+++ b/include/fkYAML/detail/output/serializer.hpp
@@ -9,6 +9,7 @@
 #ifndef FK_YAML_DETAIL_OUTPUT_SERIALIZER_HPP
 #define FK_YAML_DETAIL_OUTPUT_SERIALIZER_HPP
 
+#include <algorithm>
 #include <cmath>
 #include <sstream>
 #include <string>
@@ -19,6 +20,7 @@
 #include <fkYAML/detail/encodings/yaml_escaper.hpp>
 #include <fkYAML/detail/input/scalar_scanner.hpp>
 #include <fkYAML/detail/meta/node_traits.hpp>
+#include <fkYAML/detail/node_attrs.hpp>
 #include <fkYAML/exception.hpp>
 #include <fkYAML/node_type.hpp>
 #include <fkYAML/yaml_version_type.hpp>
@@ -30,6 +32,20 @@ FK_YAML_DETAIL_NAMESPACE_BEGIN
 template <typename BasicNodeType>
 class basic_serializer {
     static_assert(detail::is_basic_node<BasicNodeType>::value, "basic_serializer only accepts basic_node<...>");
+
+    using map_iterator = typename BasicNodeType::const_map_range::const_iterator;
+
+    struct anchor_reference {
+        anchor_reference(std::string name, const uint32_t offset, const std::size_t position)
+            : name(std::move(name)),
+              offset(offset),
+              position(position) {
+        }
+
+        std::string name;
+        uint32_t offset {0};
+        std::size_t position {0};
+    };
 
 public:
     /// @brief Construct a new basic_serializer object.
@@ -188,7 +204,7 @@ private:
                 str += "{}\n";
                 return;
             }
-            for (auto itr : node.map_items()) {
+            for (const auto& itr : get_mapping_items_in_serialization_order(node)) {
                 insert_indentation(cur_indent, str);
 
                 // serialize a mapping key node.
@@ -232,7 +248,7 @@ private:
                 try_append_anchor(value_node, true, str);
                 try_append_tag(value_node, true, str);
 
-                const bool is_scalar = itr->is_scalar();
+                const bool is_scalar = value_node.is_scalar();
                 if (is_scalar) {
                     str += " ";
                     serialize_node(value_node, cur_indent, str);
@@ -240,7 +256,7 @@ private:
                     continue;
                 }
 
-                const bool is_empty = itr->empty();
+                const bool is_empty = value_node.empty();
                 if (is_empty) {
                     str += " ";
                 }
@@ -297,6 +313,212 @@ private:
             }
             break;
         }
+        }
+    }
+
+    /// @brief Check whether two anchor references identify the same anchor.
+    /// @param lhs The first anchor reference.
+    /// @param rhs The second anchor reference.
+    /// @return true if both references identify the same anchor, false otherwise.
+    static bool is_same_anchor(const anchor_reference& lhs, const anchor_reference& rhs) noexcept {
+        return lhs.name == rhs.name && lhs.offset == rhs.offset;
+    }
+
+    /// @brief Check whether an anchor is present in a collection.
+    /// @param anchors The collection of anchor references.
+    /// @param target The anchor reference to find.
+    /// @return true if the target is present, false otherwise.
+    static bool has_anchor(const std::vector<anchor_reference>& anchors, const anchor_reference& target) {
+        for (const auto& anchor : anchors) {
+            if (is_same_anchor(anchor, target)) {
+                return true;
+            }
+        }
+        return false;
+    }
+
+    /// @brief Check whether an anchor was defined earlier in the same mapping item.
+    /// @param anchors The anchor references in the mapping item.
+    /// @param target The anchor reference whose preceding definition is checked.
+    /// @return true if a preceding definition exists, false otherwise.
+    static bool has_prior_anchor_definition(
+        const std::vector<anchor_reference>& anchors, const anchor_reference& target) {
+        for (const auto& anchor : anchors) {
+            if (anchor.position < target.position && is_same_anchor(anchor, target)) {
+                return true;
+            }
+        }
+        return false;
+    }
+
+    /// @brief Check whether an earlier anchor required by an item remains unemitted.
+    /// @param anchors The anchor references in the mapping item.
+    /// @param anchors_in_mapping The anchor references that have not been emitted.
+    /// @return true if an earlier anchor definition remains unemitted, false otherwise.
+    bool has_unemitted_prior_anchor_definition(
+        const std::vector<anchor_reference>& anchors, const std::vector<anchor_reference>& anchors_in_mapping) const {
+        for (const auto& anchor : anchors) {
+            for (const auto& mapping_anchor : anchors_in_mapping) {
+                if (mapping_anchor.name == anchor.name && mapping_anchor.offset < anchor.offset) {
+                    return true;
+                }
+            }
+        }
+        return false;
+    }
+
+    /// @brief Check whether an alias requires an anchor definition that remains unemitted.
+    /// @param anchors The anchor references in the mapping item.
+    /// @param aliases The alias references in the mapping item.
+    /// @param anchors_in_mapping The anchor references that have not been emitted.
+    /// @return true if an aliased anchor remains unemitted, false otherwise.
+    bool has_unemitted_anchor_definition(
+        const std::vector<anchor_reference>& anchors, const std::vector<anchor_reference>& aliases,
+        const std::vector<anchor_reference>& anchors_in_mapping) const {
+        for (const auto& alias : aliases) {
+            if (!has_prior_anchor_definition(anchors, alias) && has_anchor(anchors_in_mapping, alias)) {
+                return true;
+            }
+        }
+        return false;
+    }
+
+    /// @brief Check whether a mapping item can be emitted without violating anchor dependencies.
+    /// @param anchors The anchor references in the mapping item.
+    /// @param aliases The alias references in the mapping item.
+    /// @param anchors_in_mapping The anchor references that have not been emitted.
+    /// @return true if the mapping item is ready to be emitted, false otherwise.
+    bool is_ready_to_emit(
+        const std::vector<anchor_reference>& anchors, const std::vector<anchor_reference>& aliases,
+        const std::vector<anchor_reference>& anchors_in_mapping) const {
+        return !has_unemitted_prior_anchor_definition(anchors, anchors_in_mapping) &&
+               !has_unemitted_anchor_definition(anchors, aliases, anchors_in_mapping);
+    }
+
+    /// @brief Remove the anchors defined by an emitted mapping item.
+    /// @param anchors The anchor references defined by the emitted mapping item.
+    /// @param anchors_in_mapping The anchor references that have not been emitted.
+    static void remove_anchors(
+        const std::vector<anchor_reference>& anchors, std::vector<anchor_reference>& anchors_in_mapping) {
+        for (const auto& anchor : anchors) {
+            auto itr = anchors_in_mapping.begin();
+            while (itr != anchors_in_mapping.end()) {
+                itr = is_same_anchor(*itr, anchor) ? anchors_in_mapping.erase(itr) : std::next(itr);
+            }
+        }
+    }
+
+    /// @brief Reorder mapping items so that their anchor dependencies are emitted first.
+    /// @note This function uses stable topological sorting and thus changes the order of mapping items only when
+    /// necessary to satisfy anchor dependencies.
+    /// @param items The mapping items to reorder.
+    /// @param item_anchors The anchor references grouped by mapping item.
+    /// @param item_aliases The alias references grouped by mapping item.
+    /// @return The mapping items in dependency-respecting serialization order.
+    std::vector<map_iterator> reorder_mapping_items_by_dependencies(
+        const std::vector<map_iterator>& items, const std::vector<std::vector<anchor_reference>>& item_anchors,
+        const std::vector<std::vector<anchor_reference>>& item_aliases) const {
+        std::vector<bool> emitted(items.size(), false);
+        std::vector<map_iterator> ordered_items;
+        ordered_items.reserve(items.size());
+
+        std::vector<anchor_reference> anchors_in_mapping;
+        for (const auto& anchors : item_anchors) {
+            anchors_in_mapping.insert(anchors_in_mapping.end(), anchors.begin(), anchors.end());
+        }
+
+        std::size_t emitted_count = 0;
+        while (emitted_count < items.size()) {
+            std::size_t ready_item_index = items.size();
+            for (std::size_t i = 0; i < items.size(); ++i) {
+                const bool is_item_emitted = emitted[i];
+                if (is_item_emitted) {
+                    continue;
+                }
+
+                const bool is_item_ready = is_ready_to_emit(item_anchors[i], item_aliases[i], anchors_in_mapping);
+                if (is_item_ready) {
+                    ready_item_index = i;
+                    break;
+                }
+            }
+
+            if (ready_item_index == items.size()) {
+                break;
+            }
+
+            emitted[ready_item_index] = true;
+            ordered_items.emplace_back(items[ready_item_index]);
+            remove_anchors(item_anchors[ready_item_index], anchors_in_mapping);
+            ++emitted_count;
+        }
+
+        for (std::size_t i = 0; i < items.size(); ++i) {
+            const bool is_item_emitted = emitted[i];
+            if (!is_item_emitted) {
+                ordered_items.emplace_back(items[i]);
+            }
+        }
+
+        return ordered_items;
+    }
+
+    std::vector<map_iterator> get_mapping_items_in_serialization_order(const BasicNodeType& node) const {
+        std::vector<map_iterator> items;
+        std::vector<std::vector<anchor_reference>> item_anchors;
+        std::vector<std::vector<anchor_reference>> item_aliases;
+        bool has_any_anchor = false;
+        bool has_any_alias = false;
+
+        for (auto itr : node.map_items()) {
+            items.emplace_back(itr);
+            item_anchors.emplace_back();
+            item_aliases.emplace_back();
+            std::size_t position = 0;
+            collect_anchor_alias_names(itr.key(), item_anchors.back(), item_aliases.back(), position);
+            collect_anchor_alias_names(itr.value(), item_anchors.back(), item_aliases.back(), position);
+            has_any_anchor = has_any_anchor || !item_anchors.back().empty();
+            has_any_alias = has_any_alias || !item_aliases.back().empty();
+        }
+
+        // If there are no anchors (no resolving needed) or aliases (no anchor is referenced), return the items in the
+        // order `node.map_items()` returns them.
+        if (!has_any_anchor || !has_any_alias) {
+            return items;
+        }
+
+        return reorder_mapping_items_by_dependencies(items, item_anchors, item_aliases);
+    }
+
+    void collect_anchor_alias_names(
+        const BasicNodeType& node, std::vector<anchor_reference>& anchors, std::vector<anchor_reference>& aliases,
+        std::size_t& position) const {
+        if (node.is_alias()) {
+            anchor_reference alias_ref(
+                node.get_anchor_name(), detail::node_attr_bits::get_anchor_offset(node.m_attrs), position++);
+            aliases.emplace_back(std::move(alias_ref));
+            return;
+        }
+        if (node.is_anchor()) {
+            anchor_reference anchor_ref(
+                node.get_anchor_name(), detail::node_attr_bits::get_anchor_offset(node.m_attrs), position++);
+            anchors.emplace_back(std::move(anchor_ref));
+        }
+
+        switch (node.get_type()) {
+        case node_type::SEQUENCE:
+            for (const auto& item : node) {
+                collect_anchor_alias_names(item, anchors, aliases, position);
+            }
+            break;
+        case node_type::MAPPING:
+            for (auto itr : node.map_items()) {
+                collect_anchor_alias_names(itr.key(), anchors, aliases, position);
+                collect_anchor_alias_names(itr.value(), anchors, aliases, position);
+            }
+            break;
+        default:
+            break;
         }
     }
 

--- a/include/fkYAML/detail/output/serializer.hpp
+++ b/include/fkYAML/detail/output/serializer.hpp
@@ -111,6 +111,13 @@ private:
         m_mapping_item_references.clear();
         m_anchor_reference_cache.clear();
 
+        // Collect the anchor/alias events of the whole document once. Only mappings which do contain
+        // any are cached, so a mapping missing from the cache needs no reordering at all.
+        if (m_has_anchor_table) {
+            std::size_t position = 0;
+            collect_anchor_alias_names(node, position);
+        }
+
         const bool dirs_serialized = serialize_directives(node, str);
 
         // the root node cannot be an alias node.
@@ -242,14 +249,17 @@ private:
             // If there is any anchor defined for this document and the mapping has more than one entry,
             // reorder the mapping entries so the anchor resolution order is preserved.
             if (m_has_anchor_table && node.size() > 1) {
-                for (const auto& itr : get_mapping_items_in_serialization_order(node)) {
-                    serialize_mapping_entry(itr, cur_indent, str);
+                std::vector<map_iterator> ordered_items;
+                if (get_mapping_items_in_serialization_order(node, ordered_items)) {
+                    for (const auto& itr : ordered_items) {
+                        serialize_mapping_entry(itr, cur_indent, str);
+                    }
+                    break;
                 }
             }
-            else {
-                for (const auto& itr : node.map_items()) {
-                    serialize_mapping_entry(itr, cur_indent, str);
-                }
+
+            for (const auto& itr : node.map_items()) {
+                serialize_mapping_entry(itr, cur_indent, str);
             }
             break;
         case node_type::NULL_OBJECT:
@@ -369,7 +379,8 @@ private:
     /// @param rhs The second anchor reference.
     /// @return true if both references identify the same anchor, false otherwise.
     static bool is_same_anchor(const anchor_reference_event& lhs, const anchor_reference_event& rhs) noexcept {
-        return lhs.name == rhs.name && lhs.offset == rhs.offset;
+        // Compare the offset first, since it rules out most candidates without touching the name.
+        return lhs.offset == rhs.offset && lhs.name == rhs.name;
     }
 
     /// @brief Check whether an anchor is present in a collection.
@@ -501,9 +512,11 @@ private:
         ordered_items.reserve(items.size());
 
         std::size_t emitted_count = 0;
+        // Every item before this index has already been emitted, so the scan below can skip them.
+        std::size_t first_unemitted_index = 0;
         while (emitted_count < items.size()) {
             std::size_t ready_item_index = items.size();
-            for (std::size_t i = 0; i < items.size(); ++i) {
+            for (std::size_t i = first_unemitted_index; i < items.size(); ++i) {
                 const bool is_item_emitted = emitted[i];
                 if (is_item_emitted) {
                     continue;
@@ -520,28 +533,31 @@ private:
             ordered_items.emplace_back(items[ready_item_index]);
             remove_anchors(item_references[ready_item_index], anchor_indices);
             ++emitted_count;
+            while (first_unemitted_index < items.size() && emitted[first_unemitted_index]) {
+                ++first_unemitted_index;
+            }
         }
 
         return ordered_items;
     }
 
-    std::vector<map_iterator> get_mapping_items_in_serialization_order(const BasicNodeType& node) {
-        mapping_item_span mapping_reference {};
-        anchor_reference_span mapping_event_reference {};
+    /// @brief Collect the mapping items in the order they have to be serialized in.
+    /// @param node The mapping to serialize.
+    /// @param ordered_items Receives the reordered items, untouched unless reordering is needed.
+    /// @return true if the items were reordered, false if the mapping keeps its own order.
+    bool get_mapping_items_in_serialization_order(const BasicNodeType& node, std::vector<map_iterator>& ordered_items) {
         const auto mapping_reference_itr = m_anchor_reference_cache.find(&node);
         if (mapping_reference_itr == m_anchor_reference_cache.end()) {
-            std::size_t position = 0;
-            mapping_event_reference = collect_anchor_alias_names(node, position, false, &mapping_reference);
+            return false;
         }
-        else {
-            mapping_reference = mapping_reference_itr->second;
-            const auto& first_item_reference = m_mapping_item_references[mapping_reference.first_item_reference_index];
-            const auto& last_item_reference = m_mapping_item_references
-                [mapping_reference.first_item_reference_index + mapping_reference.item_count - 1];
-            mapping_event_reference = anchor_reference_span {
-                first_item_reference.first_index,
-                last_item_reference.first_index + last_item_reference.count - first_item_reference.first_index};
-        }
+
+        const mapping_item_span mapping_reference = mapping_reference_itr->second;
+        const auto& first_item_reference = m_mapping_item_references[mapping_reference.first_item_reference_index];
+        const auto& last_item_reference =
+            m_mapping_item_references[mapping_reference.first_item_reference_index + mapping_reference.item_count - 1];
+        const anchor_reference_span mapping_event_reference {
+            first_item_reference.first_index,
+            last_item_reference.first_index + last_item_reference.count - first_item_reference.first_index};
 
         bool has_any_anchor = false;
         bool has_any_alias = false;
@@ -555,12 +571,7 @@ private:
         // order `node.map_items()` returns them.
         const bool needs_reordering = has_any_anchor && has_any_alias;
         if (!needs_reordering) {
-            std::vector<map_iterator> items;
-            items.reserve(mapping_reference.item_count);
-            for (auto itr : node.map_items()) {
-                items.emplace_back(itr);
-            }
-            return items;
+            return false;
         }
 
         std::vector<map_iterator> items;
@@ -594,18 +605,18 @@ private:
                 const bool is_anchor_defined_in_different_item =
                     has_anchor(anchor_indices, alias) && !has_anchor(item_reference, alias);
                 if (is_anchor_defined_in_different_item) {
-                    return reorder_mapping_items_by_dependencies(items, item_references, std::move(anchor_indices));
+                    ordered_items =
+                        reorder_mapping_items_by_dependencies(items, item_references, std::move(anchor_indices));
+                    return true;
                 }
             }
         }
 
         // Reordering is only needed when an alias refers to an anchor in another mapping item.
-        return items;
+        return false;
     }
 
-    anchor_reference_span collect_anchor_alias_names(
-        const BasicNodeType& node, std::size_t& position, const bool cache_mapping = true,
-        mapping_item_span* p_mapping_reference = nullptr) {
+    anchor_reference_span collect_anchor_alias_names(const BasicNodeType& node, std::size_t& position) {
         const auto first_event_index = static_cast<uint32_t>(m_anchor_reference_events.size());
         if (node.is_alias()) {
             anchor_reference_event alias_event(
@@ -640,11 +651,8 @@ private:
                     m_mapping_item_references.end(), item_references.begin(), item_references.end());
                 const mapping_item_span reference {
                     first_item_reference_index, static_cast<uint32_t>(item_references.size())};
-                if (cache_mapping) {
+                if (m_anchor_reference_events.size() > first_event_index) {
                     m_anchor_reference_cache.emplace(&node, reference);
-                }
-                if (p_mapping_reference != nullptr) {
-                    *p_mapping_reference = reference;
                 }
                 break;
             }

--- a/include/fkYAML/detail/output/serializer.hpp
+++ b/include/fkYAML/detail/output/serializer.hpp
@@ -77,6 +77,8 @@ public:
 
 private:
     void serialize_document(const BasicNodeType& node, std::string& str) {
+        m_has_anchor_table = (node.mp_meta && !node.mp_meta->anchor_table.empty());
+
         const bool dirs_serialized = serialize_directives(node, str);
 
         // the root node cannot be an alias node.
@@ -204,66 +206,16 @@ private:
                 str += "{}\n";
                 return;
             }
-            for (const auto& itr : get_mapping_items_in_serialization_order(node)) {
-                insert_indentation(cur_indent, str);
 
-                // serialize a mapping key node.
-                const auto& key_node = itr.key();
-
-                bool is_appended = try_append_alias(key_node, false, str);
-                if (is_appended) {
-                    // The trailing white space is necessary since anchor names can contain a colon (:) at its end.
-                    str += " ";
+            if (m_has_anchor_table) {
+                for (const auto& itr : get_mapping_items_in_serialization_order(node)) {
+                    serialize_mapping_entry(itr, cur_indent, str);
                 }
-                else {
-                    const bool is_anchor_appended = try_append_anchor(key_node, false, str);
-                    const bool is_tag_appended = try_append_tag(key_node, is_anchor_appended, str);
-                    if (is_anchor_appended || is_tag_appended) {
-                        str += " ";
-                    }
-
-                    const bool is_container = !key_node.is_scalar();
-                    if (is_container) {
-                        str += "? ";
-                    }
-                    const auto indent = static_cast<uint32_t>(get_cur_indent(str));
-                    serialize_node(key_node, indent, str);
-                    if (is_container) {
-                        // a newline code is already inserted in the above serialize_node() call.
-                        insert_indentation(indent - 2, str);
-                    }
+            }
+            else {
+                for (const auto& itr : node.map_items()) {
+                    serialize_mapping_entry(itr, cur_indent, str);
                 }
-
-                str += ":";
-
-                // serialize a mapping value node.
-                const auto& value_node = itr.value();
-
-                is_appended = try_append_alias(value_node, true, str);
-                if (is_appended) {
-                    str += "\n";
-                    continue;
-                }
-
-                try_append_anchor(value_node, true, str);
-                try_append_tag(value_node, true, str);
-
-                const bool is_scalar = value_node.is_scalar();
-                if (is_scalar) {
-                    str += " ";
-                    serialize_node(value_node, cur_indent, str);
-                    str += "\n";
-                    continue;
-                }
-
-                const bool is_empty = value_node.empty();
-                if (is_empty) {
-                    str += " ";
-                }
-                else {
-                    str += "\n";
-                }
-                serialize_node(value_node, cur_indent + 2, str);
             }
             break;
         case node_type::NULL_OBJECT:
@@ -314,6 +266,68 @@ private:
             break;
         }
         }
+    }
+
+    void serialize_mapping_entry(const map_iterator& itr, const uint32_t cur_indent, std::string& str) {
+        insert_indentation(cur_indent, str);
+
+        // serialize a mapping key node.
+        const auto& key_node = itr.key();
+
+        bool is_appended = try_append_alias(key_node, false, str);
+        if (is_appended) {
+            // The trailing white space is necessary since anchor names can contain a colon (:) at its end.
+            str += " ";
+        }
+        else {
+            const bool is_anchor_appended = try_append_anchor(key_node, false, str);
+            const bool is_tag_appended = try_append_tag(key_node, is_anchor_appended, str);
+            if (is_anchor_appended || is_tag_appended) {
+                str += " ";
+            }
+
+            const bool is_container = !key_node.is_scalar();
+            if (is_container) {
+                str += "? ";
+            }
+            const auto indent = static_cast<uint32_t>(get_cur_indent(str));
+            serialize_node(key_node, indent, str);
+            if (is_container) {
+                // a newline code is already inserted in the above serialize_node() call.
+                insert_indentation(indent - 2, str);
+            }
+        }
+
+        str += ":";
+
+        // serialize a mapping value node.
+        const auto& value_node = itr.value();
+
+        is_appended = try_append_alias(value_node, true, str);
+        if (is_appended) {
+            str += "\n";
+            return;
+        }
+
+        try_append_anchor(value_node, true, str);
+        try_append_tag(value_node, true, str);
+
+        const bool is_scalar = value_node.is_scalar();
+        if (is_scalar) {
+            str += " ";
+            serialize_node(value_node, cur_indent, str);
+            str += "\n";
+            return;
+        }
+
+        const bool is_empty = value_node.empty();
+        if (is_empty) {
+            str += " ";
+        }
+        else {
+            str += "\n";
+        }
+        serialize_node(value_node, cur_indent + 2, str);
     }
 
     /// @brief Check whether two anchor references identify the same anchor.
@@ -638,6 +652,9 @@ private:
     }
 
 private:
+    /// Indicates whether any anchor is present in the YAML document.
+    bool m_has_anchor_table {false};
+
     /// A temporal buffer for conversion from a scalar to a string.
     std::string m_tmp_str_buff;
 };

--- a/single_include/fkYAML/node.hpp
+++ b/single_include/fkYAML/node.hpp
@@ -12658,7 +12658,8 @@ private:
     /// @return true if the mapping was serialized here, false if it needs no reordering.
     bool serialize_reordered_mapping(const BasicNodeType& node, const uint32_t cur_indent, std::string& str) {
         std::vector<map_iterator> ordered_items;
-        if (!get_mapping_items_in_serialization_order(node, ordered_items)) {
+        const bool is_reordered = get_mapping_items_in_serialization_order(node, ordered_items);
+        if (!is_reordered) {
             return false;
         }
 

--- a/single_include/fkYAML/node.hpp
+++ b/single_include/fkYAML/node.hpp
@@ -12192,6 +12192,8 @@ public:
 
 private:
     void serialize_document(const BasicNodeType& node, std::string& str) {
+        m_has_anchor_table = (node.mp_meta && !node.mp_meta->anchor_table.empty());
+
         const bool dirs_serialized = serialize_directives(node, str);
 
         // the root node cannot be an alias node.
@@ -12319,66 +12321,16 @@ private:
                 str += "{}\n";
                 return;
             }
-            for (const auto& itr : get_mapping_items_in_serialization_order(node)) {
-                insert_indentation(cur_indent, str);
 
-                // serialize a mapping key node.
-                const auto& key_node = itr.key();
-
-                bool is_appended = try_append_alias(key_node, false, str);
-                if (is_appended) {
-                    // The trailing white space is necessary since anchor names can contain a colon (:) at its end.
-                    str += " ";
+            if (m_has_anchor_table) {
+                for (const auto& itr : get_mapping_items_in_serialization_order(node)) {
+                    serialize_mapping_entry(itr, cur_indent, str);
                 }
-                else {
-                    const bool is_anchor_appended = try_append_anchor(key_node, false, str);
-                    const bool is_tag_appended = try_append_tag(key_node, is_anchor_appended, str);
-                    if (is_anchor_appended || is_tag_appended) {
-                        str += " ";
-                    }
-
-                    const bool is_container = !key_node.is_scalar();
-                    if (is_container) {
-                        str += "? ";
-                    }
-                    const auto indent = static_cast<uint32_t>(get_cur_indent(str));
-                    serialize_node(key_node, indent, str);
-                    if (is_container) {
-                        // a newline code is already inserted in the above serialize_node() call.
-                        insert_indentation(indent - 2, str);
-                    }
+            }
+            else {
+                for (const auto& itr : node.map_items()) {
+                    serialize_mapping_entry(itr, cur_indent, str);
                 }
-
-                str += ":";
-
-                // serialize a mapping value node.
-                const auto& value_node = itr.value();
-
-                is_appended = try_append_alias(value_node, true, str);
-                if (is_appended) {
-                    str += "\n";
-                    continue;
-                }
-
-                try_append_anchor(value_node, true, str);
-                try_append_tag(value_node, true, str);
-
-                const bool is_scalar = value_node.is_scalar();
-                if (is_scalar) {
-                    str += " ";
-                    serialize_node(value_node, cur_indent, str);
-                    str += "\n";
-                    continue;
-                }
-
-                const bool is_empty = value_node.empty();
-                if (is_empty) {
-                    str += " ";
-                }
-                else {
-                    str += "\n";
-                }
-                serialize_node(value_node, cur_indent + 2, str);
             }
             break;
         case node_type::NULL_OBJECT:
@@ -12429,6 +12381,68 @@ private:
             break;
         }
         }
+    }
+
+    void serialize_mapping_entry(const map_iterator& itr, const uint32_t cur_indent, std::string& str) {
+        insert_indentation(cur_indent, str);
+
+        // serialize a mapping key node.
+        const auto& key_node = itr.key();
+
+        bool is_appended = try_append_alias(key_node, false, str);
+        if (is_appended) {
+            // The trailing white space is necessary since anchor names can contain a colon (:) at its end.
+            str += " ";
+        }
+        else {
+            const bool is_anchor_appended = try_append_anchor(key_node, false, str);
+            const bool is_tag_appended = try_append_tag(key_node, is_anchor_appended, str);
+            if (is_anchor_appended || is_tag_appended) {
+                str += " ";
+            }
+
+            const bool is_container = !key_node.is_scalar();
+            if (is_container) {
+                str += "? ";
+            }
+            const auto indent = static_cast<uint32_t>(get_cur_indent(str));
+            serialize_node(key_node, indent, str);
+            if (is_container) {
+                // a newline code is already inserted in the above serialize_node() call.
+                insert_indentation(indent - 2, str);
+            }
+        }
+
+        str += ":";
+
+        // serialize a mapping value node.
+        const auto& value_node = itr.value();
+
+        is_appended = try_append_alias(value_node, true, str);
+        if (is_appended) {
+            str += "\n";
+            return;
+        }
+
+        try_append_anchor(value_node, true, str);
+        try_append_tag(value_node, true, str);
+
+        const bool is_scalar = value_node.is_scalar();
+        if (is_scalar) {
+            str += " ";
+            serialize_node(value_node, cur_indent, str);
+            str += "\n";
+            return;
+        }
+
+        const bool is_empty = value_node.empty();
+        if (is_empty) {
+            str += " ";
+        }
+        else {
+            str += "\n";
+        }
+        serialize_node(value_node, cur_indent + 2, str);
     }
 
     /// @brief Check whether two anchor references identify the same anchor.
@@ -12753,6 +12767,9 @@ private:
     }
 
 private:
+    /// Indicates whether any anchor is present in the YAML document.
+    bool m_has_anchor_table {false};
+
     /// A temporal buffer for conversion from a scalar to a string.
     std::string m_tmp_str_buff;
 };

--- a/single_include/fkYAML/node.hpp
+++ b/single_include/fkYAML/node.hpp
@@ -12020,6 +12020,7 @@ FK_YAML_DETAIL_NAMESPACE_END
 #ifndef FK_YAML_DETAIL_OUTPUT_SERIALIZER_HPP
 #define FK_YAML_DETAIL_OUTPUT_SERIALIZER_HPP
 
+#include <algorithm>
 #include <cmath>
 #include <sstream>
 #include <string>
@@ -12130,6 +12131,8 @@ FK_YAML_DETAIL_NAMESPACE_END
 
 // #include <fkYAML/detail/meta/node_traits.hpp>
 
+// #include <fkYAML/detail/node_attrs.hpp>
+
 // #include <fkYAML/exception.hpp>
 
 // #include <fkYAML/node_type.hpp>
@@ -12144,6 +12147,20 @@ FK_YAML_DETAIL_NAMESPACE_BEGIN
 template <typename BasicNodeType>
 class basic_serializer {
     static_assert(detail::is_basic_node<BasicNodeType>::value, "basic_serializer only accepts basic_node<...>");
+
+    using map_iterator = typename BasicNodeType::const_map_range::const_iterator;
+
+    struct anchor_reference {
+        anchor_reference(std::string name, const uint32_t offset, const std::size_t position)
+            : name(std::move(name)),
+              offset(offset),
+              position(position) {
+        }
+
+        std::string name;
+        uint32_t offset {0};
+        std::size_t position {0};
+    };
 
 public:
     /// @brief Construct a new basic_serializer object.
@@ -12302,7 +12319,7 @@ private:
                 str += "{}\n";
                 return;
             }
-            for (auto itr : node.map_items()) {
+            for (const auto& itr : get_mapping_items_in_serialization_order(node)) {
                 insert_indentation(cur_indent, str);
 
                 // serialize a mapping key node.
@@ -12346,7 +12363,7 @@ private:
                 try_append_anchor(value_node, true, str);
                 try_append_tag(value_node, true, str);
 
-                const bool is_scalar = itr->is_scalar();
+                const bool is_scalar = value_node.is_scalar();
                 if (is_scalar) {
                     str += " ";
                     serialize_node(value_node, cur_indent, str);
@@ -12354,7 +12371,7 @@ private:
                     continue;
                 }
 
-                const bool is_empty = itr->empty();
+                const bool is_empty = value_node.empty();
                 if (is_empty) {
                     str += " ";
                 }
@@ -12411,6 +12428,212 @@ private:
             }
             break;
         }
+        }
+    }
+
+    /// @brief Check whether two anchor references identify the same anchor.
+    /// @param lhs The first anchor reference.
+    /// @param rhs The second anchor reference.
+    /// @return true if both references identify the same anchor, false otherwise.
+    static bool is_same_anchor(const anchor_reference& lhs, const anchor_reference& rhs) noexcept {
+        return lhs.name == rhs.name && lhs.offset == rhs.offset;
+    }
+
+    /// @brief Check whether an anchor is present in a collection.
+    /// @param anchors The collection of anchor references.
+    /// @param target The anchor reference to find.
+    /// @return true if the target is present, false otherwise.
+    static bool has_anchor(const std::vector<anchor_reference>& anchors, const anchor_reference& target) {
+        for (const auto& anchor : anchors) {
+            if (is_same_anchor(anchor, target)) {
+                return true;
+            }
+        }
+        return false;
+    }
+
+    /// @brief Check whether an anchor was defined earlier in the same mapping item.
+    /// @param anchors The anchor references in the mapping item.
+    /// @param target The anchor reference whose preceding definition is checked.
+    /// @return true if a preceding definition exists, false otherwise.
+    static bool has_prior_anchor_definition(
+        const std::vector<anchor_reference>& anchors, const anchor_reference& target) {
+        for (const auto& anchor : anchors) {
+            if (anchor.position < target.position && is_same_anchor(anchor, target)) {
+                return true;
+            }
+        }
+        return false;
+    }
+
+    /// @brief Check whether an earlier anchor required by an item remains unemitted.
+    /// @param anchors The anchor references in the mapping item.
+    /// @param anchors_in_mapping The anchor references that have not been emitted.
+    /// @return true if an earlier anchor definition remains unemitted, false otherwise.
+    bool has_unemitted_prior_anchor_definition(
+        const std::vector<anchor_reference>& anchors, const std::vector<anchor_reference>& anchors_in_mapping) const {
+        for (const auto& anchor : anchors) {
+            for (const auto& mapping_anchor : anchors_in_mapping) {
+                if (mapping_anchor.name == anchor.name && mapping_anchor.offset < anchor.offset) {
+                    return true;
+                }
+            }
+        }
+        return false;
+    }
+
+    /// @brief Check whether an alias requires an anchor definition that remains unemitted.
+    /// @param anchors The anchor references in the mapping item.
+    /// @param aliases The alias references in the mapping item.
+    /// @param anchors_in_mapping The anchor references that have not been emitted.
+    /// @return true if an aliased anchor remains unemitted, false otherwise.
+    bool has_unemitted_anchor_definition(
+        const std::vector<anchor_reference>& anchors, const std::vector<anchor_reference>& aliases,
+        const std::vector<anchor_reference>& anchors_in_mapping) const {
+        for (const auto& alias : aliases) {
+            if (!has_prior_anchor_definition(anchors, alias) && has_anchor(anchors_in_mapping, alias)) {
+                return true;
+            }
+        }
+        return false;
+    }
+
+    /// @brief Check whether a mapping item can be emitted without violating anchor dependencies.
+    /// @param anchors The anchor references in the mapping item.
+    /// @param aliases The alias references in the mapping item.
+    /// @param anchors_in_mapping The anchor references that have not been emitted.
+    /// @return true if the mapping item is ready to be emitted, false otherwise.
+    bool is_ready_to_emit(
+        const std::vector<anchor_reference>& anchors, const std::vector<anchor_reference>& aliases,
+        const std::vector<anchor_reference>& anchors_in_mapping) const {
+        return !has_unemitted_prior_anchor_definition(anchors, anchors_in_mapping) &&
+               !has_unemitted_anchor_definition(anchors, aliases, anchors_in_mapping);
+    }
+
+    /// @brief Remove the anchors defined by an emitted mapping item.
+    /// @param anchors The anchor references defined by the emitted mapping item.
+    /// @param anchors_in_mapping The anchor references that have not been emitted.
+    static void remove_anchors(
+        const std::vector<anchor_reference>& anchors, std::vector<anchor_reference>& anchors_in_mapping) {
+        for (const auto& anchor : anchors) {
+            auto itr = anchors_in_mapping.begin();
+            while (itr != anchors_in_mapping.end()) {
+                itr = is_same_anchor(*itr, anchor) ? anchors_in_mapping.erase(itr) : std::next(itr);
+            }
+        }
+    }
+
+    /// @brief Reorder mapping items so that their anchor dependencies are emitted first.
+    /// @note This function uses stable topological sorting and thus changes the order of mapping items only when
+    /// necessary to satisfy anchor dependencies.
+    /// @param items The mapping items to reorder.
+    /// @param item_anchors The anchor references grouped by mapping item.
+    /// @param item_aliases The alias references grouped by mapping item.
+    /// @return The mapping items in dependency-respecting serialization order.
+    std::vector<map_iterator> reorder_mapping_items_by_dependencies(
+        const std::vector<map_iterator>& items, const std::vector<std::vector<anchor_reference>>& item_anchors,
+        const std::vector<std::vector<anchor_reference>>& item_aliases) const {
+        std::vector<bool> emitted(items.size(), false);
+        std::vector<map_iterator> ordered_items;
+        ordered_items.reserve(items.size());
+
+        std::vector<anchor_reference> anchors_in_mapping;
+        for (const auto& anchors : item_anchors) {
+            anchors_in_mapping.insert(anchors_in_mapping.end(), anchors.begin(), anchors.end());
+        }
+
+        std::size_t emitted_count = 0;
+        while (emitted_count < items.size()) {
+            std::size_t ready_item_index = items.size();
+            for (std::size_t i = 0; i < items.size(); ++i) {
+                const bool is_item_emitted = emitted[i];
+                if (is_item_emitted) {
+                    continue;
+                }
+
+                const bool is_item_ready = is_ready_to_emit(item_anchors[i], item_aliases[i], anchors_in_mapping);
+                if (is_item_ready) {
+                    ready_item_index = i;
+                    break;
+                }
+            }
+
+            if (ready_item_index == items.size()) {
+                break;
+            }
+
+            emitted[ready_item_index] = true;
+            ordered_items.emplace_back(items[ready_item_index]);
+            remove_anchors(item_anchors[ready_item_index], anchors_in_mapping);
+            ++emitted_count;
+        }
+
+        for (std::size_t i = 0; i < items.size(); ++i) {
+            const bool is_item_emitted = emitted[i];
+            if (!is_item_emitted) {
+                ordered_items.emplace_back(items[i]);
+            }
+        }
+
+        return ordered_items;
+    }
+
+    std::vector<map_iterator> get_mapping_items_in_serialization_order(const BasicNodeType& node) const {
+        std::vector<map_iterator> items;
+        std::vector<std::vector<anchor_reference>> item_anchors;
+        std::vector<std::vector<anchor_reference>> item_aliases;
+        bool has_any_anchor = false;
+        bool has_any_alias = false;
+
+        for (auto itr : node.map_items()) {
+            items.emplace_back(itr);
+            item_anchors.emplace_back();
+            item_aliases.emplace_back();
+            std::size_t position = 0;
+            collect_anchor_alias_names(itr.key(), item_anchors.back(), item_aliases.back(), position);
+            collect_anchor_alias_names(itr.value(), item_anchors.back(), item_aliases.back(), position);
+            has_any_anchor = has_any_anchor || !item_anchors.back().empty();
+            has_any_alias = has_any_alias || !item_aliases.back().empty();
+        }
+
+        // If there are no anchors (no resolving needed) or aliases (no anchor is referenced), return the items in the
+        // order `node.map_items()` returns them.
+        if (!has_any_anchor || !has_any_alias) {
+            return items;
+        }
+
+        return reorder_mapping_items_by_dependencies(items, item_anchors, item_aliases);
+    }
+
+    void collect_anchor_alias_names(
+        const BasicNodeType& node, std::vector<anchor_reference>& anchors, std::vector<anchor_reference>& aliases,
+        std::size_t& position) const {
+        if (node.is_alias()) {
+            anchor_reference alias_ref(
+                node.get_anchor_name(), detail::node_attr_bits::get_anchor_offset(node.m_attrs), position++);
+            aliases.emplace_back(std::move(alias_ref));
+            return;
+        }
+        if (node.is_anchor()) {
+            anchor_reference anchor_ref(
+                node.get_anchor_name(), detail::node_attr_bits::get_anchor_offset(node.m_attrs), position++);
+            anchors.emplace_back(std::move(anchor_ref));
+        }
+
+        switch (node.get_type()) {
+        case node_type::SEQUENCE:
+            for (const auto& item : node) {
+                collect_anchor_alias_names(item, anchors, aliases, position);
+            }
+            break;
+        case node_type::MAPPING:
+            for (auto itr : node.map_items()) {
+                collect_anchor_alias_names(itr.key(), anchors, aliases, position);
+                collect_anchor_alias_names(itr.value(), anchors, aliases, position);
+            }
+            break;
+        default:
+            break;
         }
     }
 

--- a/single_include/fkYAML/node.hpp
+++ b/single_include/fkYAML/node.hpp
@@ -12475,7 +12475,9 @@ private:
     static bool has_prior_anchor_definition(
         const std::vector<anchor_reference>& anchors, const anchor_reference& target) {
         for (const auto& anchor : anchors) {
-            if (anchor.position < target.position && is_same_anchor(anchor, target)) {
+            const bool is_anchor_defined_prior_to_target =
+                anchor.position < target.position && is_same_anchor(anchor, target);
+            if (is_anchor_defined_prior_to_target) {
                 return true;
             }
         }
@@ -12545,18 +12547,15 @@ private:
     /// @param items The mapping items to reorder.
     /// @param item_anchors The anchor references grouped by mapping item.
     /// @param item_aliases The alias references grouped by mapping item.
+    /// @param anchors_in_mapping The anchor references defined in the mapping.
     /// @return The mapping items in dependency-respecting serialization order.
     std::vector<map_iterator> reorder_mapping_items_by_dependencies(
         const std::vector<map_iterator>& items, const std::vector<std::vector<anchor_reference>>& item_anchors,
-        const std::vector<std::vector<anchor_reference>>& item_aliases) const {
+        const std::vector<std::vector<anchor_reference>>& item_aliases,
+        std::vector<anchor_reference> anchors_in_mapping) const {
         std::vector<bool> emitted(items.size(), false);
         std::vector<map_iterator> ordered_items;
         ordered_items.reserve(items.size());
-
-        std::vector<anchor_reference> anchors_in_mapping;
-        for (const auto& anchors : item_anchors) {
-            anchors_in_mapping.insert(anchors_in_mapping.end(), anchors.begin(), anchors.end());
-        }
 
         std::size_t emitted_count = 0;
         while (emitted_count < items.size()) {
@@ -12574,21 +12573,10 @@ private:
                 }
             }
 
-            if (ready_item_index == items.size()) {
-                break;
-            }
-
             emitted[ready_item_index] = true;
             ordered_items.emplace_back(items[ready_item_index]);
             remove_anchors(item_anchors[ready_item_index], anchors_in_mapping);
             ++emitted_count;
-        }
-
-        for (std::size_t i = 0; i < items.size(); ++i) {
-            const bool is_item_emitted = emitted[i];
-            if (!is_item_emitted) {
-                ordered_items.emplace_back(items[i]);
-            }
         }
 
         return ordered_items;
@@ -12614,11 +12602,29 @@ private:
 
         // If there are no anchors (no resolving needed) or aliases (no anchor is referenced), return the items in the
         // order `node.map_items()` returns them.
-        if (!has_any_anchor || !has_any_alias) {
+        const bool needs_reordering = has_any_anchor && has_any_alias;
+        if (!needs_reordering) {
             return items;
         }
 
-        return reorder_mapping_items_by_dependencies(items, item_anchors, item_aliases);
+        std::vector<anchor_reference> anchors_in_mapping;
+        for (const auto& anchors : item_anchors) {
+            anchors_in_mapping.insert(anchors_in_mapping.end(), anchors.begin(), anchors.end());
+        }
+
+        for (std::size_t i = 0; i < items.size(); ++i) {
+            for (const auto& alias : item_aliases[i]) {
+                const bool is_anchor_defined_in_different_item =
+                    has_anchor(anchors_in_mapping, alias) && !has_anchor(item_anchors[i], alias);
+                if (is_anchor_defined_in_different_item) {
+                    return reorder_mapping_items_by_dependencies(
+                        items, item_anchors, item_aliases, std::move(anchors_in_mapping));
+                }
+            }
+        }
+
+        // Reordering is only needed when an alias refers to an anchor in another mapping item.
+        return items;
     }
 
     void collect_anchor_alias_names(

--- a/single_include/fkYAML/node.hpp
+++ b/single_include/fkYAML/node.hpp
@@ -12363,14 +12363,9 @@ private:
 
             // If there is any anchor defined for this document and the mapping has more than one entry,
             // reorder the mapping entries so the anchor resolution order is preserved.
-            if (m_has_anchor_table && node.size() > 1) {
-                std::vector<map_iterator> ordered_items;
-                if (get_mapping_items_in_serialization_order(node, ordered_items)) {
-                    for (const auto& itr : ordered_items) {
-                        serialize_mapping_entry(itr, cur_indent, str);
-                    }
-                    break;
-                }
+            // Only a document which defines an anchor can ever need its mapping entries reordered.
+            if (m_has_anchor_table && node.size() > 1 && serialize_reordered_mapping(node, cur_indent, str)) {
+                break;
             }
 
             for (const auto& itr : node.map_items()) {
@@ -12656,6 +12651,22 @@ private:
         return ordered_items;
     }
 
+    /// @brief Serialize a mapping whose entries have to be reordered for anchor resolution.
+    /// @param node The mapping to serialize.
+    /// @param cur_indent The current indent width.
+    /// @param str A string to hold the serialization result.
+    /// @return true if the mapping was serialized here, false if it needs no reordering.
+    bool serialize_reordered_mapping(const BasicNodeType& node, const uint32_t cur_indent, std::string& str) {
+        std::vector<map_iterator> ordered_items;
+        if (!get_mapping_items_in_serialization_order(node, ordered_items)) {
+            return false;
+        }
+
+        for (const auto& itr : ordered_items) {
+            serialize_mapping_entry(itr, cur_indent, str);
+        }
+        return true;
+    }
     /// @brief Collect the mapping items in the order they have to be serialized in.
     /// @param node The mapping to serialize.
     /// @param ordered_items Receives the reordered items, untouched unless reordering is needed.

--- a/single_include/fkYAML/node.hpp
+++ b/single_include/fkYAML/node.hpp
@@ -12322,7 +12322,9 @@ private:
                 return;
             }
 
-            if (m_has_anchor_table) {
+            // If there is any anchor defined for this document and the mapping has more than one entry,
+            // reorder the mapping entries so the anchor resolution order is preserved.
+            if (m_has_anchor_table && node.size() > 1) {
                 for (const auto& itr : get_mapping_items_in_serialization_order(node)) {
                     serialize_mapping_entry(itr, cur_indent, str);
                 }

--- a/single_include/fkYAML/node.hpp
+++ b/single_include/fkYAML/node.hpp
@@ -12022,8 +12022,10 @@ FK_YAML_DETAIL_NAMESPACE_END
 
 #include <algorithm>
 #include <cmath>
+#include <deque>
 #include <sstream>
 #include <string>
+#include <unordered_map>
 #include <vector>
 
 // #include <fkYAML/detail/macros/define_macros.hpp>
@@ -12150,16 +12152,42 @@ class basic_serializer {
 
     using map_iterator = typename BasicNodeType::const_map_range::const_iterator;
 
-    struct anchor_reference {
-        anchor_reference(std::string name, const uint32_t offset, const std::size_t position)
+    struct anchor_reference_event {
+        anchor_reference_event(std::string name, const uint32_t offset, const std::size_t position, bool is_anchor)
             : name(std::move(name)),
               offset(offset),
-              position(position) {
+              position(position),
+              is_anchor(is_anchor) {
         }
 
         std::string name;
         uint32_t offset {0};
         std::size_t position {0};
+        bool is_anchor {false};
+    };
+
+    struct anchor_reference_span {
+        anchor_reference_span() = default;
+
+        anchor_reference_span(uint32_t first_index, uint32_t count)
+            : first_index(first_index),
+              count(count) {
+        }
+
+        uint32_t first_index {0};
+        uint32_t count {0};
+    };
+
+    struct mapping_item_span {
+        mapping_item_span() = default;
+
+        mapping_item_span(uint32_t first_item_reference_index, uint32_t item_count)
+            : first_item_reference_index(first_item_reference_index),
+              item_count(item_count) {
+        }
+
+        uint32_t first_item_reference_index {0};
+        uint32_t item_count {0};
     };
 
 public:
@@ -12193,6 +12221,10 @@ public:
 private:
     void serialize_document(const BasicNodeType& node, std::string& str) {
         m_has_anchor_table = (node.mp_meta && !node.mp_meta->anchor_table.empty());
+
+        m_anchor_reference_events.clear();
+        m_mapping_item_references.clear();
+        m_anchor_reference_cache.clear();
 
         const bool dirs_serialized = serialize_directives(node, str);
 
@@ -12451,7 +12483,7 @@ private:
     /// @param lhs The first anchor reference.
     /// @param rhs The second anchor reference.
     /// @return true if both references identify the same anchor, false otherwise.
-    static bool is_same_anchor(const anchor_reference& lhs, const anchor_reference& rhs) noexcept {
+    static bool is_same_anchor(const anchor_reference_event& lhs, const anchor_reference_event& rhs) noexcept {
         return lhs.name == rhs.name && lhs.offset == rhs.offset;
     }
 
@@ -12459,9 +12491,20 @@ private:
     /// @param anchors The collection of anchor references.
     /// @param target The anchor reference to find.
     /// @return true if the target is present, false otherwise.
-    static bool has_anchor(const std::vector<anchor_reference>& anchors, const anchor_reference& target) {
-        for (const auto& anchor : anchors) {
-            if (is_same_anchor(anchor, target)) {
+    bool has_anchor(const anchor_reference_span& anchors, const anchor_reference_event& target) const {
+        const auto last_event_index = anchors.first_index + anchors.count;
+        for (uint32_t i = anchors.first_index; i < last_event_index; ++i) {
+            const auto& anchor = m_anchor_reference_events[i];
+            if (anchor.is_anchor && is_same_anchor(anchor, target)) {
+                return true;
+            }
+        }
+        return false;
+    }
+
+    bool has_anchor(const std::vector<uint32_t>& anchor_indices, const anchor_reference_event& target) const {
+        for (const auto anchor_index : anchor_indices) {
+            if (is_same_anchor(m_anchor_reference_events[anchor_index], target)) {
                 return true;
             }
         }
@@ -12472,11 +12515,13 @@ private:
     /// @param anchors The anchor references in the mapping item.
     /// @param target The anchor reference whose preceding definition is checked.
     /// @return true if a preceding definition exists, false otherwise.
-    static bool has_prior_anchor_definition(
-        const std::vector<anchor_reference>& anchors, const anchor_reference& target) {
-        for (const auto& anchor : anchors) {
+    bool has_prior_anchor_definition(
+        const anchor_reference_span& item_reference, const anchor_reference_event& target) const {
+        const auto last_event_index = item_reference.first_index + item_reference.count;
+        for (uint32_t i = item_reference.first_index; i < last_event_index; ++i) {
+            const auto& anchor = m_anchor_reference_events[i];
             const bool is_anchor_defined_prior_to_target =
-                anchor.position < target.position && is_same_anchor(anchor, target);
+                anchor.is_anchor && anchor.position < target.position && is_same_anchor(anchor, target);
             if (is_anchor_defined_prior_to_target) {
                 return true;
             }
@@ -12489,9 +12534,15 @@ private:
     /// @param anchors_in_mapping The anchor references that have not been emitted.
     /// @return true if an earlier anchor definition remains unemitted, false otherwise.
     bool has_unemitted_prior_anchor_definition(
-        const std::vector<anchor_reference>& anchors, const std::vector<anchor_reference>& anchors_in_mapping) const {
-        for (const auto& anchor : anchors) {
-            for (const auto& mapping_anchor : anchors_in_mapping) {
+        const anchor_reference_span& item_reference, const std::vector<uint32_t>& anchor_indices) const {
+        const auto last_event_index = item_reference.first_index + item_reference.count;
+        for (uint32_t i = item_reference.first_index; i < last_event_index; ++i) {
+            const auto& anchor = m_anchor_reference_events[i];
+            if (!anchor.is_anchor) {
+                continue;
+            }
+            for (const auto anchor_index : anchor_indices) {
+                const auto& mapping_anchor = m_anchor_reference_events[anchor_index];
                 if (mapping_anchor.name == anchor.name && mapping_anchor.offset < anchor.offset) {
                     return true;
                 }
@@ -12506,10 +12557,14 @@ private:
     /// @param anchors_in_mapping The anchor references that have not been emitted.
     /// @return true if an aliased anchor remains unemitted, false otherwise.
     bool has_unemitted_anchor_definition(
-        const std::vector<anchor_reference>& anchors, const std::vector<anchor_reference>& aliases,
-        const std::vector<anchor_reference>& anchors_in_mapping) const {
-        for (const auto& alias : aliases) {
-            if (!has_prior_anchor_definition(anchors, alias) && has_anchor(anchors_in_mapping, alias)) {
+        const anchor_reference_span& item_reference, const std::vector<uint32_t>& anchor_indices) const {
+        const auto last_event_index = item_reference.first_index + item_reference.count;
+        for (uint32_t i = item_reference.first_index; i < last_event_index; ++i) {
+            const auto& alias = m_anchor_reference_events[i];
+            if (alias.is_anchor) {
+                continue;
+            }
+            if (!has_prior_anchor_definition(item_reference, alias) && has_anchor(anchor_indices, alias)) {
                 return true;
             }
         }
@@ -12522,21 +12577,25 @@ private:
     /// @param anchors_in_mapping The anchor references that have not been emitted.
     /// @return true if the mapping item is ready to be emitted, false otherwise.
     bool is_ready_to_emit(
-        const std::vector<anchor_reference>& anchors, const std::vector<anchor_reference>& aliases,
-        const std::vector<anchor_reference>& anchors_in_mapping) const {
-        return !has_unemitted_prior_anchor_definition(anchors, anchors_in_mapping) &&
-               !has_unemitted_anchor_definition(anchors, aliases, anchors_in_mapping);
+        const anchor_reference_span& item_reference, const std::vector<uint32_t>& anchor_indices) const {
+        return !has_unemitted_prior_anchor_definition(item_reference, anchor_indices) &&
+               !has_unemitted_anchor_definition(item_reference, anchor_indices);
     }
 
     /// @brief Remove the anchors defined by an emitted mapping item.
     /// @param anchors The anchor references defined by the emitted mapping item.
     /// @param anchors_in_mapping The anchor references that have not been emitted.
-    static void remove_anchors(
-        const std::vector<anchor_reference>& anchors, std::vector<anchor_reference>& anchors_in_mapping) {
-        for (const auto& anchor : anchors) {
-            auto itr = anchors_in_mapping.begin();
-            while (itr != anchors_in_mapping.end()) {
-                itr = is_same_anchor(*itr, anchor) ? anchors_in_mapping.erase(itr) : std::next(itr);
+    void remove_anchors(const anchor_reference_span& anchors, std::vector<uint32_t>& anchor_indices) const {
+        const auto last_event_index = anchors.first_index + anchors.count;
+        for (uint32_t i = anchors.first_index; i < last_event_index; ++i) {
+            const auto& anchor = m_anchor_reference_events[i];
+            if (!anchor.is_anchor) {
+                continue;
+            }
+            auto itr = anchor_indices.begin();
+            while (itr != anchor_indices.end()) {
+                const auto& mapping_anchor = m_anchor_reference_events[*itr];
+                itr = is_same_anchor(mapping_anchor, anchor) ? anchor_indices.erase(itr) : std::next(itr);
             }
         }
     }
@@ -12550,9 +12609,8 @@ private:
     /// @param anchors_in_mapping The anchor references defined in the mapping.
     /// @return The mapping items in dependency-respecting serialization order.
     std::vector<map_iterator> reorder_mapping_items_by_dependencies(
-        const std::vector<map_iterator>& items, const std::vector<std::vector<anchor_reference>>& item_anchors,
-        const std::vector<std::vector<anchor_reference>>& item_aliases,
-        std::vector<anchor_reference> anchors_in_mapping) const {
+        const std::vector<map_iterator>& items, const std::vector<anchor_reference_span>& item_references,
+        std::vector<uint32_t> anchor_indices) const {
         std::vector<bool> emitted(items.size(), false);
         std::vector<map_iterator> ordered_items;
         ordered_items.reserve(items.size());
@@ -12566,7 +12624,7 @@ private:
                     continue;
                 }
 
-                const bool is_item_ready = is_ready_to_emit(item_anchors[i], item_aliases[i], anchors_in_mapping);
+                const bool is_item_ready = is_ready_to_emit(item_references[i], anchor_indices);
                 if (is_item_ready) {
                     ready_item_index = i;
                     break;
@@ -12575,50 +12633,83 @@ private:
 
             emitted[ready_item_index] = true;
             ordered_items.emplace_back(items[ready_item_index]);
-            remove_anchors(item_anchors[ready_item_index], anchors_in_mapping);
+            remove_anchors(item_references[ready_item_index], anchor_indices);
             ++emitted_count;
         }
 
         return ordered_items;
     }
 
-    std::vector<map_iterator> get_mapping_items_in_serialization_order(const BasicNodeType& node) const {
-        std::vector<map_iterator> items;
-        std::vector<std::vector<anchor_reference>> item_anchors;
-        std::vector<std::vector<anchor_reference>> item_aliases;
+    std::vector<map_iterator> get_mapping_items_in_serialization_order(const BasicNodeType& node) {
+        mapping_item_span mapping_reference {};
+        anchor_reference_span mapping_event_reference {};
+        const auto mapping_reference_itr = m_anchor_reference_cache.find(&node);
+        if (mapping_reference_itr == m_anchor_reference_cache.end()) {
+            std::size_t position = 0;
+            mapping_event_reference = collect_anchor_alias_names(node, position, false, &mapping_reference);
+        }
+        else {
+            mapping_reference = mapping_reference_itr->second;
+            const auto& first_item_reference = m_mapping_item_references[mapping_reference.first_item_reference_index];
+            const auto& last_item_reference = m_mapping_item_references
+                [mapping_reference.first_item_reference_index + mapping_reference.item_count - 1];
+            mapping_event_reference = anchor_reference_span {
+                first_item_reference.first_index,
+                last_item_reference.first_index + last_item_reference.count - first_item_reference.first_index};
+        }
+
         bool has_any_anchor = false;
         bool has_any_alias = false;
-
-        for (auto itr : node.map_items()) {
-            items.emplace_back(itr);
-            item_anchors.emplace_back();
-            item_aliases.emplace_back();
-            std::size_t position = 0;
-            collect_anchor_alias_names(itr.key(), item_anchors.back(), item_aliases.back(), position);
-            collect_anchor_alias_names(itr.value(), item_anchors.back(), item_aliases.back(), position);
-            has_any_anchor = has_any_anchor || !item_anchors.back().empty();
-            has_any_alias = has_any_alias || !item_aliases.back().empty();
+        const auto last_index = mapping_event_reference.first_index + mapping_event_reference.count;
+        for (uint32_t event_index = mapping_event_reference.first_index; event_index < last_index; ++event_index) {
+            has_any_anchor = has_any_anchor || m_anchor_reference_events[event_index].is_anchor;
+            has_any_alias = has_any_alias || !m_anchor_reference_events[event_index].is_anchor;
         }
 
         // If there are no anchors (no resolving needed) or aliases (no anchor is referenced), return the items in the
         // order `node.map_items()` returns them.
         const bool needs_reordering = has_any_anchor && has_any_alias;
         if (!needs_reordering) {
+            std::vector<map_iterator> items;
+            items.reserve(mapping_reference.item_count);
+            for (auto itr : node.map_items()) {
+                items.emplace_back(itr);
+            }
             return items;
         }
 
-        std::vector<anchor_reference> anchors_in_mapping;
-        for (const auto& anchors : item_anchors) {
-            anchors_in_mapping.insert(anchors_in_mapping.end(), anchors.begin(), anchors.end());
+        std::vector<map_iterator> items;
+        std::vector<anchor_reference_span> item_references;
+        items.reserve(mapping_reference.item_count);
+        item_references.reserve(mapping_reference.item_count);
+        std::vector<uint32_t> anchor_indices;
+
+        auto itr = node.map_items().begin();
+        for (uint32_t i = 0; i < mapping_reference.item_count; ++i, ++itr) {
+            items.emplace_back(itr);
+            const auto& item_reference = m_mapping_item_references[mapping_reference.first_item_reference_index + i];
+            item_references.emplace_back(item_reference);
+
+            const auto last_event_index = item_reference.first_index + item_reference.count;
+            for (uint32_t event_index = item_reference.first_index; event_index < last_event_index; ++event_index) {
+                if (m_anchor_reference_events[event_index].is_anchor) {
+                    anchor_indices.emplace_back(event_index);
+                }
+            }
         }
 
         for (std::size_t i = 0; i < items.size(); ++i) {
-            for (const auto& alias : item_aliases[i]) {
+            const auto& item_reference = item_references[i];
+            const auto last_event_index = item_reference.first_index + item_reference.count;
+            for (uint32_t event_index = item_reference.first_index; event_index < last_event_index; ++event_index) {
+                const auto& alias = m_anchor_reference_events[event_index];
+                if (alias.is_anchor) {
+                    continue;
+                }
                 const bool is_anchor_defined_in_different_item =
-                    has_anchor(anchors_in_mapping, alias) && !has_anchor(item_anchors[i], alias);
+                    has_anchor(anchor_indices, alias) && !has_anchor(item_reference, alias);
                 if (is_anchor_defined_in_different_item) {
-                    return reorder_mapping_items_by_dependencies(
-                        items, item_anchors, item_aliases, std::move(anchors_in_mapping));
+                    return reorder_mapping_items_by_dependencies(items, item_references, std::move(anchor_indices));
                 }
             }
         }
@@ -12627,36 +12718,62 @@ private:
         return items;
     }
 
-    void collect_anchor_alias_names(
-        const BasicNodeType& node, std::vector<anchor_reference>& anchors, std::vector<anchor_reference>& aliases,
-        std::size_t& position) const {
+    anchor_reference_span collect_anchor_alias_names(
+        const BasicNodeType& node, std::size_t& position, const bool cache_mapping = true,
+        mapping_item_span* p_mapping_reference = nullptr) {
+        const auto first_event_index = static_cast<uint32_t>(m_anchor_reference_events.size());
         if (node.is_alias()) {
-            anchor_reference alias_ref(
-                node.get_anchor_name(), detail::node_attr_bits::get_anchor_offset(node.m_attrs), position++);
-            aliases.emplace_back(std::move(alias_ref));
-            return;
+            anchor_reference_event alias_event(
+                node.get_anchor_name(), detail::node_attr_bits::get_anchor_offset(node.m_attrs), position++, false);
+            m_anchor_reference_events.emplace_back(std::move(alias_event));
         }
-        if (node.is_anchor()) {
-            anchor_reference anchor_ref(
-                node.get_anchor_name(), detail::node_attr_bits::get_anchor_offset(node.m_attrs), position++);
-            anchors.emplace_back(std::move(anchor_ref));
+        else if (node.is_anchor()) {
+            anchor_reference_event anchor_event(
+                node.get_anchor_name(), detail::node_attr_bits::get_anchor_offset(node.m_attrs), position++, true);
+            m_anchor_reference_events.emplace_back(std::move(anchor_event));
         }
 
-        switch (node.get_type()) {
-        case node_type::SEQUENCE:
-            for (const auto& item : node) {
-                collect_anchor_alias_names(item, anchors, aliases, position);
+        if (!node.is_alias()) {
+            switch (node.get_type()) {
+            case node_type::SEQUENCE:
+                for (const auto& item : node) {
+                    collect_anchor_alias_names(item, position);
+                }
+                break;
+            case node_type::MAPPING: {
+                std::vector<anchor_reference_span> item_references;
+                item_references.reserve(node.size());
+                for (auto itr : node.map_items()) {
+                    const auto key_reference = collect_anchor_alias_names(itr.key(), position);
+                    const auto value_reference = collect_anchor_alias_names(itr.value(), position);
+                    const auto event_count =
+                        value_reference.first_index + value_reference.count - key_reference.first_index;
+                    item_references.emplace_back(anchor_reference_span {key_reference.first_index, event_count});
+                }
+                const auto first_item_reference_index = static_cast<uint32_t>(m_mapping_item_references.size());
+                m_mapping_item_references.insert(
+                    m_mapping_item_references.end(), item_references.begin(), item_references.end());
+                const mapping_item_span reference {
+                    first_item_reference_index, static_cast<uint32_t>(item_references.size())};
+                if (cache_mapping) {
+                    m_anchor_reference_cache.emplace(&node, reference);
+                }
+                if (p_mapping_reference != nullptr) {
+                    *p_mapping_reference = reference;
+                }
+                break;
             }
-            break;
-        case node_type::MAPPING:
-            for (auto itr : node.map_items()) {
-                collect_anchor_alias_names(itr.key(), anchors, aliases, position);
-                collect_anchor_alias_names(itr.value(), anchors, aliases, position);
+            default:
+                break;
             }
-            break;
-        default:
-            break;
         }
+
+        if (node.is_mapping()) {
+            const auto event_count = static_cast<uint32_t>(m_anchor_reference_events.size()) - first_event_index;
+            return anchor_reference_span {first_event_index, event_count};
+        }
+        return anchor_reference_span {
+            first_event_index, static_cast<uint32_t>(m_anchor_reference_events.size()) - first_event_index};
     }
 
     /// @brief Get the current indentation width.
@@ -12777,7 +12894,14 @@ private:
 private:
     /// Indicates whether any anchor is present in the YAML document.
     bool m_has_anchor_table {false};
-
+    /// A queue to hold anchor reference events.
+    std::deque<anchor_reference_event> m_anchor_reference_events;
+    /// Anchor reference spans for mapping items.
+    /// Each entry represents an anchor reference span for a mapping item.
+    std::vector<anchor_reference_span> m_mapping_item_references;
+    /// Anchor reference cache for quick lookup of mapping reference spans.
+    /// Each entry maps a YAML node to its corresponding mapping reference span.
+    std::unordered_map<const BasicNodeType*, mapping_item_span> m_anchor_reference_cache;
     /// A temporal buffer for conversion from a scalar to a string.
     std::string m_tmp_str_buff;
 };

--- a/single_include/fkYAML/node.hpp
+++ b/single_include/fkYAML/node.hpp
@@ -12226,6 +12226,13 @@ private:
         m_mapping_item_references.clear();
         m_anchor_reference_cache.clear();
 
+        // Collect the anchor/alias events of the whole document once. Only mappings which do contain
+        // any are cached, so a mapping missing from the cache needs no reordering at all.
+        if (m_has_anchor_table) {
+            std::size_t position = 0;
+            collect_anchor_alias_names(node, position);
+        }
+
         const bool dirs_serialized = serialize_directives(node, str);
 
         // the root node cannot be an alias node.
@@ -12357,14 +12364,17 @@ private:
             // If there is any anchor defined for this document and the mapping has more than one entry,
             // reorder the mapping entries so the anchor resolution order is preserved.
             if (m_has_anchor_table && node.size() > 1) {
-                for (const auto& itr : get_mapping_items_in_serialization_order(node)) {
-                    serialize_mapping_entry(itr, cur_indent, str);
+                std::vector<map_iterator> ordered_items;
+                if (get_mapping_items_in_serialization_order(node, ordered_items)) {
+                    for (const auto& itr : ordered_items) {
+                        serialize_mapping_entry(itr, cur_indent, str);
+                    }
+                    break;
                 }
             }
-            else {
-                for (const auto& itr : node.map_items()) {
-                    serialize_mapping_entry(itr, cur_indent, str);
-                }
+
+            for (const auto& itr : node.map_items()) {
+                serialize_mapping_entry(itr, cur_indent, str);
             }
             break;
         case node_type::NULL_OBJECT:
@@ -12484,7 +12494,8 @@ private:
     /// @param rhs The second anchor reference.
     /// @return true if both references identify the same anchor, false otherwise.
     static bool is_same_anchor(const anchor_reference_event& lhs, const anchor_reference_event& rhs) noexcept {
-        return lhs.name == rhs.name && lhs.offset == rhs.offset;
+        // Compare the offset first, since it rules out most candidates without touching the name.
+        return lhs.offset == rhs.offset && lhs.name == rhs.name;
     }
 
     /// @brief Check whether an anchor is present in a collection.
@@ -12616,9 +12627,11 @@ private:
         ordered_items.reserve(items.size());
 
         std::size_t emitted_count = 0;
+        // Every item before this index has already been emitted, so the scan below can skip them.
+        std::size_t first_unemitted_index = 0;
         while (emitted_count < items.size()) {
             std::size_t ready_item_index = items.size();
-            for (std::size_t i = 0; i < items.size(); ++i) {
+            for (std::size_t i = first_unemitted_index; i < items.size(); ++i) {
                 const bool is_item_emitted = emitted[i];
                 if (is_item_emitted) {
                     continue;
@@ -12635,28 +12648,31 @@ private:
             ordered_items.emplace_back(items[ready_item_index]);
             remove_anchors(item_references[ready_item_index], anchor_indices);
             ++emitted_count;
+            while (first_unemitted_index < items.size() && emitted[first_unemitted_index]) {
+                ++first_unemitted_index;
+            }
         }
 
         return ordered_items;
     }
 
-    std::vector<map_iterator> get_mapping_items_in_serialization_order(const BasicNodeType& node) {
-        mapping_item_span mapping_reference {};
-        anchor_reference_span mapping_event_reference {};
+    /// @brief Collect the mapping items in the order they have to be serialized in.
+    /// @param node The mapping to serialize.
+    /// @param ordered_items Receives the reordered items, untouched unless reordering is needed.
+    /// @return true if the items were reordered, false if the mapping keeps its own order.
+    bool get_mapping_items_in_serialization_order(const BasicNodeType& node, std::vector<map_iterator>& ordered_items) {
         const auto mapping_reference_itr = m_anchor_reference_cache.find(&node);
         if (mapping_reference_itr == m_anchor_reference_cache.end()) {
-            std::size_t position = 0;
-            mapping_event_reference = collect_anchor_alias_names(node, position, false, &mapping_reference);
+            return false;
         }
-        else {
-            mapping_reference = mapping_reference_itr->second;
-            const auto& first_item_reference = m_mapping_item_references[mapping_reference.first_item_reference_index];
-            const auto& last_item_reference = m_mapping_item_references
-                [mapping_reference.first_item_reference_index + mapping_reference.item_count - 1];
-            mapping_event_reference = anchor_reference_span {
-                first_item_reference.first_index,
-                last_item_reference.first_index + last_item_reference.count - first_item_reference.first_index};
-        }
+
+        const mapping_item_span mapping_reference = mapping_reference_itr->second;
+        const auto& first_item_reference = m_mapping_item_references[mapping_reference.first_item_reference_index];
+        const auto& last_item_reference =
+            m_mapping_item_references[mapping_reference.first_item_reference_index + mapping_reference.item_count - 1];
+        const anchor_reference_span mapping_event_reference {
+            first_item_reference.first_index,
+            last_item_reference.first_index + last_item_reference.count - first_item_reference.first_index};
 
         bool has_any_anchor = false;
         bool has_any_alias = false;
@@ -12670,12 +12686,7 @@ private:
         // order `node.map_items()` returns them.
         const bool needs_reordering = has_any_anchor && has_any_alias;
         if (!needs_reordering) {
-            std::vector<map_iterator> items;
-            items.reserve(mapping_reference.item_count);
-            for (auto itr : node.map_items()) {
-                items.emplace_back(itr);
-            }
-            return items;
+            return false;
         }
 
         std::vector<map_iterator> items;
@@ -12709,18 +12720,18 @@ private:
                 const bool is_anchor_defined_in_different_item =
                     has_anchor(anchor_indices, alias) && !has_anchor(item_reference, alias);
                 if (is_anchor_defined_in_different_item) {
-                    return reorder_mapping_items_by_dependencies(items, item_references, std::move(anchor_indices));
+                    ordered_items =
+                        reorder_mapping_items_by_dependencies(items, item_references, std::move(anchor_indices));
+                    return true;
                 }
             }
         }
 
         // Reordering is only needed when an alias refers to an anchor in another mapping item.
-        return items;
+        return false;
     }
 
-    anchor_reference_span collect_anchor_alias_names(
-        const BasicNodeType& node, std::size_t& position, const bool cache_mapping = true,
-        mapping_item_span* p_mapping_reference = nullptr) {
+    anchor_reference_span collect_anchor_alias_names(const BasicNodeType& node, std::size_t& position) {
         const auto first_event_index = static_cast<uint32_t>(m_anchor_reference_events.size());
         if (node.is_alias()) {
             anchor_reference_event alias_event(
@@ -12755,11 +12766,8 @@ private:
                     m_mapping_item_references.end(), item_references.begin(), item_references.end());
                 const mapping_item_span reference {
                     first_item_reference_index, static_cast<uint32_t>(item_references.size())};
-                if (cache_mapping) {
+                if (m_anchor_reference_events.size() > first_event_index) {
                     m_anchor_reference_cache.emplace(&node, reference);
-                }
-                if (p_mapping_reference != nullptr) {
-                    *p_mapping_reference = reference;
                 }
                 break;
             }

--- a/tests/unit_test/test_serializer_class.cpp
+++ b/tests/unit_test/test_serializer_class.cpp
@@ -375,6 +375,29 @@ TEST_CASE("Serializer_ShouldPreserveAnchorAliasResolutionOrder") {
         const std::string output = serializer.serialize(node);
         REQUIRE(output == input);
     }
+
+    SUBCASE("Serialization doesn't reorder mapping entries if no anchors/aliases are present") {
+        const std::string input = "root:\n"
+                                  "  a:\n"
+                                  "    z: 1\n"
+                                  "    a: 2\n"
+                                  "  b: &A\n"
+                                  "    z: 3\n"
+                                  "    a: 4\n"
+                                  "  c: *A\n";
+        const fkyaml::node node = fkyaml::node::deserialize(input);
+        fkyaml::detail::basic_serializer<fkyaml::node> serializer;
+        const std::string output = serializer.serialize(node);
+        REQUIRE(
+            output == "root:\n"
+                      "  a:\n"
+                      "    a: 2\n"
+                      "    z: 1\n"
+                      "  b: &A\n"
+                      "    a: 4\n"
+                      "    z: 3\n"
+                      "  c: *A\n");
+    }
 }
 
 TEST_CASE("Serializer_AnchorDefinitionOrderDiffersFromMapOrder") {

--- a/tests/unit_test/test_serializer_class.cpp
+++ b/tests/unit_test/test_serializer_class.cpp
@@ -236,19 +236,13 @@ TEST_CASE("Serializer_AnchorNode") {
 }
 
 TEST_CASE("Serializer_AliasNode") {
-    fkyaml::node node = {{"foo", 123}};
-    node["foo"].add_anchor_name("A");
-    node.as_map().emplace(true, fkyaml::node::alias_of(node["foo"]));
-    node.as_map().emplace(fkyaml::node::alias_of(node["foo"]), 3.14);
-    node[nullptr] = {"bar", fkyaml::node::alias_of(node["foo"])};
-
     std::string expected = "foo: &A 123\n"
                            "null:\n"
                            "  - bar\n"
                            "  - *A\n"
                            "true: *A\n"
                            "*A : 3.14\n";
-
+    const fkyaml::node node = fkyaml::node::deserialize(expected);
     fkyaml::detail::basic_serializer<fkyaml::node> serializer;
     REQUIRE(serializer.serialize(node) == expected);
 }

--- a/tests/unit_test/test_serializer_class.cpp
+++ b/tests/unit_test/test_serializer_class.cpp
@@ -403,6 +403,41 @@ TEST_CASE("Serializer_AnchorDefinitionOrderDiffersFromMapOrder") {
     REQUIRE(root["a_second_ref"].get_value<int>() == 456);
 }
 
+TEST_CASE("Serializer_AliasAfterAnchorInSameMappingEntry") {
+    const std::string input = "root:\n"
+                              "  &anchor z_key: *anchor\n"
+                              "  a_reference: *anchor\n";
+    const fkyaml::node node = fkyaml::node::deserialize(input);
+    fkyaml::detail::basic_serializer<fkyaml::node> serializer;
+
+    const std::string output = serializer.serialize(node);
+    REQUIRE(output == input);
+
+    const fkyaml::node serialized_node = fkyaml::node::deserialize(output);
+    REQUIRE(serialized_node["root"]["z_key"].get_value<std::string>() == "z_key");
+    REQUIRE(serialized_node["root"]["a_reference"].get_value<std::string>() == "z_key");
+}
+
+TEST_CASE("Serializer_ExternalAliasesDoNotRequireMappingReordering") {
+    const std::string input = "external: &external 123\n"
+                              "root:\n"
+                              "  z_local: &local 456\n"
+                              "  a_external_ref: *external\n";
+    const fkyaml::node node = fkyaml::node::deserialize(input);
+    fkyaml::detail::basic_serializer<fkyaml::node> serializer;
+
+    const std::string output = serializer.serialize(node);
+    REQUIRE(
+        output == "external: &external 123\n"
+                  "root:\n"
+                  "  a_external_ref: *external\n"
+                  "  z_local: &local 456\n");
+
+    const fkyaml::node serialized_node = fkyaml::node::deserialize(output);
+    REQUIRE(serialized_node["root"]["a_external_ref"].get_value<int>() == 123);
+    REQUIRE(serialized_node["root"]["z_local"].get_value<int>() == 456);
+}
+
 TEST_CASE("Serializer_TaggedNode") {
     fkyaml::node root = fkyaml::node::mapping();
     fkyaml::node str_node("foo");

--- a/tests/unit_test/test_serializer_class.cpp
+++ b/tests/unit_test/test_serializer_class.cpp
@@ -242,21 +242,171 @@ TEST_CASE("Serializer_AliasNode") {
     node.as_map().emplace(fkyaml::node::alias_of(node["foo"]), 3.14);
     node[nullptr] = {"bar", fkyaml::node::alias_of(node["foo"])};
 
-    // FIXME: Semantic equality between the input & the output is not guranteed
-    //        when anchors/aliases are contained in a YAML document.
-    //        This is because mappings have no information to correctly revoke
-    //        the original relations between anchors & aliases.
-    //        Using fkyaml::ordered_map as the type of mappings should solve the
-    //        issue.
-    std::string expected = "null:\n"
+    std::string expected = "foo: &A 123\n"
+                           "null:\n"
                            "  - bar\n"
                            "  - *A\n"
                            "true: *A\n"
-                           "*A : 3.14\n"
-                           "foo: &A 123\n";
+                           "*A : 3.14\n";
 
     fkyaml::detail::basic_serializer<fkyaml::node> serializer;
     REQUIRE(serializer.serialize(node) == expected);
+}
+
+TEST_CASE("Serializer_ShouldPreserveAnchorAliasResolutionOrder") {
+    SUBCASE("Nested mapping anchor") {
+        const std::string input = "root:\n"
+                                  "  z_anchor:\n"
+                                  "    value: &anchor 456\n"
+                                  "  a_alias: *anchor\n";
+        const fkyaml::node node = fkyaml::node::deserialize(input);
+        fkyaml::detail::basic_serializer<fkyaml::node> serializer;
+        const std::string output = serializer.serialize(node);
+        REQUIRE(output == input);
+
+        const fkyaml::node redeserialized_node = fkyaml::node::deserialize(output);
+        const fkyaml::node& root = redeserialized_node["root"];
+        REQUIRE(root["z_anchor"]["value"].get_value<int>() == 456);
+        REQUIRE(root["a_alias"].get_value<int>() == 456);
+    }
+
+    SUBCASE("Multiple nested mapping anchors") {
+        const std::string input = "root:\n"
+                                  "  z_first:\n"
+                                  "    value: &anchor 123\n"
+                                  "  a_first_ref: *anchor\n"
+                                  "  z_second:\n"
+                                  "    value: &anchor 456\n"
+                                  "  a_second_ref: *anchor\n";
+        const fkyaml::node node = fkyaml::node::deserialize(input);
+        fkyaml::detail::basic_serializer<fkyaml::node> serializer;
+        const std::string output = serializer.serialize(node);
+        REQUIRE(output == input);
+
+        const fkyaml::node redeserialized_node = fkyaml::node::deserialize(output);
+        const fkyaml::node& root = redeserialized_node["root"];
+        REQUIRE(root["a_first_ref"].get_value<int>() == 123);
+        REQUIRE(root["a_second_ref"].get_value<int>() == 456);
+        REQUIRE(root["z_first"]["value"].get_value<int>() == 123);
+        REQUIRE(root["z_second"]["value"].get_value<int>() == 456);
+    }
+
+    SUBCASE("Anchors and aliases in a sequence") {
+        const std::string input = "- &anchor foo: 123\n"
+                                  "  bar: *anchor\n"
+                                  "  baz:\n"
+                                  "    - &anchor 456\n"
+                                  "  *anchor : qux\n"
+                                  "- *anchor\n"
+                                  "- &anchor 789\n"
+                                  "- *anchor : foo\n"
+                                  "  bar: &anchor false\n"
+                                  "  *anchor : baz\n";
+        const fkyaml::node node = fkyaml::node::deserialize(input);
+        // The deserialized node has the following structure which invalidates the anchor resolution order:
+        // ```yaml
+        // - *anchor: qux        # *anchor=456
+        //   bar: *anchor        # *anchor=foo
+        //   baz:
+        //     - &anchor 456
+        //   &anchor foo: 123
+        // - *anchor             # *anchor=456
+        // - &anchor 789
+        // - *anchor : baz       # *anchor=false
+        //   *anchor : baz       # *anchor=789
+        //   bar: &anchor false
+        // ```
+        fkyaml::detail::basic_serializer<fkyaml::node> serializer;
+        const std::string output = serializer.serialize(node);
+        const fkyaml::node roundtrip = fkyaml::node::deserialize(output);
+
+        REQUIRE(roundtrip.is_sequence());
+        REQUIRE(roundtrip.size() == 4);
+
+        const fkyaml::node& seq0 = roundtrip[0];
+        REQUIRE(seq0.is_mapping());
+        REQUIRE(seq0["bar"].as_str() == "foo");
+        REQUIRE(seq0["baz"][0].get_value<int>() == 456);
+        REQUIRE(seq0["foo"].get_value<int>() == 123);
+
+        bool found_seq0_alias_key = false;
+        for (auto item : seq0.map_items()) {
+            if (item.key().is_alias()) {
+                REQUIRE(item.key().get_value<int>() == 456);
+                REQUIRE(item.value().as_str() == "qux");
+                found_seq0_alias_key = true;
+            }
+        }
+        REQUIRE(found_seq0_alias_key);
+
+        REQUIRE(roundtrip[1].get_value<int>() == 456);
+        REQUIRE(roundtrip[2].get_value<int>() == 789);
+
+        const fkyaml::node& seq3 = roundtrip[3];
+        REQUIRE(seq3.is_mapping());
+        REQUIRE(seq3["bar"].get_value<bool>() == false);
+
+        bool found_seq3_alias_key_for_789 = false;
+        bool found_seq3_alias_key_for_false = false;
+        for (auto item : seq3.map_items()) {
+            if (!item.key().is_alias()) {
+                continue;
+            }
+
+            if (item.key().is_integer()) {
+                REQUIRE(item.key().get_value<int>() == 789);
+                REQUIRE(item.value().as_str() == "foo");
+                found_seq3_alias_key_for_789 = true;
+                continue;
+            }
+
+            if (item.key().is_boolean()) {
+                REQUIRE(item.key().get_value<bool>() == false);
+                REQUIRE(item.value().as_str() == "baz");
+                found_seq3_alias_key_for_false = true;
+            }
+        }
+        REQUIRE(found_seq3_alias_key_for_789);
+        REQUIRE(found_seq3_alias_key_for_false);
+    }
+
+    SUBCASE("Deserialization does not invalidate anchor resolution order") {
+        const std::string input = "&anchor a: 123\n"
+                                  "b: *anchor\n"
+                                  "c:\n"
+                                  "  - &anchor d\n"
+                                  "*anchor : qux\n";
+        const fkyaml::node node = fkyaml::node::deserialize(input);
+        fkyaml::detail::basic_serializer<fkyaml::node> serializer;
+        const std::string output = serializer.serialize(node);
+        REQUIRE(output == input);
+    }
+}
+
+TEST_CASE("Serializer_AnchorDefinitionOrderDiffersFromMapOrder") {
+    const std::string input = "root:\n"
+                              "  z_first:\n"
+                              "    value: &first 123\n"
+                              "  a_second:\n"
+                              "    value: &second 456\n"
+                              "  z_first_ref: *first\n"
+                              "  a_second_ref: *second\n";
+    const fkyaml::node node = fkyaml::node::deserialize(input);
+    fkyaml::detail::basic_serializer<fkyaml::node> serializer;
+
+    const std::string output = serializer.serialize(node);
+    REQUIRE(
+        output == "root:\n"
+                  "  a_second:\n"
+                  "    value: &second 456\n"
+                  "  a_second_ref: *second\n"
+                  "  z_first:\n"
+                  "    value: &first 123\n"
+                  "  z_first_ref: *first\n");
+    const fkyaml::node serialized_node = fkyaml::node::deserialize(output);
+    const fkyaml::node& root = serialized_node["root"];
+    REQUIRE(root["z_first_ref"].get_value<int>() == 123);
+    REQUIRE(root["a_second_ref"].get_value<int>() == 456);
 }
 
 TEST_CASE("Serializer_TaggedNode") {

--- a/tests/unit_test/test_serializer_class.cpp
+++ b/tests/unit_test/test_serializer_class.cpp
@@ -418,6 +418,21 @@ TEST_CASE("Serializer_AliasAfterAnchorInSameMappingEntry") {
     REQUIRE(serialized_node["root"]["a_reference"].get_value<std::string>() == "z_key");
 }
 
+TEST_CASE("Serializer_AliasAfterAnchorInFirstMappingEntry") {
+    const std::string input = "root:\n"
+                              "  &anchor a_key: *anchor\n"
+                              "  b_reference: *anchor\n";
+    const fkyaml::node node = fkyaml::node::deserialize(input);
+    fkyaml::detail::basic_serializer<fkyaml::node> serializer;
+
+    const std::string output = serializer.serialize(node);
+    REQUIRE(output == input);
+
+    const fkyaml::node serialized_node = fkyaml::node::deserialize(output);
+    REQUIRE(serialized_node["root"]["a_key"].get_value<std::string>() == "a_key");
+    REQUIRE(serialized_node["root"]["b_reference"].get_value<std::string>() == "a_key");
+}
+
 TEST_CASE("Serializer_ExternalAliasesDoNotRequireMappingReordering") {
     const std::string input = "external: &external 123\n"
                               "root:\n"


### PR DESCRIPTION
This PR fixes #584, an issue where YAML documents containing anchors and aliases could not be serialized correctly after deserialization when the underlying mapping type is `std::map`, the mapping type of `fkyaml::node`.  

## Problem

`std::map` orders mapping entries by their keys, so the serialization order can differ from the original YAML document.  
This can cause a problem when an alias is serialized before the anchor it refers to. In particular, the problem an occur when:

- the same anchor name is used multiple times with different anchor occurrences;
- an anchor is redefined while traversing a sequence;
- an alias is used as a mapping key;
- the resolved value of an alias key affects the `std::map` ordering.

The deserialized node already retains the information necessary to identify which anchor occurrence an alias refers to, but the serializer did not previously that information into account when determining the mapping entry order.

## Fix

This PR adjusts the serialization order of mapping entries based on anchor/alias dependencies by stable topological sorting.  
For each mapping:

1. Anchor and alias references are collected recursively from each mapping entry.
2. Anchor occurrences are identified using the anchor name and anchor offset.
3. A mapping entry that references an anchor is postponed until the corresponding anchor has been serialized.
4. Otherwise, mapping entries retain their original `std::map` order.
5. Sequence ordering is never changed' the ordering adjustment is applied only to mapping entries.

This allows the serializer to emit anchors before the aliases that reference them while preserving the existing ordering behavior as much as possible.

I had originally considered switching to a mapping type that preserves the insertion order, but I decided against it because it would have caused significant performance degradation. Thanks to advice from @sndth in #584, I arrived at this approach, which avoids the need for a breaking change.

## Tests

Added round-trip tests to `tests/unit_test/test_serializer_class.cpp`, including cases with:

- nested mappings and sequences;
- repeated anchor names;
- anchor redefinition across entries;
- aliases used as mapping keys;
- multiple anchor/alias occurrences within the same mapping.

The tests verify that the documents can be deserialized and serialized again while preserving the correct anchor/alias relationships.

The existing serializer tests also continue to pass without any changes to their expected output.  
This confirms that the serialization output remains unchanged in cases where changing the mapping order is not necessary to preserve anchor/alias resolution.

---

## Pull Request Checklist

Read the [CONTRIBUTING.md](https://github.com/fktn-k/fkYAML/blob/develop/.github/CONTRIBUTING.md) file for detailed information.  

- [x] Changes are described in the pull request or in a referenced [issue](https://github.com/fktn-k/fkYAML/issues).
- [x] The test suite compiles and runs without any error.
- [x] [The code coverage](https://coveralls.io/github/fktn-k/fkYAML) on your branch is 100%.
- [x] The documentation is updated if you added/changed a feature.

## Please don't

- The C++11 support varies between different **compilers** and versions. Please note the [list of supported compilers](https://github.com/fktn-k/fkYAML/blob/develop/README.md#supported-compilers). Some compilers like GCC 4.7 (and earlier), Clang 3.3 (and earlier), or Microsoft Visual Studio 13.0 and earlier are known not to work due to missing or incomplete C++11 support. Please refrain from proposing changes that work around these compiler's limitations with `#ifdef`s or other means.
- Please refrain from proposing changes that would **break [YAML](https://yaml.org/) specifications**. If you propose a conformant extension of YAML to be supported by the library, please motivate this extension.
- Please do not open pull requests that address **multiple issues**.
