### PR TITLE
Fix pkg-config failure on Ubuntu/Debian due to no Name field

### DIFF
--- a/cmake/pkg-config.pc.in
+++ b/cmake/pkg-config.pc.in
@@ -1,4 +1,4 @@
-NAME: ${PROJECT_NAME}
+Name: ${PROJECT_NAME}
 Description: A header-only C++ library for YAML
 Version: ${PROJECT_VERSION}
 Cflags: -I"${CMAKE_INSTALL_FULL_INCLUDEDIR}"


### PR DESCRIPTION
This PR fixes #599, fkYAML cannot be built using pkg-config on some Ubuntu/Debian environment due to the missing Name field in `fkYAML.pc`.  
See the linked issue for details.  

I reproduced the issue on Ubuntu 22.04 and confirmed the issue is resolved with this patch.

---

## Pull Request Checklist

Read the [CONTRIBUTING.md](https://github.com/fktn-k/fkYAML/blob/develop/.github/CONTRIBUTING.md) file for detailed information.  

- [x] Changes are described in the pull request or in a referenced [issue](https://github.com/fktn-k/fkYAML/issues).
- [x] The test suite compiles and runs without any error.
- [x] [The code coverage](https://coveralls.io/github/fktn-k/fkYAML) on your branch is 100%.
- [x] The documentation is updated if you added/changed a feature.

## Please don't

- The C++11 support varies between different **compilers** and versions. Please note the [list of supported compilers](https://github.com/fktn-k/fkYAML/blob/develop/README.md#supported-compilers). Some compilers like GCC 4.7 (and earlier), Clang 3.3 (and earlier), or Microsoft Visual Studio 13.0 and earlier are known not to work due to missing or incomplete C++11 support. Please refrain from proposing changes that work around these compiler's limitations with `#ifdef`s or other means.
- Please refrain from proposing changes that would **break [YAML](https://yaml.org/) specifications**. If you propose a conformant extension of YAML to be supported by the library, please motivate this extension.
- Please do not open pull requests that address **multiple issues**.
