### PR TITLE
Support a flow mapping entry which omits the value indicator

### DIFF
--- a/include/fkYAML/detail/input/deserializer.hpp
+++ b/include/fkYAML/detail/input/deserializer.hpp
@@ -1370,11 +1370,20 @@ private:
             // ```
             const bool is_key_sep_followed = (token.type == lexical_token_t::KEY_SEPARATOR) &&
                                              (line == lexer.get_lines_processed() || m_flow_context_depth > 0);
-            if FK_YAML_UNLIKELY (!is_key_sep_followed) {
-                throw parse_error(
-                    "The \":\" mapping value indicator must be followed after a mapping key.",
-                    lexer.get_lines_processed(),
-                    lexer.get_last_token_begin_pos());
+            if (!is_key_sep_followed) {
+                // A flow mapping entry may consist of a key alone, with both the ":" indicator and the
+                // value omitted. The entry then ends at the separator or the suffix which follows it.
+                // ```yaml
+                // {foo, bar: baz}
+                // ```
+                const bool ends_omitted_entry = (token.type == lexical_token_t::VALUE_SEPARATOR) ||
+                                                (token.type == lexical_token_t::MAPPING_FLOW_END);
+                if FK_YAML_UNLIKELY (!ends_omitted_entry) {
+                    throw parse_error(
+                        "The \":\" mapping value indicator must be followed after a mapping key.",
+                        lexer.get_lines_processed(),
+                        lexer.get_last_token_begin_pos());
+                }
             }
             add_new_key(std::move(node), line, indent);
         }

--- a/single_include/fkYAML/node.hpp
+++ b/single_include/fkYAML/node.hpp
@@ -9026,11 +9026,20 @@ private:
             // ```
             const bool is_key_sep_followed = (token.type == lexical_token_t::KEY_SEPARATOR) &&
                                              (line == lexer.get_lines_processed() || m_flow_context_depth > 0);
-            if FK_YAML_UNLIKELY (!is_key_sep_followed) {
-                throw parse_error(
-                    "The \":\" mapping value indicator must be followed after a mapping key.",
-                    lexer.get_lines_processed(),
-                    lexer.get_last_token_begin_pos());
+            if (!is_key_sep_followed) {
+                // A flow mapping entry may consist of a key alone, with both the ":" indicator and the
+                // value omitted. The entry then ends at the separator or the suffix which follows it.
+                // ```yaml
+                // {foo, bar: baz}
+                // ```
+                const bool ends_omitted_entry = (token.type == lexical_token_t::VALUE_SEPARATOR) ||
+                                                (token.type == lexical_token_t::MAPPING_FLOW_END);
+                if FK_YAML_UNLIKELY (!ends_omitted_entry) {
+                    throw parse_error(
+                        "The \":\" mapping value indicator must be followed after a mapping key.",
+                        lexer.get_lines_processed(),
+                        lexer.get_last_token_begin_pos());
+                }
             }
             add_new_key(std::move(node), line, indent);
         }

--- a/tests/unit_test/test_deserializer_class.cpp
+++ b/tests/unit_test/test_deserializer_class.cpp
@@ -2694,6 +2694,31 @@ TEST_CASE("Deserializer_OmittedFlowMappingValue") {
         REQUIRE(root["foo"].is_null());
     }
 
+    SUBCASE("the only entry omits the value indicator as well") {
+        auto input = GENERATE(std::string("{foo}"), std::string("{\"foo\"}"), std::string("{foo, }"));
+        REQUIRE_NOTHROW(root = deserializer.deserialize(fkyaml::detail::input_adapter(input)));
+
+        REQUIRE(root.is_mapping());
+        REQUIRE(root.size() == 1);
+        REQUIRE(root.contains("foo"));
+        REQUIRE(root["foo"].is_null());
+    }
+
+    SUBCASE("an entry omitting the value indicator is followed by a complete one") {
+        auto input = GENERATE(std::string("{foo, bar: baz}"), std::string("{\"foo\", bar: baz}"));
+        REQUIRE_NOTHROW(root = deserializer.deserialize(fkyaml::detail::input_adapter(input)));
+
+        REQUIRE(root.is_mapping());
+        REQUIRE(root.size() == 2);
+        REQUIRE(root["foo"].is_null());
+        REQUIRE(root["bar"].as_str() == "baz");
+    }
+
+    SUBCASE("a key followed by anything else is still rejected") {
+        auto input = GENERATE(std::string("{foo [bar]}"), std::string("{foo {bar}}"));
+        REQUIRE_THROWS_AS(root = deserializer.deserialize(fkyaml::detail::input_adapter(input)), fkyaml::parse_error);
+    }
+
     SUBCASE("the first entry has no value") {
         std::string input = "{foo: , bar: 1}";
         REQUIRE_NOTHROW(root = deserializer.deserialize(fkyaml::detail::input_adapter(input)));


### PR DESCRIPTION
A flow mapping entry may consist of a key alone, with both the `:` indicator and the value omitted, but such an entry is rejected with `The ":" mapping value indicator must be followed after a mapping key.`

```yaml
{foo, bar: baz}
```

`ns-flow-map-yaml-key-entry` allows an `e-node` in place of the separate value, so the entry ends at the `,` separator or at the `}` suffix which follows the key.

A key followed by anything else is still rejected, and the relaxation does not reach the block context, where `,` and `}` remain errors.

### Results

yaml-test-suite: 95 -> 92 failures with no regressions. `4ABK`, `8KB6` and `9BXH` now pass.

---

## Pull Request Checklist

Read the [CONTRIBUTING.md](https://github.com/fktn-k/fkYAML/blob/develop/.github/CONTRIBUTING.md) file for detailed information.  

- [x] Changes are described in the pull request or in a referenced [issue](https://github.com/fktn-k/fkYAML/issues).
- [x] The test suite compiles and runs without any error.
- [x] [The code coverage](https://coveralls.io/github/fktn-k/fkYAML) on your branch is 100%.
- [x] The documentation is updated if you added/changed a feature.

## Please don't

- The C++11 support varies between different **compilers** and versions. Please note the [list of supported compilers](https://github.com/fktn-k/fkYAML/blob/develop/README.md#supported-compilers). Some compilers like GCC 4.7 (and earlier), Clang 3.3 (and earlier), or Microsoft Visual Studio 13.0 and earlier are known not to work due to missing or incomplete C++11 support. Please refrain from proposing changes that work around these compiler's limitations with `#ifdef`s or other means.
- Please refrain from proposing changes that would **break [YAML](https://yaml.org/) specifications**. If you propose a conformant extension of YAML to be supported by the library, please motivate this extension.
- Please do not open pull requests that address **multiple issues**.
