### PR TITLE
Fix tab used as indentation

### DIFF
--- a/include/fkYAML/detail/input/deserializer.hpp
+++ b/include/fkYAML/detail/input/deserializer.hpp
@@ -218,6 +218,7 @@ private:
 
         switch (token.type) {
         case lexical_token_t::SEQUENCE_BLOCK_PREFIX: {
+            check_tab_in_indentation(lexer, lexer.get_lines_processed(), lexer.get_last_token_begin_pos());
             root = basic_node_type::sequence({basic_node_type()});
             apply_directive_set(root);
             if (found_props) {
@@ -517,6 +518,8 @@ private:
 
                 token = lexer.get_next_token();
                 if (token.type == lexical_token_t::SEQUENCE_BLOCK_PREFIX) {
+                    check_tab_in_indentation(lexer, lexer.get_lines_processed(), lexer.get_last_token_begin_pos());
+
                     // The key node is owned by its context until the corresponding KEY_SEPARATOR event.
                     std::unique_ptr<basic_node_type> key_node(new basic_node_type(node_type::SEQUENCE));
                     basic_node_type* p_node = key_node.get();
@@ -803,6 +806,7 @@ private:
                 // ```
                 continue;
             case lexical_token_t::SEQUENCE_BLOCK_PREFIX: {
+                check_tab_in_indentation(lexer, lexer.get_lines_processed(), lexer.get_last_token_begin_pos());
                 if FK_YAML_UNLIKELY (m_flow_context_depth > 0) {
                     throw parse_error("A block sequence entry is not allowed in the flow context.", line, indent);
                 }
@@ -1281,6 +1285,22 @@ private:
         return prop_specified;
     }
 
+    /// @brief Reject a tab character used as the indentation of a block collection.
+    /// @note Indentation must consist of spaces only, while a tab which follows it is valid separation
+    /// white space. See https://yaml.org/spec/1.2.2/#61-indentation-spaces for more details.
+    /// ```yaml
+    /// -\t-    # the nested sequence is indented with a tab, which is an error
+    /// -\t-1   # the tab only separates the entry from its scalar, which is valid
+    /// ```
+    /// @param lexer The lexical analyzer to be used.
+    /// @param line The line of the node which begins the block collection.
+    /// @param indent The indentation width of the node which begins the block collection.
+    void check_tab_in_indentation(lexer_type& lexer, const uint32_t line, const uint32_t indent) const {
+        if FK_YAML_UNLIKELY (m_flow_context_depth == 0 && lexer.has_tab_in_indentation(indent)) {
+            throw parse_error("A tab character cannot be used as indentation.", line, indent);
+        }
+    }
+
     /// @brief Add new key string to the current YAML node.
     /// @param key a key string to be added to the current YAML node.
     /// @param line The line where the key is found.
@@ -1399,6 +1419,7 @@ private:
                         lexer.get_last_token_begin_pos());
                 }
             }
+            check_tab_in_indentation(lexer, line, indent);
             add_new_key(std::move(node), line, indent);
         }
         else if (token.type == lexical_token_t::KEY_SEPARATOR) {
@@ -1450,6 +1471,7 @@ private:
                             // # -> {foo: null, bar: 123}
                             // ```
                             add_explicit_key_with_null_value();
+                            check_tab_in_indentation(lexer, line, indent);
                             add_new_key(std::move(node), line, indent);
                             indent = lexer.get_last_token_begin_pos();
                             line = lexer.get_lines_processed();
@@ -1475,6 +1497,7 @@ private:
                             pop_to_parent_node(line, indent, [indent](const parse_context& c) {
                                 return c.state == context_state_t::BLOCK_MAPPING && indent == c.indent;
                             });
+                            check_tab_in_indentation(lexer, line, indent);
                             add_new_key(std::move(node), line, indent);
                             indent = lexer.get_last_token_begin_pos();
                             line = lexer.get_lines_processed();
@@ -1515,6 +1538,7 @@ private:
                     }
                 }
             }
+            check_tab_in_indentation(lexer, line, indent);
             add_new_key(std::move(node), line, indent);
         }
         else {

--- a/include/fkYAML/detail/input/lexical_analyzer.hpp
+++ b/include/fkYAML/detail/input/lexical_analyzer.hpp
@@ -58,6 +58,7 @@ class lexical_analyzer {
         lexical_token token;
         uint32_t begin_pos {0};
         uint32_t begin_line {0};
+        const char* begin_itr {nullptr};
     };
 
     // whether the current context is flow(1) or block(0)
@@ -71,7 +72,8 @@ public:
     explicit lexical_analyzer(str_view input_buffer) noexcept
         : m_begin_itr(input_buffer.begin()),
           m_cur_itr(input_buffer.begin()),
-          m_end_itr(input_buffer.end()) {
+          m_end_itr(input_buffer.end()),
+          m_last_token_begin_itr(input_buffer.begin()) {
         m_pos_tracker.set_target_buffer(input_buffer);
     }
 
@@ -89,6 +91,7 @@ public:
 
         m_last_token_begin_pos = info.begin_pos;
         m_last_token_begin_line = info.begin_line;
+        m_last_token_begin_itr = info.begin_itr;
         return info.token;
     }
 
@@ -107,6 +110,16 @@ public:
     /// @return uint32_t The beginning position of a last token.
     uint32_t get_last_token_begin_pos() const noexcept {
         return m_last_token_begin_pos;
+    }
+
+    /// @brief Check whether a tab character is used within the indentation of the last token line.
+    /// @note Indentation must consist of spaces only, so a tab which appears before the given width
+    /// cannot be part of it. A tab which follows the indentation is valid separation white space.
+    /// https://yaml.org/spec/1.2.2/#61-indentation-spaces
+    /// @param indent The indentation width required at the beginning of the last token line.
+    /// @return true if a tab appears before the required indentation, false otherwise.
+    bool has_tab_in_indentation(uint32_t indent) const noexcept {
+        return has_tab_before(m_last_token_begin_itr, indent);
     }
 
     /// @brief Get the number of lines already processed.
@@ -145,6 +158,9 @@ public:
         m_state &= ~flow_context_bit;
         if (is_flow_context) {
             m_state |= flow_context_bit;
+            // The outermost flow collection owns the indentation which its lines must have. Only that
+            // one reaches here, since the deserializer enters the flow context from the block one alone.
+            m_flow_required_indent = get_required_continuation_indent();
         }
     }
 
@@ -166,10 +182,16 @@ private:
         token_info info {};
         info.begin_pos = m_pos_tracker.get_cur_pos_in_line();
         info.begin_line = m_pos_tracker.get_lines_read();
+        info.begin_itr = m_token_begin_itr;
 
         if (m_cur_itr == m_end_itr) {
             info.token.type = lexical_token_t::END_OF_BUFFER;
             return info;
+        }
+
+        const bool continues_flow_line = (m_state & flow_context_bit) != 0 && info.begin_line > m_last_token_begin_line;
+        if FK_YAML_UNLIKELY (continues_flow_line && has_tab_before(m_token_begin_itr, m_flow_required_indent)) {
+            emit_error("A tab character cannot be used as indentation.");
         }
 
         switch (*m_cur_itr) {
@@ -179,7 +201,9 @@ private:
                 return info;
             }
 
-            if (*m_cur_itr == ' ') {
+            // Any separation white space may follow the explicit key indicator, just like the block
+            // sequence entry indicator. https://yaml.org/spec/1.2.2/#rule-c-l-block-map-explicit-key
+            if (*m_cur_itr == ' ' || *m_cur_itr == '\t') {
                 info.token.type = lexical_token_t::EXPLICIT_KEY_PREFIX;
                 return info;
             }
@@ -928,6 +952,76 @@ private:
         return tag_name;
     }
 
+    /// @brief Check that the continuation lines of a multi-line token are indented with spaces.
+    /// @note A node continues on lines which are indented at least as deep as itself, and indentation
+    /// consists of spaces only. A tab which follows that indentation is valid separation white space,
+    /// and a line which holds nothing but white space is empty.
+    /// https://yaml.org/spec/1.2.2/#rule-s-flow-line-prefix
+    /// @param content The token contents, which may span multiple lines.
+    void check_continuation_indent(str_view content) {
+        const uint32_t required = get_required_continuation_indent();
+
+        for (std::size_t pos = content.find('\n'); pos != str_view::npos; pos = content.find('\n', pos + 1)) {
+            const std::size_t line_begin_pos = pos + 1;
+            const std::size_t content_pos = content.find_first_not_of(" \t", line_begin_pos);
+            const bool is_empty_line = (content_pos == str_view::npos) || content[content_pos] == '\n';
+            if (is_empty_line) {
+                continue;
+            }
+
+            const std::size_t tab_pos = content.find('\t', line_begin_pos);
+            if FK_YAML_UNLIKELY (tab_pos < content_pos && tab_pos - line_begin_pos < required) {
+                m_cur_itr = content.begin() + content_pos;
+                emit_error("A tab character cannot be used as indentation.");
+            }
+        }
+    }
+
+    /// @brief Get the indentation which the continuation lines of the current token must have.
+    /// @note A token which begins a line is the node at that indentation, so its continuation lines only
+    /// need the same one. A token preceded by something else on its line, a mapping value for instance,
+    /// belongs to a collection which owns that indentation, so its own contents must be indented deeper.
+    /// ```yaml
+    /// "1st          # the scalar is the node at column 0, so 0 is required
+    /// 2nd"
+    /// foo: "1st     # the scalar belongs to a mapping at column 0, so 1 is required
+    ///  2nd"
+    /// ```
+    /// @return uint32_t The indentation width required for the continuation lines.
+    uint32_t get_required_continuation_indent() const noexcept {
+        const char* p_line_begin = find_line_begin(m_token_begin_itr);
+
+        uint32_t indent = 0;
+        while (p_line_begin + indent < m_token_begin_itr && p_line_begin[indent] == ' ') {
+            ++indent;
+        }
+
+        // The token of a quoted scalar begins just after its opening quotation mark, which is the real
+        // beginning of the node, so one extra column still counts as beginning the line.
+        const bool begins_the_line = (m_token_begin_itr <= p_line_begin + indent + 1);
+        return begins_the_line ? indent : indent + 1;
+    }
+
+    /// @brief Check whether a tab appears before the given column on the line of `p_token_begin`.
+    /// @param p_token_begin The beginning of the token whose line is inspected.
+    /// @param indent The indentation width required at the beginning of that line.
+    /// @return true if a tab appears before the required indentation, false otherwise.
+    bool has_tab_before(const char* p_token_begin, uint32_t indent) const noexcept {
+        const char* p_line_begin = find_line_begin(p_token_begin);
+        const str_view line_head {p_line_begin, static_cast<std::size_t>(p_token_begin - p_line_begin)};
+        return line_head.find('\t') < indent;
+    }
+
+    /// @brief Get the beginning of the line which contains the given position.
+    /// @param p The position to start from.
+    /// @return const char* The beginning of its line.
+    const char* find_line_begin(const char* p) const noexcept {
+        while (p != m_begin_itr && *(p - 1) != '\n') {
+            --p;
+        }
+        return p;
+    }
+
     /// @brief Determines the range of single quoted scalar by scanning remaining input buffer contents.
     /// @return A single quoted scalar.
     str_view determine_single_quoted_scalar_range() {
@@ -941,6 +1035,7 @@ private:
                 m_cur_itr = m_token_begin_itr + (pos + 1);
                 str_view single_quoted_scalar {m_token_begin_itr, pos};
                 check_scalar_content(single_quoted_scalar);
+                check_continuation_indent(single_quoted_scalar);
                 return single_quoted_scalar;
             }
 
@@ -992,6 +1087,7 @@ private:
                 m_cur_itr = m_token_begin_itr + (pos + 1);
                 str_view double_quoted_scalar {m_token_begin_itr, pos};
                 check_scalar_content(double_quoted_scalar);
+                check_continuation_indent(double_quoted_scalar);
                 return double_quoted_scalar;
             }
 
@@ -1478,6 +1574,10 @@ private:
     str_view m_tag_prefix;
     /// The last block scalar header.
     block_scalar_header m_block_scalar_header {};
+    /// The beginning of the last lexical token, used to inspect the indentation of its line.
+    const char* m_last_token_begin_itr;
+    /// The indentation which the lines of the current flow collection must have.
+    uint32_t m_flow_required_indent {0};
     /// The beginning position of the last lexical token. (zero origin)
     uint32_t m_last_token_begin_pos {0};
     /// The beginning line of the last lexical token. (zero origin)

--- a/single_include/fkYAML/node.hpp
+++ b/single_include/fkYAML/node.hpp
@@ -3331,6 +3331,7 @@ class lexical_analyzer {
         lexical_token token;
         uint32_t begin_pos {0};
         uint32_t begin_line {0};
+        const char* begin_itr {nullptr};
     };
 
     // whether the current context is flow(1) or block(0)
@@ -3344,7 +3345,8 @@ public:
     explicit lexical_analyzer(str_view input_buffer) noexcept
         : m_begin_itr(input_buffer.begin()),
           m_cur_itr(input_buffer.begin()),
-          m_end_itr(input_buffer.end()) {
+          m_end_itr(input_buffer.end()),
+          m_last_token_begin_itr(input_buffer.begin()) {
         m_pos_tracker.set_target_buffer(input_buffer);
     }
 
@@ -3362,6 +3364,7 @@ public:
 
         m_last_token_begin_pos = info.begin_pos;
         m_last_token_begin_line = info.begin_line;
+        m_last_token_begin_itr = info.begin_itr;
         return info.token;
     }
 
@@ -3380,6 +3383,16 @@ public:
     /// @return uint32_t The beginning position of a last token.
     uint32_t get_last_token_begin_pos() const noexcept {
         return m_last_token_begin_pos;
+    }
+
+    /// @brief Check whether a tab character is used within the indentation of the last token line.
+    /// @note Indentation must consist of spaces only, so a tab which appears before the given width
+    /// cannot be part of it. A tab which follows the indentation is valid separation white space.
+    /// https://yaml.org/spec/1.2.2/#61-indentation-spaces
+    /// @param indent The indentation width required at the beginning of the last token line.
+    /// @return true if a tab appears before the required indentation, false otherwise.
+    bool has_tab_in_indentation(uint32_t indent) const noexcept {
+        return has_tab_before(m_last_token_begin_itr, indent);
     }
 
     /// @brief Get the number of lines already processed.
@@ -3418,6 +3431,9 @@ public:
         m_state &= ~flow_context_bit;
         if (is_flow_context) {
             m_state |= flow_context_bit;
+            // The outermost flow collection owns the indentation which its lines must have. Only that
+            // one reaches here, since the deserializer enters the flow context from the block one alone.
+            m_flow_required_indent = get_required_continuation_indent();
         }
     }
 
@@ -3439,10 +3455,16 @@ private:
         token_info info {};
         info.begin_pos = m_pos_tracker.get_cur_pos_in_line();
         info.begin_line = m_pos_tracker.get_lines_read();
+        info.begin_itr = m_token_begin_itr;
 
         if (m_cur_itr == m_end_itr) {
             info.token.type = lexical_token_t::END_OF_BUFFER;
             return info;
+        }
+
+        const bool continues_flow_line = (m_state & flow_context_bit) != 0 && info.begin_line > m_last_token_begin_line;
+        if FK_YAML_UNLIKELY (continues_flow_line && has_tab_before(m_token_begin_itr, m_flow_required_indent)) {
+            emit_error("A tab character cannot be used as indentation.");
         }
 
         switch (*m_cur_itr) {
@@ -3452,7 +3474,9 @@ private:
                 return info;
             }
 
-            if (*m_cur_itr == ' ') {
+            // Any separation white space may follow the explicit key indicator, just like the block
+            // sequence entry indicator. https://yaml.org/spec/1.2.2/#rule-c-l-block-map-explicit-key
+            if (*m_cur_itr == ' ' || *m_cur_itr == '\t') {
                 info.token.type = lexical_token_t::EXPLICIT_KEY_PREFIX;
                 return info;
             }
@@ -4201,6 +4225,76 @@ private:
         return tag_name;
     }
 
+    /// @brief Check that the continuation lines of a multi-line token are indented with spaces.
+    /// @note A node continues on lines which are indented at least as deep as itself, and indentation
+    /// consists of spaces only. A tab which follows that indentation is valid separation white space,
+    /// and a line which holds nothing but white space is empty.
+    /// https://yaml.org/spec/1.2.2/#rule-s-flow-line-prefix
+    /// @param content The token contents, which may span multiple lines.
+    void check_continuation_indent(str_view content) {
+        const uint32_t required = get_required_continuation_indent();
+
+        for (std::size_t pos = content.find('\n'); pos != str_view::npos; pos = content.find('\n', pos + 1)) {
+            const std::size_t line_begin_pos = pos + 1;
+            const std::size_t content_pos = content.find_first_not_of(" \t", line_begin_pos);
+            const bool is_empty_line = (content_pos == str_view::npos) || content[content_pos] == '\n';
+            if (is_empty_line) {
+                continue;
+            }
+
+            const std::size_t tab_pos = content.find('\t', line_begin_pos);
+            if FK_YAML_UNLIKELY (tab_pos < content_pos && tab_pos - line_begin_pos < required) {
+                m_cur_itr = content.begin() + content_pos;
+                emit_error("A tab character cannot be used as indentation.");
+            }
+        }
+    }
+
+    /// @brief Get the indentation which the continuation lines of the current token must have.
+    /// @note A token which begins a line is the node at that indentation, so its continuation lines only
+    /// need the same one. A token preceded by something else on its line, a mapping value for instance,
+    /// belongs to a collection which owns that indentation, so its own contents must be indented deeper.
+    /// ```yaml
+    /// "1st          # the scalar is the node at column 0, so 0 is required
+    /// 2nd"
+    /// foo: "1st     # the scalar belongs to a mapping at column 0, so 1 is required
+    ///  2nd"
+    /// ```
+    /// @return uint32_t The indentation width required for the continuation lines.
+    uint32_t get_required_continuation_indent() const noexcept {
+        const char* p_line_begin = find_line_begin(m_token_begin_itr);
+
+        uint32_t indent = 0;
+        while (p_line_begin + indent < m_token_begin_itr && p_line_begin[indent] == ' ') {
+            ++indent;
+        }
+
+        // The token of a quoted scalar begins just after its opening quotation mark, which is the real
+        // beginning of the node, so one extra column still counts as beginning the line.
+        const bool begins_the_line = (m_token_begin_itr <= p_line_begin + indent + 1);
+        return begins_the_line ? indent : indent + 1;
+    }
+
+    /// @brief Check whether a tab appears before the given column on the line of `p_token_begin`.
+    /// @param p_token_begin The beginning of the token whose line is inspected.
+    /// @param indent The indentation width required at the beginning of that line.
+    /// @return true if a tab appears before the required indentation, false otherwise.
+    bool has_tab_before(const char* p_token_begin, uint32_t indent) const noexcept {
+        const char* p_line_begin = find_line_begin(p_token_begin);
+        const str_view line_head {p_line_begin, static_cast<std::size_t>(p_token_begin - p_line_begin)};
+        return line_head.find('\t') < indent;
+    }
+
+    /// @brief Get the beginning of the line which contains the given position.
+    /// @param p The position to start from.
+    /// @return const char* The beginning of its line.
+    const char* find_line_begin(const char* p) const noexcept {
+        while (p != m_begin_itr && *(p - 1) != '\n') {
+            --p;
+        }
+        return p;
+    }
+
     /// @brief Determines the range of single quoted scalar by scanning remaining input buffer contents.
     /// @return A single quoted scalar.
     str_view determine_single_quoted_scalar_range() {
@@ -4214,6 +4308,7 @@ private:
                 m_cur_itr = m_token_begin_itr + (pos + 1);
                 str_view single_quoted_scalar {m_token_begin_itr, pos};
                 check_scalar_content(single_quoted_scalar);
+                check_continuation_indent(single_quoted_scalar);
                 return single_quoted_scalar;
             }
 
@@ -4265,6 +4360,7 @@ private:
                 m_cur_itr = m_token_begin_itr + (pos + 1);
                 str_view double_quoted_scalar {m_token_begin_itr, pos};
                 check_scalar_content(double_quoted_scalar);
+                check_continuation_indent(double_quoted_scalar);
                 return double_quoted_scalar;
             }
 
@@ -4751,6 +4847,10 @@ private:
     str_view m_tag_prefix;
     /// The last block scalar header.
     block_scalar_header m_block_scalar_header {};
+    /// The beginning of the last lexical token, used to inspect the indentation of its line.
+    const char* m_last_token_begin_itr;
+    /// The indentation which the lines of the current flow collection must have.
+    uint32_t m_flow_required_indent {0};
     /// The beginning position of the last lexical token. (zero origin)
     uint32_t m_last_token_begin_pos {0};
     /// The beginning line of the last lexical token. (zero origin)
@@ -7883,6 +7983,7 @@ private:
 
         switch (token.type) {
         case lexical_token_t::SEQUENCE_BLOCK_PREFIX: {
+            check_tab_in_indentation(lexer, lexer.get_lines_processed(), lexer.get_last_token_begin_pos());
             root = basic_node_type::sequence({basic_node_type()});
             apply_directive_set(root);
             if (found_props) {
@@ -8182,6 +8283,8 @@ private:
 
                 token = lexer.get_next_token();
                 if (token.type == lexical_token_t::SEQUENCE_BLOCK_PREFIX) {
+                    check_tab_in_indentation(lexer, lexer.get_lines_processed(), lexer.get_last_token_begin_pos());
+
                     // The key node is owned by its context until the corresponding KEY_SEPARATOR event.
                     std::unique_ptr<basic_node_type> key_node(new basic_node_type(node_type::SEQUENCE));
                     basic_node_type* p_node = key_node.get();
@@ -8468,6 +8571,7 @@ private:
                 // ```
                 continue;
             case lexical_token_t::SEQUENCE_BLOCK_PREFIX: {
+                check_tab_in_indentation(lexer, lexer.get_lines_processed(), lexer.get_last_token_begin_pos());
                 if FK_YAML_UNLIKELY (m_flow_context_depth > 0) {
                     throw parse_error("A block sequence entry is not allowed in the flow context.", line, indent);
                 }
@@ -8946,6 +9050,22 @@ private:
         return prop_specified;
     }
 
+    /// @brief Reject a tab character used as the indentation of a block collection.
+    /// @note Indentation must consist of spaces only, while a tab which follows it is valid separation
+    /// white space. See https://yaml.org/spec/1.2.2/#61-indentation-spaces for more details.
+    /// ```yaml
+    /// -\t-    # the nested sequence is indented with a tab, which is an error
+    /// -\t-1   # the tab only separates the entry from its scalar, which is valid
+    /// ```
+    /// @param lexer The lexical analyzer to be used.
+    /// @param line The line of the node which begins the block collection.
+    /// @param indent The indentation width of the node which begins the block collection.
+    void check_tab_in_indentation(lexer_type& lexer, const uint32_t line, const uint32_t indent) const {
+        if FK_YAML_UNLIKELY (m_flow_context_depth == 0 && lexer.has_tab_in_indentation(indent)) {
+            throw parse_error("A tab character cannot be used as indentation.", line, indent);
+        }
+    }
+
     /// @brief Add new key string to the current YAML node.
     /// @param key a key string to be added to the current YAML node.
     /// @param line The line where the key is found.
@@ -9064,6 +9184,7 @@ private:
                         lexer.get_last_token_begin_pos());
                 }
             }
+            check_tab_in_indentation(lexer, line, indent);
             add_new_key(std::move(node), line, indent);
         }
         else if (token.type == lexical_token_t::KEY_SEPARATOR) {
@@ -9115,6 +9236,7 @@ private:
                             // # -> {foo: null, bar: 123}
                             // ```
                             add_explicit_key_with_null_value();
+                            check_tab_in_indentation(lexer, line, indent);
                             add_new_key(std::move(node), line, indent);
                             indent = lexer.get_last_token_begin_pos();
                             line = lexer.get_lines_processed();
@@ -9140,6 +9262,7 @@ private:
                             pop_to_parent_node(line, indent, [indent](const parse_context& c) {
                                 return c.state == context_state_t::BLOCK_MAPPING && indent == c.indent;
                             });
+                            check_tab_in_indentation(lexer, line, indent);
                             add_new_key(std::move(node), line, indent);
                             indent = lexer.get_last_token_begin_pos();
                             line = lexer.get_lines_processed();
@@ -9180,6 +9303,7 @@ private:
                     }
                 }
             }
+            check_tab_in_indentation(lexer, line, indent);
             add_new_key(std::move(node), line, indent);
         }
         else {

--- a/tests/unit_test/test_deserializer_class.cpp
+++ b/tests/unit_test/test_deserializer_class.cpp
@@ -4098,3 +4098,96 @@ TEST_CASE("Deserializer_MultipleDocuments") {
         REQUIRE(docs[1].is_null());
     }
 }
+
+TEST_CASE("Deserializer_TabInIndentation") {
+    fkyaml::detail::basic_deserializer<fkyaml::node> deserializer;
+    fkyaml::node root;
+
+    SUBCASE("a tab cannot indent a block collection") {
+        auto input = GENERATE(
+            std::string("-\t-\n"),        // a nested sequence after the entry indicator
+            std::string("- \t-\n"),       // ... with the tab following a space
+            std::string("?\t-\n"),        // a sequence as an explicit key
+            std::string("?\tkey:\n"),     // a mapping as an explicit key
+            std::string("? -\n:\t-\n"),   // a sequence as an explicit value
+            std::string("a:\n\tb: 1\n")); // a mapping entry indented with a tab
+
+        REQUIRE_THROWS_AS(root = deserializer.deserialize(fkyaml::detail::input_adapter(input)), fkyaml::parse_error);
+    }
+
+    SUBCASE("a tab which only separates tokens is valid") {
+        SUBCASE("before a scalar entry") {
+            std::string input = "-\t-1\n";
+            REQUIRE_NOTHROW(root = deserializer.deserialize(fkyaml::detail::input_adapter(input)));
+            REQUIRE(root.is_sequence());
+            REQUIRE(root.size() == 1);
+            REQUIRE(root[0].get_value<int>() == -1);
+        }
+
+        SUBCASE("after the indentation of a mapping value") {
+            std::string input = "foo:\n \tbar\n";
+            REQUIRE_NOTHROW(root = deserializer.deserialize(fkyaml::detail::input_adapter(input)));
+            REQUIRE(root["foo"].as_str() == "bar");
+        }
+
+        SUBCASE("after a mapping value indicator") {
+            std::string input = "foo:\t bar\n";
+            REQUIRE_NOTHROW(root = deserializer.deserialize(fkyaml::detail::input_adapter(input)));
+            REQUIRE(root["foo"].as_str() == "bar");
+        }
+
+        SUBCASE("after an explicit key indicator") {
+            std::string input = "?\tfoo\n: bar\n";
+            REQUIRE_NOTHROW(root = deserializer.deserialize(fkyaml::detail::input_adapter(input)));
+            REQUIRE(root["foo"].as_str() == "bar");
+        }
+
+        SUBCASE("on an otherwise empty line") {
+            std::string input = "foo: 1\n\t\nbar: 2\n";
+            REQUIRE_NOTHROW(root = deserializer.deserialize(fkyaml::detail::input_adapter(input)));
+            REQUIRE(root.size() == 2);
+        }
+    }
+
+    SUBCASE("a tab cannot indent a continuation line") {
+        auto input = GENERATE(
+            std::string("foo: \"bar\n\tbaz\"\n"),    // of a multi-line quoted scalar
+            std::string("- [\n\tfoo,\n foo\n ]\n")); // of a multi-line flow collection
+
+        REQUIRE_THROWS_AS(root = deserializer.deserialize(fkyaml::detail::input_adapter(input)), fkyaml::parse_error);
+    }
+
+    SUBCASE("a tab after the indentation of a continuation line is valid") {
+        SUBCASE("in a quoted scalar") {
+            std::string input = "foo: \"bar\n  \tbaz\"\n";
+            REQUIRE_NOTHROW(root = deserializer.deserialize(fkyaml::detail::input_adapter(input)));
+            REQUIRE(root["foo"].as_str() == "bar baz");
+        }
+
+        SUBCASE("in a quoted scalar which contains an empty line") {
+            // An empty line may hold white space of any kind, tabs included.
+            std::string input = "foo: \"bar\n\n  \tbaz\"\n";
+            REQUIRE_NOTHROW(root = deserializer.deserialize(fkyaml::detail::input_adapter(input)));
+            REQUIRE(root["foo"].as_str() == "bar\nbaz");
+        }
+
+        SUBCASE("in a quoted scalar which ends with a white space only line") {
+            std::string input = "foo: \"bar\n\t\"\n";
+            REQUIRE_NOTHROW(root = deserializer.deserialize(fkyaml::detail::input_adapter(input)));
+            REQUIRE(root["foo"].as_str() == "bar ");
+        }
+
+        SUBCASE("in a flow collection") {
+            std::string input = "- [\n\t\n foo\n ]\n";
+            REQUIRE_NOTHROW(root = deserializer.deserialize(fkyaml::detail::input_adapter(input)));
+            REQUIRE(root[0][0].as_str() == "foo");
+        }
+
+        SUBCASE("in a scalar which is the whole document") {
+            // The node begins the line, so it owns that indentation and needs no more.
+            std::string input = "\"1st\n\t2nd\"\n";
+            REQUIRE_NOTHROW(root = deserializer.deserialize(fkyaml::detail::input_adapter(input)));
+            REQUIRE(root.as_str() == "1st 2nd");
+        }
+    }
+}


### PR DESCRIPTION
Indentation must consist of spaces, while a tab which follows it is valid separation white space. Tabs used where indentation is required are currently accepted:

```yaml
-	-              # a nested sequence indented with a tab
?	key:           # a mapping used as an explicit key
foo: "bar
	baz"           # a continuation line of a quoted scalar
- [
	foo, bar ]     # a continuation line of a flow collection
```

Tabs which only separate tokens keep working:

```yaml
-	-1             # separates the entry from its scalar
foo:
 	bar            # the space indents, the tab follows
"1st
	2nd"           # the scalar begins the line, so it owns that indentation
```

Three places consult the required indentation: the deserializer asks the lexer wherever a block indicator begins a collection, the quoted scalar scanners check their own continuation lines, and the lexer checks each new line within a flow collection. Nothing is tracked while lexing documents which contain no tabs.

`?` also accepts a tab after it now, the same way `-` already did. Without it `?\t` was not an explicit key indicator at all.

Refs https://github.com/fktn-k/fkYAML/discussions/591 (first group).

### Results

yaml-test-suite: 78 -> 70 failures with no regressions. `4EJS`, `DK95-01`, `Y79Y-003`, `Y79Y-004`, `Y79Y-005`, `Y79Y-006`, `Y79Y-007` and `Y79Y-008` now pass, which covers every case the suite marks invalid because of a tab. The 45 valid cases which contain tabs are unaffected.

---

## Pull Request Checklist

Read the [CONTRIBUTING.md](https://github.com/fktn-k/fkYAML/blob/develop/.github/CONTRIBUTING.md) file for detailed information.  

- [x] Changes are described in the pull request or in a referenced [issue](https://github.com/fktn-k/fkYAML/issues).
- [x] The test suite compiles and runs without any error.
- [x] [The code coverage](https://coveralls.io/github/fktn-k/fkYAML) on your branch is 100%.
- [x] The documentation is updated if you added/changed a feature.

## Please don't

- The C++11 support varies between different **compilers** and versions. Please note the [list of supported compilers](https://github.com/fktn-k/fkYAML/blob/develop/README.md#supported-compilers). Some compilers like GCC 4.7 (and earlier), Clang 3.3 (and earlier), or Microsoft Visual Studio 13.0 and earlier are known not to work due to missing or incomplete C++11 support. Please refrain from proposing changes that work around these compiler's limitations with `#ifdef`s or other means.
- Please refrain from proposing changes that would **break [YAML](https://yaml.org/) specifications**. If you propose a conformant extension of YAML to be supported by the library, please motivate this extension.
- Please do not open pull requests that address **multiple issues**.
