### PR TITLE
Fix errors on tagged empty nodes

### DIFF
--- a/include/fkYAML/detail/input/deserializer.hpp
+++ b/include/fkYAML/detail/input/deserializer.hpp
@@ -562,6 +562,17 @@ private:
                 if FK_YAML_UNLIKELY (m_context_stack.empty()) {
                     throw parse_error("A key separator is not allowed in this context.", line, indent);
                 }
+                if ((m_context_stack.back().state == context_state_t::BLOCK_SEQUENCE_ENTRY ||
+                     m_context_stack.back().state == context_state_t::MAPPING_VALUE) &&
+                    (m_needs_tag_impl || m_needs_anchor_impl) && m_context_stack.back().line != line &&
+                    indent <= m_context_stack.back().indent) {
+                    pop_to_parent_node(line, indent, [indent](const parse_context& c) {
+                        return c.state == context_state_t::BLOCK_MAPPING && indent == c.indent;
+                    });
+                    add_empty_key_entry(lexer, token, line, indent);
+                    continue;
+                }
+
                 if (m_context_stack.back().state == context_state_t::BLOCK_SEQUENCE_ENTRY) {
                     // The entry is a mapping whose first key is empty.
                     // ```yaml
@@ -571,11 +582,7 @@ private:
                     *mp_current_node = basic_node_type::mapping();
                     apply_directive_set(*mp_current_node);
                     m_context_stack.emplace_back(line, indent, context_state_t::BLOCK_MAPPING, mp_current_node);
-                    add_new_key(basic_node_type(), line, indent);
-
-                    token = lexer.get_next_token();
-                    indent = lexer.get_last_token_begin_pos();
-                    line = lexer.get_lines_processed();
+                    add_empty_key_entry(lexer, token, line, indent);
                     continue;
                 }
 
@@ -672,20 +679,16 @@ private:
                     }
 
                     if (token.type == lexical_token_t::SEQUENCE_BLOCK_PREFIX) {
-                        // a key separator preceding block sequence entries
-                        *mp_current_node = basic_node_type::sequence({basic_node_type()});
-                        apply_directive_set(*mp_current_node);
-                        apply_deferred_properties(*mp_current_node);
-                        apply_node_properties(*mp_current_node);
-                        auto& cur_context = m_context_stack.back();
-                        cur_context.line = line;
-                        cur_context.indent = indent;
-                        cur_context.state = context_state_t::BLOCK_SEQUENCE;
+                        if (m_context_stack.back().state == context_state_t::MAPPING_VALUE && defers_props() &&
+                            indent < m_context_stack.back().indent) {
+                            pop_to_parent_node(line, indent, [indent](const parse_context& c) {
+                                return c.state == context_state_t::BLOCK_SEQUENCE && indent == c.indent;
+                            });
+                            continue;
+                        }
 
-                        mp_current_node = &(mp_current_node->as_seq().back());
-                        apply_directive_set(*mp_current_node);
-                        m_context_stack.emplace_back(
-                            line, indent, context_state_t::BLOCK_SEQUENCE_ENTRY, mp_current_node);
+                        // a key separator preceding block sequence entries
+                        initialize_block_sequence_value(line, indent, true);
 
                         token = lexer.get_next_token();
                         line = lexer.get_lines_processed();
@@ -797,14 +800,7 @@ private:
                 add_explicit_key_with_empty_value(old_line, old_indent);
 
                 if (token.type == lexical_token_t::SEQUENCE_BLOCK_PREFIX) {
-                    *mp_current_node = basic_node_type::sequence({basic_node_type()});
-                    apply_directive_set(*mp_current_node);
-                    apply_deferred_properties(*mp_current_node);
-                    apply_node_properties(*mp_current_node);
-                    m_context_stack.emplace_back(line, indent, context_state_t::BLOCK_SEQUENCE, mp_current_node);
-
-                    mp_current_node = &(mp_current_node->as_seq().back());
-                    m_context_stack.emplace_back(line, indent, context_state_t::BLOCK_SEQUENCE_ENTRY, mp_current_node);
+                    initialize_block_sequence_value(line, indent, false);
                     break;
                 }
 
@@ -1649,11 +1645,42 @@ private:
         line = lexer.get_lines_processed();
         indent = lexer.get_last_token_begin_pos();
 
+        if (token.type == lexical_token_t::SEQUENCE_BLOCK_PREFIX && line > key_line && indent <= key_indent) {
+            initialize_block_sequence_value(line, indent, false);
+
+            token = lexer.get_next_token();
+            line = lexer.get_lines_processed();
+            indent = lexer.get_last_token_begin_pos();
+            return;
+        }
+
         if (line > key_line && indent <= key_indent) {
             pop_to_parent_node(line, indent, [key_indent](const parse_context& c) {
                 return c.state == context_state_t::BLOCK_MAPPING && key_indent == c.indent;
             });
         }
+    }
+
+    /// @brief Initializes a block sequence as the current mapping value.
+    /// @param line The line where the sequence begins.
+    /// @param indent The indentation width where the sequence begins.
+    /// @param apply_properties Whether pending node properties belong to the sequence.
+    void initialize_block_sequence_value(const uint32_t line, const uint32_t indent, const bool apply_properties) {
+        *mp_current_node = basic_node_type::sequence({basic_node_type()});
+        apply_directive_set(*mp_current_node);
+        if (apply_properties) {
+            apply_deferred_properties(*mp_current_node);
+            apply_node_properties(*mp_current_node);
+        }
+
+        auto& cur_context = m_context_stack.back();
+        cur_context.line = line;
+        cur_context.indent = indent;
+        cur_context.state = context_state_t::BLOCK_SEQUENCE;
+
+        mp_current_node = &(mp_current_node->as_seq().back());
+        apply_directive_set(*mp_current_node);
+        m_context_stack.emplace_back(line, indent, context_state_t::BLOCK_SEQUENCE_ENTRY, mp_current_node);
     }
 
     /// @brief Adds an entry for an explicit key and makes its value node the current node.
@@ -1801,12 +1828,12 @@ private:
     /// @param line Current line.
     /// @param indent Current indentation.
     void materialize_tagged_empty_node(
-        BasicNodeType& node, tag_t tag_type, const uint32_t line, const uint32_t indent) {
+        basic_node_type& node, tag_t tag_type, const uint32_t line, const uint32_t indent) {
         switch (tag_type) {
         case tag_t::STRING:
         case tag_t::NON_SPECIFIC:
         case tag_t::CUSTOM_TAG:
-            node = BasicNodeType(typename BasicNodeType::string_type());
+            node = basic_node_type(typename basic_node_type::string_type());
             break;
         case tag_t::NULL_VALUE:
             // A null value is already represented by a default-constructed node.

--- a/include/fkYAML/detail/input/deserializer.hpp
+++ b/include/fkYAML/detail/input/deserializer.hpp
@@ -286,9 +286,8 @@ private:
             root = basic_node_type::mapping();
             apply_directive_set(root);
             apply_deferred_properties(root);
-            apply_node_properties(root);
-            m_context_stack.emplace_back(
-                lexer.get_lines_processed(), lexer.get_last_token_begin_pos(), context_state_t::BLOCK_MAPPING, &root);
+            // apply_node_properties(root);
+            m_context_stack.emplace_back(line, indent, context_state_t::BLOCK_MAPPING, &root);
             add_empty_key_entry(lexer, token, line, indent);
             break;
         case lexical_token_t::BLOCK_LITERAL_SCALAR:
@@ -303,20 +302,9 @@ private:
             // Defer handling the above token events until the next call on the deserialize_scalar() function since the
             // meaning depends on subsequent events.
             if (found_props && line < lexer.get_lines_processed()) {
-                // If node properties and a followed node are on the different line, the properties belong to the root
-                // node.
-                if (m_needs_anchor_impl) {
-                    m_root_anchor_name = m_anchor_name;
-                    m_needs_anchor_impl = false;
-                    m_anchor_name = {};
-                }
-
-                if (m_needs_tag_impl) {
-                    m_root_tag_name = m_tag_name;
-                    m_needs_tag_impl = false;
-                    m_tag_name = {};
-                }
-
+                // If node properties and a followed node are on different lines, defer the properties until the root
+                // node type is known.
+                defer_node_properties();
                 line = lexer.get_lines_processed();
                 indent = lexer.get_last_token_begin_pos();
             }
@@ -331,6 +319,18 @@ private:
         FK_YAML_ASSERT(
             last_type == lexical_token_t::END_OF_BUFFER || last_type == lexical_token_t::END_OF_DIRECTIVES ||
             last_type == lexical_token_t::END_OF_DOCUMENT);
+
+        if (m_needs_tag_impl) {
+            const tag_t tag_type = resolve_scalar_tag(line, indent);
+            materialize_tagged_empty_node(*mp_current_node, tag_type, line, indent);
+        }
+        apply_node_properties(*mp_current_node);
+        if (m_defers_tag) {
+            const tag_t tag_type = tag_resolver_type::resolve_tag(m_deferred_tag_name, mp_meta);
+            ensure_scalar_tag(tag_type, line, indent);
+            materialize_tagged_empty_node(*mp_current_node, tag_type, line, indent);
+        }
+        apply_deferred_properties(*mp_current_node);
 
         // An explicit key at the end of a document has no value either. Its own contents may have left
         // more contexts on the stack, so those are unwound first.
@@ -579,6 +579,14 @@ private:
                     continue;
                 }
 
+                if (m_context_stack.back().state == context_state_t::BLOCK_MAPPING_EXPLICIT_VALUE) {
+                    *mp_current_node = basic_node_type::mapping();
+                    apply_directive_set(*mp_current_node);
+                    m_context_stack.emplace_back(line, indent, context_state_t::BLOCK_MAPPING, mp_current_node);
+                    add_empty_key_entry(lexer, token, line, indent);
+                    continue;
+                }
+
                 {
                     const parse_context& cur_context = m_context_stack.back();
                     const bool is_explicit_key_content =
@@ -606,7 +614,8 @@ private:
                         // { : foo }
                         // # -> {null: foo}
                         // ```
-                        add_new_key(basic_node_type(), line, indent);
+                        add_empty_key_entry(lexer, token, line, indent);
+                        continue;
                     }
                     break;
                 }
@@ -620,12 +629,13 @@ private:
                 indent = lexer.get_last_token_begin_pos();
 
                 const bool found_props = deserialize_node_properties(lexer, token, line, indent);
-                if (found_props && line == lexer.get_lines_processed()) {
+                if (found_props && line == lexer.get_lines_processed() &&
+                    token.type != lexical_token_t::KEY_SEPARATOR) {
                     // defer applying node properties for the subsequent node on the same line.
                     continue;
                 }
 
-                if (found_props) {
+                if (found_props && token.type != lexical_token_t::KEY_SEPARATOR) {
                     // The properties belong to whatever begins on the following line, which the token
                     // after it decides.
                     // ```yaml
@@ -1490,6 +1500,17 @@ private:
             if (mp_current_node->is_scalar()) {
                 if FK_YAML_LIKELY (!m_context_stack.empty()) {
                     parse_context& cur_context = m_context_stack.back();
+                    if (cur_context.state == context_state_t::MAPPING_VALUE && cur_context.indent == indent &&
+                        defers_props()) {
+                        pop_to_parent_node(line, indent, [indent](const parse_context& c) {
+                            return c.state == context_state_t::BLOCK_MAPPING && indent == c.indent;
+                        });
+                        check_tab_in_indentation(lexer, line, indent);
+                        add_new_key(std::move(node), line, indent);
+                        indent = lexer.get_last_token_begin_pos();
+                        line = lexer.get_lines_processed();
+                        return;
+                    }
                     switch (cur_context.state) {
                     case context_state_t::BLOCK_MAPPING_EXPLICIT_KEY:
                         if (cur_context.indent == indent) {
@@ -1557,17 +1578,7 @@ private:
                     m_context_stack.emplace_back(line, indent, context_state_t::BLOCK_MAPPING, mp_current_node);
                     *mp_current_node = basic_node_type::mapping();
                     apply_directive_set(*mp_current_node);
-
-                    // apply node properties if any to the root mapping node.
-                    if (!m_root_anchor_name.empty()) {
-                        mp_current_node->add_anchor_name(
-                            std::string(m_root_anchor_name.begin(), m_root_anchor_name.end()));
-                        m_root_anchor_name = {};
-                    }
-                    if (!m_root_tag_name.empty()) {
-                        mp_current_node->add_tag_name(std::string(m_root_tag_name.begin(), m_root_tag_name.end()));
-                        m_root_tag_name = {};
-                    }
+                    apply_deferred_properties(*mp_current_node);
                 }
             }
             check_tab_in_indentation(lexer, line, indent);
@@ -1625,7 +1636,14 @@ private:
     void add_empty_key_entry(lexer_type& lexer, lexical_token& token, uint32_t& line, uint32_t& indent) {
         const uint32_t key_line = line;
         const uint32_t key_indent = indent;
-        add_new_key(basic_node_type(), line, indent);
+        basic_node_type key_node;
+        if (m_needs_tag_impl) {
+            tag_t tag_type = resolve_scalar_tag(line, indent);
+            materialize_tagged_empty_node(key_node, tag_type, line, indent);
+        }
+        apply_directive_set(key_node);
+        apply_node_properties(key_node);
+        add_new_key(std::move(key_node), line, indent);
 
         token = lexer.get_next_token();
         line = lexer.get_lines_processed();
@@ -1710,7 +1728,7 @@ private:
             if (m_defers_tag) {
                 const tag_t tag_type = tag_resolver_type::resolve_tag(m_deferred_tag_name, mp_meta);
                 ensure_scalar_tag(tag_type, line, indent);
-                materialize_tagged_empty_node(tag_type, line, indent);
+                materialize_tagged_empty_node(*mp_current_node, tag_type, line, indent);
             }
             apply_deferred_properties(*mp_current_node);
         }
@@ -1768,7 +1786,7 @@ private:
         if (m_context_stack.back().state == context_state_t::MAPPING_VALUE) {
             if (m_needs_tag_impl) {
                 tag_t tag_type = resolve_scalar_tag(line, indent);
-                materialize_tagged_empty_node(tag_type, line, indent);
+                materialize_tagged_empty_node(*mp_current_node, tag_type, line, indent);
             }
             apply_directive_set(*mp_current_node);
             apply_node_properties(*mp_current_node);
@@ -1782,11 +1800,13 @@ private:
     /// @param tag_type The tag type to apply to the empty node.
     /// @param line Current line.
     /// @param indent Current indentation.
-    void materialize_tagged_empty_node(tag_t tag_type, const uint32_t line, const uint32_t indent) {
+    void materialize_tagged_empty_node(
+        BasicNodeType& node, tag_t tag_type, const uint32_t line, const uint32_t indent) {
         switch (tag_type) {
         case tag_t::STRING:
         case tag_t::NON_SPECIFIC:
-            *mp_current_node = BasicNodeType(typename BasicNodeType::string_type());
+        case tag_t::CUSTOM_TAG:
+            node = BasicNodeType(typename BasicNodeType::string_type());
             break;
         case tag_t::NULL_VALUE:
             // A null value is already represented by a default-constructed node.
@@ -1923,10 +1943,6 @@ private:
     str_view m_anchor_name;
     /// The last tag name.
     str_view m_tag_name;
-    /// The root YAML anchor name. (maybe empty and unused)
-    str_view m_root_anchor_name;
-    /// The root tag name. (maybe empty and unused)
-    str_view m_root_tag_name;
 };
 
 FK_YAML_DETAIL_NAMESPACE_END

--- a/include/fkYAML/detail/input/deserializer.hpp
+++ b/include/fkYAML/detail/input/deserializer.hpp
@@ -178,7 +178,8 @@ public:
                 // A next document may start from the directive part. Ensure '%' is lexed as a directive token
                 // during the lookahead; otherwise it can be cached as a plain scalar and break parsing.
                 lexer.set_document_state(true);
-                if (lexer.peek_next_token().type == lexical_token_t::END_OF_BUFFER) {
+                const lexical_token_t next_type = lexer.peek_next_token().type;
+                if (next_type == lexical_token_t::END_OF_BUFFER) {
                     break;
                 }
             }
@@ -734,8 +735,10 @@ private:
                     // Processing the second separator here would close the explicit key
                     // with a null value before the tag determines the type of the inner mapping's
                     // omitted value.
-                    if ((token.type != lexical_token_t::KEY_SEPARATOR || !defers_props()) &&
-                        indent <= m_context_stack.back().indent) {
+                    const bool is_omitted_mapping_value_without_properties =
+                        (token.type != lexical_token_t::KEY_SEPARATOR || !defers_props()) &&
+                        indent <= m_context_stack.back().indent;
+                    if (is_omitted_mapping_value_without_properties) {
                         // An explicit key can omit its value as well, in which case the entry must still be
                         // added to the parent mapping.
                         // ```yaml
@@ -1496,8 +1499,11 @@ private:
             if (mp_current_node->is_scalar()) {
                 if FK_YAML_LIKELY (!m_context_stack.empty()) {
                     parse_context& cur_context = m_context_stack.back();
-                    if (cur_context.state == context_state_t::MAPPING_VALUE && cur_context.indent == indent &&
-                        defers_props()) {
+
+                    const bool is_omitted_mapping_value_with_properties =
+                        cur_context.state == context_state_t::MAPPING_VALUE && cur_context.indent == indent &&
+                        defers_props();
+                    if (is_omitted_mapping_value_with_properties) {
                         pop_to_parent_node(line, indent, [indent](const parse_context& c) {
                             return c.state == context_state_t::BLOCK_MAPPING && indent == c.indent;
                         });
@@ -1507,6 +1513,7 @@ private:
                         line = lexer.get_lines_processed();
                         return;
                     }
+
                     switch (cur_context.state) {
                     case context_state_t::BLOCK_MAPPING_EXPLICIT_KEY:
                         if (cur_context.indent == indent) {
@@ -1552,6 +1559,7 @@ private:
 
                         m_context_stack.emplace_back(line, indent, context_state_t::BLOCK_MAPPING, mp_current_node);
                         break;
+                    case context_state_t::MAPPING_VALUE:
                     default:
                         if FK_YAML_UNLIKELY (cur_context.line == line) {
                             throw parse_error("Multiple mapping keys are specified on the same line.", line, indent);
@@ -1634,7 +1642,7 @@ private:
         const uint32_t key_indent = indent;
         basic_node_type key_node;
         if (m_needs_tag_impl) {
-            tag_t tag_type = resolve_scalar_tag(line, indent);
+            const tag_t tag_type = resolve_scalar_tag(line, indent);
             materialize_tagged_empty_node(key_node, tag_type, line, indent);
         }
         apply_directive_set(key_node);
@@ -1645,7 +1653,9 @@ private:
         line = lexer.get_lines_processed();
         indent = lexer.get_last_token_begin_pos();
 
-        if (token.type == lexical_token_t::SEQUENCE_BLOCK_PREFIX && line > key_line && indent <= key_indent) {
+        const bool is_block_sequence_entry =
+            token.type == lexical_token_t::SEQUENCE_BLOCK_PREFIX && line > key_line && indent <= key_indent;
+        if (is_block_sequence_entry) {
             initialize_block_sequence_value(line, indent, false);
 
             token = lexer.get_next_token();
@@ -1812,7 +1822,7 @@ private:
 
         if (m_context_stack.back().state == context_state_t::MAPPING_VALUE) {
             if (m_needs_tag_impl) {
-                tag_t tag_type = resolve_scalar_tag(line, indent);
+                const tag_t tag_type = resolve_scalar_tag(line, indent);
                 materialize_tagged_empty_node(*mp_current_node, tag_type, line, indent);
             }
             apply_directive_set(*mp_current_node);

--- a/include/fkYAML/detail/input/deserializer.hpp
+++ b/include/fkYAML/detail/input/deserializer.hpp
@@ -712,7 +712,17 @@ private:
                         continue;
                     }
 
-                    if (indent <= m_context_stack.back().indent) {
+                    // A property for an omitted value inside an explicit key is deferred until the
+                    // key context is closed:
+                    // ```yaml
+                    // ? foo: !!str # the tag belongs to this omitted value
+                    // : foo: !!str # this separator begins the explicit key's value
+                    // ```
+                    // Processing the second separator here would close the explicit key
+                    // with a null value before the tag determines the type of the inner mapping's
+                    // omitted value.
+                    if ((token.type != lexical_token_t::KEY_SEPARATOR || !defers_props()) &&
+                        indent <= m_context_stack.back().indent) {
                         // An explicit key can omit its value as well, in which case the entry must still be
                         // added to the parent mapping.
                         // ```yaml
@@ -943,6 +953,7 @@ private:
                     m_flow_base_indent = -1;
                 }
 
+                close_omitted_mapping_value(line, indent);
                 close_single_pair_mapping(line, indent);
 
                 const bool has_valid_beginning =
@@ -1696,6 +1707,11 @@ private:
             // foo: &anchor
             // bar: 1        # the anchor is for the empty value of "foo".
             // ```
+            if (m_defers_tag) {
+                const tag_t tag_type = tag_resolver_type::resolve_tag(m_deferred_tag_name, mp_meta);
+                ensure_scalar_tag(tag_type, line, indent);
+                materialize_tagged_empty_node(tag_type, line, indent);
+            }
             apply_deferred_properties(*mp_current_node);
         }
 
@@ -1750,9 +1766,36 @@ private:
         // LCOV_EXCL_STOP
 
         if (m_context_stack.back().state == context_state_t::MAPPING_VALUE) {
+            if (m_needs_tag_impl) {
+                tag_t tag_type = resolve_scalar_tag(line, indent);
+                materialize_tagged_empty_node(tag_type, line, indent);
+            }
+            apply_directive_set(*mp_current_node);
+            apply_node_properties(*mp_current_node);
             m_context_stack.pop_back();
             mp_current_node = current_context(line, indent).p_node;
             m_flow_token_state = flow_token_state_t::NEEDS_SEPARATOR_OR_SUFFIX;
+        }
+    }
+
+    /// @brief Materializes an empty node with the specified tag type.
+    /// @param tag_type The tag type to apply to the empty node.
+    /// @param line Current line.
+    /// @param indent Current indentation.
+    void materialize_tagged_empty_node(tag_t tag_type, const uint32_t line, const uint32_t indent) {
+        switch (tag_type) {
+        case tag_t::STRING:
+        case tag_t::NON_SPECIFIC:
+            *mp_current_node = BasicNodeType(typename BasicNodeType::string_type());
+            break;
+        case tag_t::NULL_VALUE:
+            // A null value is already represented by a default-constructed node.
+            break;
+        default: {
+            auto msg = format("Unsupported tag (%s) for an empty node.", m_tag_name.data());
+            throw parse_error(msg.c_str(), line, indent);
+            break;
+        }
         }
     }
 
@@ -1766,14 +1809,21 @@ private:
         }
 
         const tag_t tag_type = tag_resolver_type::resolve_tag(m_tag_name, mp_meta);
+        ensure_scalar_tag(tag_type, line, indent);
 
+        return tag_type;
+    }
+
+    /// @brief Ensure that the given tag type is valid for a scalar node.
+    /// @param tag_type The tag type to check.
+    /// @param line Current line.
+    /// @param indent Current indentation.
+    static void ensure_scalar_tag(tag_t tag_type, const uint32_t line, const uint32_t indent) {
         // A collection tag denotes a sequence or a mapping, so it cannot apply to a scalar node.
         // Such an input is a syntax error rather than an internal inconsistency.
         if FK_YAML_UNLIKELY (tag_type == tag_t::SEQUENCE || tag_type == tag_t::MAPPING) {
             throw parse_error("A sequence or mapping tag cannot be specified to a scalar node.", line, indent);
         }
-
-        return tag_type;
     }
 
     /// @brief Move the pending node properties aside until the node they belong to is known.

--- a/include/fkYAML/detail/output/serializer.hpp
+++ b/include/fkYAML/detail/output/serializer.hpp
@@ -768,7 +768,7 @@ private:
             return false;
         }
 
-        typedef typename BasicNodeType::string_type string_type;
+        using string_type = typename BasicNodeType::string_type;
         if (s.find_first_of(" \t\n\r,[]{}") != string_type::npos) {
             return false;
         }

--- a/single_include/fkYAML/node.hpp
+++ b/single_include/fkYAML/node.hpp
@@ -7977,7 +7977,8 @@ public:
                 // A next document may start from the directive part. Ensure '%' is lexed as a directive token
                 // during the lookahead; otherwise it can be cached as a plain scalar and break parsing.
                 lexer.set_document_state(true);
-                if (lexer.peek_next_token().type == lexical_token_t::END_OF_BUFFER) {
+                const lexical_token_t next_type = lexer.peek_next_token().type;
+                if (next_type == lexical_token_t::END_OF_BUFFER) {
                     break;
                 }
             }
@@ -8533,8 +8534,10 @@ private:
                     // Processing the second separator here would close the explicit key
                     // with a null value before the tag determines the type of the inner mapping's
                     // omitted value.
-                    if ((token.type != lexical_token_t::KEY_SEPARATOR || !defers_props()) &&
-                        indent <= m_context_stack.back().indent) {
+                    const bool is_omitted_mapping_value_without_properties =
+                        (token.type != lexical_token_t::KEY_SEPARATOR || !defers_props()) &&
+                        indent <= m_context_stack.back().indent;
+                    if (is_omitted_mapping_value_without_properties) {
                         // An explicit key can omit its value as well, in which case the entry must still be
                         // added to the parent mapping.
                         // ```yaml
@@ -9295,8 +9298,11 @@ private:
             if (mp_current_node->is_scalar()) {
                 if FK_YAML_LIKELY (!m_context_stack.empty()) {
                     parse_context& cur_context = m_context_stack.back();
-                    if (cur_context.state == context_state_t::MAPPING_VALUE && cur_context.indent == indent &&
-                        defers_props()) {
+
+                    const bool is_omitted_mapping_value_with_properties =
+                        cur_context.state == context_state_t::MAPPING_VALUE && cur_context.indent == indent &&
+                        defers_props();
+                    if (is_omitted_mapping_value_with_properties) {
                         pop_to_parent_node(line, indent, [indent](const parse_context& c) {
                             return c.state == context_state_t::BLOCK_MAPPING && indent == c.indent;
                         });
@@ -9306,6 +9312,7 @@ private:
                         line = lexer.get_lines_processed();
                         return;
                     }
+
                     switch (cur_context.state) {
                     case context_state_t::BLOCK_MAPPING_EXPLICIT_KEY:
                         if (cur_context.indent == indent) {
@@ -9351,6 +9358,7 @@ private:
 
                         m_context_stack.emplace_back(line, indent, context_state_t::BLOCK_MAPPING, mp_current_node);
                         break;
+                    case context_state_t::MAPPING_VALUE:
                     default:
                         if FK_YAML_UNLIKELY (cur_context.line == line) {
                             throw parse_error("Multiple mapping keys are specified on the same line.", line, indent);
@@ -9433,7 +9441,7 @@ private:
         const uint32_t key_indent = indent;
         basic_node_type key_node;
         if (m_needs_tag_impl) {
-            tag_t tag_type = resolve_scalar_tag(line, indent);
+            const tag_t tag_type = resolve_scalar_tag(line, indent);
             materialize_tagged_empty_node(key_node, tag_type, line, indent);
         }
         apply_directive_set(key_node);
@@ -9444,7 +9452,9 @@ private:
         line = lexer.get_lines_processed();
         indent = lexer.get_last_token_begin_pos();
 
-        if (token.type == lexical_token_t::SEQUENCE_BLOCK_PREFIX && line > key_line && indent <= key_indent) {
+        const bool is_block_sequence_entry =
+            token.type == lexical_token_t::SEQUENCE_BLOCK_PREFIX && line > key_line && indent <= key_indent;
+        if (is_block_sequence_entry) {
             initialize_block_sequence_value(line, indent, false);
 
             token = lexer.get_next_token();
@@ -9611,7 +9621,7 @@ private:
 
         if (m_context_stack.back().state == context_state_t::MAPPING_VALUE) {
             if (m_needs_tag_impl) {
-                tag_t tag_type = resolve_scalar_tag(line, indent);
+                const tag_t tag_type = resolve_scalar_tag(line, indent);
                 materialize_tagged_empty_node(*mp_current_node, tag_type, line, indent);
             }
             apply_directive_set(*mp_current_node);
@@ -12998,7 +13008,7 @@ private:
             return false;
         }
 
-        typedef typename BasicNodeType::string_type string_type;
+        using string_type = typename BasicNodeType::string_type;
         if (s.find_first_of(" \t\n\r,[]{}") != string_type::npos) {
             return false;
         }

--- a/single_include/fkYAML/node.hpp
+++ b/single_include/fkYAML/node.hpp
@@ -8085,9 +8085,8 @@ private:
             root = basic_node_type::mapping();
             apply_directive_set(root);
             apply_deferred_properties(root);
-            apply_node_properties(root);
-            m_context_stack.emplace_back(
-                lexer.get_lines_processed(), lexer.get_last_token_begin_pos(), context_state_t::BLOCK_MAPPING, &root);
+            // apply_node_properties(root);
+            m_context_stack.emplace_back(line, indent, context_state_t::BLOCK_MAPPING, &root);
             add_empty_key_entry(lexer, token, line, indent);
             break;
         case lexical_token_t::BLOCK_LITERAL_SCALAR:
@@ -8102,20 +8101,9 @@ private:
             // Defer handling the above token events until the next call on the deserialize_scalar() function since the
             // meaning depends on subsequent events.
             if (found_props && line < lexer.get_lines_processed()) {
-                // If node properties and a followed node are on the different line, the properties belong to the root
-                // node.
-                if (m_needs_anchor_impl) {
-                    m_root_anchor_name = m_anchor_name;
-                    m_needs_anchor_impl = false;
-                    m_anchor_name = {};
-                }
-
-                if (m_needs_tag_impl) {
-                    m_root_tag_name = m_tag_name;
-                    m_needs_tag_impl = false;
-                    m_tag_name = {};
-                }
-
+                // If node properties and a followed node are on different lines, defer the properties until the root
+                // node type is known.
+                defer_node_properties();
                 line = lexer.get_lines_processed();
                 indent = lexer.get_last_token_begin_pos();
             }
@@ -8130,6 +8118,18 @@ private:
         FK_YAML_ASSERT(
             last_type == lexical_token_t::END_OF_BUFFER || last_type == lexical_token_t::END_OF_DIRECTIVES ||
             last_type == lexical_token_t::END_OF_DOCUMENT);
+
+        if (m_needs_tag_impl) {
+            const tag_t tag_type = resolve_scalar_tag(line, indent);
+            materialize_tagged_empty_node(*mp_current_node, tag_type, line, indent);
+        }
+        apply_node_properties(*mp_current_node);
+        if (m_defers_tag) {
+            const tag_t tag_type = tag_resolver_type::resolve_tag(m_deferred_tag_name, mp_meta);
+            ensure_scalar_tag(tag_type, line, indent);
+            materialize_tagged_empty_node(*mp_current_node, tag_type, line, indent);
+        }
+        apply_deferred_properties(*mp_current_node);
 
         // An explicit key at the end of a document has no value either. Its own contents may have left
         // more contexts on the stack, so those are unwound first.
@@ -8378,6 +8378,14 @@ private:
                     continue;
                 }
 
+                if (m_context_stack.back().state == context_state_t::BLOCK_MAPPING_EXPLICIT_VALUE) {
+                    *mp_current_node = basic_node_type::mapping();
+                    apply_directive_set(*mp_current_node);
+                    m_context_stack.emplace_back(line, indent, context_state_t::BLOCK_MAPPING, mp_current_node);
+                    add_empty_key_entry(lexer, token, line, indent);
+                    continue;
+                }
+
                 {
                     const parse_context& cur_context = m_context_stack.back();
                     const bool is_explicit_key_content =
@@ -8405,7 +8413,8 @@ private:
                         // { : foo }
                         // # -> {null: foo}
                         // ```
-                        add_new_key(basic_node_type(), line, indent);
+                        add_empty_key_entry(lexer, token, line, indent);
+                        continue;
                     }
                     break;
                 }
@@ -8419,12 +8428,13 @@ private:
                 indent = lexer.get_last_token_begin_pos();
 
                 const bool found_props = deserialize_node_properties(lexer, token, line, indent);
-                if (found_props && line == lexer.get_lines_processed()) {
+                if (found_props && line == lexer.get_lines_processed() &&
+                    token.type != lexical_token_t::KEY_SEPARATOR) {
                     // defer applying node properties for the subsequent node on the same line.
                     continue;
                 }
 
-                if (found_props) {
+                if (found_props && token.type != lexical_token_t::KEY_SEPARATOR) {
                     // The properties belong to whatever begins on the following line, which the token
                     // after it decides.
                     // ```yaml
@@ -9289,6 +9299,17 @@ private:
             if (mp_current_node->is_scalar()) {
                 if FK_YAML_LIKELY (!m_context_stack.empty()) {
                     parse_context& cur_context = m_context_stack.back();
+                    if (cur_context.state == context_state_t::MAPPING_VALUE && cur_context.indent == indent &&
+                        defers_props()) {
+                        pop_to_parent_node(line, indent, [indent](const parse_context& c) {
+                            return c.state == context_state_t::BLOCK_MAPPING && indent == c.indent;
+                        });
+                        check_tab_in_indentation(lexer, line, indent);
+                        add_new_key(std::move(node), line, indent);
+                        indent = lexer.get_last_token_begin_pos();
+                        line = lexer.get_lines_processed();
+                        return;
+                    }
                     switch (cur_context.state) {
                     case context_state_t::BLOCK_MAPPING_EXPLICIT_KEY:
                         if (cur_context.indent == indent) {
@@ -9356,17 +9377,7 @@ private:
                     m_context_stack.emplace_back(line, indent, context_state_t::BLOCK_MAPPING, mp_current_node);
                     *mp_current_node = basic_node_type::mapping();
                     apply_directive_set(*mp_current_node);
-
-                    // apply node properties if any to the root mapping node.
-                    if (!m_root_anchor_name.empty()) {
-                        mp_current_node->add_anchor_name(
-                            std::string(m_root_anchor_name.begin(), m_root_anchor_name.end()));
-                        m_root_anchor_name = {};
-                    }
-                    if (!m_root_tag_name.empty()) {
-                        mp_current_node->add_tag_name(std::string(m_root_tag_name.begin(), m_root_tag_name.end()));
-                        m_root_tag_name = {};
-                    }
+                    apply_deferred_properties(*mp_current_node);
                 }
             }
             check_tab_in_indentation(lexer, line, indent);
@@ -9424,7 +9435,14 @@ private:
     void add_empty_key_entry(lexer_type& lexer, lexical_token& token, uint32_t& line, uint32_t& indent) {
         const uint32_t key_line = line;
         const uint32_t key_indent = indent;
-        add_new_key(basic_node_type(), line, indent);
+        basic_node_type key_node;
+        if (m_needs_tag_impl) {
+            tag_t tag_type = resolve_scalar_tag(line, indent);
+            materialize_tagged_empty_node(key_node, tag_type, line, indent);
+        }
+        apply_directive_set(key_node);
+        apply_node_properties(key_node);
+        add_new_key(std::move(key_node), line, indent);
 
         token = lexer.get_next_token();
         line = lexer.get_lines_processed();
@@ -9509,7 +9527,7 @@ private:
             if (m_defers_tag) {
                 const tag_t tag_type = tag_resolver_type::resolve_tag(m_deferred_tag_name, mp_meta);
                 ensure_scalar_tag(tag_type, line, indent);
-                materialize_tagged_empty_node(tag_type, line, indent);
+                materialize_tagged_empty_node(*mp_current_node, tag_type, line, indent);
             }
             apply_deferred_properties(*mp_current_node);
         }
@@ -9567,7 +9585,7 @@ private:
         if (m_context_stack.back().state == context_state_t::MAPPING_VALUE) {
             if (m_needs_tag_impl) {
                 tag_t tag_type = resolve_scalar_tag(line, indent);
-                materialize_tagged_empty_node(tag_type, line, indent);
+                materialize_tagged_empty_node(*mp_current_node, tag_type, line, indent);
             }
             apply_directive_set(*mp_current_node);
             apply_node_properties(*mp_current_node);
@@ -9581,11 +9599,13 @@ private:
     /// @param tag_type The tag type to apply to the empty node.
     /// @param line Current line.
     /// @param indent Current indentation.
-    void materialize_tagged_empty_node(tag_t tag_type, const uint32_t line, const uint32_t indent) {
+    void materialize_tagged_empty_node(
+        BasicNodeType& node, tag_t tag_type, const uint32_t line, const uint32_t indent) {
         switch (tag_type) {
         case tag_t::STRING:
         case tag_t::NON_SPECIFIC:
-            *mp_current_node = BasicNodeType(typename BasicNodeType::string_type());
+        case tag_t::CUSTOM_TAG:
+            node = BasicNodeType(typename BasicNodeType::string_type());
             break;
         case tag_t::NULL_VALUE:
             // A null value is already represented by a default-constructed node.
@@ -9722,10 +9742,6 @@ private:
     str_view m_anchor_name;
     /// The last tag name.
     str_view m_tag_name;
-    /// The root YAML anchor name. (maybe empty and unused)
-    str_view m_root_anchor_name;
-    /// The root tag name. (maybe empty and unused)
-    str_view m_root_tag_name;
 };
 
 FK_YAML_DETAIL_NAMESPACE_END

--- a/single_include/fkYAML/node.hpp
+++ b/single_include/fkYAML/node.hpp
@@ -8361,6 +8361,17 @@ private:
                 if FK_YAML_UNLIKELY (m_context_stack.empty()) {
                     throw parse_error("A key separator is not allowed in this context.", line, indent);
                 }
+                if ((m_context_stack.back().state == context_state_t::BLOCK_SEQUENCE_ENTRY ||
+                     m_context_stack.back().state == context_state_t::MAPPING_VALUE) &&
+                    (m_needs_tag_impl || m_needs_anchor_impl) && m_context_stack.back().line != line &&
+                    indent <= m_context_stack.back().indent) {
+                    pop_to_parent_node(line, indent, [indent](const parse_context& c) {
+                        return c.state == context_state_t::BLOCK_MAPPING && indent == c.indent;
+                    });
+                    add_empty_key_entry(lexer, token, line, indent);
+                    continue;
+                }
+
                 if (m_context_stack.back().state == context_state_t::BLOCK_SEQUENCE_ENTRY) {
                     // The entry is a mapping whose first key is empty.
                     // ```yaml
@@ -8370,11 +8381,7 @@ private:
                     *mp_current_node = basic_node_type::mapping();
                     apply_directive_set(*mp_current_node);
                     m_context_stack.emplace_back(line, indent, context_state_t::BLOCK_MAPPING, mp_current_node);
-                    add_new_key(basic_node_type(), line, indent);
-
-                    token = lexer.get_next_token();
-                    indent = lexer.get_last_token_begin_pos();
-                    line = lexer.get_lines_processed();
+                    add_empty_key_entry(lexer, token, line, indent);
                     continue;
                 }
 
@@ -8471,20 +8478,16 @@ private:
                     }
 
                     if (token.type == lexical_token_t::SEQUENCE_BLOCK_PREFIX) {
-                        // a key separator preceding block sequence entries
-                        *mp_current_node = basic_node_type::sequence({basic_node_type()});
-                        apply_directive_set(*mp_current_node);
-                        apply_deferred_properties(*mp_current_node);
-                        apply_node_properties(*mp_current_node);
-                        auto& cur_context = m_context_stack.back();
-                        cur_context.line = line;
-                        cur_context.indent = indent;
-                        cur_context.state = context_state_t::BLOCK_SEQUENCE;
+                        if (m_context_stack.back().state == context_state_t::MAPPING_VALUE && defers_props() &&
+                            indent < m_context_stack.back().indent) {
+                            pop_to_parent_node(line, indent, [indent](const parse_context& c) {
+                                return c.state == context_state_t::BLOCK_SEQUENCE && indent == c.indent;
+                            });
+                            continue;
+                        }
 
-                        mp_current_node = &(mp_current_node->as_seq().back());
-                        apply_directive_set(*mp_current_node);
-                        m_context_stack.emplace_back(
-                            line, indent, context_state_t::BLOCK_SEQUENCE_ENTRY, mp_current_node);
+                        // a key separator preceding block sequence entries
+                        initialize_block_sequence_value(line, indent, true);
 
                         token = lexer.get_next_token();
                         line = lexer.get_lines_processed();
@@ -8596,14 +8599,7 @@ private:
                 add_explicit_key_with_empty_value(old_line, old_indent);
 
                 if (token.type == lexical_token_t::SEQUENCE_BLOCK_PREFIX) {
-                    *mp_current_node = basic_node_type::sequence({basic_node_type()});
-                    apply_directive_set(*mp_current_node);
-                    apply_deferred_properties(*mp_current_node);
-                    apply_node_properties(*mp_current_node);
-                    m_context_stack.emplace_back(line, indent, context_state_t::BLOCK_SEQUENCE, mp_current_node);
-
-                    mp_current_node = &(mp_current_node->as_seq().back());
-                    m_context_stack.emplace_back(line, indent, context_state_t::BLOCK_SEQUENCE_ENTRY, mp_current_node);
+                    initialize_block_sequence_value(line, indent, false);
                     break;
                 }
 
@@ -9448,11 +9444,42 @@ private:
         line = lexer.get_lines_processed();
         indent = lexer.get_last_token_begin_pos();
 
+        if (token.type == lexical_token_t::SEQUENCE_BLOCK_PREFIX && line > key_line && indent <= key_indent) {
+            initialize_block_sequence_value(line, indent, false);
+
+            token = lexer.get_next_token();
+            line = lexer.get_lines_processed();
+            indent = lexer.get_last_token_begin_pos();
+            return;
+        }
+
         if (line > key_line && indent <= key_indent) {
             pop_to_parent_node(line, indent, [key_indent](const parse_context& c) {
                 return c.state == context_state_t::BLOCK_MAPPING && key_indent == c.indent;
             });
         }
+    }
+
+    /// @brief Initializes a block sequence as the current mapping value.
+    /// @param line The line where the sequence begins.
+    /// @param indent The indentation width where the sequence begins.
+    /// @param apply_properties Whether pending node properties belong to the sequence.
+    void initialize_block_sequence_value(const uint32_t line, const uint32_t indent, const bool apply_properties) {
+        *mp_current_node = basic_node_type::sequence({basic_node_type()});
+        apply_directive_set(*mp_current_node);
+        if (apply_properties) {
+            apply_deferred_properties(*mp_current_node);
+            apply_node_properties(*mp_current_node);
+        }
+
+        auto& cur_context = m_context_stack.back();
+        cur_context.line = line;
+        cur_context.indent = indent;
+        cur_context.state = context_state_t::BLOCK_SEQUENCE;
+
+        mp_current_node = &(mp_current_node->as_seq().back());
+        apply_directive_set(*mp_current_node);
+        m_context_stack.emplace_back(line, indent, context_state_t::BLOCK_SEQUENCE_ENTRY, mp_current_node);
     }
 
     /// @brief Adds an entry for an explicit key and makes its value node the current node.
@@ -9600,12 +9627,12 @@ private:
     /// @param line Current line.
     /// @param indent Current indentation.
     void materialize_tagged_empty_node(
-        BasicNodeType& node, tag_t tag_type, const uint32_t line, const uint32_t indent) {
+        basic_node_type& node, tag_t tag_type, const uint32_t line, const uint32_t indent) {
         switch (tag_type) {
         case tag_t::STRING:
         case tag_t::NON_SPECIFIC:
         case tag_t::CUSTOM_TAG:
-            node = BasicNodeType(typename BasicNodeType::string_type());
+            node = basic_node_type(typename basic_node_type::string_type());
             break;
         case tag_t::NULL_VALUE:
             // A null value is already represented by a default-constructed node.

--- a/single_include/fkYAML/node.hpp
+++ b/single_include/fkYAML/node.hpp
@@ -8511,7 +8511,17 @@ private:
                         continue;
                     }
 
-                    if (indent <= m_context_stack.back().indent) {
+                    // A property for an omitted value inside an explicit key is deferred until the
+                    // key context is closed:
+                    // ```yaml
+                    // ? foo: !!str # the tag belongs to this omitted value
+                    // : foo: !!str # this separator begins the explicit key's value
+                    // ```
+                    // Processing the second separator here would close the explicit key
+                    // with a null value before the tag determines the type of the inner mapping's
+                    // omitted value.
+                    if ((token.type != lexical_token_t::KEY_SEPARATOR || !defers_props()) &&
+                        indent <= m_context_stack.back().indent) {
                         // An explicit key can omit its value as well, in which case the entry must still be
                         // added to the parent mapping.
                         // ```yaml
@@ -8742,6 +8752,7 @@ private:
                     m_flow_base_indent = -1;
                 }
 
+                close_omitted_mapping_value(line, indent);
                 close_single_pair_mapping(line, indent);
 
                 const bool has_valid_beginning =
@@ -9495,6 +9506,11 @@ private:
             // foo: &anchor
             // bar: 1        # the anchor is for the empty value of "foo".
             // ```
+            if (m_defers_tag) {
+                const tag_t tag_type = tag_resolver_type::resolve_tag(m_deferred_tag_name, mp_meta);
+                ensure_scalar_tag(tag_type, line, indent);
+                materialize_tagged_empty_node(tag_type, line, indent);
+            }
             apply_deferred_properties(*mp_current_node);
         }
 
@@ -9549,9 +9565,36 @@ private:
         // LCOV_EXCL_STOP
 
         if (m_context_stack.back().state == context_state_t::MAPPING_VALUE) {
+            if (m_needs_tag_impl) {
+                tag_t tag_type = resolve_scalar_tag(line, indent);
+                materialize_tagged_empty_node(tag_type, line, indent);
+            }
+            apply_directive_set(*mp_current_node);
+            apply_node_properties(*mp_current_node);
             m_context_stack.pop_back();
             mp_current_node = current_context(line, indent).p_node;
             m_flow_token_state = flow_token_state_t::NEEDS_SEPARATOR_OR_SUFFIX;
+        }
+    }
+
+    /// @brief Materializes an empty node with the specified tag type.
+    /// @param tag_type The tag type to apply to the empty node.
+    /// @param line Current line.
+    /// @param indent Current indentation.
+    void materialize_tagged_empty_node(tag_t tag_type, const uint32_t line, const uint32_t indent) {
+        switch (tag_type) {
+        case tag_t::STRING:
+        case tag_t::NON_SPECIFIC:
+            *mp_current_node = BasicNodeType(typename BasicNodeType::string_type());
+            break;
+        case tag_t::NULL_VALUE:
+            // A null value is already represented by a default-constructed node.
+            break;
+        default: {
+            auto msg = format("Unsupported tag (%s) for an empty node.", m_tag_name.data());
+            throw parse_error(msg.c_str(), line, indent);
+            break;
+        }
         }
     }
 
@@ -9565,14 +9608,21 @@ private:
         }
 
         const tag_t tag_type = tag_resolver_type::resolve_tag(m_tag_name, mp_meta);
+        ensure_scalar_tag(tag_type, line, indent);
 
+        return tag_type;
+    }
+
+    /// @brief Ensure that the given tag type is valid for a scalar node.
+    /// @param tag_type The tag type to check.
+    /// @param line Current line.
+    /// @param indent Current indentation.
+    static void ensure_scalar_tag(tag_t tag_type, const uint32_t line, const uint32_t indent) {
         // A collection tag denotes a sequence or a mapping, so it cannot apply to a scalar node.
         // Such an input is a syntax error rather than an internal inconsistency.
         if FK_YAML_UNLIKELY (tag_type == tag_t::SEQUENCE || tag_type == tag_t::MAPPING) {
             throw parse_error("A sequence or mapping tag cannot be specified to a scalar node.", line, indent);
         }
-
-        return tag_type;
     }
 
     /// @brief Move the pending node properties aside until the node they belong to is known.

--- a/tests/unit_test/test_deserializer_class.cpp
+++ b/tests/unit_test/test_deserializer_class.cpp
@@ -1394,127 +1394,6 @@ TEST_CASE("Deserializer_BlockMapping") {
         REQUIRE(root["baz"].is_null());
     }
 
-    SUBCASE("tagged empty nodes in various contexts") {
-        std::string input = "!!str : !!str\n"
-                            "bar: {!!str : !!str}\n"
-                            "baz: [!!str : !!str]\n"
-                            "qux:\n"
-                            "- !!str : !!str\n"
-                            "- !!str\n"
-                            "? !!str : !!str\n"
-                            ": !!str : !!str\n"
-                            "!!null :\n"
-                            "- ? !!null\n";
-
-        REQUIRE_NOTHROW(root = deserializer.deserialize(fkyaml::detail::input_adapter(input)));
-
-        CAPTURE(root);
-
-        REQUIRE(root.is_mapping());
-        REQUIRE(root.size() == 6);
-        REQUIRE(root.contains(""));
-        REQUIRE(root.contains("bar"));
-        REQUIRE(root.contains("baz"));
-        REQUIRE(root.contains("qux"));
-        auto map_key = fkyaml::node {{"", ""}};
-        REQUIRE(root.contains(map_key));
-        REQUIRE(root.contains(nullptr));
-
-        auto itr = root.as_map().find("");
-        const auto& empty_key = itr->first;
-        REQUIRE(empty_key.get_tag_name() == "!!str");
-
-        REQUIRE(root[""].is_string());
-        REQUIRE(root[""].as_str().empty());
-        REQUIRE(root[""].get_tag_name() == "!!str");
-
-        REQUIRE(root["bar"].is_mapping());
-        REQUIRE(root["bar"].size() == 1);
-        REQUIRE(root["bar"].contains(""));
-
-        auto bar_itr = root["bar"].as_map().find("");
-        const auto& bar_empty_key = bar_itr->first;
-        REQUIRE(bar_empty_key.get_tag_name() == "!!str");
-
-        REQUIRE(root["bar"][""].is_string());
-        REQUIRE(root["bar"][""].as_str().empty());
-        REQUIRE(root["bar"][""].get_tag_name() == "!!str");
-
-        REQUIRE(root["baz"].is_sequence());
-        REQUIRE(root["baz"].size() == 1);
-        REQUIRE(root["baz"][0].is_mapping());
-        REQUIRE(root["baz"][0].size() == 1);
-        REQUIRE(root["baz"][0].contains(""));
-
-        auto baz_itr = root["baz"][0].as_map().find("");
-        const auto& baz_empty_key = baz_itr->first;
-        REQUIRE(baz_empty_key.get_tag_name() == "!!str");
-
-        REQUIRE(root["baz"][0][""].is_string());
-        REQUIRE(root["baz"][0][""].as_str().empty());
-        REQUIRE(root["baz"][0][""].get_tag_name() == "!!str");
-
-        REQUIRE(root["qux"].is_sequence());
-        REQUIRE(root["qux"].size() == 2);
-        REQUIRE(root["qux"][0].is_mapping());
-        REQUIRE(root["qux"][0].size() == 1);
-        REQUIRE(root["qux"][0].contains(""));
-
-        auto qux_itr = root["qux"][0].as_map().find("");
-        const auto& qux_empty_key = qux_itr->first;
-        REQUIRE(qux_empty_key.get_tag_name() == "!!str");
-
-        REQUIRE(root["qux"][0][""].is_string());
-        REQUIRE(root["qux"][0][""].as_str().empty());
-        REQUIRE(root["qux"][0][""].get_tag_name() == "!!str");
-
-        REQUIRE(root["qux"][1].is_string());
-        REQUIRE(root["qux"][1].as_str().empty());
-        REQUIRE(root["qux"][1].get_tag_name() == "!!str");
-
-        auto map_key_itr = root.as_map().find(map_key);
-        const auto& map_empty_key = map_key_itr->first;
-        REQUIRE(map_empty_key.is_mapping());
-        REQUIRE(map_empty_key.size() == 1);
-        REQUIRE(map_empty_key.contains(""));
-
-        auto map_empty_key_itr = map_empty_key.as_map().find("");
-        const auto& map_empty_key_inner = map_empty_key_itr->first;
-        REQUIRE(map_empty_key_inner.is_string());
-        REQUIRE(map_empty_key_inner.as_str().empty());
-        REQUIRE(map_empty_key_inner.get_tag_name() == "!!str");
-
-        REQUIRE(root[map_key].is_mapping());
-        REQUIRE(root[map_key].size() == 1);
-        REQUIRE(root[map_key].contains(""));
-
-        auto map_key_value_itr = root[map_key].as_map().find("");
-        const auto& map_key_value = map_key_value_itr->first;
-        REQUIRE(map_key_value.is_string());
-        REQUIRE(map_key_value.as_str().empty());
-        REQUIRE(map_key_value.get_tag_name() == "!!str");
-
-        REQUIRE(root[map_key][""].is_string());
-        REQUIRE(root[map_key][""].as_str().empty());
-        REQUIRE(root[map_key][""].get_tag_name() == "!!str");
-
-        auto null_itr = root.as_map().find(nullptr);
-        auto null_key = null_itr->first;
-        REQUIRE(null_key.get_tag_name() == "!!null");
-
-        REQUIRE(root[nullptr].is_sequence());
-        REQUIRE(root[nullptr].size() == 1);
-        REQUIRE(root[nullptr][0].is_mapping());
-        REQUIRE(root[nullptr][0].size() == 1);
-        REQUIRE(root[nullptr][0].contains(nullptr));
-
-        auto null_inner_itr = root[nullptr][0].as_map().find(nullptr);
-        const auto& null_inner_key = null_inner_itr->first;
-        REQUIRE(null_inner_key.get_tag_name() == "!!null");
-
-        REQUIRE(root[nullptr][0][nullptr].is_null());
-    }
-
     // regression test for https://github.com/fktn-k/fkYAML/issues/487
     SUBCASE("block mapping after an empty block sequence entry (same indentation)") {
         std::string input = "test:\n"
@@ -4043,6 +3922,132 @@ TEST_CASE("Deserializer_NodeProperties") {
             std::string("&x {a: *x}"),
             std::string("{&x [*x]: 0, &y [*y]: 1}"),
             std::string("&x {a: {b: *x}}"));
+        REQUIRE_THROWS_AS(root = deserializer.deserialize(fkyaml::detail::input_adapter(input)), fkyaml::parse_error);
+    }
+
+    SUBCASE("tagged empty nodes in various contexts") {
+        std::string input = "!!str : !!str\n"
+                            "bar: {!!str : !!str}\n"
+                            "baz: [!!str : !!str]\n"
+                            "qux:\n"
+                            "- !!str : !!str\n"
+                            "- !!str\n"
+                            "? !!str : !!str\n"
+                            ": !!str : !!str\n"
+                            "!!null :\n"
+                            "- ? !!null\n";
+
+        REQUIRE_NOTHROW(root = deserializer.deserialize(fkyaml::detail::input_adapter(input)));
+
+        CAPTURE(root);
+
+        REQUIRE(root.is_mapping());
+        REQUIRE(root.size() == 6);
+        REQUIRE(root.contains(""));
+        REQUIRE(root.contains("bar"));
+        REQUIRE(root.contains("baz"));
+        REQUIRE(root.contains("qux"));
+        auto map_key = fkyaml::node {{"", ""}};
+        REQUIRE(root.contains(map_key));
+        REQUIRE(root.contains(nullptr));
+
+        auto itr = root.as_map().find("");
+        const auto& empty_key = itr->first;
+        REQUIRE(empty_key.get_tag_name() == "!!str");
+
+        REQUIRE(root[""].is_string());
+        REQUIRE(root[""].as_str().empty());
+        REQUIRE(root[""].get_tag_name() == "!!str");
+
+        REQUIRE(root["bar"].is_mapping());
+        REQUIRE(root["bar"].size() == 1);
+        REQUIRE(root["bar"].contains(""));
+
+        auto bar_itr = root["bar"].as_map().find("");
+        const auto& bar_empty_key = bar_itr->first;
+        REQUIRE(bar_empty_key.get_tag_name() == "!!str");
+
+        REQUIRE(root["bar"][""].is_string());
+        REQUIRE(root["bar"][""].as_str().empty());
+        REQUIRE(root["bar"][""].get_tag_name() == "!!str");
+
+        REQUIRE(root["baz"].is_sequence());
+        REQUIRE(root["baz"].size() == 1);
+        REQUIRE(root["baz"][0].is_mapping());
+        REQUIRE(root["baz"][0].size() == 1);
+        REQUIRE(root["baz"][0].contains(""));
+
+        auto baz_itr = root["baz"][0].as_map().find("");
+        const auto& baz_empty_key = baz_itr->first;
+        REQUIRE(baz_empty_key.get_tag_name() == "!!str");
+
+        REQUIRE(root["baz"][0][""].is_string());
+        REQUIRE(root["baz"][0][""].as_str().empty());
+        REQUIRE(root["baz"][0][""].get_tag_name() == "!!str");
+
+        REQUIRE(root["qux"].is_sequence());
+        REQUIRE(root["qux"].size() == 2);
+        REQUIRE(root["qux"][0].is_mapping());
+        REQUIRE(root["qux"][0].size() == 1);
+        REQUIRE(root["qux"][0].contains(""));
+
+        auto qux_itr = root["qux"][0].as_map().find("");
+        const auto& qux_empty_key = qux_itr->first;
+        REQUIRE(qux_empty_key.get_tag_name() == "!!str");
+
+        REQUIRE(root["qux"][0][""].is_string());
+        REQUIRE(root["qux"][0][""].as_str().empty());
+        REQUIRE(root["qux"][0][""].get_tag_name() == "!!str");
+
+        REQUIRE(root["qux"][1].is_string());
+        REQUIRE(root["qux"][1].as_str().empty());
+        REQUIRE(root["qux"][1].get_tag_name() == "!!str");
+
+        auto map_key_itr = root.as_map().find(map_key);
+        const auto& map_empty_key = map_key_itr->first;
+        REQUIRE(map_empty_key.is_mapping());
+        REQUIRE(map_empty_key.size() == 1);
+        REQUIRE(map_empty_key.contains(""));
+
+        auto map_empty_key_itr = map_empty_key.as_map().find("");
+        const auto& map_empty_key_inner = map_empty_key_itr->first;
+        REQUIRE(map_empty_key_inner.is_string());
+        REQUIRE(map_empty_key_inner.as_str().empty());
+        REQUIRE(map_empty_key_inner.get_tag_name() == "!!str");
+
+        REQUIRE(root[map_key].is_mapping());
+        REQUIRE(root[map_key].size() == 1);
+        REQUIRE(root[map_key].contains(""));
+
+        auto map_key_value_itr = root[map_key].as_map().find("");
+        const auto& map_key_value = map_key_value_itr->first;
+        REQUIRE(map_key_value.is_string());
+        REQUIRE(map_key_value.as_str().empty());
+        REQUIRE(map_key_value.get_tag_name() == "!!str");
+
+        REQUIRE(root[map_key][""].is_string());
+        REQUIRE(root[map_key][""].as_str().empty());
+        REQUIRE(root[map_key][""].get_tag_name() == "!!str");
+
+        auto null_itr = root.as_map().find(nullptr);
+        auto null_key = null_itr->first;
+        REQUIRE(null_key.get_tag_name() == "!!null");
+
+        REQUIRE(root[nullptr].is_sequence());
+        REQUIRE(root[nullptr].size() == 1);
+        REQUIRE(root[nullptr][0].is_mapping());
+        REQUIRE(root[nullptr][0].size() == 1);
+        REQUIRE(root[nullptr][0].contains(nullptr));
+
+        auto null_inner_itr = root[nullptr][0].as_map().find(nullptr);
+        const auto& null_inner_key = null_inner_itr->first;
+        REQUIRE(null_inner_key.get_tag_name() == "!!null");
+
+        REQUIRE(root[nullptr][0][nullptr].is_null());
+    }
+
+    SUBCASE("invalid tagged empty node") {
+        std::string input = "!!int : bar\n";
         REQUIRE_THROWS_AS(root = deserializer.deserialize(fkyaml::detail::input_adapter(input)), fkyaml::parse_error);
     }
 }

--- a/tests/unit_test/test_deserializer_class.cpp
+++ b/tests/unit_test/test_deserializer_class.cpp
@@ -1394,24 +1394,31 @@ TEST_CASE("Deserializer_BlockMapping") {
         REQUIRE(root["baz"].is_null());
     }
 
-    SUBCASE("omitted mapping values with a tag") {
+    SUBCASE("tagged empty nodes in various contexts") {
         std::string input = "!!str : !!str\n"
                             "bar: {!!str : !!str}\n"
                             "baz: [!!str : !!str]\n"
+                            "qux:\n"
+                            "- !!str : !!str\n"
+                            "- !!str\n"
                             "? !!str : !!str\n"
-                            ": !!str : !!str\n";
+                            ": !!str : !!str\n"
+                            "!!null :\n"
+                            "- ? !!null\n";
 
         REQUIRE_NOTHROW(root = deserializer.deserialize(fkyaml::detail::input_adapter(input)));
 
         CAPTURE(root);
 
         REQUIRE(root.is_mapping());
-        REQUIRE(root.size() == 4);
+        REQUIRE(root.size() == 6);
         REQUIRE(root.contains(""));
         REQUIRE(root.contains("bar"));
         REQUIRE(root.contains("baz"));
+        REQUIRE(root.contains("qux"));
         auto map_key = fkyaml::node {{"", ""}};
         REQUIRE(root.contains(map_key));
+        REQUIRE(root.contains(nullptr));
 
         auto itr = root.as_map().find("");
         const auto& empty_key = itr->first;
@@ -1447,6 +1454,24 @@ TEST_CASE("Deserializer_BlockMapping") {
         REQUIRE(root["baz"][0][""].as_str().empty());
         REQUIRE(root["baz"][0][""].get_tag_name() == "!!str");
 
+        REQUIRE(root["qux"].is_sequence());
+        REQUIRE(root["qux"].size() == 2);
+        REQUIRE(root["qux"][0].is_mapping());
+        REQUIRE(root["qux"][0].size() == 1);
+        REQUIRE(root["qux"][0].contains(""));
+
+        auto qux_itr = root["qux"][0].as_map().find("");
+        const auto& qux_empty_key = qux_itr->first;
+        REQUIRE(qux_empty_key.get_tag_name() == "!!str");
+
+        REQUIRE(root["qux"][0][""].is_string());
+        REQUIRE(root["qux"][0][""].as_str().empty());
+        REQUIRE(root["qux"][0][""].get_tag_name() == "!!str");
+
+        REQUIRE(root["qux"][1].is_string());
+        REQUIRE(root["qux"][1].as_str().empty());
+        REQUIRE(root["qux"][1].get_tag_name() == "!!str");
+
         auto map_key_itr = root.as_map().find(map_key);
         const auto& map_empty_key = map_key_itr->first;
         REQUIRE(map_empty_key.is_mapping());
@@ -1472,6 +1497,22 @@ TEST_CASE("Deserializer_BlockMapping") {
         REQUIRE(root[map_key][""].is_string());
         REQUIRE(root[map_key][""].as_str().empty());
         REQUIRE(root[map_key][""].get_tag_name() == "!!str");
+
+        auto null_itr = root.as_map().find(nullptr);
+        auto null_key = null_itr->first;
+        REQUIRE(null_key.get_tag_name() == "!!null");
+
+        REQUIRE(root[nullptr].is_sequence());
+        REQUIRE(root[nullptr].size() == 1);
+        REQUIRE(root[nullptr][0].is_mapping());
+        REQUIRE(root[nullptr][0].size() == 1);
+        REQUIRE(root[nullptr][0].contains(nullptr));
+
+        auto null_inner_itr = root[nullptr][0].as_map().find(nullptr);
+        const auto& null_inner_key = null_inner_itr->first;
+        REQUIRE(null_inner_key.get_tag_name() == "!!null");
+
+        REQUIRE(root[nullptr][0][nullptr].is_null());
     }
 
     // regression test for https://github.com/fktn-k/fkYAML/issues/487

--- a/tests/unit_test/test_deserializer_class.cpp
+++ b/tests/unit_test/test_deserializer_class.cpp
@@ -1394,6 +1394,53 @@ TEST_CASE("Deserializer_BlockMapping") {
         REQUIRE(root["baz"].is_null());
     }
 
+    SUBCASE("omitted mapping values with a tag") {
+        std::string input = "foo: !!str\n"
+                            "bar: {foo: !!str}\n"
+                            "baz: [foo: !!str]\n"
+                            "? foo: !!str\n"
+                            ": foo: !!str\n";
+
+        REQUIRE_NOTHROW(root = deserializer.deserialize(fkyaml::detail::input_adapter(input)));
+
+        CAPTURE(root);
+
+        REQUIRE(root.is_mapping());
+        REQUIRE(root.size() == 4);
+        REQUIRE(root.contains("foo"));
+        REQUIRE(root.contains("bar"));
+        REQUIRE(root.contains("baz"));
+        auto map_key = fkyaml::node {{"foo", ""}};
+        REQUIRE(root.contains(map_key));
+
+        REQUIRE(root["foo"].is_string());
+        REQUIRE(root["foo"].as_str().empty());
+        REQUIRE(root["foo"].get_tag_name() == "!!str");
+
+        REQUIRE(root["bar"].is_mapping());
+        REQUIRE(root["bar"].size() == 1);
+        REQUIRE(root["bar"].contains("foo"));
+        REQUIRE(root["bar"]["foo"].is_string());
+        REQUIRE(root["bar"]["foo"].as_str().empty());
+        REQUIRE(root["bar"]["foo"].get_tag_name() == "!!str");
+
+        REQUIRE(root["baz"].is_sequence());
+        REQUIRE(root["baz"].size() == 1);
+        REQUIRE(root["baz"][0].is_mapping());
+        REQUIRE(root["baz"][0].size() == 1);
+        REQUIRE(root["baz"][0].contains("foo"));
+        REQUIRE(root["baz"][0]["foo"].is_string());
+        REQUIRE(root["baz"][0]["foo"].as_str().empty());
+        REQUIRE(root["baz"][0]["foo"].get_tag_name() == "!!str");
+
+        REQUIRE(root[map_key].is_mapping());
+        REQUIRE(root[map_key].size() == 1);
+        REQUIRE(root[map_key].contains("foo"));
+        REQUIRE(root[map_key]["foo"].is_string());
+        REQUIRE(root[map_key]["foo"].as_str().empty());
+        REQUIRE(root[map_key]["foo"].get_tag_name() == "!!str");
+    }
+
     // regression test for https://github.com/fktn-k/fkYAML/issues/487
     SUBCASE("block mapping after an empty block sequence entry (same indentation)") {
         std::string input = "test:\n"

--- a/tests/unit_test/test_deserializer_class.cpp
+++ b/tests/unit_test/test_deserializer_class.cpp
@@ -1395,11 +1395,11 @@ TEST_CASE("Deserializer_BlockMapping") {
     }
 
     SUBCASE("omitted mapping values with a tag") {
-        std::string input = "foo: !!str\n"
-                            "bar: {foo: !!str}\n"
-                            "baz: [foo: !!str]\n"
-                            "? foo: !!str\n"
-                            ": foo: !!str\n";
+        std::string input = "!!str : !!str\n"
+                            "bar: {!!str : !!str}\n"
+                            "baz: [!!str : !!str]\n"
+                            "? !!str : !!str\n"
+                            ": !!str : !!str\n";
 
         REQUIRE_NOTHROW(root = deserializer.deserialize(fkyaml::detail::input_adapter(input)));
 
@@ -1407,38 +1407,71 @@ TEST_CASE("Deserializer_BlockMapping") {
 
         REQUIRE(root.is_mapping());
         REQUIRE(root.size() == 4);
-        REQUIRE(root.contains("foo"));
+        REQUIRE(root.contains(""));
         REQUIRE(root.contains("bar"));
         REQUIRE(root.contains("baz"));
-        auto map_key = fkyaml::node {{"foo", ""}};
+        auto map_key = fkyaml::node {{"", ""}};
         REQUIRE(root.contains(map_key));
 
-        REQUIRE(root["foo"].is_string());
-        REQUIRE(root["foo"].as_str().empty());
-        REQUIRE(root["foo"].get_tag_name() == "!!str");
+        auto itr = root.as_map().find("");
+        const auto& empty_key = itr->first;
+        REQUIRE(empty_key.get_tag_name() == "!!str");
+
+        REQUIRE(root[""].is_string());
+        REQUIRE(root[""].as_str().empty());
+        REQUIRE(root[""].get_tag_name() == "!!str");
 
         REQUIRE(root["bar"].is_mapping());
         REQUIRE(root["bar"].size() == 1);
-        REQUIRE(root["bar"].contains("foo"));
-        REQUIRE(root["bar"]["foo"].is_string());
-        REQUIRE(root["bar"]["foo"].as_str().empty());
-        REQUIRE(root["bar"]["foo"].get_tag_name() == "!!str");
+        REQUIRE(root["bar"].contains(""));
+
+        auto bar_itr = root["bar"].as_map().find("");
+        const auto& bar_empty_key = bar_itr->first;
+        REQUIRE(bar_empty_key.get_tag_name() == "!!str");
+
+        REQUIRE(root["bar"][""].is_string());
+        REQUIRE(root["bar"][""].as_str().empty());
+        REQUIRE(root["bar"][""].get_tag_name() == "!!str");
 
         REQUIRE(root["baz"].is_sequence());
         REQUIRE(root["baz"].size() == 1);
         REQUIRE(root["baz"][0].is_mapping());
         REQUIRE(root["baz"][0].size() == 1);
-        REQUIRE(root["baz"][0].contains("foo"));
-        REQUIRE(root["baz"][0]["foo"].is_string());
-        REQUIRE(root["baz"][0]["foo"].as_str().empty());
-        REQUIRE(root["baz"][0]["foo"].get_tag_name() == "!!str");
+        REQUIRE(root["baz"][0].contains(""));
+
+        auto baz_itr = root["baz"][0].as_map().find("");
+        const auto& baz_empty_key = baz_itr->first;
+        REQUIRE(baz_empty_key.get_tag_name() == "!!str");
+
+        REQUIRE(root["baz"][0][""].is_string());
+        REQUIRE(root["baz"][0][""].as_str().empty());
+        REQUIRE(root["baz"][0][""].get_tag_name() == "!!str");
+
+        auto map_key_itr = root.as_map().find(map_key);
+        const auto& map_empty_key = map_key_itr->first;
+        REQUIRE(map_empty_key.is_mapping());
+        REQUIRE(map_empty_key.size() == 1);
+        REQUIRE(map_empty_key.contains(""));
+
+        auto map_empty_key_itr = map_empty_key.as_map().find("");
+        const auto& map_empty_key_inner = map_empty_key_itr->first;
+        REQUIRE(map_empty_key_inner.is_string());
+        REQUIRE(map_empty_key_inner.as_str().empty());
+        REQUIRE(map_empty_key_inner.get_tag_name() == "!!str");
 
         REQUIRE(root[map_key].is_mapping());
         REQUIRE(root[map_key].size() == 1);
-        REQUIRE(root[map_key].contains("foo"));
-        REQUIRE(root[map_key]["foo"].is_string());
-        REQUIRE(root[map_key]["foo"].as_str().empty());
-        REQUIRE(root[map_key]["foo"].get_tag_name() == "!!str");
+        REQUIRE(root[map_key].contains(""));
+
+        auto map_key_value_itr = root[map_key].as_map().find("");
+        const auto& map_key_value = map_key_value_itr->first;
+        REQUIRE(map_key_value.is_string());
+        REQUIRE(map_key_value.as_str().empty());
+        REQUIRE(map_key_value.get_tag_name() == "!!str");
+
+        REQUIRE(root[map_key][""].is_string());
+        REQUIRE(root[map_key][""].as_str().empty());
+        REQUIRE(root[map_key][""].get_tag_name() == "!!str");
     }
 
     // regression test for https://github.com/fktn-k/fkYAML/issues/487


### PR DESCRIPTION
This pull request fixes errors around handling empty mapping keys and values with a tag.  
Such nodes were silently ignored.  
The changes refactor and clarify how node properties (like tags and anchors) are applied, improve context management for mappings and sequences, and introduce utility methods to reduce code duplication and improve correctness.

## Changes

### Improved handling of empty mapping values and deferred properties

* Refactored how empty mapping values are added by introducing the `add_empty_key_entry` method, which now applies any pending tags and properties to the empty node, and properly initializes block sequences as mapping values when appropriate.
* Improved logic for deferring and applying node properties (tags, anchors) so that they are correctly associated with the intended node, especially when properties are for omitted values.

### Context and state management enhancements

* Added more precise popping of the context stack when closing omitted mapping values, and clarified how context is managed for explicit keys and mapping values with or without properties.
* Improved handling of block sequences as a mapping value with a new `initialize_block_sequence_value` helper to encapsulate repeated logic.

### Tag and property application improvements

* Added the `materialize_tagged_empty_node` utility to consistently create empty nodes with the correct tag type, and used it throughout the deserializer where empty nodes with tags are needed.
* Ensured that deferred tags and properties are correctly applied to root nodes, mapping values, and omitted values, removing previous ad-hoc property applications.

### Bug fixes and code clarity

* Fixed subtle bugs where node properties could be incorrectly applied to the wrong node due to line/indent mismatches, and clarified comments and control flow to make the deserializer's intent more explicit.

## Testing

* Added a new test case to `test_deserializer_class.cpp` that verifies tags can be correctly associated with an empty node in various contexts. All the test cases pass successfully.
* This fix affects `35KP`, `FH7J`, `LE5A`, `PW8X`, and `WZ62` in the YAML test suite. `PW8X` still fails since it contains an empty node with an anchor, which will be addressed in a separate PR. As a result, 60 failing cases has decreased to 56 with no newly failing case.

---

## Pull Request Checklist

Read the [CONTRIBUTING.md](https://github.com/fktn-k/fkYAML/blob/develop/.github/CONTRIBUTING.md) file for detailed information.  

- [x] Changes are described in the pull request or in a referenced [issue](https://github.com/fktn-k/fkYAML/issues).
- [x] The test suite compiles and runs without any error.
- [x] [The code coverage](https://coveralls.io/github/fktn-k/fkYAML) on your branch is 100%.
- [x] The documentation is updated if you added/changed a feature.

## Please don't

- The C++11 support varies between different **compilers** and versions. Please note the [list of supported compilers](https://github.com/fktn-k/fkYAML/blob/develop/README.md#supported-compilers). Some compilers like GCC 4.7 (and earlier), Clang 3.3 (and earlier), or Microsoft Visual Studio 13.0 and earlier are known not to work due to missing or incomplete C++11 support. Please refrain from proposing changes that work around these compiler's limitations with `#ifdef`s or other means.
- Please refrain from proposing changes that would **break [YAML](https://yaml.org/) specifications**. If you propose a conformant extension of YAML to be supported by the library, please motivate this extension.
- Please do not open pull requests that address **multiple issues**.
