### PR TITLE
Count a document only if it has contents or a directives end marker

### DIFF
--- a/include/fkYAML/detail/input/deserializer.hpp
+++ b/include/fkYAML/detail/input/deserializer.hpp
@@ -158,9 +158,15 @@ public:
 
         std::vector<basic_node_type> nodes {};
         lexical_token_t type {lexical_token_t::END_OF_BUFFER};
+        bool begun_by_marker = false;
 
         do {
-            nodes.emplace_back(deserialize_document(lexer, type));
+            basic_node_type doc = deserialize_document(lexer, type);
+            if (m_has_document || begun_by_marker) {
+                nodes.emplace_back(std::move(doc));
+            }
+            // A "---" which ends a document begins the next one, even if that one is empty.
+            begun_by_marker = (type == lexical_token_t::END_OF_DIRECTIVES);
             // Break the loop if the last end-of-document marker is followed by the end-of-buffer token,
             // which indicates that there are no more documents to parse.
             // ```yaml
@@ -189,6 +195,8 @@ private:
     basic_node_type deserialize_document(lexer_type& lexer, lexical_token_t& last_type) {
         lexical_token token {};
 
+        m_has_document = false;
+
         basic_node_type root;
         mp_current_node = &root;
         // One metainfo object is created per document and shared by all of its nodes.
@@ -202,6 +210,11 @@ private:
         uint32_t line = lexer.get_lines_processed();
         uint32_t indent = lexer.get_last_token_begin_pos();
         const bool found_props = deserialize_node_properties(lexer, token, line, indent);
+
+        // A stream which only holds comments, white spaces or a bare "..." contains no document.
+        if (token.type != lexical_token_t::END_OF_BUFFER && token.type != lexical_token_t::END_OF_DOCUMENT) {
+            m_has_document = true;
+        }
 
         switch (token.type) {
         case lexical_token_t::SEQUENCE_BLOCK_PREFIX: {
@@ -416,6 +429,7 @@ private:
                 break;
             case lexical_token_t::END_OF_DIRECTIVES:
                 lacks_end_of_directives_marker = false;
+                m_has_document = true;
                 break;
             default:
                 if FK_YAML_UNLIKELY (lacks_end_of_directives_marker) {
@@ -1720,6 +1734,8 @@ private:
     int32_t m_flow_base_indent {-1};
     /// The set of YAML directives.
     std::shared_ptr<doc_metainfo_type> mp_meta {};
+    /// Whether the document being parsed exists at all: it has contents or an explicit "---".
+    bool m_has_document {false};
     /// A flag to determine the need for YAML anchor node implementation.
     bool m_needs_anchor_impl {false};
     /// A flag to determine the need for a corresponding node with the last YAML tag.

--- a/single_include/fkYAML/node.hpp
+++ b/single_include/fkYAML/node.hpp
@@ -7814,9 +7814,15 @@ public:
 
         std::vector<basic_node_type> nodes {};
         lexical_token_t type {lexical_token_t::END_OF_BUFFER};
+        bool begun_by_marker = false;
 
         do {
-            nodes.emplace_back(deserialize_document(lexer, type));
+            basic_node_type doc = deserialize_document(lexer, type);
+            if (m_has_document || begun_by_marker) {
+                nodes.emplace_back(std::move(doc));
+            }
+            // A "---" which ends a document begins the next one, even if that one is empty.
+            begun_by_marker = (type == lexical_token_t::END_OF_DIRECTIVES);
             // Break the loop if the last end-of-document marker is followed by the end-of-buffer token,
             // which indicates that there are no more documents to parse.
             // ```yaml
@@ -7845,6 +7851,8 @@ private:
     basic_node_type deserialize_document(lexer_type& lexer, lexical_token_t& last_type) {
         lexical_token token {};
 
+        m_has_document = false;
+
         basic_node_type root;
         mp_current_node = &root;
         // One metainfo object is created per document and shared by all of its nodes.
@@ -7858,6 +7866,11 @@ private:
         uint32_t line = lexer.get_lines_processed();
         uint32_t indent = lexer.get_last_token_begin_pos();
         const bool found_props = deserialize_node_properties(lexer, token, line, indent);
+
+        // A stream which only holds comments, white spaces or a bare "..." contains no document.
+        if (token.type != lexical_token_t::END_OF_BUFFER && token.type != lexical_token_t::END_OF_DOCUMENT) {
+            m_has_document = true;
+        }
 
         switch (token.type) {
         case lexical_token_t::SEQUENCE_BLOCK_PREFIX: {
@@ -8072,6 +8085,7 @@ private:
                 break;
             case lexical_token_t::END_OF_DIRECTIVES:
                 lacks_end_of_directives_marker = false;
+                m_has_document = true;
                 break;
             default:
                 if FK_YAML_UNLIKELY (lacks_end_of_directives_marker) {
@@ -9376,6 +9390,8 @@ private:
     int32_t m_flow_base_indent {-1};
     /// The set of YAML directives.
     std::shared_ptr<doc_metainfo_type> mp_meta {};
+    /// Whether the document being parsed exists at all: it has contents or an explicit "---".
+    bool m_has_document {false};
     /// A flag to determine the need for YAML anchor node implementation.
     bool m_needs_anchor_impl {false};
     /// A flag to determine the need for a corresponding node with the last YAML tag.

--- a/tests/unit_test/test_deserializer_class.cpp
+++ b/tests/unit_test/test_deserializer_class.cpp
@@ -4009,4 +4009,38 @@ TEST_CASE("Deserializer_MultipleDocuments") {
             REQUIRE(d_node.as_str() == "e");
         }
     }
+
+    SUBCASE("stream which contains no document") {
+        auto input = GENERATE(std::string(""), std::string("# comment only\n"), std::string("...\n"));
+        REQUIRE_NOTHROW(docs = deserializer.deserialize_docs(fkyaml::detail::input_adapter(input)));
+        REQUIRE(docs.empty());
+    }
+
+    SUBCASE("comments between document end markers are not a document") {
+        std::string input = "foo: 123\n"
+                            "...\n"
+                            "# comment\n"
+                            "...\n"
+                            "bar: 456\n";
+
+        REQUIRE_NOTHROW(docs = deserializer.deserialize_docs(fkyaml::detail::input_adapter(input)));
+        REQUIRE(docs.size() == 2);
+
+        REQUIRE(docs[0].is_mapping());
+        REQUIRE(docs[0]["foo"].get_value<int>() == 123);
+        REQUIRE(docs[1].is_mapping());
+        REQUIRE(docs[1]["bar"].get_value<int>() == 456);
+    }
+
+    SUBCASE("a trailing directives end marker begins an empty document") {
+        std::string input = "foo: 123\n"
+                            "---\n";
+
+        REQUIRE_NOTHROW(docs = deserializer.deserialize_docs(fkyaml::detail::input_adapter(input)));
+        REQUIRE(docs.size() == 2);
+
+        REQUIRE(docs[0].is_mapping());
+        REQUIRE(docs[0]["foo"].get_value<int>() == 123);
+        REQUIRE(docs[1].is_null());
+    }
 }


### PR DESCRIPTION
`deserialize_docs()` emits a node for every stream section, including one which holds only comments, white spaces or a bare `...`. Such a section is not a document, so an empty node is added for it.

This counts a document only if it has contents or begins with an explicit `---`. A `---` which ends a document still begins the next one, so a trailing marker keeps producing an empty document.

Refs #591.

### Results

yaml-test-suite: 95 -> 84 failures with no regressions. `8G76`, `98YD`, `AVM7`, `HWV9`, `M7A3` and `QT73` now pass.

### Not covered

Consecutive directives end markers are still counted as a single document, so `6XDY` keeps failing:

```yaml
---
---
```

`deserialize_docs()` returns 1 document instead of 2, because `deserialize_directives()` consumes every `---` it sees within one call. Changing that looked separable from this PR, so I left it out. Happy to fold it in here if you would rather have both.

---

## Pull Request Checklist

Read the [CONTRIBUTING.md](https://github.com/fktn-k/fkYAML/blob/develop/.github/CONTRIBUTING.md) file for detailed information.  

- [x] Changes are described in the pull request or in a referenced [issue](https://github.com/fktn-k/fkYAML/issues).
- [x] The test suite compiles and runs without any error.
- [x] [The code coverage](https://coveralls.io/github/fktn-k/fkYAML) on your branch is 100%.
- [x] The documentation is updated if you added/changed a feature.

## Please don't

- The C++11 support varies between different **compilers** and versions. Please note the [list of supported compilers](https://github.com/fktn-k/fkYAML/blob/develop/README.md#supported-compilers). Some compilers like GCC 4.7 (and earlier), Clang 3.3 (and earlier), or Microsoft Visual Studio 13.0 and earlier are known not to work due to missing or incomplete C++11 support. Please refrain from proposing changes that work around these compiler's limitations with `#ifdef`s or other means.
- Please refrain from proposing changes that would **break [YAML](https://yaml.org/) specifications**. If you propose a conformant extension of YAML to be supported by the library, please motivate this extension.
- Please do not open pull requests that address **multiple issues**.
