### PR TITLE
Bind node properties to the node they precede

### DIFF
--- a/include/fkYAML/detail/input/deserializer.hpp
+++ b/include/fkYAML/detail/input/deserializer.hpp
@@ -661,27 +661,6 @@ private:
                         add_explicit_key_with_empty_value(old_line, old_indent);
                     }
 
-                    if (m_needs_tag_impl) {
-                        const tag_t tag_type = tag_resolver_type::resolve_tag(m_tag_name, mp_meta);
-                        if (tag_type == tag_t::MAPPING || tag_type == tag_t::CUSTOM_TAG) {
-                            // set YAML node properties here to distinguish them from those for the first key node
-                            // as shown in the following snippet:
-                            //
-                            // ```yaml
-                            // foo: !!map
-                            //   !!str 123: true
-                            //   ^
-                            //   this !!str tag overwrites the preceding !!map tag.
-                            // ```
-                            *mp_current_node = basic_node_type::mapping();
-                            apply_directive_set(*mp_current_node);
-                            apply_deferred_properties(*mp_current_node);
-                            apply_node_properties(*mp_current_node);
-                            m_context_stack.emplace_back(line, indent, context_state_t::BLOCK_MAPPING, mp_current_node);
-                            continue;
-                        }
-                    }
-
                     if (token.type == lexical_token_t::SEQUENCE_BLOCK_PREFIX) {
                         // a key separator preceding block sequence entries
                         *mp_current_node = basic_node_type::sequence({basic_node_type()});

--- a/include/fkYAML/detail/input/deserializer.hpp
+++ b/include/fkYAML/detail/input/deserializer.hpp
@@ -224,6 +224,7 @@ private:
             if (found_props) {
                 // If node properties are found before the block sequence entry prefix, the properties belong to the
                 // root sequence node.
+                apply_deferred_properties(root);
                 apply_node_properties(root);
             }
 
@@ -245,6 +246,7 @@ private:
             lexer.set_context_state(true);
             root = basic_node_type::sequence();
             apply_directive_set(root);
+            apply_deferred_properties(root);
             apply_node_properties(root);
             m_context_stack.emplace_back(
                 lexer.get_lines_processed(), lexer.get_last_token_begin_pos(), context_state_t::FLOW_SEQUENCE, &root);
@@ -257,6 +259,7 @@ private:
             lexer.set_context_state(true);
             root = basic_node_type::mapping();
             apply_directive_set(root);
+            apply_deferred_properties(root);
             apply_node_properties(root);
             m_context_stack.emplace_back(
                 lexer.get_lines_processed(), lexer.get_last_token_begin_pos(), context_state_t::FLOW_MAPPING, &root);
@@ -270,6 +273,7 @@ private:
             // No get_next_token() call here to handle the token event in the deserialize_node() function.
             root = basic_node_type::mapping();
             apply_directive_set(root);
+            apply_deferred_properties(root);
             apply_node_properties(root);
             parse_context context(
                 lexer.get_lines_processed(), lexer.get_last_token_begin_pos(), context_state_t::BLOCK_MAPPING, &root);
@@ -281,6 +285,7 @@ private:
         case lexical_token_t::KEY_SEPARATOR:
             root = basic_node_type::mapping();
             apply_directive_set(root);
+            apply_deferred_properties(root);
             apply_node_properties(root);
             m_context_stack.emplace_back(
                 lexer.get_lines_processed(), lexer.get_last_token_begin_pos(), context_state_t::BLOCK_MAPPING, &root);
@@ -627,7 +632,7 @@ private:
                     // foo: &anchor
                     //   bar: baz   # the anchor is for the mapping, not for the "bar" key.
                     // ```
-                    m_defers_props = true;
+                    defer_node_properties();
                 }
 
                 line = lexer.get_lines_processed();
@@ -670,6 +675,7 @@ private:
                             // ```
                             *mp_current_node = basic_node_type::mapping();
                             apply_directive_set(*mp_current_node);
+                            apply_deferred_properties(*mp_current_node);
                             apply_node_properties(*mp_current_node);
                             m_context_stack.emplace_back(line, indent, context_state_t::BLOCK_MAPPING, mp_current_node);
                             continue;
@@ -680,6 +686,7 @@ private:
                         // a key separator preceding block sequence entries
                         *mp_current_node = basic_node_type::sequence({basic_node_type()});
                         apply_directive_set(*mp_current_node);
+                        apply_deferred_properties(*mp_current_node);
                         apply_node_properties(*mp_current_node);
                         auto& cur_context = m_context_stack.back();
                         cur_context.line = line;
@@ -719,6 +726,7 @@ private:
                             m_context_stack.emplace_back(
                                 line_after_props, indent, context_state_t::BLOCK_MAPPING, mp_current_node);
                             apply_directive_set(*mp_current_node);
+                            apply_deferred_properties(*mp_current_node);
                             apply_node_properties(*mp_current_node);
                         }
 
@@ -792,6 +800,7 @@ private:
                 if (token.type == lexical_token_t::SEQUENCE_BLOCK_PREFIX) {
                     *mp_current_node = basic_node_type::sequence({basic_node_type()});
                     apply_directive_set(*mp_current_node);
+                    apply_deferred_properties(*mp_current_node);
                     apply_node_properties(*mp_current_node);
                     m_context_stack.emplace_back(line, indent, context_state_t::BLOCK_SEQUENCE, mp_current_node);
 
@@ -814,7 +823,7 @@ private:
                     // - !circle
                     //   center: 1   # the tag is for the mapping, not for the "center" key.
                     // ```
-                    m_defers_props = true;
+                    defer_node_properties();
                     line = lexer.get_lines_processed();
                     indent = lexer.get_last_token_begin_pos();
                     continue;
@@ -873,6 +882,7 @@ private:
                     *mp_current_node = basic_node_type::sequence();
                     m_context_stack.emplace_back(line, indent, context_state_t::BLOCK_SEQUENCE, mp_current_node);
                     apply_directive_set(*mp_current_node);
+                    apply_deferred_properties(*mp_current_node);
                     apply_node_properties(*mp_current_node);
                 }
 
@@ -939,6 +949,7 @@ private:
                 }
 
                 apply_directive_set(*mp_current_node);
+                apply_deferred_properties(*mp_current_node);
                 apply_node_properties(*mp_current_node);
 
                 m_flow_token_state = flow_token_state_t::NEEDS_VALUE_OR_SUFFIX;
@@ -1063,6 +1074,7 @@ private:
                 }
 
                 apply_directive_set(*mp_current_node);
+                apply_deferred_properties(*mp_current_node);
                 apply_node_properties(*mp_current_node);
 
                 line = lexer.get_lines_processed();
@@ -1149,10 +1161,10 @@ private:
                 // An alias node must not specify any properties (tag, anchor), but deferred ones are
                 // for the collection which this alias begins rather than for the alias itself.
                 // https://yaml.org/spec/1.2.2/#71-alias-nodes
-                if FK_YAML_UNLIKELY (m_needs_tag_impl && !m_defers_props) {
+                if FK_YAML_UNLIKELY (m_needs_tag_impl) {
                     throw parse_error("Tag cannot be specified to an alias node", line, indent);
                 }
-                if FK_YAML_UNLIKELY (m_needs_anchor_impl && !m_defers_props) {
+                if FK_YAML_UNLIKELY (m_needs_anchor_impl) {
                     throw parse_error("Anchor cannot be specified to an alias node.", line, indent);
                 }
 
@@ -1169,9 +1181,7 @@ private:
                 detail::node_attr_bits::set_anchor_offset(anchor_counts - 1, node.m_attrs);
 
                 apply_directive_set(node);
-                if (!m_defers_props) {
-                    apply_node_properties(node);
-                }
+                apply_node_properties(node);
 
                 deserialize_scalar(lexer, std::move(node), indent, line, token);
 
@@ -1195,9 +1205,7 @@ private:
 
                 basic_node_type node = scalar_parser_type(line, indent).parse_flow(token.type, tag_type, token.str);
                 apply_directive_set(node);
-                if (!m_defers_props) {
-                    apply_node_properties(node);
-                }
+                apply_node_properties(node);
 
                 deserialize_scalar(lexer, std::move(node), indent, line, token);
                 continue;
@@ -1210,9 +1218,7 @@ private:
                     scalar_parser_type(line, indent)
                         .parse_block(token.type, tag_type, token.str, lexer.get_block_scalar_header());
                 apply_directive_set(node);
-                if (!m_defers_props) {
-                    apply_node_properties(node);
-                }
+                apply_node_properties(node);
 
                 deserialize_scalar(lexer, std::move(node), indent, line, token);
                 continue;
@@ -1551,11 +1557,9 @@ private:
 
                     *mp_current_node = basic_node_type::mapping();
                     apply_directive_set(*mp_current_node);
-                    if (m_defers_props) {
-                        // The scalar turned out to be a key, so the deferred properties are for the
-                        // mapping which it begins.
-                        apply_node_properties(*mp_current_node);
-                    }
+                    // The scalar turned out to be a key, so any deferred properties are for the mapping
+                    // which it begins rather than for the key itself.
+                    apply_deferred_properties(*mp_current_node);
                 }
                 else {
                     // root mapping node
@@ -1580,7 +1584,7 @@ private:
             add_new_key(std::move(node), line, indent);
         }
         else {
-            if (m_defers_props) {
+            if (defers_props()) {
                 // No key separator follows, so the node is a value and owns the deferred properties.
                 // An alias node must not carry any, which is only known once it turns out not to be a
                 // key of the mapping the properties belong to.
@@ -1588,7 +1592,7 @@ private:
                 if FK_YAML_UNLIKELY (node.is_alias()) {
                     throw parse_error("Node properties cannot be specified to an alias node.", line, indent);
                 }
-                apply_node_properties(node);
+                apply_deferred_properties(node);
             }
             assign_node_value(std::move(node), line, indent);
         }
@@ -1705,6 +1709,16 @@ private:
 
         const auto pop_num = static_cast<uint32_t>(std::distance(m_context_stack.rbegin(), itr));
 
+        if (pop_num > 0 && defers_props() && mp_current_node->is_null()) {
+            // The entry which the properties preceded ends here without a node of its own, so they
+            // belong to its empty value.
+            // ```yaml
+            // foo: &anchor
+            // bar: 1        # the anchor is for the empty value of "foo".
+            // ```
+            apply_deferred_properties(*mp_current_node);
+        }
+
         // move back to the parent block mapping.
         for (uint32_t i = 0; i < pop_num; i++) {
             m_context_stack.pop_back();
@@ -1767,8 +1781,7 @@ private:
     /// @param indent Current indentation.
     /// @return The resolved tag type, or tag_t::NONE if no tag is pending.
     tag_t resolve_scalar_tag(const uint32_t line, const uint32_t indent) const {
-        if (!m_needs_tag_impl || m_defers_props) {
-            // A deferred tag belongs to the collection which this scalar begins, not to the scalar.
+        if (!m_needs_tag_impl) {
             return tag_t::NONE;
         }
 
@@ -1783,10 +1796,53 @@ private:
         return tag_type;
     }
 
+    /// @brief Move the pending node properties aside until the node they belong to is known.
+    /// @note They precede their node by a line, so the node which follows may carry properties of its
+    /// own. Keeping the two apart lets both be bound to the right node.
+    /// ```yaml
+    /// foo: &map
+    ///   &key bar: baz   # &map is for the mapping, &key is for the "bar" key.
+    /// ```
+    void defer_node_properties() {
+        if (m_needs_anchor_impl) {
+            m_deferred_anchor_name = m_anchor_name;
+            m_defers_anchor = true;
+            m_needs_anchor_impl = false;
+            m_anchor_name = {};
+        }
+        if (m_needs_tag_impl) {
+            m_deferred_tag_name = m_tag_name;
+            m_defers_tag = true;
+            m_needs_tag_impl = false;
+            m_tag_name = {};
+        }
+    }
+
+    /// @brief Check whether any node properties are waiting to be bound.
+    /// @return true if properties precede a node whose kind is not known yet, false otherwise.
+    bool defers_props() const noexcept {
+        return m_defers_anchor || m_defers_tag;
+    }
+
+    /// @brief Set the node properties which precede their node to the given node.
+    /// @param node A node type object the deferred properties belong to.
+    void apply_deferred_properties(basic_node_type& node) {
+        if (m_defers_anchor) {
+            node.add_anchor_name(std::string(m_deferred_anchor_name.begin(), m_deferred_anchor_name.end()));
+            m_defers_anchor = false;
+            m_deferred_anchor_name = {};
+        }
+
+        if (m_defers_tag) {
+            node.add_tag_name(std::string(m_deferred_tag_name.begin(), m_deferred_tag_name.end()));
+            m_defers_tag = false;
+            m_deferred_tag_name = {};
+        }
+    }
+
     /// @brief Set YAML node properties (anchor and/or tag names) to the given node.
     /// @param node A node type object to be set YAML node properties.
     void apply_node_properties(basic_node_type& node) {
-        m_defers_props = false;
         if (m_needs_anchor_impl) {
             node.add_anchor_name(std::string(m_anchor_name.begin(), m_anchor_name.end()));
             m_needs_anchor_impl = false;
@@ -1820,7 +1876,13 @@ private:
     /// Whether the document being parsed exists at all: it has contents or an explicit "---".
     bool m_has_document {false};
     /// Whether the pending node properties precede their node and are not bound yet.
-    bool m_defers_props {false};
+    bool m_defers_anchor {false};
+    /// Whether a tag which precedes its node is waiting to be bound.
+    bool m_defers_tag {false};
+    /// The anchor name which precedes its node.
+    str_view m_deferred_anchor_name;
+    /// The tag name which precedes its node.
+    str_view m_deferred_tag_name;
     /// A flag to determine the need for YAML anchor node implementation.
     bool m_needs_anchor_impl {false};
     /// A flag to determine the need for a corresponding node with the last YAML tag.

--- a/include/fkYAML/detail/input/deserializer.hpp
+++ b/include/fkYAML/detail/input/deserializer.hpp
@@ -620,6 +620,16 @@ private:
                     continue;
                 }
 
+                if (found_props) {
+                    // The properties belong to whatever begins on the following line, which the token
+                    // after it decides.
+                    // ```yaml
+                    // foo: &anchor
+                    //   bar: baz   # the anchor is for the mapping, not for the "bar" key.
+                    // ```
+                    m_defers_props = true;
+                }
+
                 line = lexer.get_lines_processed();
                 indent = lexer.get_last_token_begin_pos();
 
@@ -793,8 +803,23 @@ private:
                 continue;
             }
             case lexical_token_t::ANCHOR_PREFIX:
-            case lexical_token_t::TAG_PREFIX:
+            case lexical_token_t::TAG_PREFIX: {
+                const uint32_t props_line = lexer.get_lines_processed();
                 deserialize_node_properties(lexer, token, line, indent);
+
+                if (lexer.get_lines_processed() > props_line) {
+                    // The properties belong to whatever begins on the following line. Which node that
+                    // is depends on the token after it, so the binding waits until that is known.
+                    // ```yaml
+                    // - !circle
+                    //   center: 1   # the tag is for the mapping, not for the "center" key.
+                    // ```
+                    m_defers_props = true;
+                    line = lexer.get_lines_processed();
+                    indent = lexer.get_last_token_begin_pos();
+                    continue;
+                }
+
                 // Skip updating the current indent to avoid stacking a wrong indentation.
                 // Note that node properties for block sequences as a mapping value are processed when a
                 // `lexical_token_t::KEY_SEPARATOR` token is processed.
@@ -805,6 +830,7 @@ private:
                 // the correct indent width for the "bar" node key.
                 // ```
                 continue;
+            }
             case lexical_token_t::SEQUENCE_BLOCK_PREFIX: {
                 check_tab_in_indentation(lexer, lexer.get_lines_processed(), lexer.get_last_token_begin_pos());
                 if FK_YAML_UNLIKELY (m_flow_context_depth > 0) {
@@ -1120,12 +1146,13 @@ private:
                 m_flow_token_state = flow_token_state_t::NEEDS_VALUE_OR_SUFFIX;
                 break;
             case lexical_token_t::ALIAS_PREFIX: {
-                // An alias node must not specify any properties (tag, anchor).
+                // An alias node must not specify any properties (tag, anchor), but deferred ones are
+                // for the collection which this alias begins rather than for the alias itself.
                 // https://yaml.org/spec/1.2.2/#71-alias-nodes
-                if FK_YAML_UNLIKELY (m_needs_tag_impl) {
+                if FK_YAML_UNLIKELY (m_needs_tag_impl && !m_defers_props) {
                     throw parse_error("Tag cannot be specified to an alias node", line, indent);
                 }
-                if FK_YAML_UNLIKELY (m_needs_anchor_impl) {
+                if FK_YAML_UNLIKELY (m_needs_anchor_impl && !m_defers_props) {
                     throw parse_error("Anchor cannot be specified to an alias node.", line, indent);
                 }
 
@@ -1142,7 +1169,9 @@ private:
                 detail::node_attr_bits::set_anchor_offset(anchor_counts - 1, node.m_attrs);
 
                 apply_directive_set(node);
-                apply_node_properties(node);
+                if (!m_defers_props) {
+                    apply_node_properties(node);
+                }
 
                 deserialize_scalar(lexer, std::move(node), indent, line, token);
 
@@ -1166,7 +1195,9 @@ private:
 
                 basic_node_type node = scalar_parser_type(line, indent).parse_flow(token.type, tag_type, token.str);
                 apply_directive_set(node);
-                apply_node_properties(node);
+                if (!m_defers_props) {
+                    apply_node_properties(node);
+                }
 
                 deserialize_scalar(lexer, std::move(node), indent, line, token);
                 continue;
@@ -1179,7 +1210,9 @@ private:
                     scalar_parser_type(line, indent)
                         .parse_block(token.type, tag_type, token.str, lexer.get_block_scalar_header());
                 apply_directive_set(node);
-                apply_node_properties(node);
+                if (!m_defers_props) {
+                    apply_node_properties(node);
+                }
 
                 deserialize_scalar(lexer, std::move(node), indent, line, token);
                 continue;
@@ -1518,6 +1551,11 @@ private:
 
                     *mp_current_node = basic_node_type::mapping();
                     apply_directive_set(*mp_current_node);
+                    if (m_defers_props) {
+                        // The scalar turned out to be a key, so the deferred properties are for the
+                        // mapping which it begins.
+                        apply_node_properties(*mp_current_node);
+                    }
                 }
                 else {
                     // root mapping node
@@ -1542,6 +1580,16 @@ private:
             add_new_key(std::move(node), line, indent);
         }
         else {
+            if (m_defers_props) {
+                // No key separator follows, so the node is a value and owns the deferred properties.
+                // An alias node must not carry any, which is only known once it turns out not to be a
+                // key of the mapping the properties belong to.
+                // https://yaml.org/spec/1.2.2/#71-alias-nodes
+                if FK_YAML_UNLIKELY (node.is_alias()) {
+                    throw parse_error("Node properties cannot be specified to an alias node.", line, indent);
+                }
+                apply_node_properties(node);
+            }
             assign_node_value(std::move(node), line, indent);
         }
 
@@ -1719,7 +1767,8 @@ private:
     /// @param indent Current indentation.
     /// @return The resolved tag type, or tag_t::NONE if no tag is pending.
     tag_t resolve_scalar_tag(const uint32_t line, const uint32_t indent) const {
-        if (!m_needs_tag_impl) {
+        if (!m_needs_tag_impl || m_defers_props) {
+            // A deferred tag belongs to the collection which this scalar begins, not to the scalar.
             return tag_t::NONE;
         }
 
@@ -1737,6 +1786,7 @@ private:
     /// @brief Set YAML node properties (anchor and/or tag names) to the given node.
     /// @param node A node type object to be set YAML node properties.
     void apply_node_properties(basic_node_type& node) {
+        m_defers_props = false;
         if (m_needs_anchor_impl) {
             node.add_anchor_name(std::string(m_anchor_name.begin(), m_anchor_name.end()));
             m_needs_anchor_impl = false;
@@ -1769,6 +1819,8 @@ private:
     std::shared_ptr<doc_metainfo_type> mp_meta {};
     /// Whether the document being parsed exists at all: it has contents or an explicit "---".
     bool m_has_document {false};
+    /// Whether the pending node properties precede their node and are not bound yet.
+    bool m_defers_props {false};
     /// A flag to determine the need for YAML anchor node implementation.
     bool m_needs_anchor_impl {false};
     /// A flag to determine the need for a corresponding node with the last YAML tag.

--- a/include/fkYAML/detail/input/deserializer.hpp
+++ b/include/fkYAML/detail/input/deserializer.hpp
@@ -1688,9 +1688,10 @@ private:
 
         const auto pop_num = static_cast<uint32_t>(std::distance(m_context_stack.rbegin(), itr));
 
-        if (pop_num > 0 && defers_props() && mp_current_node->is_null()) {
+        if (pop_num > 0 && defers_props()) {
             // The entry which the properties preceded ends here without a node of its own, so they
-            // belong to its empty value.
+            // belong to its empty value. Any node which did follow them would have taken them before
+            // its context could be popped, so the current node is still the empty one.
             // ```yaml
             // foo: &anchor
             // bar: 1        # the anchor is for the empty value of "foo".

--- a/single_include/fkYAML/node.hpp
+++ b/single_include/fkYAML/node.hpp
@@ -8000,6 +8000,7 @@ private:
             if (found_props) {
                 // If node properties are found before the block sequence entry prefix, the properties belong to the
                 // root sequence node.
+                apply_deferred_properties(root);
                 apply_node_properties(root);
             }
 
@@ -8021,6 +8022,7 @@ private:
             lexer.set_context_state(true);
             root = basic_node_type::sequence();
             apply_directive_set(root);
+            apply_deferred_properties(root);
             apply_node_properties(root);
             m_context_stack.emplace_back(
                 lexer.get_lines_processed(), lexer.get_last_token_begin_pos(), context_state_t::FLOW_SEQUENCE, &root);
@@ -8033,6 +8035,7 @@ private:
             lexer.set_context_state(true);
             root = basic_node_type::mapping();
             apply_directive_set(root);
+            apply_deferred_properties(root);
             apply_node_properties(root);
             m_context_stack.emplace_back(
                 lexer.get_lines_processed(), lexer.get_last_token_begin_pos(), context_state_t::FLOW_MAPPING, &root);
@@ -8046,6 +8049,7 @@ private:
             // No get_next_token() call here to handle the token event in the deserialize_node() function.
             root = basic_node_type::mapping();
             apply_directive_set(root);
+            apply_deferred_properties(root);
             apply_node_properties(root);
             parse_context context(
                 lexer.get_lines_processed(), lexer.get_last_token_begin_pos(), context_state_t::BLOCK_MAPPING, &root);
@@ -8057,6 +8061,7 @@ private:
         case lexical_token_t::KEY_SEPARATOR:
             root = basic_node_type::mapping();
             apply_directive_set(root);
+            apply_deferred_properties(root);
             apply_node_properties(root);
             m_context_stack.emplace_back(
                 lexer.get_lines_processed(), lexer.get_last_token_begin_pos(), context_state_t::BLOCK_MAPPING, &root);
@@ -8403,7 +8408,7 @@ private:
                     // foo: &anchor
                     //   bar: baz   # the anchor is for the mapping, not for the "bar" key.
                     // ```
-                    m_defers_props = true;
+                    defer_node_properties();
                 }
 
                 line = lexer.get_lines_processed();
@@ -8446,6 +8451,7 @@ private:
                             // ```
                             *mp_current_node = basic_node_type::mapping();
                             apply_directive_set(*mp_current_node);
+                            apply_deferred_properties(*mp_current_node);
                             apply_node_properties(*mp_current_node);
                             m_context_stack.emplace_back(line, indent, context_state_t::BLOCK_MAPPING, mp_current_node);
                             continue;
@@ -8456,6 +8462,7 @@ private:
                         // a key separator preceding block sequence entries
                         *mp_current_node = basic_node_type::sequence({basic_node_type()});
                         apply_directive_set(*mp_current_node);
+                        apply_deferred_properties(*mp_current_node);
                         apply_node_properties(*mp_current_node);
                         auto& cur_context = m_context_stack.back();
                         cur_context.line = line;
@@ -8495,6 +8502,7 @@ private:
                             m_context_stack.emplace_back(
                                 line_after_props, indent, context_state_t::BLOCK_MAPPING, mp_current_node);
                             apply_directive_set(*mp_current_node);
+                            apply_deferred_properties(*mp_current_node);
                             apply_node_properties(*mp_current_node);
                         }
 
@@ -8568,6 +8576,7 @@ private:
                 if (token.type == lexical_token_t::SEQUENCE_BLOCK_PREFIX) {
                     *mp_current_node = basic_node_type::sequence({basic_node_type()});
                     apply_directive_set(*mp_current_node);
+                    apply_deferred_properties(*mp_current_node);
                     apply_node_properties(*mp_current_node);
                     m_context_stack.emplace_back(line, indent, context_state_t::BLOCK_SEQUENCE, mp_current_node);
 
@@ -8590,7 +8599,7 @@ private:
                     // - !circle
                     //   center: 1   # the tag is for the mapping, not for the "center" key.
                     // ```
-                    m_defers_props = true;
+                    defer_node_properties();
                     line = lexer.get_lines_processed();
                     indent = lexer.get_last_token_begin_pos();
                     continue;
@@ -8649,6 +8658,7 @@ private:
                     *mp_current_node = basic_node_type::sequence();
                     m_context_stack.emplace_back(line, indent, context_state_t::BLOCK_SEQUENCE, mp_current_node);
                     apply_directive_set(*mp_current_node);
+                    apply_deferred_properties(*mp_current_node);
                     apply_node_properties(*mp_current_node);
                 }
 
@@ -8715,6 +8725,7 @@ private:
                 }
 
                 apply_directive_set(*mp_current_node);
+                apply_deferred_properties(*mp_current_node);
                 apply_node_properties(*mp_current_node);
 
                 m_flow_token_state = flow_token_state_t::NEEDS_VALUE_OR_SUFFIX;
@@ -8839,6 +8850,7 @@ private:
                 }
 
                 apply_directive_set(*mp_current_node);
+                apply_deferred_properties(*mp_current_node);
                 apply_node_properties(*mp_current_node);
 
                 line = lexer.get_lines_processed();
@@ -8925,10 +8937,10 @@ private:
                 // An alias node must not specify any properties (tag, anchor), but deferred ones are
                 // for the collection which this alias begins rather than for the alias itself.
                 // https://yaml.org/spec/1.2.2/#71-alias-nodes
-                if FK_YAML_UNLIKELY (m_needs_tag_impl && !m_defers_props) {
+                if FK_YAML_UNLIKELY (m_needs_tag_impl) {
                     throw parse_error("Tag cannot be specified to an alias node", line, indent);
                 }
-                if FK_YAML_UNLIKELY (m_needs_anchor_impl && !m_defers_props) {
+                if FK_YAML_UNLIKELY (m_needs_anchor_impl) {
                     throw parse_error("Anchor cannot be specified to an alias node.", line, indent);
                 }
 
@@ -8945,9 +8957,7 @@ private:
                 detail::node_attr_bits::set_anchor_offset(anchor_counts - 1, node.m_attrs);
 
                 apply_directive_set(node);
-                if (!m_defers_props) {
-                    apply_node_properties(node);
-                }
+                apply_node_properties(node);
 
                 deserialize_scalar(lexer, std::move(node), indent, line, token);
 
@@ -8971,9 +8981,7 @@ private:
 
                 basic_node_type node = scalar_parser_type(line, indent).parse_flow(token.type, tag_type, token.str);
                 apply_directive_set(node);
-                if (!m_defers_props) {
-                    apply_node_properties(node);
-                }
+                apply_node_properties(node);
 
                 deserialize_scalar(lexer, std::move(node), indent, line, token);
                 continue;
@@ -8986,9 +8994,7 @@ private:
                     scalar_parser_type(line, indent)
                         .parse_block(token.type, tag_type, token.str, lexer.get_block_scalar_header());
                 apply_directive_set(node);
-                if (!m_defers_props) {
-                    apply_node_properties(node);
-                }
+                apply_node_properties(node);
 
                 deserialize_scalar(lexer, std::move(node), indent, line, token);
                 continue;
@@ -9327,11 +9333,9 @@ private:
 
                     *mp_current_node = basic_node_type::mapping();
                     apply_directive_set(*mp_current_node);
-                    if (m_defers_props) {
-                        // The scalar turned out to be a key, so the deferred properties are for the
-                        // mapping which it begins.
-                        apply_node_properties(*mp_current_node);
-                    }
+                    // The scalar turned out to be a key, so any deferred properties are for the mapping
+                    // which it begins rather than for the key itself.
+                    apply_deferred_properties(*mp_current_node);
                 }
                 else {
                     // root mapping node
@@ -9356,7 +9360,7 @@ private:
             add_new_key(std::move(node), line, indent);
         }
         else {
-            if (m_defers_props) {
+            if (defers_props()) {
                 // No key separator follows, so the node is a value and owns the deferred properties.
                 // An alias node must not carry any, which is only known once it turns out not to be a
                 // key of the mapping the properties belong to.
@@ -9364,7 +9368,7 @@ private:
                 if FK_YAML_UNLIKELY (node.is_alias()) {
                     throw parse_error("Node properties cannot be specified to an alias node.", line, indent);
                 }
-                apply_node_properties(node);
+                apply_deferred_properties(node);
             }
             assign_node_value(std::move(node), line, indent);
         }
@@ -9481,6 +9485,16 @@ private:
 
         const auto pop_num = static_cast<uint32_t>(std::distance(m_context_stack.rbegin(), itr));
 
+        if (pop_num > 0 && defers_props() && mp_current_node->is_null()) {
+            // The entry which the properties preceded ends here without a node of its own, so they
+            // belong to its empty value.
+            // ```yaml
+            // foo: &anchor
+            // bar: 1        # the anchor is for the empty value of "foo".
+            // ```
+            apply_deferred_properties(*mp_current_node);
+        }
+
         // move back to the parent block mapping.
         for (uint32_t i = 0; i < pop_num; i++) {
             m_context_stack.pop_back();
@@ -9543,8 +9557,7 @@ private:
     /// @param indent Current indentation.
     /// @return The resolved tag type, or tag_t::NONE if no tag is pending.
     tag_t resolve_scalar_tag(const uint32_t line, const uint32_t indent) const {
-        if (!m_needs_tag_impl || m_defers_props) {
-            // A deferred tag belongs to the collection which this scalar begins, not to the scalar.
+        if (!m_needs_tag_impl) {
             return tag_t::NONE;
         }
 
@@ -9559,10 +9572,53 @@ private:
         return tag_type;
     }
 
+    /// @brief Move the pending node properties aside until the node they belong to is known.
+    /// @note They precede their node by a line, so the node which follows may carry properties of its
+    /// own. Keeping the two apart lets both be bound to the right node.
+    /// ```yaml
+    /// foo: &map
+    ///   &key bar: baz   # &map is for the mapping, &key is for the "bar" key.
+    /// ```
+    void defer_node_properties() {
+        if (m_needs_anchor_impl) {
+            m_deferred_anchor_name = m_anchor_name;
+            m_defers_anchor = true;
+            m_needs_anchor_impl = false;
+            m_anchor_name = {};
+        }
+        if (m_needs_tag_impl) {
+            m_deferred_tag_name = m_tag_name;
+            m_defers_tag = true;
+            m_needs_tag_impl = false;
+            m_tag_name = {};
+        }
+    }
+
+    /// @brief Check whether any node properties are waiting to be bound.
+    /// @return true if properties precede a node whose kind is not known yet, false otherwise.
+    bool defers_props() const noexcept {
+        return m_defers_anchor || m_defers_tag;
+    }
+
+    /// @brief Set the node properties which precede their node to the given node.
+    /// @param node A node type object the deferred properties belong to.
+    void apply_deferred_properties(basic_node_type& node) {
+        if (m_defers_anchor) {
+            node.add_anchor_name(std::string(m_deferred_anchor_name.begin(), m_deferred_anchor_name.end()));
+            m_defers_anchor = false;
+            m_deferred_anchor_name = {};
+        }
+
+        if (m_defers_tag) {
+            node.add_tag_name(std::string(m_deferred_tag_name.begin(), m_deferred_tag_name.end()));
+            m_defers_tag = false;
+            m_deferred_tag_name = {};
+        }
+    }
+
     /// @brief Set YAML node properties (anchor and/or tag names) to the given node.
     /// @param node A node type object to be set YAML node properties.
     void apply_node_properties(basic_node_type& node) {
-        m_defers_props = false;
         if (m_needs_anchor_impl) {
             node.add_anchor_name(std::string(m_anchor_name.begin(), m_anchor_name.end()));
             m_needs_anchor_impl = false;
@@ -9596,7 +9652,13 @@ private:
     /// Whether the document being parsed exists at all: it has contents or an explicit "---".
     bool m_has_document {false};
     /// Whether the pending node properties precede their node and are not bound yet.
-    bool m_defers_props {false};
+    bool m_defers_anchor {false};
+    /// Whether a tag which precedes its node is waiting to be bound.
+    bool m_defers_tag {false};
+    /// The anchor name which precedes its node.
+    str_view m_deferred_anchor_name;
+    /// The tag name which precedes its node.
+    str_view m_deferred_tag_name;
     /// A flag to determine the need for YAML anchor node implementation.
     bool m_needs_anchor_impl {false};
     /// A flag to determine the need for a corresponding node with the last YAML tag.

--- a/single_include/fkYAML/node.hpp
+++ b/single_include/fkYAML/node.hpp
@@ -8396,6 +8396,16 @@ private:
                     continue;
                 }
 
+                if (found_props) {
+                    // The properties belong to whatever begins on the following line, which the token
+                    // after it decides.
+                    // ```yaml
+                    // foo: &anchor
+                    //   bar: baz   # the anchor is for the mapping, not for the "bar" key.
+                    // ```
+                    m_defers_props = true;
+                }
+
                 line = lexer.get_lines_processed();
                 indent = lexer.get_last_token_begin_pos();
 
@@ -8569,8 +8579,23 @@ private:
                 continue;
             }
             case lexical_token_t::ANCHOR_PREFIX:
-            case lexical_token_t::TAG_PREFIX:
+            case lexical_token_t::TAG_PREFIX: {
+                const uint32_t props_line = lexer.get_lines_processed();
                 deserialize_node_properties(lexer, token, line, indent);
+
+                if (lexer.get_lines_processed() > props_line) {
+                    // The properties belong to whatever begins on the following line. Which node that
+                    // is depends on the token after it, so the binding waits until that is known.
+                    // ```yaml
+                    // - !circle
+                    //   center: 1   # the tag is for the mapping, not for the "center" key.
+                    // ```
+                    m_defers_props = true;
+                    line = lexer.get_lines_processed();
+                    indent = lexer.get_last_token_begin_pos();
+                    continue;
+                }
+
                 // Skip updating the current indent to avoid stacking a wrong indentation.
                 // Note that node properties for block sequences as a mapping value are processed when a
                 // `lexical_token_t::KEY_SEPARATOR` token is processed.
@@ -8581,6 +8606,7 @@ private:
                 // the correct indent width for the "bar" node key.
                 // ```
                 continue;
+            }
             case lexical_token_t::SEQUENCE_BLOCK_PREFIX: {
                 check_tab_in_indentation(lexer, lexer.get_lines_processed(), lexer.get_last_token_begin_pos());
                 if FK_YAML_UNLIKELY (m_flow_context_depth > 0) {
@@ -8896,12 +8922,13 @@ private:
                 m_flow_token_state = flow_token_state_t::NEEDS_VALUE_OR_SUFFIX;
                 break;
             case lexical_token_t::ALIAS_PREFIX: {
-                // An alias node must not specify any properties (tag, anchor).
+                // An alias node must not specify any properties (tag, anchor), but deferred ones are
+                // for the collection which this alias begins rather than for the alias itself.
                 // https://yaml.org/spec/1.2.2/#71-alias-nodes
-                if FK_YAML_UNLIKELY (m_needs_tag_impl) {
+                if FK_YAML_UNLIKELY (m_needs_tag_impl && !m_defers_props) {
                     throw parse_error("Tag cannot be specified to an alias node", line, indent);
                 }
-                if FK_YAML_UNLIKELY (m_needs_anchor_impl) {
+                if FK_YAML_UNLIKELY (m_needs_anchor_impl && !m_defers_props) {
                     throw parse_error("Anchor cannot be specified to an alias node.", line, indent);
                 }
 
@@ -8918,7 +8945,9 @@ private:
                 detail::node_attr_bits::set_anchor_offset(anchor_counts - 1, node.m_attrs);
 
                 apply_directive_set(node);
-                apply_node_properties(node);
+                if (!m_defers_props) {
+                    apply_node_properties(node);
+                }
 
                 deserialize_scalar(lexer, std::move(node), indent, line, token);
 
@@ -8942,7 +8971,9 @@ private:
 
                 basic_node_type node = scalar_parser_type(line, indent).parse_flow(token.type, tag_type, token.str);
                 apply_directive_set(node);
-                apply_node_properties(node);
+                if (!m_defers_props) {
+                    apply_node_properties(node);
+                }
 
                 deserialize_scalar(lexer, std::move(node), indent, line, token);
                 continue;
@@ -8955,7 +8986,9 @@ private:
                     scalar_parser_type(line, indent)
                         .parse_block(token.type, tag_type, token.str, lexer.get_block_scalar_header());
                 apply_directive_set(node);
-                apply_node_properties(node);
+                if (!m_defers_props) {
+                    apply_node_properties(node);
+                }
 
                 deserialize_scalar(lexer, std::move(node), indent, line, token);
                 continue;
@@ -9294,6 +9327,11 @@ private:
 
                     *mp_current_node = basic_node_type::mapping();
                     apply_directive_set(*mp_current_node);
+                    if (m_defers_props) {
+                        // The scalar turned out to be a key, so the deferred properties are for the
+                        // mapping which it begins.
+                        apply_node_properties(*mp_current_node);
+                    }
                 }
                 else {
                     // root mapping node
@@ -9318,6 +9356,16 @@ private:
             add_new_key(std::move(node), line, indent);
         }
         else {
+            if (m_defers_props) {
+                // No key separator follows, so the node is a value and owns the deferred properties.
+                // An alias node must not carry any, which is only known once it turns out not to be a
+                // key of the mapping the properties belong to.
+                // https://yaml.org/spec/1.2.2/#71-alias-nodes
+                if FK_YAML_UNLIKELY (node.is_alias()) {
+                    throw parse_error("Node properties cannot be specified to an alias node.", line, indent);
+                }
+                apply_node_properties(node);
+            }
             assign_node_value(std::move(node), line, indent);
         }
 
@@ -9495,7 +9543,8 @@ private:
     /// @param indent Current indentation.
     /// @return The resolved tag type, or tag_t::NONE if no tag is pending.
     tag_t resolve_scalar_tag(const uint32_t line, const uint32_t indent) const {
-        if (!m_needs_tag_impl) {
+        if (!m_needs_tag_impl || m_defers_props) {
+            // A deferred tag belongs to the collection which this scalar begins, not to the scalar.
             return tag_t::NONE;
         }
 
@@ -9513,6 +9562,7 @@ private:
     /// @brief Set YAML node properties (anchor and/or tag names) to the given node.
     /// @param node A node type object to be set YAML node properties.
     void apply_node_properties(basic_node_type& node) {
+        m_defers_props = false;
         if (m_needs_anchor_impl) {
             node.add_anchor_name(std::string(m_anchor_name.begin(), m_anchor_name.end()));
             m_needs_anchor_impl = false;
@@ -9545,6 +9595,8 @@ private:
     std::shared_ptr<doc_metainfo_type> mp_meta {};
     /// Whether the document being parsed exists at all: it has contents or an explicit "---".
     bool m_has_document {false};
+    /// Whether the pending node properties precede their node and are not bound yet.
+    bool m_defers_props {false};
     /// A flag to determine the need for YAML anchor node implementation.
     bool m_needs_anchor_impl {false};
     /// A flag to determine the need for a corresponding node with the last YAML tag.

--- a/single_include/fkYAML/node.hpp
+++ b/single_include/fkYAML/node.hpp
@@ -8437,27 +8437,6 @@ private:
                         add_explicit_key_with_empty_value(old_line, old_indent);
                     }
 
-                    if (m_needs_tag_impl) {
-                        const tag_t tag_type = tag_resolver_type::resolve_tag(m_tag_name, mp_meta);
-                        if (tag_type == tag_t::MAPPING || tag_type == tag_t::CUSTOM_TAG) {
-                            // set YAML node properties here to distinguish them from those for the first key node
-                            // as shown in the following snippet:
-                            //
-                            // ```yaml
-                            // foo: !!map
-                            //   !!str 123: true
-                            //   ^
-                            //   this !!str tag overwrites the preceding !!map tag.
-                            // ```
-                            *mp_current_node = basic_node_type::mapping();
-                            apply_directive_set(*mp_current_node);
-                            apply_deferred_properties(*mp_current_node);
-                            apply_node_properties(*mp_current_node);
-                            m_context_stack.emplace_back(line, indent, context_state_t::BLOCK_MAPPING, mp_current_node);
-                            continue;
-                        }
-                    }
-
                     if (token.type == lexical_token_t::SEQUENCE_BLOCK_PREFIX) {
                         // a key separator preceding block sequence entries
                         *mp_current_node = basic_node_type::sequence({basic_node_type()});

--- a/single_include/fkYAML/node.hpp
+++ b/single_include/fkYAML/node.hpp
@@ -9464,9 +9464,10 @@ private:
 
         const auto pop_num = static_cast<uint32_t>(std::distance(m_context_stack.rbegin(), itr));
 
-        if (pop_num > 0 && defers_props() && mp_current_node->is_null()) {
+        if (pop_num > 0 && defers_props()) {
             // The entry which the properties preceded ends here without a node of its own, so they
-            // belong to its empty value.
+            // belong to its empty value. Any node which did follow them would have taken them before
+            // its context could be popped, so the current node is still the empty one.
             // ```yaml
             // foo: &anchor
             // bar: 1        # the anchor is for the empty value of "foo".

--- a/tests/unit_test/test_deserializer_class.cpp
+++ b/tests/unit_test/test_deserializer_class.cpp
@@ -4215,3 +4215,110 @@ TEST_CASE("Deserializer_TabInIndentation") {
         }
     }
 }
+
+TEST_CASE("Deserializer_NodePropertiesBeforeBlockMapping") {
+    fkyaml::detail::basic_deserializer<fkyaml::node> deserializer;
+    fkyaml::node root;
+
+    SUBCASE("properties belong to the mapping which begins on the next line") {
+        SUBCASE("an anchor for a mapping as a mapping value") {
+            std::string input = "foo: &anchor\n  bar: baz\n";
+            REQUIRE_NOTHROW(root = deserializer.deserialize(fkyaml::detail::input_adapter(input)));
+
+            fkyaml::node& foo_node = root["foo"];
+            REQUIRE(foo_node.is_mapping());
+            REQUIRE(foo_node.is_anchor());
+            REQUIRE(foo_node.get_anchor_name() == "anchor");
+            REQUIRE_FALSE(foo_node.begin().key().is_anchor());
+        }
+
+        SUBCASE("an anchor for a mapping as a sequence entry") {
+            std::string input = "- &anchor\n  bar: baz\n";
+            REQUIRE_NOTHROW(root = deserializer.deserialize(fkyaml::detail::input_adapter(input)));
+
+            fkyaml::node& entry = root[0];
+            REQUIRE(entry.is_mapping());
+            REQUIRE(entry.is_anchor());
+            REQUIRE(entry.get_anchor_name() == "anchor");
+        }
+
+        SUBCASE("a tag for a mapping as a sequence entry") {
+            std::string input = "- !circle\n  center: 1\n";
+            REQUIRE_NOTHROW(root = deserializer.deserialize(fkyaml::detail::input_adapter(input)));
+
+            fkyaml::node& entry = root[0];
+            REQUIRE(entry.is_mapping());
+            REQUIRE(entry.has_tag_name());
+            REQUIRE(entry.get_tag_name() == "!circle");
+            REQUIRE_FALSE(entry.begin().key().has_tag_name());
+        }
+
+        SUBCASE("an alias key does not take the properties") {
+            std::string input = "a: &key foo\nb: &node\n  *key : bar\n";
+            REQUIRE_NOTHROW(root = deserializer.deserialize(fkyaml::detail::input_adapter(input)));
+
+            fkyaml::node& b_node = root["b"];
+            REQUIRE(b_node.is_mapping());
+            REQUIRE(b_node.is_anchor());
+            REQUIRE(b_node.get_anchor_name() == "node");
+        }
+    }
+
+    SUBCASE("properties on the same line still belong to the node which follows them") {
+        SUBCASE("a key") {
+            std::string input = "&key foo: bar\n";
+            REQUIRE_NOTHROW(root = deserializer.deserialize(fkyaml::detail::input_adapter(input)));
+
+            REQUIRE(root.begin().key().is_anchor());
+            REQUIRE(root.begin().key().get_anchor_name() == "key");
+            REQUIRE_FALSE(root.is_anchor());
+        }
+
+        SUBCASE("a scalar value") {
+            std::string input = "foo: &value bar\n";
+            REQUIRE_NOTHROW(root = deserializer.deserialize(fkyaml::detail::input_adapter(input)));
+
+            REQUIRE(root["foo"].is_anchor());
+            REQUIRE(root["foo"].get_anchor_name() == "value");
+        }
+    }
+
+    SUBCASE("a block sequence on the next line keeps taking them") {
+        std::string input = "foo: &anchor\n  - 1\n";
+        REQUIRE_NOTHROW(root = deserializer.deserialize(fkyaml::detail::input_adapter(input)));
+
+        fkyaml::node& foo_node = root["foo"];
+        REQUIRE(foo_node.is_sequence());
+        REQUIRE(foo_node.is_anchor());
+        REQUIRE(foo_node.get_anchor_name() == "anchor");
+    }
+
+    SUBCASE("a block scalar on the next line takes them") {
+        auto input = GENERATE(std::string("foo: &anchor\n  |\n    text\n"), std::string("- &anchor\n  |\n    text\n"));
+        REQUIRE_NOTHROW(root = deserializer.deserialize(fkyaml::detail::input_adapter(input)));
+
+        const fkyaml::node& value = root.is_mapping() ? root["foo"] : root[0];
+        REQUIRE(value.is_string());
+        REQUIRE(value.as_str() == "text\n");
+        REQUIRE(value.is_anchor());
+        REQUIRE(value.get_anchor_name() == "anchor");
+    }
+
+    SUBCASE("an alias node cannot take them") {
+        // The alias is the whole value rather than a key of the mapping the properties belong to,
+        // so it would be carrying them itself, which is not allowed.
+        auto input = GENERATE(std::string("a: &x 1\nb: !!str\n  *x\n"), std::string("a: &x 1\nb: &y\n  *x\n"));
+
+        REQUIRE_THROWS_AS(root = deserializer.deserialize(fkyaml::detail::input_adapter(input)), fkyaml::parse_error);
+    }
+
+    SUBCASE("a collection tag is not rejected as a scalar one") {
+        // The tag is for the mapping which begins on the next line, so it never reaches the key as a
+        // scalar tag. See https://github.com/fktn-k/fkYAML/issues/594.
+        std::string input = "foo: !!map\n  bar: baz\n";
+        REQUIRE_NOTHROW(root = deserializer.deserialize(fkyaml::detail::input_adapter(input)));
+
+        REQUIRE(root["foo"].is_mapping());
+        REQUIRE(root["foo"].get_tag_name() == "!!map");
+    }
+}

--- a/tests/unit_test/test_deserializer_class.cpp
+++ b/tests/unit_test/test_deserializer_class.cpp
@@ -4321,9 +4321,9 @@ TEST_CASE("Deserializer_NodePropertiesBeforeBlockMapping") {
         REQUIRE(top_node.is_anchor());
         REQUIRE(top_node.get_anchor_name() == "map");
 
-        const fkyaml::node& key = top_node.begin().key();
-        REQUIRE(key.is_anchor());
-        REQUIRE(key.get_anchor_name() == "key");
+        auto itr = top_node.begin();
+        REQUIRE(itr.key().is_anchor());
+        REQUIRE(itr.key().get_anchor_name() == "key");
     }
 
     SUBCASE("nothing follows them but the next entry") {

--- a/tests/unit_test/test_deserializer_class.cpp
+++ b/tests/unit_test/test_deserializer_class.cpp
@@ -4312,6 +4312,31 @@ TEST_CASE("Deserializer_NodePropertiesBeforeBlockMapping") {
         REQUIRE_THROWS_AS(root = deserializer.deserialize(fkyaml::detail::input_adapter(input)), fkyaml::parse_error);
     }
 
+    SUBCASE("the node which follows may carry properties of its own") {
+        std::string input = "top: &map\n  &key bar: baz\n";
+        REQUIRE_NOTHROW(root = deserializer.deserialize(fkyaml::detail::input_adapter(input)));
+
+        fkyaml::node& top_node = root["top"];
+        REQUIRE(top_node.is_mapping());
+        REQUIRE(top_node.is_anchor());
+        REQUIRE(top_node.get_anchor_name() == "map");
+
+        const fkyaml::node& key = top_node.begin().key();
+        REQUIRE(key.is_anchor());
+        REQUIRE(key.get_anchor_name() == "key");
+    }
+
+    SUBCASE("nothing follows them but the next entry") {
+        std::string input = "foo: &anchor\nbar: 1\n";
+        REQUIRE_NOTHROW(root = deserializer.deserialize(fkyaml::detail::input_adapter(input)));
+
+        fkyaml::node& foo_node = root["foo"];
+        REQUIRE(foo_node.is_null());
+        REQUIRE(foo_node.is_anchor());
+        REQUIRE(foo_node.get_anchor_name() == "anchor");
+        REQUIRE_FALSE(root["bar"].is_anchor());
+    }
+
     SUBCASE("a collection tag is not rejected as a scalar one") {
         // The tag is for the mapping which begins on the next line, so it never reaches the key as a
         // scalar tag. See https://github.com/fktn-k/fkYAML/issues/594.

--- a/tests/unit_test/test_deserializer_class.cpp
+++ b/tests/unit_test/test_deserializer_class.cpp
@@ -4346,4 +4346,18 @@ TEST_CASE("Deserializer_NodePropertiesBeforeBlockMapping") {
         REQUIRE(root["foo"].is_mapping());
         REQUIRE(root["foo"].get_tag_name() == "!!map");
     }
+
+    SUBCASE("a tag on the first key does not take the one for its mapping") {
+        std::string input = "foo: !!map\n  !!str 123: true\n";
+        REQUIRE_NOTHROW(root = deserializer.deserialize(fkyaml::detail::input_adapter(input)));
+
+        fkyaml::node& foo_node = root["foo"];
+        REQUIRE(foo_node.is_mapping());
+        REQUIRE(foo_node.get_tag_name() == "!!map");
+
+        auto itr = foo_node.begin();
+        REQUIRE(itr.key().is_string());
+        REQUIRE(itr.key().get_tag_name() == "!!str");
+        REQUIRE(itr.value().get_value<bool>());
+    }
 }


### PR DESCRIPTION
This PR fixes #594, node properties which precede their node by a line are bound to the mapping key which follows them instead of to the node they belong to.

The properties are applied before it is known whether the scalar which follows is a value or a mapping key, so they end up on the key:

```yaml
foo: &anchor
  bar: baz     # the anchor lands on "bar" instead of on the mapping
- !circle
  center: 1    # parse_error: Detected invalid indentation.
```

## What's changed

* The binding is deferred until the token after the scalar decides what it is, which is the point suggested in #594. If a key separator follows, the properties belong to the mapping which the key begins, otherwise the node is a value and keeps them.

* Properties which precede their node are held apart from those found on the node's own line, so both reach the right node. Sharing one slot meant the later ones overwrote the earlier:

```yaml
top: &map
  &key bar: baz   # &map is for the mapping, &key is for the "bar" key
```

* This makes the special case for a mapping tag unnecessary, so it is removed. It existed to apply the tag before the first key could overwrite it, and both now survive instead:

```yaml
foo: !!map
  !!str 123: true   # !!map stays on the mapping, !!str goes to the key
```

* A deferred tag no longer reaches `resolve_scalar_tag()`, so a collection tag is not rejected as a scalar one.

* An alias node cannot carry deferred properties, which is only known once it turns out not to be a key of the mapping they belong to.

* If nothing follows them but the next entry, the properties belong to the empty value they preceded:

```yaml
foo: &anchor
bar: 1        # the anchor is for the empty value of "foo"
```

Properties on the same line as their node keep binding to it, and a block sequence on the next line is unaffected.

All unit tests pass.
This also fixes `26DV`, `7BMT`, `C4HZ`, `U3XV` and `UGM3` in the YAML test suite, as well as `6JWB`, `735Y` and `BU8L`, which failed on `A sequence or mapping tag cannot be specified to a scalar node`.
As a result, 68 failing cases has decreased to 60 with no newly failing case.

`6KGN` and `9KAX` still fail, for reasons which are not about which node the properties are bound to:

* `6KGN` needs an anchor which is still deferred to be visible to alias resolution. The anchor does reach the empty value it belongs to, but an alias on the next line is looked up before it is registered.
* `9KAX` is about properties which precede the document root node, which has a path of its own rather than the one this PR changes.

---

## Pull Request Checklist

Read the [CONTRIBUTING.md](https://github.com/fktn-k/fkYAML/blob/develop/.github/CONTRIBUTING.md) file for detailed information.  

- [x] Changes are described in the pull request or in a referenced [issue](https://github.com/fktn-k/fkYAML/issues).
- [x] The test suite compiles and runs without any error.
- [x] [The code coverage](https://coveralls.io/github/fktn-k/fkYAML) on your branch is 100%.
- [x] The documentation is updated if you added/changed a feature.

## Please don't

- The C++11 support varies between different **compilers** and versions. Please note the [list of supported compilers](https://github.com/fktn-k/fkYAML/blob/develop/README.md#supported-compilers). Some compilers like GCC 4.7 (and earlier), Clang 3.3 (and earlier), or Microsoft Visual Studio 13.0 and earlier are known not to work due to missing or incomplete C++11 support. Please refrain from proposing changes that work around these compiler's limitations with `#ifdef`s or other means.
- Please refrain from proposing changes that would **break [YAML](https://yaml.org/) specifications**. If you propose a conformant extension of YAML to be supported by the library, please motivate this extension.
- Please do not open pull requests that address **multiple issues**.
