### PR TITLE
End a block scalar at a less indented trailing comment

### DIFF
--- a/include/fkYAML/detail/input/lexical_analyzer.hpp
+++ b/include/fkYAML/detail/input/lexical_analyzer.hpp
@@ -1240,7 +1240,16 @@ private:
             FK_YAML_ASSERT(last_newline_pos < cur_line_content_begin_pos);
             cur_indent = static_cast<uint32_t>(cur_line_content_begin_pos - last_newline_pos - 1);
             if (cur_indent < content_indent && sv[cur_line_content_begin_pos] != '\n') {
-                if FK_YAML_UNLIKELY (cur_indent > base_indent) {
+                // Trailing comments may be less indented than the contents, so they end the block scalar
+                // instead of being part of it.
+                // ```yaml
+                // foo: |
+                //   text
+                //  # comment
+                // ```
+                // https://yaml.org/spec/1.2.2/#8112-block-chomping-indicator
+                const bool begins_comment = sv[cur_line_content_begin_pos] == '#';
+                if FK_YAML_UNLIKELY (!begins_comment && cur_indent > base_indent) {
                     // This path assumes an input like the following:
                     // ```yaml
                     // foo: |

--- a/single_include/fkYAML/node.hpp
+++ b/single_include/fkYAML/node.hpp
@@ -4513,7 +4513,16 @@ private:
             FK_YAML_ASSERT(last_newline_pos < cur_line_content_begin_pos);
             cur_indent = static_cast<uint32_t>(cur_line_content_begin_pos - last_newline_pos - 1);
             if (cur_indent < content_indent && sv[cur_line_content_begin_pos] != '\n') {
-                if FK_YAML_UNLIKELY (cur_indent > base_indent) {
+                // Trailing comments may be less indented than the contents, so they end the block scalar
+                // instead of being part of it.
+                // ```yaml
+                // foo: |
+                //   text
+                //  # comment
+                // ```
+                // https://yaml.org/spec/1.2.2/#8112-block-chomping-indicator
+                const bool begins_comment = sv[cur_line_content_begin_pos] == '#';
+                if FK_YAML_UNLIKELY (!begins_comment && cur_indent > base_indent) {
                     // This path assumes an input like the following:
                     // ```yaml
                     // foo: |

--- a/tests/unit_test/test_deserializer_class.cpp
+++ b/tests/unit_test/test_deserializer_class.cpp
@@ -368,6 +368,35 @@ TEST_CASE("Deserializer_BlockLiteralScalar") {
         REQUIRE(root.is_string());
         REQUIRE(root.as_str() == "first sentence.\nsecond sentence.\nlast sentence.\n");
     }
+
+    SUBCASE("a less indented trailing comment ends the scalar") {
+        std::string input = "foo: |\n"
+                            "  text\n"
+                            " # comment\n"
+                            "bar: 123\n";
+
+        REQUIRE_NOTHROW(root = deserializer.deserialize(fkyaml::detail::input_adapter(input)));
+        REQUIRE(root.is_mapping());
+        REQUIRE(root.size() == 2);
+        REQUIRE(root["foo"].as_str() == "text\n");
+        REQUIRE(root["bar"].as_int() == 123);
+    }
+
+    SUBCASE("a comment at the content indentation is still content") {
+        std::string input = "foo: |\n"
+                            "  # text\n";
+
+        REQUIRE_NOTHROW(root = deserializer.deserialize(fkyaml::detail::input_adapter(input)));
+        REQUIRE(root["foo"].as_str() == "# text\n");
+    }
+
+    SUBCASE("a less indented line which is not a comment is still rejected") {
+        std::string input = "foo: |\n"
+                            "  text\n"
+                            " invalid\n";
+
+        REQUIRE_THROWS_AS(root = deserializer.deserialize(fkyaml::detail::input_adapter(input)), fkyaml::parse_error);
+    }
 }
 
 TEST_CASE("Deserializer_BlockFoldedScalar") {


### PR DESCRIPTION
A comment line which is less indented than the contents of a block scalar is rejected with `A content line of the block scalar is less indented.`, but the YAML specification allows it: it ends the scalar instead of being part of it.

> `l-trail-comments(n) ::= s-indent(<n) c-nb-comment-text b-comment l-comment*`
> -- https://yaml.org/spec/1.2.2/#8112-block-chomping-indicator

```yaml
foo: |
  text
 # comment
bar: 123
```

A comment at or beyond the content indentation is still content, and a less indented line which is not a comment is still rejected.

### Results

yaml-test-suite: 95 -> 92 failures with no regressions. `DWX9`, `F8F9` and `T26H` now pass.

---

## Pull Request Checklist

Read the [CONTRIBUTING.md](https://github.com/fktn-k/fkYAML/blob/develop/.github/CONTRIBUTING.md) file for detailed information.  

- [x] Changes are described in the pull request or in a referenced [issue](https://github.com/fktn-k/fkYAML/issues).
- [x] The test suite compiles and runs without any error.
- [x] [The code coverage](https://coveralls.io/github/fktn-k/fkYAML) on your branch is 100%.
- [x] The documentation is updated if you added/changed a feature.

## Please don't

- The C++11 support varies between different **compilers** and versions. Please note the [list of supported compilers](https://github.com/fktn-k/fkYAML/blob/develop/README.md#supported-compilers). Some compilers like GCC 4.7 (and earlier), Clang 3.3 (and earlier), or Microsoft Visual Studio 13.0 and earlier are known not to work due to missing or incomplete C++11 support. Please refrain from proposing changes that work around these compiler's limitations with `#ifdef`s or other means.
- Please refrain from proposing changes that would **break [YAML](https://yaml.org/) specifications**. If you propose a conformant extension of YAML to be supported by the library, please motivate this extension.
- Please do not open pull requests that address **multiple issues**.
