### PR TITLE
Terminate a block scalar when a document marker begins a content line

### DIFF
--- a/include/fkYAML/detail/input/lexical_analyzer.hpp
+++ b/include/fkYAML/detail/input/lexical_analyzer.hpp
@@ -492,6 +492,14 @@ private:
             return false;
         }
 
+        return begins_document_marker(sv, pos);
+    }
+
+    /// @brief Checks if the given position begins a document marker (`---` or `...`).
+    /// @param sv The buffer contents being scanned.
+    /// @param pos The position to inspect.
+    /// @return true if a document marker begins at the given position.
+    static bool begins_document_marker(str_view sv, std::size_t pos) noexcept {
         const bool begins_marker = (sv.compare(pos, 3, "---") == 0) || (sv.compare(pos, 3, "...") == 0);
         return begins_marker && is_followed_by_white_space(sv, pos + 3);
     }
@@ -1335,6 +1343,15 @@ private:
 
             FK_YAML_ASSERT(last_newline_pos < cur_line_content_begin_pos);
             cur_indent = static_cast<uint32_t>(cur_line_content_begin_pos - last_newline_pos - 1);
+
+            const bool line_starts_with_document_marker =
+                is_document_root && cur_indent == 0 && begins_document_marker(sv, cur_line_content_begin_pos);
+            if (line_starts_with_document_marker) {
+                // The content lines are forbidden to begin with document markers (`---` or `...`).
+                // https://yaml.org/spec/1.2.2/#912-document-markers
+                break;
+            }
+
             if (cur_indent < content_indent && sv[cur_line_content_begin_pos] != '\n') {
                 // Trailing comments may be less indented than the contents, so they end the block scalar
                 // instead of being part of it.

--- a/single_include/fkYAML/node.hpp
+++ b/single_include/fkYAML/node.hpp
@@ -3765,6 +3765,14 @@ private:
             return false;
         }
 
+        return begins_document_marker(sv, pos);
+    }
+
+    /// @brief Checks if the given position begins a document marker (`---` or `...`).
+    /// @param sv The buffer contents being scanned.
+    /// @param pos The position to inspect.
+    /// @return true if a document marker begins at the given position.
+    static bool begins_document_marker(str_view sv, std::size_t pos) noexcept {
         const bool begins_marker = (sv.compare(pos, 3, "---") == 0) || (sv.compare(pos, 3, "...") == 0);
         return begins_marker && is_followed_by_white_space(sv, pos + 3);
     }
@@ -4608,6 +4616,15 @@ private:
 
             FK_YAML_ASSERT(last_newline_pos < cur_line_content_begin_pos);
             cur_indent = static_cast<uint32_t>(cur_line_content_begin_pos - last_newline_pos - 1);
+
+            const bool line_starts_with_document_marker =
+                is_document_root && cur_indent == 0 && begins_document_marker(sv, cur_line_content_begin_pos);
+            if (line_starts_with_document_marker) {
+                // The content lines are forbidden to begin with document markers (`---` or `...`).
+                // https://yaml.org/spec/1.2.2/#912-document-markers
+                break;
+            }
+
             if (cur_indent < content_indent && sv[cur_line_content_begin_pos] != '\n') {
                 // Trailing comments may be less indented than the contents, so they end the block scalar
                 // instead of being part of it.

--- a/tests/unit_test/test_deserializer_class.cpp
+++ b/tests/unit_test/test_deserializer_class.cpp
@@ -496,6 +496,30 @@ TEST_CASE("Deserializer_DocumentLevelBlockScalar") {
             std::string("--- foo: >\nline1\n"), std::string("--- -x: >\nline1\n"), std::string("--- --x: >\nline1\n"));
         REQUIRE_THROWS_AS(root = deserializer.deserialize(fkyaml::detail::input_adapter(input)), fkyaml::parse_error);
     }
+
+    SUBCASE("a block scalar content is terminated by a directive end marker") {
+        std::string input = "--- >\nline1\nline2\n---\n";
+        REQUIRE_NOTHROW(root = deserializer.deserialize(fkyaml::detail::input_adapter(input)));
+
+        REQUIRE(root.is_string());
+        REQUIRE(root.as_str() == "line1 line2\n");
+    }
+
+    SUBCASE("a block scalar content is terminated by an end-of-document marker") {
+        std::string input = "--- |\nline1\nline2\n...\n";
+        REQUIRE_NOTHROW(root = deserializer.deserialize(fkyaml::detail::input_adapter(input)));
+
+        REQUIRE(root.is_string());
+        REQUIRE(root.as_str() == "line1\nline2\n");
+    }
+
+    SUBCASE("a block scalar content is not terminated by \"---\" followed by non-space characters") {
+        std::string input = "--- |\nline1\nline2\n---foo\n";
+        REQUIRE_NOTHROW(root = deserializer.deserialize(fkyaml::detail::input_adapter(input)));
+
+        REQUIRE(root.is_string());
+        REQUIRE(root.as_str() == "line1\nline2\n---foo\n");
+    }
 }
 
 TEST_CASE("Deserializer_MultilinePlainScalarInBlockContext") {


### PR DESCRIPTION
This PR is a follow up to #589 and improves the YAML parser's handling of document markers within a document-level block scalars. The main changes include updating the lexical analyzer to correctly detect and handle document markers (`---` and `...`) at the start of lines within block scalars, and adding comprehensive unit tests to validate the new behavior.

## Changes

* Updated the `lexical_analyzer` class to break out of block scalar parsing when a document marker (`---` or `...`) is encountered at the start of a line at the document root, as required by [the YAML specification](https://yaml.org/spec/1.2.2/#912-document-markers).
* Added a helper method `begins_document_marker` to encapsulate the logic for detecting document markers at a given position in the buffer.

## Testing

* Introduced new unit tests in `test_deserializer_class.cpp` to verify that block scalar content is terminated by document markers and not by markers followed by non-space characters, ensuring correct and robust parsing behavior.
* `Y4TN` in the YAML test suite is now deserialized correctly. As a result, 70 failing cases has decreased to 69 with no newly failing case.

---

## Pull Request Checklist

Read the [CONTRIBUTING.md](https://github.com/fktn-k/fkYAML/blob/develop/.github/CONTRIBUTING.md) file for detailed information.  

- [x] Changes are described in the pull request or in a referenced [issue](https://github.com/fktn-k/fkYAML/issues).
- [x] The test suite compiles and runs without any error.
- [x] [The code coverage](https://coveralls.io/github/fktn-k/fkYAML) on your branch is 100%.
- [x] The documentation is updated if you added/changed a feature.

## Please don't

- The C++11 support varies between different **compilers** and versions. Please note the [list of supported compilers](https://github.com/fktn-k/fkYAML/blob/develop/README.md#supported-compilers). Some compilers like GCC 4.7 (and earlier), Clang 3.3 (and earlier), or Microsoft Visual Studio 13.0 and earlier are known not to work due to missing or incomplete C++11 support. Please refrain from proposing changes that work around these compiler's limitations with `#ifdef`s or other means.
- Please refrain from proposing changes that would **break [YAML](https://yaml.org/) specifications**. If you propose a conformant extension of YAML to be supported by the library, please motivate this extension.
- Please do not open pull requests that address **multiple issues**.
