### PR TITLE
Update the YAML libraries used for the benchmark

### DIFF
--- a/README.md
+++ b/README.md
@@ -224,33 +224,33 @@ The following tables are created from the benchmarking results in the following 
 
 | Benchmark                          | processed bytes per second (Release) |
 | ---------------------------------- | ------------------------------------ |
-| fkYAML                             | 77.8628Mi/s                          |
-| libfyaml                           | 34.7381Mi/s                          |
-| rapidyaml<br>(with mutable buff)   | 150.988Mi/s                          |
-| rapidyaml<br>(with immutable buff) | 135.589Mi/s                          |
-| yaml-cpp                           | 10.1239Mi/s                          |
+| fkYAML                             | 76.1277Mi/s                          |
+| libfyaml                           | 35.9803Mi/s                          |
+| rapidyaml<br>(with mutable buff)   | 151.126Mi/s                          |
+| rapidyaml<br>(with immutable buff) | 132.36Mi/s                           |
+| yaml-cpp                           | 10.122Mi/s                           |
 
 ### Parsing [citm_catalog.json](https://github.com/fktn-k/fkYAML/blob/develop/tools/benchmark/cases/citm_catalog.json)
 
 | Benchmark                          | processed bytes per second (Release) |
 | ---------------------------------- | ------------------------------------ |
-| fkYAML                             | 126.783Mi/s                          |
-| libfyaml                           | 49.9466Mi/s                          |
-| rapidyaml<br>(with mutable buff)   | 120.681Mi/s                          |
-| rapidyaml<br>(with immutable buff) | 118.728Mi/s                          |
-| yaml-cpp                           | 16.5976Mi/s                          |
+| fkYAML                             | 121.04Mi/s                          |
+| libfyaml                           | 50.7076Mi/s                          |
+| rapidyaml<br>(with mutable buff)   | 109.535Mi/s                          |
+| rapidyaml<br>(with immutable buff) | 113.083Mi/s                          |
+| yaml-cpp                           | 16.6685Mi/s                          |
 
 ### Parsing [citm_catalog.yml](https://github.com/fktn-k/fkYAML/blob/develop/tools/benchmark/cases/citm_catalog.yml)
 
 | Benchmark                          | processed bytes per second (Release) |
 | ---------------------------------- | ------------------------------------ |
-| fkYAML                             | 55.9384Mi/s                          |
-| libfyaml                           | 21.6074Mi/s                          |
-| rapidyaml<br>(with mutable buff)   | 54.2151Mi/s                          |
-| rapidyaml<br>(with immutable buff) | 53.7195Mi/s                          |
-| yaml-cpp                           | 7.0331Mi/s                           |
+| fkYAML                             | 56.0765Mi/s                          |
+| libfyaml                           | 21.9363Mi/s                          |
+| rapidyaml<br>(with mutable buff)   | 53.6721Mi/s                          |
+| rapidyaml<br>(with immutable buff) | 53.3632Mi/s                          |
+| yaml-cpp                           | 7.30883Mi/s                           |
 
-Although [rapidyaml](https://github.com/biojppm/rapidyaml) focuses on high performance and can be up to about 1.9x faster than fkYAML depending on the input, fkYAML is in general 2.2x to 2.6x faster than [libfyaml](https://github.com/pantoniou/libfyaml) and also more than 7x faster than [yaml-cpp](https://github.com/jbeder/yaml-cpp).  
+Although [rapidyaml](https://github.com/biojppm/rapidyaml) focuses on high performance and can be up to about 2x faster than fkYAML depending on the input, fkYAML is in general 2.1x to 2.6x faster than [libfyaml](https://github.com/pantoniou/libfyaml) and also more than 7x faster than [yaml-cpp](https://github.com/jbeder/yaml-cpp).
 Note that, since fkYAML deserializes scalars into native booleans or integers during the parsing, the performance could be more faster in some use cases since there is no need for string manipulations upon data queries.  
 
 ## Community Support

--- a/tools/benchmark/CMakeLists.txt
+++ b/tools/benchmark/CMakeLists.txt
@@ -11,7 +11,7 @@ set(BENCHMARK_ENABLE_TESTING OFF CACHE BOOL "" FORCE)
 set(BENCHMARK_ENABLE_GTEST_TESTS OFF CACHE BOOL "" FORCE)
 FetchContent_Declare(
   gbench
-  URL https://github.com/google/benchmark/archive/refs/tags/v1.8.4.zip
+  URL https://github.com/google/benchmark/archive/refs/tags/v1.9.5.zip
 )
 FetchContent_MakeAvailable(gbench)
 
@@ -24,7 +24,7 @@ if(NOT WIN32)
   FetchContent_Declare(
     libfyaml
     GIT_REPOSITORY https://github.com/pantoniou/libfyaml
-    GIT_TAG v0.9
+    GIT_TAG v1.0.0-beta1
   )
   FetchContent_MakeAvailable(libfyaml)
 endif()
@@ -33,8 +33,7 @@ endif()
 FetchContent_Declare(
   rapidyaml
   GIT_REPOSITORY https://github.com/biojppm/rapidyaml
-  GIT_TAG v0.7.2
-  GIT_SUBMODULES "ext/c4core"
+  GIT_TAG v0.16.0
 )
 FetchContent_MakeAvailable(rapidyaml)
 
@@ -44,7 +43,7 @@ set(YAML_CPP_BUILD_TOOLS OFF CACHE BOOL "" FORCE)
 FetchContent_Declare(
   yaml_cpp
   GIT_REPOSITORY https://github.com/jbeder/yaml-cpp
-  GIT_TAG 0.8.0
+  GIT_TAG yaml-cpp-0.9.0
 )
 FetchContent_MakeAvailable(yaml_cpp)
 

--- a/tools/benchmark/CMakeLists.txt
+++ b/tools/benchmark/CMakeLists.txt
@@ -19,15 +19,17 @@ FetchContent_MakeAvailable(gbench)
 #   Set up YAML parsers   #
 ###########################
 
-# libfyaml (not implemented for Windows)
-if(NOT WIN32)
-  FetchContent_Declare(
-    libfyaml
-    GIT_REPOSITORY https://github.com/pantoniou/libfyaml
-    GIT_TAG v1.0.0-beta1
-  )
-  FetchContent_MakeAvailable(libfyaml)
-endif()
+# libfyaml
+# build statically so that no shared library has to be found at run time, and disable building
+# its tests, which would download the YAML and JSON test suites.
+set(BUILD_SHARED_LIBS OFF)
+set(BUILD_TESTING OFF)
+FetchContent_Declare(
+  libfyaml
+  GIT_REPOSITORY https://github.com/pantoniou/libfyaml
+  GIT_TAG v1.0.0-beta1
+)
+FetchContent_MakeAvailable(libfyaml)
 
 # rapidyaml
 FetchContent_Declare(
@@ -80,19 +82,8 @@ target_link_libraries(
   benchmarker
   PRIVATE
     fkYAML::fkYAML
+    fyaml
     ryml::ryml
     yaml-cpp::yaml-cpp
     benchmark::benchmark
 )
-if(NOT WIN32)
-  target_link_libraries(
-    benchmarker
-    PRIVATE
-      fyaml
-  )
-  target_compile_definitions(
-    benchmarker
-    PRIVATE
-      FK_YAML_BM_HAS_LIBFYAML
-  )
-endif()

--- a/tools/benchmark/CMakeLists.txt
+++ b/tools/benchmark/CMakeLists.txt
@@ -11,7 +11,7 @@ set(BENCHMARK_ENABLE_TESTING OFF CACHE BOOL "" FORCE)
 set(BENCHMARK_ENABLE_GTEST_TESTS OFF CACHE BOOL "" FORCE)
 FetchContent_Declare(
   gbench
-  URL https://github.com/google/benchmark/archive/refs/tags/v1.9.5.zip
+  URL https://github.com/google/benchmark/archive/refs/tags/v1.8.4.zip
 )
 FetchContent_MakeAvailable(gbench)
 

--- a/tools/benchmark/README.md
+++ b/tools/benchmark/README.md
@@ -1,13 +1,13 @@
 # Benchmark
 
-This tool runs benchmarking of deserialization performance with [the Google Benchmark library](https://github.com/google/benchmark/) (tag: [v1.8.4](https://github.com/google/benchmark/releases/tag/v1.8.4), the latest version supporting C++11) against fkYAML and some C++ YAML library.  
+This tool runs benchmarking of deserialization performance with [the Google Benchmark library](https://github.com/google/benchmark/) (tag: [v1.9.5](https://github.com/google/benchmark/releases/tag/v1.9.5)) against fkYAML and some C++ YAML library.  
 
 ## Used YAML library for Comparison
 
 Currently, the following C++ YAML libraries tagged with the specified versions respectively:  
-* [libfyaml](https://github.com/pantoniou/libfyaml) ([v0.9](https://github.com/pantoniou/libfyaml/releases/tag/v0.9))
-* [rapidyaml](https://github.com/biojppm/rapidyaml) ([v0.7.2](https://github.com/biojppm/rapidyaml/releases/tag/v0.7.2))
-* [yaml-cpp](https://github.com/jbeder/yaml-cpp) ([0.8.0](https://github.com/jbeder/yaml-cpp/releases/tag/0.8.0))
+* [libfyaml](https://github.com/pantoniou/libfyaml) ([v1.0.0-beta1](https://github.com/pantoniou/libfyaml/releases/tag/v1.0.0-beta1))
+* [rapidyaml](https://github.com/biojppm/rapidyaml) ([v0.16.0](https://github.com/biojppm/rapidyaml/releases/tag/v0.16.0))
+* [yaml-cpp](https://github.com/jbeder/yaml-cpp) ([0.9.0](https://github.com/jbeder/yaml-cpp/releases/tag/yaml-cpp-0.9.0))
 
 Currently, the following files are located in the [tools/benchmark/cases](https://github.com/fktn-k/fkYAML/tree/develop/tools/benchmark/cases) directory for benchmarking:  
 
@@ -46,4 +46,4 @@ bm_fkyaml_parse                 xxxxx ns        xxxxx ns        xxxxx bytes_per_
 ...
 ```
 
-Visit [the user guide](https://github.com/google/benchmark/blob/v1.8.4/docs/user_guide.md) in the Google Benchmark repository for more information on the output format.  
+Visit [the user guide](https://github.com/google/benchmark/blob/v1.9.5/docs/user_guide.md) in the Google Benchmark repository for more information on the output format.  

--- a/tools/benchmark/README.md
+++ b/tools/benchmark/README.md
@@ -1,6 +1,6 @@
 # Benchmark
 
-This tool runs benchmarking of deserialization performance with [the Google Benchmark library](https://github.com/google/benchmark/) (tag: [v1.9.5](https://github.com/google/benchmark/releases/tag/v1.9.5)) against fkYAML and some C++ YAML library.  
+This tool runs benchmarking of deserialization performance with [the Google Benchmark library](https://github.com/google/benchmark/) (tag: [v1.8.4](https://github.com/google/benchmark/releases/tag/v1.8.4), the latest version supporting C++11) against fkYAML and some C++ YAML library.  
 
 ## Used YAML library for Comparison
 
@@ -46,4 +46,4 @@ bm_fkyaml_parse                 xxxxx ns        xxxxx ns        xxxxx bytes_per_
 ...
 ```
 
-Visit [the user guide](https://github.com/google/benchmark/blob/v1.9.5/docs/user_guide.md) in the Google Benchmark repository for more information on the output format.  
+Visit [the user guide](https://github.com/google/benchmark/blob/v1.8.4/docs/user_guide.md) in the Google Benchmark repository for more information on the output format.  

--- a/tools/benchmark/main.cpp
+++ b/tools/benchmark/main.cpp
@@ -20,9 +20,7 @@
 #include <fkYAML/node.hpp>
 #include <yaml-cpp/yaml.h>
 
-#ifdef FK_YAML_BM_HAS_LIBFYAML
 #include <libfyaml.h>
-#endif
 
 #include <ryml.hpp>
 #include <ryml_std.hpp>
@@ -76,7 +74,6 @@ void bm_yamlcpp_parse(benchmark::State& st) {
     st.SetBytesProcessed(st.iterations() * test_src.size());
 }
 
-#ifdef FK_YAML_BM_HAS_LIBFYAML
 // libfyaml
 void bm_libfyaml_parse(benchmark::State& st) {
     const char* p_test_src = test_src.c_str();
@@ -90,7 +87,6 @@ void bm_libfyaml_parse(benchmark::State& st) {
     st.SetItemsProcessed(st.iterations());
     st.SetBytesProcessed(st.iterations() * test_src.size());
 }
-#endif
 
 // rapidyaml (in place)
 void bm_rapidyaml_parse_inplace(benchmark::State& st) {
@@ -132,9 +128,7 @@ void bm_rapidyaml_parse_arena(benchmark::State& st) {
 BENCHMARK(bm_fkyaml_parse);
 BENCHMARK(bm_yamlcpp_parse);
 
-#ifdef FK_YAML_BM_HAS_LIBFYAML
 BENCHMARK(bm_libfyaml_parse);
-#endif
 
 BENCHMARK(bm_rapidyaml_parse_inplace);
 BENCHMARK(bm_rapidyaml_parse_arena);

--- a/tools/benchmark/results/result_debug_citm_catalog_json.txt
+++ b/tools/benchmark/results/result_debug_citm_catalog_json.txt
@@ -1,4 +1,4 @@
-2026-08-24T22:44:32+09:00
+2026-09-05T13:46:45+09:00
 Running ./build_bm_debug/tools/benchmark/benchmarker
 Run on (16 X 3193.92 MHz CPU s)
 CPU Caches:
@@ -6,13 +6,13 @@ CPU Caches:
   L1 Instruction 32 KiB (x8)
   L2 Unified 512 KiB (x8)
   L3 Unified 16384 KiB (x1)
-Load Average: 0.40, 0.34, 0.28
+Load Average: 0.53, 0.51, 0.32
 ***WARNING*** Library was built as DEBUG. Timings may be affected.
 -------------------------------------------------------------------------------------
 Benchmark                           Time             CPU   Iterations UserCounters...
 -------------------------------------------------------------------------------------
-bm_fkyaml_parse              13400686 ns     13399506 ns           51 bytes_per_second=122.929Mi/s items_per_second=74.6296/s
-bm_yamlcpp_parse            778784708 ns    778724867 ns            1 bytes_per_second=2.11524Mi/s items_per_second=1.28415/s
-bm_libfyaml_parse           114571220 ns    114557764 ns            7 bytes_per_second=14.3787Mi/s items_per_second=8.72922/s
-bm_rapidyaml_parse_inplace   42024214 ns     42020532 ns           17 bytes_per_second=39.1996Mi/s items_per_second=23.7979/s
-bm_rapidyaml_parse_arena     42989432 ns     42985133 ns           16 bytes_per_second=38.32Mi/s items_per_second=23.2639/s
+bm_fkyaml_parse              15559613 ns     15553447 ns           44 bytes_per_second=105.905Mi/s items_per_second=64.2944/s
+bm_yamlcpp_parse            747949464 ns    747276528 ns            1 bytes_per_second=2.20426Mi/s items_per_second=1.33819/s
+bm_libfyaml_parse           144003055 ns    143986224 ns            5 bytes_per_second=11.4399Mi/s items_per_second=6.94511/s
+bm_rapidyaml_parse_inplace   44732930 ns     44663942 ns           16 bytes_per_second=36.8796Mi/s items_per_second=22.3894/s
+bm_rapidyaml_parse_arena     45848000 ns     45841967 ns           15 bytes_per_second=35.9319Mi/s items_per_second=21.8141/s

--- a/tools/benchmark/results/result_debug_citm_catalog_yml.txt
+++ b/tools/benchmark/results/result_debug_citm_catalog_yml.txt
@@ -1,4 +1,4 @@
-2026-08-24T22:44:37+09:00
+2026-09-05T13:46:50+09:00
 Running ./build_bm_debug/tools/benchmark/benchmarker
 Run on (16 X 3193.92 MHz CPU s)
 CPU Caches:
@@ -6,13 +6,13 @@ CPU Caches:
   L1 Instruction 32 KiB (x8)
   L2 Unified 512 KiB (x8)
   L3 Unified 16384 KiB (x1)
-Load Average: 0.45, 0.35, 0.28
+Load Average: 0.57, 0.52, 0.32
 ***WARNING*** Library was built as DEBUG. Timings may be affected.
 -------------------------------------------------------------------------------------
 Benchmark                           Time             CPU   Iterations UserCounters...
 -------------------------------------------------------------------------------------
-bm_fkyaml_parse              12875783 ns     12874828 ns           54 bytes_per_second=53.142Mi/s items_per_second=77.6709/s
-bm_yamlcpp_parse            790313133 ns    790237532 ns            1 bytes_per_second=886.587Ki/s items_per_second=1.26544/s
-bm_libfyaml_parse           107533176 ns    107524523 ns            8 bytes_per_second=6.36314Mi/s items_per_second=9.3002/s
-bm_rapidyaml_parse_inplace   36668917 ns     36666063 ns           19 bytes_per_second=18.6601Mi/s items_per_second=27.2732/s
-bm_rapidyaml_parse_arena     36726880 ns     36723818 ns           19 bytes_per_second=18.6308Mi/s items_per_second=27.2303/s
+bm_fkyaml_parse              14009726 ns     14008620 ns           50 bytes_per_second=48.8409Mi/s items_per_second=71.3846/s
+bm_yamlcpp_parse            766884063 ns    766543056 ns            1 bytes_per_second=913.992Ki/s items_per_second=1.30456/s
+bm_libfyaml_parse           129471210 ns    129418630 ns            6 bytes_per_second=5.28667Mi/s items_per_second=7.72686/s
+bm_rapidyaml_parse_inplace   38611517 ns     38572180 ns           18 bytes_per_second=17.738Mi/s items_per_second=25.9254/s
+bm_rapidyaml_parse_arena     38627270 ns     38622891 ns           18 bytes_per_second=17.7147Mi/s items_per_second=25.8914/s

--- a/tools/benchmark/results/result_debug_ubuntu_yml.txt
+++ b/tools/benchmark/results/result_debug_ubuntu_yml.txt
@@ -1,4 +1,4 @@
-2026-08-24T22:44:28+09:00
+2026-09-05T13:46:40+09:00
 Running ./build_bm_debug/tools/benchmark/benchmarker
 Run on (16 X 3193.92 MHz CPU s)
 CPU Caches:
@@ -6,13 +6,13 @@ CPU Caches:
   L1 Instruction 32 KiB (x8)
   L2 Unified 512 KiB (x8)
   L3 Unified 16384 KiB (x1)
-Load Average: 0.35, 0.33, 0.27
+Load Average: 0.49, 0.50, 0.31
 ***WARNING*** Library was built as DEBUG. Timings may be affected.
 -------------------------------------------------------------------------------------
 Benchmark                           Time             CPU   Iterations UserCounters...
 -------------------------------------------------------------------------------------
-bm_fkyaml_parse                113503 ns       113496 ns         6183 bytes_per_second=74.1033Mi/s items_per_second=8.81086k/s
-bm_yamlcpp_parse              7613398 ns      7612853 ns           92 bytes_per_second=1.10477Mi/s items_per_second=131.357/s
-bm_libfyaml_parse              991501 ns       991383 ns          706 bytes_per_second=8.48355Mi/s items_per_second=1.00869k/s
-bm_rapidyaml_parse_inplace     274196 ns       274300 ns         2542 bytes_per_second=30.6615Mi/s items_per_second=3.64564k/s
-bm_rapidyaml_parse_arena       279563 ns       279539 ns         2503 bytes_per_second=30.0869Mi/s items_per_second=3.57732k/s
+bm_fkyaml_parse                122247 ns       122119 ns         5727 bytes_per_second=68.8707Mi/s items_per_second=8.1887k/s
+bm_yamlcpp_parse              7263550 ns      7261038 ns           96 bytes_per_second=1.1583Mi/s items_per_second=137.721/s
+bm_libfyaml_parse             1250108 ns      1249212 ns          558 bytes_per_second=6.73261Mi/s items_per_second=800.505/s
+bm_rapidyaml_parse_inplace     288735 ns       288845 ns         2423 bytes_per_second=29.1176Mi/s items_per_second=3.46207k/s
+bm_rapidyaml_parse_arena       294603 ns       294172 ns         2368 bytes_per_second=28.5903Mi/s items_per_second=3.39938k/s

--- a/tools/benchmark/results/result_release_citm_catalog_json.txt
+++ b/tools/benchmark/results/result_release_citm_catalog_json.txt
@@ -1,4 +1,4 @@
-2026-08-24T22:42:26+09:00
+2026-09-05T13:43:21+09:00
 Running ./build_bm_release/tools/benchmark/benchmarker
 Run on (16 X 3193.92 MHz CPU s)
 CPU Caches:
@@ -6,12 +6,12 @@ CPU Caches:
   L1 Instruction 32 KiB (x8)
   L2 Unified 512 KiB (x8)
   L3 Unified 16384 KiB (x1)
-Load Average: 0.15, 0.29, 0.25
+Load Average: 0.37, 0.38, 0.23
 -------------------------------------------------------------------------------------
 Benchmark                           Time             CPU   Iterations UserCounters...
 -------------------------------------------------------------------------------------
-bm_fkyaml_parse              12993470 ns     12992218 ns           53 bytes_per_second=126.783Mi/s items_per_second=76.9691/s
-bm_yamlcpp_parse             99251969 ns     99242492 ns            7 bytes_per_second=16.5976Mi/s items_per_second=10.0763/s
-bm_libfyaml_parse            32983392 ns     32978992 ns           21 bytes_per_second=49.9466Mi/s items_per_second=30.3223/s
-bm_rapidyaml_parse_inplace   13650212 ns     13649138 ns           51 bytes_per_second=120.681Mi/s items_per_second=73.2647/s
-bm_rapidyaml_parse_arena     13874457 ns     13873671 ns           50 bytes_per_second=118.728Mi/s items_per_second=72.079/s
+bm_fkyaml_parse              13614165 ns     13608623 ns           51 bytes_per_second=121.04Mi/s items_per_second=73.4828/s
+bm_yamlcpp_parse             98830791 ns     98820520 ns            6 bytes_per_second=16.6685Mi/s items_per_second=10.1194/s
+bm_libfyaml_parse            32492247 ns     32484108 ns           22 bytes_per_second=50.7076Mi/s items_per_second=30.7843/s
+bm_rapidyaml_parse_inplace   15040221 ns     15038061 ns           46 bytes_per_second=109.535Mi/s items_per_second=66.4979/s
+bm_rapidyaml_parse_arena     14568265 ns     14566258 ns           48 bytes_per_second=113.083Mi/s items_per_second=68.6518/s

--- a/tools/benchmark/results/result_release_citm_catalog_yml.txt
+++ b/tools/benchmark/results/result_release_citm_catalog_yml.txt
@@ -1,4 +1,4 @@
-2026-08-24T22:42:30+09:00
+2026-09-05T13:43:25+09:00
 Running ./build_bm_release/tools/benchmark/benchmarker
 Run on (16 X 3193.92 MHz CPU s)
 CPU Caches:
@@ -6,12 +6,12 @@ CPU Caches:
   L1 Instruction 32 KiB (x8)
   L2 Unified 512 KiB (x8)
   L3 Unified 16384 KiB (x1)
-Load Average: 0.15, 0.29, 0.25
+Load Average: 0.42, 0.39, 0.24
 -------------------------------------------------------------------------------------
 Benchmark                           Time             CPU   Iterations UserCounters...
 -------------------------------------------------------------------------------------
-bm_fkyaml_parse              12234863 ns     12231206 ns           57 bytes_per_second=55.9384Mi/s items_per_second=81.7581/s
-bm_yamlcpp_parse             97293420 ns     97281934 ns            6 bytes_per_second=7.0331Mi/s items_per_second=10.2794/s
-bm_libfyaml_parse            31668190 ns     31664814 ns           22 bytes_per_second=21.6074Mi/s items_per_second=31.5808/s
-bm_rapidyaml_parse_inplace   12620463 ns     12619981 ns           55 bytes_per_second=54.2151Mi/s items_per_second=79.2394/s
-bm_rapidyaml_parse_arena     12737953 ns     12736422 ns           55 bytes_per_second=53.7195Mi/s items_per_second=78.515/s
+bm_fkyaml_parse              12205778 ns     12201085 ns           57 bytes_per_second=56.0765Mi/s items_per_second=81.9599/s
+bm_yamlcpp_parse             93619373 ns     93611950 ns            6 bytes_per_second=7.30883Mi/s items_per_second=10.6824/s
+bm_libfyaml_parse            31194609 ns     31190021 ns           23 bytes_per_second=21.9363Mi/s items_per_second=32.0615/s
+bm_rapidyaml_parse_inplace   12753699 ns     12747668 ns           51 bytes_per_second=53.6721Mi/s items_per_second=78.4457/s
+bm_rapidyaml_parse_arena     12826431 ns     12821446 ns           54 bytes_per_second=53.3632Mi/s items_per_second=77.9943/s

--- a/tools/benchmark/results/result_release_ubuntu_yml.txt
+++ b/tools/benchmark/results/result_release_ubuntu_yml.txt
@@ -1,4 +1,4 @@
-2026-08-24T22:42:22+09:00
+2026-09-05T13:43:17+09:00
 Running ./build_bm_release/tools/benchmark/benchmarker
 Run on (12 X 3711.75 MHz CPU s)
 CPU Caches:
@@ -6,12 +6,12 @@ CPU Caches:
   L1 Instruction 32 KiB (x6)
   L2 Unified 512 KiB (x6)
   L3 Unified 16384 KiB (x1)
-Load Average: 0.07, 0.28, 0.25
+Load Average: 0.23, 0.35, 0.22
 -------------------------------------------------------------------------------------
 Benchmark                           Time             CPU   Iterations UserCounters...
 -------------------------------------------------------------------------------------
-bm_fkyaml_parse                108029 ns       108016 ns         6491 bytes_per_second=77.8628Mi/s items_per_second=9.25786k/s
-bm_yamlcpp_parse               830822 ns       830749 ns          844 bytes_per_second=10.1239Mi/s items_per_second=1.20373k/s
-bm_libfyaml_parse              242131 ns       242110 ns         2871 bytes_per_second=34.7381Mi/s items_per_second=4.13035k/s
-bm_rapidyaml_parse_inplace      55647 ns        55703 ns        12635 bytes_per_second=150.988Mi/s items_per_second=17.9524k/s
-bm_rapidyaml_parse_arena        62033 ns        62029 ns        11310 bytes_per_second=135.589Mi/s items_per_second=16.1215k/s
+bm_fkyaml_parse                110490 ns       110478 ns         6327 bytes_per_second=76.1277Mi/s items_per_second=9.05155k/s
+bm_yamlcpp_parse               831071 ns       830911 ns          842 bytes_per_second=10.122Mi/s items_per_second=1.2035k/s
+bm_libfyaml_parse              233797 ns       233752 ns         2987 bytes_per_second=35.9803Mi/s items_per_second=4.27805k/s
+bm_rapidyaml_parse_inplace      55597 ns        55652 ns        12501 bytes_per_second=151.126Mi/s items_per_second=17.9688k/s
+bm_rapidyaml_parse_arena        63567 ns        63542 ns        10881 bytes_per_second=132.36Mi/s items_per_second=15.7375k/s


### PR DESCRIPTION
This PR updates libraries used for the benchmark to the latest available:

| library | before | after |
|---|---|---|
| libfyaml | `v0.9` | `v1.0.0-beta1` |
| rapidyaml | `v0.7.2` | `v0.16.0` |
| yaml-cpp | `0.8.0` | `yaml-cpp-0.9.0` |

Two things the bump needed beyond the tags:

- rapidyaml no longer uses submodules as of 0.16.0, so `GIT_SUBMODULES "ext/c4core"` is removed.
  Keeping it fails the fetch.
- yaml-cpp changed its tag naming. `0.8.0` is a bare tag, but 0.9.0 exists only as `yaml-cpp-0.9.0`.

libfyaml supports Windows natively since 0.9.4, so the `if(NOT WIN32)` guard is gone and it is now
benchmarked there too. That needed `set(BUILD_TESTING OFF)`, since its tests download the YAML and
JSON test suites at configure time and cloning the latter fails on the Windows path length limit,
and `set(BUILD_SHARED_LIBS OFF)`, since libfyaml defaults that option to `ON` for every dependency
and the resulting DLLs are not found next to `benchmarker.exe`.

I have not regenerated `tools/benchmark/results/`, since those were measured on your machine and a
rerun here would just swap the hardware. They are worth regenerating on the reference environment
before the release.

Refs #583.

---

## Pull Request Checklist

Read the [CONTRIBUTING.md](https://github.com/fktn-k/fkYAML/blob/develop/.github/CONTRIBUTING.md) file for detailed information.  

- [x] Changes are described in the pull request or in a referenced [issue](https://github.com/fktn-k/fkYAML/issues).
- [x] The test suite compiles and runs without any error.
- [x] [The code coverage](https://coveralls.io/github/fktn-k/fkYAML) on your branch is 100%.
- [x] The documentation is updated if you added/changed a feature.

## Please don't

- The C++11 support varies between different **compilers** and versions. Please note the [list of supported compilers](https://github.com/fktn-k/fkYAML/blob/develop/README.md#supported-compilers). Some compilers like GCC 4.7 (and earlier), Clang 3.3 (and earlier), or Microsoft Visual Studio 13.0 and earlier are known not to work due to missing or incomplete C++11 support. Please refrain from proposing changes that work around these compiler's limitations with `#ifdef`s or other means.
- Please refrain from proposing changes that would **break [YAML](https://yaml.org/) specifications**. If you propose a conformant extension of YAML to be supported by the library, please motivate this extension.
- Please do not open pull requests that address **multiple issues**.
