### PR TITLE
Let ordered_map entries be moved when the storage grows

### DIFF
--- a/docs/docs/api/ordered_map/index.md
+++ b/docs/docs/api/ordered_map/index.md
@@ -5,12 +5,12 @@
 ```cpp
 template<
     typename Key, typename Value, typename IgnoredCompare = std::less<Key>,
-    typename Allocator = std::allocator<std::pair<const Key, Value>>>
-class ordered_map : public std::vector<std::pair<const Key, Value>>;
+    typename Allocator = std::allocator<std::pair<Key, Value>>>
+class ordered_map : public std::vector<std::pair<Key, Value>>;
 ```
 
 A minimal map-like container which preserves insertion order.  
-This documentation only describes APIs which are not of the parent class [`std::vector<std::pair<const Key, Value>>`](https://en.cppreference.com/w/cpp/container/vector).  
+This documentation only describes APIs which are not of the parent class [`std::vector<std::pair<Key, Value>>`](https://en.cppreference.com/w/cpp/container/vector).  
 
 !!! Question annotate "How is this class useful?"
 

--- a/include/fkYAML/ordered_map.hpp
+++ b/include/fkYAML/ordered_map.hpp
@@ -29,8 +29,8 @@ FK_YAML_NAMESPACE_BEGIN
 /// @sa https://fktn-k.github.io/fkYAML/api/ordered_map/
 template <
     typename Key, typename Value, typename IgnoredCompare = std::less<Key>,
-    typename Allocator = std::allocator<std::pair<const Key, Value>>>
-class ordered_map : public std::vector<std::pair<const Key, Value>, Allocator> {
+    typename Allocator = std::allocator<std::pair<Key, Value>>>
+class ordered_map : public std::vector<std::pair<Key, Value>, Allocator> {
 public:
     /// @brief A type for keys.
     /// @sa https://fktn-k.github.io/fkYAML/api/ordered_map/
@@ -42,7 +42,7 @@ public:
 
     /// @brief A type for internal key-value containers.
     /// @sa https://fktn-k.github.io/fkYAML/api/ordered_map/
-    using Container = std::vector<std::pair<const Key, Value>, Allocator>;
+    using Container = std::vector<std::pair<Key, Value>, Allocator>;
 
     /// @brief A type for key-value pairs.
     /// @sa https://fktn-k.github.io/fkYAML/api/ordered_map/

--- a/single_include/fkYAML/node.hpp
+++ b/single_include/fkYAML/node.hpp
@@ -13370,8 +13370,8 @@ FK_YAML_NAMESPACE_BEGIN
 /// @sa https://fktn-k.github.io/fkYAML/api/ordered_map/
 template <
     typename Key, typename Value, typename IgnoredCompare = std::less<Key>,
-    typename Allocator = std::allocator<std::pair<const Key, Value>>>
-class ordered_map : public std::vector<std::pair<const Key, Value>, Allocator> {
+    typename Allocator = std::allocator<std::pair<Key, Value>>>
+class ordered_map : public std::vector<std::pair<Key, Value>, Allocator> {
 public:
     /// @brief A type for keys.
     /// @sa https://fktn-k.github.io/fkYAML/api/ordered_map/
@@ -13383,7 +13383,7 @@ public:
 
     /// @brief A type for internal key-value containers.
     /// @sa https://fktn-k.github.io/fkYAML/api/ordered_map/
-    using Container = std::vector<std::pair<const Key, Value>, Allocator>;
+    using Container = std::vector<std::pair<Key, Value>, Allocator>;
 
     /// @brief A type for key-value pairs.
     /// @sa https://fktn-k.github.io/fkYAML/api/ordered_map/

--- a/tests/unit_test/test_ordered_map_class.cpp
+++ b/tests/unit_test/test_ordered_map_class.cpp
@@ -98,3 +98,38 @@ TEST_CASE("OrderedMap_ConstFind") {
     REQUIRE(map__.find("foo")->second == true);
     REQUIRE(map__.find("bar") == map__.end());
 }
+
+TEST_CASE("OrderedMap_InsertionOrderSurvivesGrowth") {
+    // The entries must keep their insertion order across the reallocations which growing causes.
+    fkyaml::ordered_map<std::string, int> map;
+    constexpr int entry_count = 64;
+    for (int i = 0; i < entry_count; i++) {
+        map.emplace(std::to_string(i), i);
+    }
+
+    REQUIRE(map.size() == entry_count);
+
+    int index = 0;
+    for (const auto& entry : map) {
+        REQUIRE(entry.first == std::to_string(index));
+        REQUIRE(entry.second == index);
+        ++index;
+    }
+}
+
+TEST_CASE("OrderedMap_AsMappingTypeKeepsKeyOrder") {
+    using ordered_node = fkyaml::basic_node<std::vector, fkyaml::ordered_map>;
+
+    // An alias must not be emitted before the anchor it refers to, which is what reordering the keys
+    // would cause. See https://github.com/fktn-k/fkYAML/issues/584.
+    const std::string input = "foo: &anchor 123\nbar: *anchor\n";
+    ordered_node root;
+    REQUIRE_NOTHROW(root = ordered_node::deserialize(input));
+
+    std::string output;
+    REQUIRE_NOTHROW(output = ordered_node::serialize(root));
+    REQUIRE(output == input);
+
+    // The emitted document must be parsable again.
+    REQUIRE_NOTHROW(ordered_node::deserialize(output));
+}


### PR DESCRIPTION
`ordered_map` derives from `std::vector<std::pair<const Key, Value>>`. The `const Key` member makes the pair effectively non-movable, so every reallocation during growth copy-constructs every entry instead of moving it. For `basic_node` values that means deep-copying whole subtrees, repeatedly, as the mapping grows.

This changes the base container and the default `Allocator` to `std::pair<Key, Value>` so the entries move.

### Effect

`ordered_map` is not the default `MappingType`, so this does not change anything for `fkyaml::node`. It does change things for anyone using `basic_node<std::vector, fkyaml::ordered_map>` today, and it is measurable: flipping the default locally (not part of this PR) and running the repo benchmarker on `citm_catalog.yml` in Release:

| | parse |
|---|---|
| `develop`, `std::map` | 51.6 MiB/s |
| `ordered_map` before this change | 30.3 MiB/s |
| `ordered_map` after this change | 55.4 MiB/s |

This is relevant to #584 / #592: the ~2x slowdown reported there when trying `ordered_map` as the default reproduces exactly, and it comes from these copies rather than from the linear `find()`. That is also why adding a key-to-index map did not help - an index removes lookups, not copies. Whether the default `MappingType` should change is a separate question and is not proposed here.

### Breaking change

`ordered_map::value_type` changes from `std::pair<const Key, Value>` to `std::pair<Key, Value>`. Code that spells the pair type out explicitly, e.g.

```cpp
for (std::pair<const std::string, int>& entry : map) { ... }
```

needs the `const` dropped. Iterating with `auto&` is unaffected. Keys become assignable in place, which callers should not do - the class has no way to detect the duplicates that would create.

### Tests

- `OrderedMap_InsertionOrderSurvivesGrowth`: insertion order across the reallocations that growth
  causes.
- `OrderedMap_AsMappingTypeKeepsKeyOrder`: round trip of the #584 document through
  `basic_node<std::vector, fkyaml::ordered_map>`.

Both the unit tests and the yaml-test-suite runner pass unchanged on this branch.

---

## Pull Request Checklist

Read the [CONTRIBUTING.md](https://github.com/fktn-k/fkYAML/blob/develop/.github/CONTRIBUTING.md) file for detailed information.  

- [x] Changes are described in the pull request or in a referenced [issue](https://github.com/fktn-k/fkYAML/issues).
- [x] The test suite compiles and runs without any error.
- [x] [The code coverage](https://coveralls.io/github/fktn-k/fkYAML) on your branch is 100%.
- [x] The documentation is updated if you added/changed a feature.

## Please don't

- The C++11 support varies between different **compilers** and versions. Please note the [list of supported compilers](https://github.com/fktn-k/fkYAML/blob/develop/README.md#supported-compilers). Some compilers like GCC 4.7 (and earlier), Clang 3.3 (and earlier), or Microsoft Visual Studio 13.0 and earlier are known not to work due to missing or incomplete C++11 support. Please refrain from proposing changes that work around these compiler's limitations with `#ifdef`s or other means.
- Please refrain from proposing changes that would **break [YAML](https://yaml.org/) specifications**. If you propose a conformant extension of YAML to be supported by the library, please motivate this extension.
- Please do not open pull requests that address **multiple issues**.
