### PR TITLE
Terminate tags at flow collection delimiters in a flow context

### DIFF
--- a/include/fkYAML/detail/input/lexical_analyzer.hpp
+++ b/include/fkYAML/detail/input/lexical_analyzer.hpp
@@ -858,6 +858,13 @@ private:
         case '\n':
             // Just "!" is a non-specific tag.
             return {m_token_begin_itr, m_cur_itr};
+        case '}':
+        case ']':
+        case ',':
+            if ((m_state & flow_context_bit) != 0) {
+                return {m_token_begin_itr, m_cur_itr};
+            }
+            break;
         case '!':
             // Secondary tag handles (!!suffix)
             break;
@@ -875,6 +882,7 @@ private:
         }
 
         bool is_named_handle = false;
+        bool is_in_verbatim_uri = is_verbatim;
         bool ends_loop = false;
         do {
             if (++m_cur_itr == m_end_itr) {
@@ -888,6 +896,10 @@ private:
             case '\n':
                 ends_loop = true;
                 break;
+            case '>':
+                // End of a verbatim tag (!<TAG>)
+                is_in_verbatim_uri = false;
+                break;
             case '!':
                 if FK_YAML_UNLIKELY (!allows_another_tag_prefix) {
                     emit_error("invalid tag prefix (!) is found.");
@@ -896,6 +908,16 @@ private:
                 is_named_handle = true;
                 // tag prefix must not appear three times.
                 allows_another_tag_prefix = false;
+                break;
+            case '}':
+            case ']':
+            case ',':
+                // Since these indicators can terminate a flow collection or its entry in a flow context,
+                // the trailing part is cut off so that the tag only includes the part before the flow indicator.
+                // ```yaml
+                // {foo: !!str, bar: !<tag:yaml.org,2002:str>}
+                // ```
+                ends_loop = !is_in_verbatim_uri && (m_state & flow_context_bit) != 0;
                 break;
             default:
                 break;

--- a/single_include/fkYAML/node.hpp
+++ b/single_include/fkYAML/node.hpp
@@ -4131,6 +4131,13 @@ private:
         case '\n':
             // Just "!" is a non-specific tag.
             return {m_token_begin_itr, m_cur_itr};
+        case '}':
+        case ']':
+        case ',':
+            if ((m_state & flow_context_bit) != 0) {
+                return {m_token_begin_itr, m_cur_itr};
+            }
+            break;
         case '!':
             // Secondary tag handles (!!suffix)
             break;
@@ -4148,6 +4155,7 @@ private:
         }
 
         bool is_named_handle = false;
+        bool is_in_verbatim_uri = is_verbatim;
         bool ends_loop = false;
         do {
             if (++m_cur_itr == m_end_itr) {
@@ -4161,6 +4169,10 @@ private:
             case '\n':
                 ends_loop = true;
                 break;
+            case '>':
+                // End of a verbatim tag (!<TAG>)
+                is_in_verbatim_uri = false;
+                break;
             case '!':
                 if FK_YAML_UNLIKELY (!allows_another_tag_prefix) {
                     emit_error("invalid tag prefix (!) is found.");
@@ -4169,6 +4181,16 @@ private:
                 is_named_handle = true;
                 // tag prefix must not appear three times.
                 allows_another_tag_prefix = false;
+                break;
+            case '}':
+            case ']':
+            case ',':
+                // Since these indicators can terminate a flow collection or its entry in a flow context,
+                // the trailing part is cut off so that the tag only includes the part before the flow indicator.
+                // ```yaml
+                // {foo: !!str, bar: !<tag:yaml.org,2002:str>}
+                // ```
+                ends_loop = !is_in_verbatim_uri && (m_state & flow_context_bit) != 0;
                 break;
             default:
                 break;

--- a/tests/unit_test/test_lexical_analyzer_class.cpp
+++ b/tests/unit_test/test_lexical_analyzer_class.cpp
@@ -1669,6 +1669,56 @@ TEST_CASE("LexicalAnalyzer_Tag") {
         REQUIRE(token.str == input);
     }
 
+    SUBCASE("tag can be terminated by flow indicators in flow context") {
+        std::string input = "[!!str, !, {foo: !<tag:yaml.org,2002:str>}, !foo!bar]";
+        fkyaml::detail::lexical_analyzer lexer(input);
+
+        REQUIRE_NOTHROW(token = lexer.get_next_token());
+        REQUIRE(token.type == fkyaml::detail::lexical_token_t::SEQUENCE_FLOW_BEGIN);
+        lexer.set_context_state(true);
+
+        REQUIRE_NOTHROW(token = lexer.get_next_token());
+        REQUIRE(token.type == fkyaml::detail::lexical_token_t::TAG_PREFIX);
+        REQUIRE(token.str == "!!str");
+
+        REQUIRE_NOTHROW(token = lexer.get_next_token());
+        REQUIRE(token.type == fkyaml::detail::lexical_token_t::VALUE_SEPARATOR);
+
+        REQUIRE_NOTHROW(token = lexer.get_next_token());
+        REQUIRE(token.type == fkyaml::detail::lexical_token_t::TAG_PREFIX);
+        REQUIRE(token.str == "!");
+
+        REQUIRE_NOTHROW(token = lexer.get_next_token());
+        REQUIRE(token.type == fkyaml::detail::lexical_token_t::VALUE_SEPARATOR);
+
+        REQUIRE_NOTHROW(token = lexer.get_next_token());
+        REQUIRE(token.type == fkyaml::detail::lexical_token_t::MAPPING_FLOW_BEGIN);
+
+        REQUIRE_NOTHROW(token = lexer.get_next_token());
+        REQUIRE(token.type == fkyaml::detail::lexical_token_t::PLAIN_SCALAR);
+        REQUIRE(token.str == "foo");
+
+        REQUIRE_NOTHROW(token = lexer.get_next_token());
+        REQUIRE(token.type == fkyaml::detail::lexical_token_t::KEY_SEPARATOR);
+
+        REQUIRE_NOTHROW(token = lexer.get_next_token());
+        REQUIRE(token.type == fkyaml::detail::lexical_token_t::TAG_PREFIX);
+        REQUIRE(token.str == "!<tag:yaml.org,2002:str>");
+
+        REQUIRE_NOTHROW(token = lexer.get_next_token());
+        REQUIRE(token.type == fkyaml::detail::lexical_token_t::MAPPING_FLOW_END);
+
+        REQUIRE_NOTHROW(token = lexer.get_next_token());
+        REQUIRE(token.type == fkyaml::detail::lexical_token_t::VALUE_SEPARATOR);
+
+        REQUIRE_NOTHROW(token = lexer.get_next_token());
+        REQUIRE(token.type == fkyaml::detail::lexical_token_t::TAG_PREFIX);
+        REQUIRE(token.str == "!foo!bar");
+
+        REQUIRE_NOTHROW(token = lexer.get_next_token());
+        REQUIRE(token.type == fkyaml::detail::lexical_token_t::SEQUENCE_FLOW_END);
+    }
+
     SUBCASE("invalid tag names") {
         auto input = GENERATE(
             fkyaml::detail::str_view("!!f!oo tag"),
@@ -1677,6 +1727,7 @@ TEST_CASE("LexicalAnalyzer_Tag") {
             fkyaml::detail::str_view("!<> tag"),
             fkyaml::detail::str_view("!<%f:oo> tag"),
             fkyaml::detail::str_view("!<!%f:oo> tag"),
+            fkyaml::detail::str_view("!<foo>bar tag"),
             fkyaml::detail::str_view("!foo! tag"),
             fkyaml::detail::str_view("!foo!%f:oo tag"),
             fkyaml::detail::str_view("!foo{ tag"),
@@ -1689,11 +1740,15 @@ TEST_CASE("LexicalAnalyzer_Tag") {
             fkyaml::detail::str_view("!!foo[ tag"),
             fkyaml::detail::str_view("!!foo] tag"),
             fkyaml::detail::str_view("!!foo, tag"),
+            // flow indicators are not allowed in a block context
             fkyaml::detail::str_view("!foo!bar{ tag"),
             fkyaml::detail::str_view("!foo!bar} tag"),
             fkyaml::detail::str_view("!foo!bar[ tag"),
             fkyaml::detail::str_view("!foo!bar] tag"),
-            fkyaml::detail::str_view("!foo!bar, tag"));
+            fkyaml::detail::str_view("!foo!bar, tag"),
+            fkyaml::detail::str_view("!}"),
+            fkyaml::detail::str_view("!]"),
+            fkyaml::detail::str_view("!,"));
 
         fkyaml::detail::lexical_analyzer lexer(input);
         REQUIRE_THROWS_AS(token = lexer.get_next_token(), fkyaml::parse_error);


### PR DESCRIPTION
This pull request updates the YAML lexical analyzer to improve its handling of tag parsing, especially in flow contexts, and adds comprehensive tests to ensure correctness. The changes make the parser more compliant with the YAML specification regarding tag termination by flow indicators (`}`, `]`, `,`) and enhance error detection for invalid tag names.

**Parser Improvements:**

* Updated `lexical_analyzer` to allow tags to be terminated by flow indicators (`}`, `]`, `,`) when in flow context, ensuring correct tokenization according to YAML spec.
* Improved handling of verbatim tags (those using `!<...>`) by properly tracking the end of the verbatim URI and ensuring flow indicators do not prematurely terminate the tag.
* Tags in block context are not affected and still rejected if they contains the flow indicators.

**Testing Enhancements:**

* Added a new test case to `test_lexical_analyzer_class.cpp` that verifies tags can be terminated by flow indicators in flow context and they are still rejected in block context.
* This fix affects `WZ62` in the YAML test suite but discovers another issue where the tag is not associated to an empty plain scalar. This will be addressed separately. There is no new failing case in the other cases.

---

## Pull Request Checklist

Read the [CONTRIBUTING.md](https://github.com/fktn-k/fkYAML/blob/develop/.github/CONTRIBUTING.md) file for detailed information.  

- [x] Changes are described in the pull request or in a referenced [issue](https://github.com/fktn-k/fkYAML/issues).
- [x] The test suite compiles and runs without any error.
- [x] [The code coverage](https://coveralls.io/github/fktn-k/fkYAML) on your branch is 100%.
- [x] The documentation is updated if you added/changed a feature.

## Please don't

- The C++11 support varies between different **compilers** and versions. Please note the [list of supported compilers](https://github.com/fktn-k/fkYAML/blob/develop/README.md#supported-compilers). Some compilers like GCC 4.7 (and earlier), Clang 3.3 (and earlier), or Microsoft Visual Studio 13.0 and earlier are known not to work due to missing or incomplete C++11 support. Please refrain from proposing changes that work around these compiler's limitations with `#ifdef`s or other means.
- Please refrain from proposing changes that would **break [YAML](https://yaml.org/) specifications**. If you propose a conformant extension of YAML to be supported by the library, please motivate this extension.
- Please do not open pull requests that address **multiple issues**.
