### PR TITLE
Update Google Benchmark to v1.9.5

### DIFF
--- a/tools/benchmark/CMakeLists.txt
+++ b/tools/benchmark/CMakeLists.txt
@@ -11,7 +11,7 @@ set(BENCHMARK_ENABLE_TESTING OFF CACHE BOOL "" FORCE)
 set(BENCHMARK_ENABLE_GTEST_TESTS OFF CACHE BOOL "" FORCE)
 FetchContent_Declare(
   gbench
-  URL https://github.com/google/benchmark/archive/refs/tags/v1.8.4.zip
+  URL https://github.com/google/benchmark/archive/refs/tags/v1.9.5.zip
 )
 FetchContent_MakeAvailable(gbench)
 

--- a/tools/benchmark/README.md
+++ b/tools/benchmark/README.md
@@ -1,6 +1,6 @@
 # Benchmark
 
-This tool runs benchmarking of deserialization performance with [the Google Benchmark library](https://github.com/google/benchmark/) (tag: [v1.8.4](https://github.com/google/benchmark/releases/tag/v1.8.4), the latest version supporting C++11) against fkYAML and some C++ YAML library.  
+This tool runs benchmarking of deserialization performance with [the Google Benchmark library](https://github.com/google/benchmark/) (tag: [v1.9.5](https://github.com/google/benchmark/releases/tag/v1.9.5), which requires C++17 to build although it can be used from C++11 code) against fkYAML and some C++ YAML library.  
 
 ## Used YAML library for Comparison
 
@@ -46,4 +46,4 @@ bm_fkyaml_parse                 xxxxx ns        xxxxx ns        xxxxx bytes_per_
 ...
 ```
 
-Visit [the user guide](https://github.com/google/benchmark/blob/v1.8.4/docs/user_guide.md) in the Google Benchmark repository for more information on the output format.  
+Visit [the user guide](https://github.com/google/benchmark/blob/v1.9.5/docs/user_guide.md) in the Google Benchmark repository for more information on the output format.  


### PR DESCRIPTION
This PR updates the Google Benchmark library used for the benchmark from `v1.8.4` to `v1.9.5` (requested in #603).

The note calling `v1.8.4` the latest version supporting C++11 turned out to be narrower than it reads. Google Benchmark's own README for v1.9.5 states that the library can be used with C++11 but requires C++17 to build, including compiler and standard library support. That holds up in the code:

- `benchmark::benchmark` exports no `cxx_std_*` compile feature, and `BENCHMARK_CXX_STANDARD 17` is
  a plain variable set in Google Benchmark's own directory scope, so nothing is imposed on the
  `benchmarker` target.
- `benchmark.h` uses nothing newer than C++11 and still keeps its `__cplusplus < 201402L` fallback
  for `make_unique`.

So fkYAML and `tools/benchmark/main.cpp` keep compiling as before. What changes is that the toolchain building the benchmarking tool now needs C++17 support. That applies to this tool only, not to the library or its supported compilers, and the tool is not built in CI.

Verified on Windows (MSVC 19.51).

---

## Pull Request Checklist

Read the [CONTRIBUTING.md](https://github.com/fktn-k/fkYAML/blob/develop/.github/CONTRIBUTING.md) file for detailed information.  

- [x] Changes are described in the pull request or in a referenced [issue](https://github.com/fktn-k/fkYAML/issues).
- [x] The test suite compiles and runs without any error.
- [x] [The code coverage](https://coveralls.io/github/fktn-k/fkYAML) on your branch is 100%.
- [x] The documentation is updated if you added/changed a feature.

## Please don't

- The C++11 support varies between different **compilers** and versions. Please note the [list of supported compilers](https://github.com/fktn-k/fkYAML/blob/develop/README.md#supported-compilers). Some compilers like GCC 4.7 (and earlier), Clang 3.3 (and earlier), or Microsoft Visual Studio 13.0 and earlier are known not to work due to missing or incomplete C++11 support. Please refrain from proposing changes that work around these compiler's limitations with `#ifdef`s or other means.
- Please refrain from proposing changes that would **break [YAML](https://yaml.org/) specifications**. If you propose a conformant extension of YAML to be supported by the library, please motivate this extension.
- Please do not open pull requests that address **multiple issues**.
