### PR TITLE
Let any number of white spaces separate plain scalar characters

### DIFF
--- a/include/fkYAML/detail/input/lexical_analyzer.hpp
+++ b/include/fkYAML/detail/input/lexical_analyzer.hpp
@@ -1162,39 +1162,40 @@ private:
                 break;
             }
             case ' ':
-            case '\t':
-                if FK_YAML_UNLIKELY (pos == sv.size() - 1) {
-                    // trim trailing space.
+            case '\t': {
+                // Any number of white spaces may separate the characters of a plain scalar, so the whole
+                // run of them belongs to it and what follows the run decides whether it ends.
+                // See https://yaml.org/spec/1.2.2/#733-plain-style for more details.
+                const std::size_t next_pos = sv.find_first_not_of(" \t", pos + 1);
+                if FK_YAML_UNLIKELY (next_pos == str_view::npos) {
+                    // trim trailing white space.
                     ends_loop = true;
                     break;
                 }
 
-                // Allow a space in a plain scalar only if the space is surrounded by non-space characters, but not
-                // followed by the comment prefix " #".
-                // Also, flow indicators are not allowed to be followed after a space in a flow context.
-                // See https://yaml.org/spec/1.2.2/#733-plain-style for more details.
-                switch (sv[pos + 1]) {
-                case ' ':
-                case '\t':
+                // White space is not allowed to be followed by the comment prefix " #", and flow
+                // indicators are not allowed to follow it in a flow context.
+                switch (sv[next_pos]) {
                 case '\n':
                 case '#':
                     ends_loop = true;
                     break;
                 case ':':
                     // " :" is permitted in a plain style string token, but not when followed by a space.
-                    ends_loop = (pos < sv.size() - 2) && (sv[pos + 2] == ' ');
+                    ends_loop = (next_pos + 1 < sv.size()) && (sv[next_pos + 1] == ' ');
                     break;
                 case '{':
                 case '}':
                 case '[':
                 case ']':
                 case ',':
-                    ends_loop = (m_state & flow_context_bit);
+                    ends_loop = ((m_state & flow_context_bit) != 0);
                     break;
                 default:
                     break;
                 }
                 break;
+            }
             case ':':
                 if FK_YAML_LIKELY (pos + 1 < sv.size()) {
                     switch (sv[pos + 1]) {

--- a/single_include/fkYAML/node.hpp
+++ b/single_include/fkYAML/node.hpp
@@ -4435,39 +4435,40 @@ private:
                 break;
             }
             case ' ':
-            case '\t':
-                if FK_YAML_UNLIKELY (pos == sv.size() - 1) {
-                    // trim trailing space.
+            case '\t': {
+                // Any number of white spaces may separate the characters of a plain scalar, so the whole
+                // run of them belongs to it and what follows the run decides whether it ends.
+                // See https://yaml.org/spec/1.2.2/#733-plain-style for more details.
+                const std::size_t next_pos = sv.find_first_not_of(" \t", pos + 1);
+                if FK_YAML_UNLIKELY (next_pos == str_view::npos) {
+                    // trim trailing white space.
                     ends_loop = true;
                     break;
                 }
 
-                // Allow a space in a plain scalar only if the space is surrounded by non-space characters, but not
-                // followed by the comment prefix " #".
-                // Also, flow indicators are not allowed to be followed after a space in a flow context.
-                // See https://yaml.org/spec/1.2.2/#733-plain-style for more details.
-                switch (sv[pos + 1]) {
-                case ' ':
-                case '\t':
+                // White space is not allowed to be followed by the comment prefix " #", and flow
+                // indicators are not allowed to follow it in a flow context.
+                switch (sv[next_pos]) {
                 case '\n':
                 case '#':
                     ends_loop = true;
                     break;
                 case ':':
                     // " :" is permitted in a plain style string token, but not when followed by a space.
-                    ends_loop = (pos < sv.size() - 2) && (sv[pos + 2] == ' ');
+                    ends_loop = (next_pos + 1 < sv.size()) && (sv[next_pos + 1] == ' ');
                     break;
                 case '{':
                 case '}':
                 case '[':
                 case ']':
                 case ',':
-                    ends_loop = (m_state & flow_context_bit);
+                    ends_loop = ((m_state & flow_context_bit) != 0);
                     break;
                 default:
                     break;
                 }
                 break;
+            }
             case ':':
                 if FK_YAML_LIKELY (pos + 1 < sv.size()) {
                     switch (sv[pos + 1]) {

--- a/tests/unit_test/test_deserializer_class.cpp
+++ b/tests/unit_test/test_deserializer_class.cpp
@@ -2195,7 +2195,7 @@ TEST_CASE("Deserializer_FlowSequence") {
     }
 
     SUBCASE("lack the beginning of a flow sequence") {
-        auto input = GENERATE(std::string("test: {]}"), std::string("test: {foo: bar]}"), std::string("test: bar  ]"));
+        auto input = GENERATE(std::string("test: {]}"), std::string("test: {foo: bar]}"));
         REQUIRE_THROWS_AS(deserializer.deserialize(fkyaml::detail::input_adapter(input)), fkyaml::parse_error);
     }
 
@@ -2304,12 +2304,13 @@ TEST_CASE("Deserializer_FlowSequence") {
     }
 
     SUBCASE("missing value separators") {
+        // White space alone does not separate entries, since it may appear within a plain scalar. A
+        // missing separator is only detectable where the next entry cannot continue the current one.
         auto input = GENERATE(
-            std::string("[123  true, 3.14]"),
-            std::string("[123, true  3.14]"),
-            // std::string("[123  [true, 3.14]]"),
-            std::string("[123, [true  3.14]]"),
-            // std::string("[123  {foo: true, bar: 3.14}]"),
+            std::string("[[1] [2]]"),
+            std::string("[\"a\" \"b\"]"),
+            std::string("[123  [true, 3.14]]"),
+            std::string("[123  {foo: true, bar: 3.14}]"),
             std::string("[123, {foo: true  bar: 3.14}]"));
         REQUIRE_THROWS_AS(deserializer.deserialize(fkyaml::detail::input_adapter(input)), fkyaml::parse_error);
     }
@@ -2439,7 +2440,7 @@ TEST_CASE("Deserializer_FlowMapping") {
     }
 
     SUBCASE("lack the beginning of a flow mapping") {
-        auto input = GENERATE(std::string("test: [}]"), std::string("test: [true}]"), std::string("test: foo  }"));
+        auto input = GENERATE(std::string("test: [}]"), std::string("test: [true}]"));
         REQUIRE_THROWS_AS(deserializer.deserialize(fkyaml::detail::input_adapter(input)), fkyaml::parse_error);
     }
 
@@ -4359,5 +4360,74 @@ TEST_CASE("Deserializer_NodePropertiesBeforeBlockMapping") {
         REQUIRE(itr.key().is_string());
         REQUIRE(itr.key().get_tag_name() == "!!str");
         REQUIRE(itr.value().get_value<bool>());
+    }
+}
+
+TEST_CASE("Deserializer_WhiteSpaceInsidePlainScalar") {
+    fkyaml::detail::basic_deserializer<fkyaml::node> deserializer;
+    fkyaml::node root;
+
+    SUBCASE("any number of white spaces may separate its characters") {
+        SUBCASE("two spaces") {
+            std::string input = "foo: bar  baz\n";
+            REQUIRE_NOTHROW(root = deserializer.deserialize(fkyaml::detail::input_adapter(input)));
+            REQUIRE(root["foo"].as_str() == "bar  baz");
+        }
+
+        SUBCASE("more than two, and more than once") {
+            std::string input = "foo: bar   baz  qux\n";
+            REQUIRE_NOTHROW(root = deserializer.deserialize(fkyaml::detail::input_adapter(input)));
+            REQUIRE(root["foo"].as_str() == "bar   baz  qux");
+        }
+
+        SUBCASE("tabs count as white space too") {
+            std::string input = "foo: bar \t baz\n";
+            REQUIRE_NOTHROW(root = deserializer.deserialize(fkyaml::detail::input_adapter(input)));
+            REQUIRE(root["foo"].as_str() == "bar \t baz");
+        }
+
+        SUBCASE("a following indicator is an ordinary character in a block context") {
+            auto input = GENERATE(
+                std::string("foo: bar  ]\n"),
+                std::string("foo: bar  }\n"),
+                std::string("foo: bar  ? baz\n"),
+                std::string("foo: bar  |- baz\n"));
+            REQUIRE_NOTHROW(root = deserializer.deserialize(fkyaml::detail::input_adapter(input)));
+            REQUIRE(root["foo"].as_str().find("bar  ") == 0);
+        }
+
+        SUBCASE("in a flow context") {
+            std::string input = "[foo  bar, baz]";
+            REQUIRE_NOTHROW(root = deserializer.deserialize(fkyaml::detail::input_adapter(input)));
+            REQUIRE(root[0].as_str() == "foo  bar");
+            REQUIRE(root[1].as_str() == "baz");
+        }
+    }
+
+    SUBCASE("white space still ends it where it used to") {
+        SUBCASE("before the comment prefix") {
+            std::string input = "foo: bar  # baz\n";
+            REQUIRE_NOTHROW(root = deserializer.deserialize(fkyaml::detail::input_adapter(input)));
+            REQUIRE(root["foo"].as_str() == "bar");
+        }
+
+        SUBCASE("at the end of a line") {
+            std::string input = "foo: bar  \n";
+            REQUIRE_NOTHROW(root = deserializer.deserialize(fkyaml::detail::input_adapter(input)));
+            REQUIRE(root["foo"].as_str() == "bar");
+        }
+
+        SUBCASE("before a value indicator") {
+            std::string input = "foo  : bar\n";
+            REQUIRE_NOTHROW(root = deserializer.deserialize(fkyaml::detail::input_adapter(input)));
+            REQUIRE(root["foo"].as_str() == "bar");
+        }
+
+        SUBCASE("before a flow indicator in a flow context") {
+            std::string input = "[foo  ]";
+            REQUIRE_NOTHROW(root = deserializer.deserialize(fkyaml::detail::input_adapter(input)));
+            REQUIRE(root.size() == 1);
+            REQUIRE(root[0].as_str() == "foo");
+        }
     }
 }

--- a/tests/unit_test/test_fuzz_regression.cpp
+++ b/tests/unit_test/test_fuzz_regression.cpp
@@ -97,11 +97,14 @@ TEST_CASE("FuzzRegression") {
         REQUIRE_THROWS_AS(root = fkyaml::node::deserialize(p_begin, p_end), fkyaml::parse_error);
     }
 
-    SUBCASE("explicit key indicator without a parent context") {
+    SUBCASE("an explicit key indicator inside a plain scalar") {
+        // White space may separate the characters of a plain scalar, so the indicator is part of
+        // its contents rather than the beginning of an entry.
         const char input[] = "a  ? a";
         p_begin = input;
         p_end = input + sizeof(input) - 1;
-        REQUIRE_THROWS_AS(root = fkyaml::node::deserialize(p_begin, p_end), fkyaml::parse_error);
+        REQUIRE_NOTHROW(root = fkyaml::node::deserialize(p_begin, p_end));
+        REQUIRE(root.as_str() == "a  ? a");
     }
 
     SUBCASE("key separator without a parent context") {

--- a/tests/unit_test/test_lexical_analyzer_class.cpp
+++ b/tests/unit_test/test_lexical_analyzer_class.cpp
@@ -1277,10 +1277,11 @@ TEST_CASE("LexicalAnalyzer_LiteralStringScalar") {
         REQUIRE_THROWS_AS(token = lexer.get_next_token(), fkyaml::parse_error);
     }
 
-    SUBCASE("literal string scalar with invalid header position") {
+    SUBCASE("a block scalar header which follows contents belongs to them") {
+        // A header indicator only begins a block scalar where a node does. Anywhere else it is an
+        // ordinary character of the plain scalar which is already being read.
         const char input[] = "root:\n"
-                             "  c]h:di     |- \n"
-                             " a  ) - b\n";
+                             "  c]h:di     |- \n";
         fkyaml::detail::lexical_analyzer lexer(input);
 
         REQUIRE_NOTHROW(token = lexer.get_next_token());
@@ -1293,10 +1294,8 @@ TEST_CASE("LexicalAnalyzer_LiteralStringScalar") {
 
         REQUIRE_NOTHROW(token = lexer.get_next_token());
         REQUIRE(token.type == fkyaml::detail::lexical_token_t::PLAIN_SCALAR);
-        REQUIRE(token.str.begin() == &input[8]); // "c]h:di"
-        REQUIRE(token.str.end() == &input[14]);
-
-        REQUIRE_THROWS_AS(token = lexer.get_next_token(), fkyaml::parse_error);
+        REQUIRE(token.str.begin() == &input[8]); // "c]h:di     |-"
+        REQUIRE(token.str.end() == &input[21]);
     }
 }
 


### PR DESCRIPTION
This PR fixes a plain scalar being cut short at the first pair of consecutive white spaces, so ordinary documents fail to parse:

```cpp
auto root = fkyaml::node::deserialize("foo: bar  baz\n");
// parse_error: The ":" mapping value indicator must be followed after a mapping key.
```

The clearest sign that this is not intended is that one space and two spaces disagree. On `develop`:

| input | result |
|---|---|
| `test: bar ]` | `bar ]` |
| `test: bar  ]` | `parse_error: Flow sequence ending is found outside the flow context.` |
| `test: a ? b` | `a ? b` |
| `test: a  ? b` | parses, but the value is silently truncated to `a` |

The last row loses data without an error.

The specification allows any amount of white space between the characters of a plain scalar, and in a block context none of the indicators are special once the scalar has begun:

```
[134] nb-ns-plain-in-line(c) ::= ( s-white* ns-plain-char(c) )*
[132] ns-plain-safe(FLOW-OUT) ::= ns-char
```

https://yaml.org/spec/1.2.2/#733-plain-style

## What's changed

* When white space is found, the whole run of it is skipped and the character which follows the run decides whether the scalar ends, instead of only the character right after the first space.
* What ended a plain scalar before still ends it: the comment prefix ` #`, a line break, ` : `, and a flow indicator in a flow context. Trailing white space is still trimmed.

## Tests which described the old behaviour

Seven inputs asserted results which only occurred because of this, so they are updated:

* `test: bar  ]` and `test: foo  }` expected an error. Both are plain scalars in a block context.
* `a  ? a` in the fuzz regressions expected an error. It is the plain scalar `a  ? a`.
* A lexer case expected `|-` after contents to begin a block scalar header. A header only begins a block scalar where a node does, so it is an ordinary character there.
* Three "missing value separators" inputs used plain scalars, where white space cannot separate entries at all. They are replaced with inputs where the next entry cannot continue the current one, such as `[[1] [2]]` and `["a" "b"]`.

The two inputs which were commented out in that same case, `[123  [true, 3.14]]` and `[123  {foo: true, bar: 3.14}]`, work as error cases now and are enabled again.

New tests cover two or more spaces, tabs, indicators which follow them, the flow context, and each way a plain scalar still ends.

The YAML test suite is unchanged at 68 failing cases, since it contains no case with a plain scalar which has consecutive white spaces inside it. That is presumably why this survived: I ran into it through [throneproj/Throne#1338](https://github.com/throneproj/Throne/issues/1338), where Clash subscription names such as `Cool  Name` fail to parse while other clients accept them.

---

## Pull Request Checklist

Read the [CONTRIBUTING.md](https://github.com/fktn-k/fkYAML/blob/develop/.github/CONTRIBUTING.md) file for detailed information.  

- [x] Changes are described in the pull request or in a referenced [issue](https://github.com/fktn-k/fkYAML/issues).
- [x] The test suite compiles and runs without any error.
- [x] [The code coverage](https://coveralls.io/github/fktn-k/fkYAML) on your branch is 100%.
- [x] The documentation is updated if you added/changed a feature.

## Please don't

- The C++11 support varies between different **compilers** and versions. Please note the [list of supported compilers](https://github.com/fktn-k/fkYAML/blob/develop/README.md#supported-compilers). Some compilers like GCC 4.7 (and earlier), Clang 3.3 (and earlier), or Microsoft Visual Studio 13.0 and earlier are known not to work due to missing or incomplete C++11 support. Please refrain from proposing changes that work around these compiler's limitations with `#ifdef`s or other means.
- Please refrain from proposing changes that would **break [YAML](https://yaml.org/) specifications**. If you propose a conformant extension of YAML to be supported by the library, please motivate this extension.
- Please do not open pull requests that address **multiple issues**.
