### PR TITLE
Emit an error on an end-of-document marker followed by non-whitespace characters

### DIFF
--- a/include/fkYAML/detail/input/lexical_analyzer.hpp
+++ b/include/fkYAML/detail/input/lexical_analyzer.hpp
@@ -368,21 +368,15 @@ private:
                 if FK_YAML_LIKELY (rem_size > 2) {
                     const bool is_doc_end = std::equal(m_cur_itr, m_cur_itr + 3, "...");
                     if (is_doc_end) {
-                        if (rem_size > 3) {
-                            switch (*(m_cur_itr + 3)) {
-                            case ' ':
-                            case '\t':
-                            case '\n':
-                                m_cur_itr += 4;
-                                break;
-                            default:
-                                // See https://yaml.org/spec/1.2.2/#912-document-markers for more details.
-                                emit_error("The document end marker \"...\" must not be followed by non-ws char.");
-                            }
+                        const char* cur_itr = m_cur_itr + 3;
+                        while (cur_itr != m_end_itr && (*cur_itr == ' ' || *cur_itr == '\t')) {
+                            ++cur_itr;
                         }
-                        else {
-                            m_cur_itr += 3;
+                        if FK_YAML_UNLIKELY (cur_itr != m_end_itr && *cur_itr != '\n' && *cur_itr != '#') {
+                            // See https://yaml.org/spec/1.2.2/#912-document-markers for more details.
+                            emit_error("The document end marker \"...\" must not be followed by non-ws char.");
                         }
+                        m_cur_itr = cur_itr;
                         info.token.type = lexical_token_t::END_OF_DOCUMENT;
                         return info;
                     }

--- a/single_include/fkYAML/node.hpp
+++ b/single_include/fkYAML/node.hpp
@@ -3641,21 +3641,15 @@ private:
                 if FK_YAML_LIKELY (rem_size > 2) {
                     const bool is_doc_end = std::equal(m_cur_itr, m_cur_itr + 3, "...");
                     if (is_doc_end) {
-                        if (rem_size > 3) {
-                            switch (*(m_cur_itr + 3)) {
-                            case ' ':
-                            case '\t':
-                            case '\n':
-                                m_cur_itr += 4;
-                                break;
-                            default:
-                                // See https://yaml.org/spec/1.2.2/#912-document-markers for more details.
-                                emit_error("The document end marker \"...\" must not be followed by non-ws char.");
-                            }
+                        const char* cur_itr = m_cur_itr + 3;
+                        while (cur_itr != m_end_itr && (*cur_itr == ' ' || *cur_itr == '\t')) {
+                            ++cur_itr;
                         }
-                        else {
-                            m_cur_itr += 3;
+                        if FK_YAML_UNLIKELY (cur_itr != m_end_itr && *cur_itr != '\n' && *cur_itr != '#') {
+                            // See https://yaml.org/spec/1.2.2/#912-document-markers for more details.
+                            emit_error("The document end marker \"...\" must not be followed by non-ws char.");
                         }
+                        m_cur_itr = cur_itr;
                         info.token.type = lexical_token_t::END_OF_DOCUMENT;
                         return info;
                     }

--- a/tests/unit_test/test_lexical_analyzer_class.cpp
+++ b/tests/unit_test/test_lexical_analyzer_class.cpp
@@ -241,8 +241,17 @@ TEST_CASE("LexicalAnalyzer_EndOfDocuments") {
         REQUIRE(token.type == fkyaml::detail::lexical_token_t::END_OF_BUFFER);
     }
 
+    SUBCASE("document end marker followed by a comment") {
+        fkyaml::detail::lexical_analyzer lexer("... # comment");
+        REQUIRE_NOTHROW(token = lexer.get_next_token());
+        REQUIRE(token.type == fkyaml::detail::lexical_token_t::END_OF_DOCUMENT);
+        REQUIRE_NOTHROW(token = lexer.get_next_token());
+        REQUIRE(token.type == fkyaml::detail::lexical_token_t::END_OF_BUFFER);
+    }
+
     SUBCASE("invalid document end marker") {
-        fkyaml::detail::lexical_analyzer lexer("...invalid");
+        auto input = GENERATE(std::string("...invalid"), std::string("... invalid"));
+        fkyaml::detail::lexical_analyzer lexer(input);
         REQUIRE_THROWS_AS(lexer.get_next_token(), fkyaml::parse_error);
     }
 }


### PR DESCRIPTION
This PR improves the handling of YAML document end markers (`...`) in the lexical analyzer so an end-of-document marker followed by non-whitespace characters is correctly rejected. It also adds new unit tests to ensure correct behavior for valid and invalid document end markers.

## Changes

* Updated the logic in `lexical_analyzer` to skip over any spaces or tabs after the `...` marker, and to ensure that only whitespace, a newline, or a comment (`#`) can follow the marker; otherwise, an error is emitted.

## Testing

* Added a new unit test to verify that a document end marker followed by a comment (e.g., `... # comment`) is correctly recognized as the end of a document, and a document end marker followed by non-whitespace characters is rejected.
* `3HFZ` in the YAML test suite is now correctly rejected. As a result, 69 failing cases has decreased to 68 with no newly failing case.

---

## Pull Request Checklist

Read the [CONTRIBUTING.md](https://github.com/fktn-k/fkYAML/blob/develop/.github/CONTRIBUTING.md) file for detailed information.  

- [x] Changes are described in the pull request or in a referenced [issue](https://github.com/fktn-k/fkYAML/issues).
- [x] The test suite compiles and runs without any error.
- [x] [The code coverage](https://coveralls.io/github/fktn-k/fkYAML) on your branch is 100%.
- [x] The documentation is updated if you added/changed a feature.

## Please don't

- The C++11 support varies between different **compilers** and versions. Please note the [list of supported compilers](https://github.com/fktn-k/fkYAML/blob/develop/README.md#supported-compilers). Some compilers like GCC 4.7 (and earlier), Clang 3.3 (and earlier), or Microsoft Visual Studio 13.0 and earlier are known not to work due to missing or incomplete C++11 support. Please refrain from proposing changes that work around these compiler's limitations with `#ifdef`s or other means.
- Please refrain from proposing changes that would **break [YAML](https://yaml.org/) specifications**. If you propose a conformant extension of YAML to be supported by the library, please motivate this extension.
- Please do not open pull requests that address **multiple issues**.
