### PR TITLE
Fix errors on empty nodes with anchor

### DIFF
--- a/include/fkYAML/detail/input/deserializer.hpp
+++ b/include/fkYAML/detail/input/deserializer.hpp
@@ -325,12 +325,15 @@ private:
             const tag_t tag_type = resolve_scalar_tag(line, indent);
             materialize_tagged_empty_node(*mp_current_node, tag_type, line, indent);
         }
-        apply_node_properties(*mp_current_node);
         if (m_defers_tag) {
             const tag_t tag_type = tag_resolver_type::resolve_tag(m_deferred_tag_name, mp_meta);
             ensure_scalar_tag(tag_type, line, indent);
             materialize_tagged_empty_node(*mp_current_node, tag_type, line, indent);
         }
+        // The current node may be an empty node which never received the document metainfo. An anchor
+        // name must be registered in the shared metainfo, or aliases cannot resolve it.
+        apply_directive_set(*mp_current_node);
+        apply_node_properties(*mp_current_node);
         apply_deferred_properties(*mp_current_node);
 
         // An explicit key at the end of a document has no value either. Its own contents may have left
@@ -664,6 +667,30 @@ private:
                 }
 
                 if (line > old_line) {
+                    // The separator may close an explicit key whose contents were mapping entries, in
+                    // which case the contents have left their own contexts on the stack:
+                    // ```yaml
+                    // ? e:
+                    // :
+                    //   f: 1
+                    // # -> {{e: null}: {f: 1}}
+                    // ```
+                    // Pop back to the explicit key context so that the separator is handled as the
+                    // explicit key's one. Any deferred properties belong to the omitted value of the
+                    // last entry in the contents.
+                    if (m_context_stack.back().state != context_state_t::BLOCK_MAPPING_EXPLICIT_KEY &&
+                        old_indent < m_context_stack.back().indent) {
+                        const auto is_enclosing_explicit_key = [old_indent](const parse_context& c) {
+                            return c.state == context_state_t::BLOCK_MAPPING_EXPLICIT_KEY &&
+                                   old_indent == c.indent;
+                        };
+                        const bool has_explicit_key_context = std::any_of(
+                            m_context_stack.rbegin(), m_context_stack.rend(), is_enclosing_explicit_key);
+                        if (has_explicit_key_context) {
+                            pop_to_parent_node(old_line, old_indent, is_enclosing_explicit_key);
+                        }
+                    }
+
                     const bool is_explicit_value_begin =
                         m_context_stack.back().state == context_state_t::BLOCK_MAPPING_EXPLICIT_KEY &&
                         (token.type == lexical_token_t::SEQUENCE_BLOCK_PREFIX ||
@@ -726,15 +753,28 @@ private:
                         continue;
                     }
 
-                    // A property for an omitted value inside an explicit key is deferred until the
-                    // key context is closed:
+                    // A key separator on a following line may be the value separator of an explicit
+                    // key whose contents were mapping entries, rather than a separator in the current
+                    // mapping:
                     // ```yaml
                     // ? foo: !!str # the tag belongs to this omitted value
                     // : foo: !!str # this separator begins the explicit key's value
                     // ```
-                    // Processing the second separator here would close the explicit key
-                    // with a null value before the tag determines the type of the inner mapping's
-                    // omitted value.
+                    // Defer the properties of the omitted value and leave the separator to the next
+                    // iteration, which closes the explicit key and applies them.
+                    if (token.type == lexical_token_t::KEY_SEPARATOR) {
+                        const auto is_explicit_key_at_indent = [indent](const parse_context& c) {
+                            return c.state == context_state_t::BLOCK_MAPPING_EXPLICIT_KEY && indent == c.indent;
+                        };
+                        const bool closes_explicit_key =
+                            indent < m_context_stack.back().indent &&
+                            std::any_of(m_context_stack.rbegin(), m_context_stack.rend(), is_explicit_key_at_indent);
+                        if (closes_explicit_key) {
+                            defer_node_properties();
+                            continue;
+                        }
+                    }
+
                     const bool is_omitted_mapping_value_without_properties =
                         (token.type != lexical_token_t::KEY_SEPARATOR || !defers_props()) &&
                         indent <= m_context_stack.back().indent;
@@ -1767,6 +1807,9 @@ private:
                 ensure_scalar_tag(tag_type, line, indent);
                 materialize_tagged_empty_node(*mp_current_node, tag_type, line, indent);
             }
+            // The empty node never received the document metainfo, in which an anchor name must be
+            // registered for aliases to resolve it.
+            apply_directive_set(*mp_current_node);
             apply_deferred_properties(*mp_current_node);
         }
 

--- a/include/fkYAML/detail/input/deserializer.hpp
+++ b/include/fkYAML/detail/input/deserializer.hpp
@@ -642,11 +642,14 @@ private:
                 const bool found_props = deserialize_node_properties(lexer, token, line, indent);
                 if (found_props && line == lexer.get_lines_processed() &&
                     token.type != lexical_token_t::KEY_SEPARATOR) {
+                    settle_explicit_key_value_with_props(old_line, old_indent);
                     // defer applying node properties for the subsequent node on the same line.
                     continue;
                 }
 
-                if (found_props && token.type != lexical_token_t::KEY_SEPARATOR) {
+                const bool has_explicit_key_context = has_explicit_key_context_at(old_indent);
+
+                if (found_props && token.type != lexical_token_t::KEY_SEPARATOR && !has_explicit_key_context) {
                     // The properties belong to whatever begins on the following line, which the token
                     // after it decides.
                     // ```yaml
@@ -654,6 +657,14 @@ private:
                     //   bar: baz   # the anchor is for the mapping, not for the "bar" key.
                     // ```
                     defer_node_properties();
+                }
+
+                if (found_props && has_explicit_key_context) {
+                    // The properties follow the separator of an explicit key, so they belong to its
+                    // value. They must not be deferred here, or they would overwrite the properties
+                    // of the key which are already deferred.
+                    settle_explicit_key_value_with_props(old_line, old_indent);
+                    continue;
                 }
 
                 line = lexer.get_lines_processed();
@@ -667,30 +678,6 @@ private:
                 }
 
                 if (line > old_line) {
-                    // The separator may close an explicit key whose contents were mapping entries, in
-                    // which case the contents have left their own contexts on the stack:
-                    // ```yaml
-                    // ? e:
-                    // :
-                    //   f: 1
-                    // # -> {{e: null}: {f: 1}}
-                    // ```
-                    // Pop back to the explicit key context so that the separator is handled as the
-                    // explicit key's one. Any deferred properties belong to the omitted value of the
-                    // last entry in the contents.
-                    if (m_context_stack.back().state != context_state_t::BLOCK_MAPPING_EXPLICIT_KEY &&
-                        old_indent < m_context_stack.back().indent) {
-                        const auto is_enclosing_explicit_key = [old_indent](const parse_context& c) {
-                            return c.state == context_state_t::BLOCK_MAPPING_EXPLICIT_KEY &&
-                                   old_indent == c.indent;
-                        };
-                        const bool has_explicit_key_context = std::any_of(
-                            m_context_stack.rbegin(), m_context_stack.rend(), is_enclosing_explicit_key);
-                        if (has_explicit_key_context) {
-                            pop_to_parent_node(old_line, old_indent, is_enclosing_explicit_key);
-                        }
-                    }
-
                     const bool is_explicit_value_begin =
                         m_context_stack.back().state == context_state_t::BLOCK_MAPPING_EXPLICIT_KEY &&
                         (token.type == lexical_token_t::SEQUENCE_BLOCK_PREFIX ||
@@ -1733,12 +1720,44 @@ private:
         m_context_stack.emplace_back(line, indent, context_state_t::BLOCK_SEQUENCE_ENTRY, mp_current_node);
     }
 
+    /// @brief Checks whether an explicit key context exists at the given indentation.
+    /// @param indent The indentation width of the explicit key context to look for.
+    /// @return true if such a context is on the context stack, false otherwise.
+    bool has_explicit_key_context_at(const uint32_t indent) const noexcept {
+        const auto is_explicit_key_context = [indent](const parse_context& c) {
+            return c.state == context_state_t::BLOCK_MAPPING_EXPLICIT_KEY && indent == c.indent;
+        };
+        return std::any_of(m_context_stack.rbegin(), m_context_stack.rend(), is_explicit_key_context);
+    }
+
+    /// @brief Settles an explicit key into its value context when properties follow its separator.
+    /// @note As in `? key` followed by `: &anchor`, the value context of the explicit key is settled
+    /// before its node is known so that the properties which follow the separator are bound to the
+    /// (empty) value node. Does nothing when no matching explicit key context exists.
+    /// @param line The line of the key separator.
+    /// @param indent The indentation width of the key separator.
+    void settle_explicit_key_value_with_props(const uint32_t line, const uint32_t indent) {
+        if (!has_explicit_key_context_at(indent)) {
+            return;
+        }
+        if (m_context_stack.back().state != context_state_t::BLOCK_MAPPING_EXPLICIT_KEY) {
+            const auto is_explicit_key_context = [indent](const parse_context& c) {
+                return c.state == context_state_t::BLOCK_MAPPING_EXPLICIT_KEY && indent == c.indent;
+            };
+            pop_to_parent_node(line, indent, is_explicit_key_context);
+        }
+        add_explicit_key_with_empty_value(line, indent);
+    }
+
     /// @brief Adds an entry for an explicit key and makes its value node the current node.
     /// @note The current context must be the context of the explicit key.
     /// @param line The line where the value of the explicit key begins.
     /// @param indent The indentation width where the value of the explicit key begins.
     void add_explicit_key_with_empty_value(const uint32_t line, const uint32_t indent) {
         FK_YAML_ASSERT(m_context_stack.back().state == context_state_t::BLOCK_MAPPING_EXPLICIT_KEY);
+
+        // Deferred properties precede the key, so they belong to the key rather than to its value.
+        apply_deferred_properties(*m_context_stack.back().p_node);
 
         basic_node_type key_node = std::move(*m_context_stack.back().p_node);
         m_context_stack.pop_back();
@@ -1765,6 +1784,9 @@ private:
             return false;
         }
 
+        // Deferred properties precede the key, so they belong to the key rather than to its value.
+        apply_deferred_properties(*m_context_stack.back().p_node);
+
         basic_node_type key_node = std::move(*m_context_stack.back().p_node);
         m_context_stack.pop_back();
         m_context_stack.back().p_node->as_map().emplace(std::move(key_node), basic_node_type());
@@ -1784,40 +1806,49 @@ private:
         }
         // LCOV_EXCL_STOP
 
-        // LCOV_EXCL_START
-        auto itr = std::find_if(m_context_stack.rbegin(), m_context_stack.rend(), std::forward<Pred>(pred));
-        // LCOV_EXCL_STOP
-        const bool is_indent_valid = (itr != m_context_stack.rend());
-        if FK_YAML_UNLIKELY (!is_indent_valid) {
-            throw parse_error("Detected invalid indentation.", line, indent);
-        }
-
-        const auto pop_num = static_cast<uint32_t>(std::distance(m_context_stack.rbegin(), itr));
-
-        if (pop_num > 0 && defers_props()) {
-            // The entry which the properties preceded ends here without a node of its own, so they
-            // belong to its empty value. Any node which did follow them would have taken them before
-            // its context could be popped, so the current node is still the empty one.
-            // ```yaml
-            // foo: &anchor
-            // bar: 1        # the anchor is for the empty value of "foo".
-            // ```
-            if (m_defers_tag) {
-                const tag_t tag_type = tag_resolver_type::resolve_tag(m_deferred_tag_name, mp_meta);
-                ensure_scalar_tag(tag_type, line, indent);
-                materialize_tagged_empty_node(*mp_current_node, tag_type, line, indent);
+        for (;;) {
+            // LCOV_EXCL_START
+            auto itr = std::find_if(m_context_stack.rbegin(), m_context_stack.rend(), std::forward<Pred>(pred));
+            // LCOV_EXCL_STOP
+            const bool is_indent_valid = (itr != m_context_stack.rend());
+            if FK_YAML_UNLIKELY (!is_indent_valid) {
+                throw parse_error("Detected invalid indentation.", line, indent);
             }
-            // The empty node never received the document metainfo, in which an anchor name must be
-            // registered for aliases to resolve it.
-            apply_directive_set(*mp_current_node);
-            apply_deferred_properties(*mp_current_node);
-        }
 
-        // move back to the parent block mapping.
-        for (uint32_t i = 0; i < pop_num; i++) {
+            const auto pop_num = static_cast<uint32_t>(std::distance(m_context_stack.rbegin(), itr));
+            if (pop_num == 0) {
+                mp_current_node = m_context_stack.back().p_node;
+                return;
+            }
+
+            if (m_context_stack.back().state == context_state_t::BLOCK_MAPPING_EXPLICIT_KEY) {
+                // Simply popping an explicit key context would drop the entry for the `? key`
+                // entirely. Settle it as an entry with a null value before moving to the parent.
+                add_explicit_key_with_null_value();
+                continue;
+            }
+
+            if (defers_props()) {
+                // The entry which the properties preceded ends here without a node of its own, so they
+                // belong to its empty value. Any node which did follow them would have taken them before
+                // its context could be popped, so the current node is still the empty one.
+                // ```yaml
+                // foo: &anchor
+                // bar: 1        # the anchor is for the empty value of "foo".
+                // ```
+                if (m_defers_tag) {
+                    const tag_t tag_type = tag_resolver_type::resolve_tag(m_deferred_tag_name, mp_meta);
+                    ensure_scalar_tag(tag_type, line, indent);
+                    materialize_tagged_empty_node(*mp_current_node, tag_type, line, indent);
+                }
+                // The empty node never received the document metainfo, in which an anchor name must be
+                // registered for aliases to resolve it.
+                apply_directive_set(*mp_current_node);
+                apply_deferred_properties(*mp_current_node);
+            }
+
             m_context_stack.pop_back();
         }
-        mp_current_node = m_context_stack.back().p_node;
     }
 
     /// @brief Set YAML directive properties to the given node.

--- a/single_include/fkYAML/node.hpp
+++ b/single_include/fkYAML/node.hpp
@@ -8441,11 +8441,14 @@ private:
                 const bool found_props = deserialize_node_properties(lexer, token, line, indent);
                 if (found_props && line == lexer.get_lines_processed() &&
                     token.type != lexical_token_t::KEY_SEPARATOR) {
+                    settle_explicit_key_value_with_props(old_line, old_indent);
                     // defer applying node properties for the subsequent node on the same line.
                     continue;
                 }
 
-                if (found_props && token.type != lexical_token_t::KEY_SEPARATOR) {
+                const bool has_explicit_key_context = has_explicit_key_context_at(old_indent);
+
+                if (found_props && token.type != lexical_token_t::KEY_SEPARATOR && !has_explicit_key_context) {
                     // The properties belong to whatever begins on the following line, which the token
                     // after it decides.
                     // ```yaml
@@ -8453,6 +8456,14 @@ private:
                     //   bar: baz   # the anchor is for the mapping, not for the "bar" key.
                     // ```
                     defer_node_properties();
+                }
+
+                if (found_props && has_explicit_key_context) {
+                    // The properties follow the separator of an explicit key, so they belong to its
+                    // value. They must not be deferred here, or they would overwrite the properties
+                    // of the key which are already deferred.
+                    settle_explicit_key_value_with_props(old_line, old_indent);
+                    continue;
                 }
 
                 line = lexer.get_lines_processed();
@@ -8466,30 +8477,6 @@ private:
                 }
 
                 if (line > old_line) {
-                    // The separator may close an explicit key whose contents were mapping entries, in
-                    // which case the contents have left their own contexts on the stack:
-                    // ```yaml
-                    // ? e:
-                    // :
-                    //   f: 1
-                    // # -> {{e: null}: {f: 1}}
-                    // ```
-                    // Pop back to the explicit key context so that the separator is handled as the
-                    // explicit key's one. Any deferred properties belong to the omitted value of the
-                    // last entry in the contents.
-                    if (m_context_stack.back().state != context_state_t::BLOCK_MAPPING_EXPLICIT_KEY &&
-                        old_indent < m_context_stack.back().indent) {
-                        const auto is_enclosing_explicit_key = [old_indent](const parse_context& c) {
-                            return c.state == context_state_t::BLOCK_MAPPING_EXPLICIT_KEY &&
-                                   old_indent == c.indent;
-                        };
-                        const bool has_explicit_key_context = std::any_of(
-                            m_context_stack.rbegin(), m_context_stack.rend(), is_enclosing_explicit_key);
-                        if (has_explicit_key_context) {
-                            pop_to_parent_node(old_line, old_indent, is_enclosing_explicit_key);
-                        }
-                    }
-
                     const bool is_explicit_value_begin =
                         m_context_stack.back().state == context_state_t::BLOCK_MAPPING_EXPLICIT_KEY &&
                         (token.type == lexical_token_t::SEQUENCE_BLOCK_PREFIX ||
@@ -9532,12 +9519,44 @@ private:
         m_context_stack.emplace_back(line, indent, context_state_t::BLOCK_SEQUENCE_ENTRY, mp_current_node);
     }
 
+    /// @brief Checks whether an explicit key context exists at the given indentation.
+    /// @param indent The indentation width of the explicit key context to look for.
+    /// @return true if such a context is on the context stack, false otherwise.
+    bool has_explicit_key_context_at(const uint32_t indent) const noexcept {
+        const auto is_explicit_key_context = [indent](const parse_context& c) {
+            return c.state == context_state_t::BLOCK_MAPPING_EXPLICIT_KEY && indent == c.indent;
+        };
+        return std::any_of(m_context_stack.rbegin(), m_context_stack.rend(), is_explicit_key_context);
+    }
+
+    /// @brief Settles an explicit key into its value context when properties follow its separator.
+    /// @note As in `? key` followed by `: &anchor`, the value context of the explicit key is settled
+    /// before its node is known so that the properties which follow the separator are bound to the
+    /// (empty) value node. Does nothing when no matching explicit key context exists.
+    /// @param line The line of the key separator.
+    /// @param indent The indentation width of the key separator.
+    void settle_explicit_key_value_with_props(const uint32_t line, const uint32_t indent) {
+        if (!has_explicit_key_context_at(indent)) {
+            return;
+        }
+        if (m_context_stack.back().state != context_state_t::BLOCK_MAPPING_EXPLICIT_KEY) {
+            const auto is_explicit_key_context = [indent](const parse_context& c) {
+                return c.state == context_state_t::BLOCK_MAPPING_EXPLICIT_KEY && indent == c.indent;
+            };
+            pop_to_parent_node(line, indent, is_explicit_key_context);
+        }
+        add_explicit_key_with_empty_value(line, indent);
+    }
+
     /// @brief Adds an entry for an explicit key and makes its value node the current node.
     /// @note The current context must be the context of the explicit key.
     /// @param line The line where the value of the explicit key begins.
     /// @param indent The indentation width where the value of the explicit key begins.
     void add_explicit_key_with_empty_value(const uint32_t line, const uint32_t indent) {
         FK_YAML_ASSERT(m_context_stack.back().state == context_state_t::BLOCK_MAPPING_EXPLICIT_KEY);
+
+        // Deferred properties precede the key, so they belong to the key rather than to its value.
+        apply_deferred_properties(*m_context_stack.back().p_node);
 
         basic_node_type key_node = std::move(*m_context_stack.back().p_node);
         m_context_stack.pop_back();
@@ -9564,6 +9583,9 @@ private:
             return false;
         }
 
+        // Deferred properties precede the key, so they belong to the key rather than to its value.
+        apply_deferred_properties(*m_context_stack.back().p_node);
+
         basic_node_type key_node = std::move(*m_context_stack.back().p_node);
         m_context_stack.pop_back();
         m_context_stack.back().p_node->as_map().emplace(std::move(key_node), basic_node_type());
@@ -9583,40 +9605,49 @@ private:
         }
         // LCOV_EXCL_STOP
 
-        // LCOV_EXCL_START
-        auto itr = std::find_if(m_context_stack.rbegin(), m_context_stack.rend(), std::forward<Pred>(pred));
-        // LCOV_EXCL_STOP
-        const bool is_indent_valid = (itr != m_context_stack.rend());
-        if FK_YAML_UNLIKELY (!is_indent_valid) {
-            throw parse_error("Detected invalid indentation.", line, indent);
-        }
-
-        const auto pop_num = static_cast<uint32_t>(std::distance(m_context_stack.rbegin(), itr));
-
-        if (pop_num > 0 && defers_props()) {
-            // The entry which the properties preceded ends here without a node of its own, so they
-            // belong to its empty value. Any node which did follow them would have taken them before
-            // its context could be popped, so the current node is still the empty one.
-            // ```yaml
-            // foo: &anchor
-            // bar: 1        # the anchor is for the empty value of "foo".
-            // ```
-            if (m_defers_tag) {
-                const tag_t tag_type = tag_resolver_type::resolve_tag(m_deferred_tag_name, mp_meta);
-                ensure_scalar_tag(tag_type, line, indent);
-                materialize_tagged_empty_node(*mp_current_node, tag_type, line, indent);
+        for (;;) {
+            // LCOV_EXCL_START
+            auto itr = std::find_if(m_context_stack.rbegin(), m_context_stack.rend(), std::forward<Pred>(pred));
+            // LCOV_EXCL_STOP
+            const bool is_indent_valid = (itr != m_context_stack.rend());
+            if FK_YAML_UNLIKELY (!is_indent_valid) {
+                throw parse_error("Detected invalid indentation.", line, indent);
             }
-            // The empty node never received the document metainfo, in which an anchor name must be
-            // registered for aliases to resolve it.
-            apply_directive_set(*mp_current_node);
-            apply_deferred_properties(*mp_current_node);
-        }
 
-        // move back to the parent block mapping.
-        for (uint32_t i = 0; i < pop_num; i++) {
+            const auto pop_num = static_cast<uint32_t>(std::distance(m_context_stack.rbegin(), itr));
+            if (pop_num == 0) {
+                mp_current_node = m_context_stack.back().p_node;
+                return;
+            }
+
+            if (m_context_stack.back().state == context_state_t::BLOCK_MAPPING_EXPLICIT_KEY) {
+                // Simply popping an explicit key context would drop the entry for the `? key`
+                // entirely. Settle it as an entry with a null value before moving to the parent.
+                add_explicit_key_with_null_value();
+                continue;
+            }
+
+            if (defers_props()) {
+                // The entry which the properties preceded ends here without a node of its own, so they
+                // belong to its empty value. Any node which did follow them would have taken them before
+                // its context could be popped, so the current node is still the empty one.
+                // ```yaml
+                // foo: &anchor
+                // bar: 1        # the anchor is for the empty value of "foo".
+                // ```
+                if (m_defers_tag) {
+                    const tag_t tag_type = tag_resolver_type::resolve_tag(m_deferred_tag_name, mp_meta);
+                    ensure_scalar_tag(tag_type, line, indent);
+                    materialize_tagged_empty_node(*mp_current_node, tag_type, line, indent);
+                }
+                // The empty node never received the document metainfo, in which an anchor name must be
+                // registered for aliases to resolve it.
+                apply_directive_set(*mp_current_node);
+                apply_deferred_properties(*mp_current_node);
+            }
+
             m_context_stack.pop_back();
         }
-        mp_current_node = m_context_stack.back().p_node;
     }
 
     /// @brief Set YAML directive properties to the given node.

--- a/single_include/fkYAML/node.hpp
+++ b/single_include/fkYAML/node.hpp
@@ -8124,12 +8124,15 @@ private:
             const tag_t tag_type = resolve_scalar_tag(line, indent);
             materialize_tagged_empty_node(*mp_current_node, tag_type, line, indent);
         }
-        apply_node_properties(*mp_current_node);
         if (m_defers_tag) {
             const tag_t tag_type = tag_resolver_type::resolve_tag(m_deferred_tag_name, mp_meta);
             ensure_scalar_tag(tag_type, line, indent);
             materialize_tagged_empty_node(*mp_current_node, tag_type, line, indent);
         }
+        // The current node may be an empty node which never received the document metainfo. An anchor
+        // name must be registered in the shared metainfo, or aliases cannot resolve it.
+        apply_directive_set(*mp_current_node);
+        apply_node_properties(*mp_current_node);
         apply_deferred_properties(*mp_current_node);
 
         // An explicit key at the end of a document has no value either. Its own contents may have left
@@ -8463,6 +8466,30 @@ private:
                 }
 
                 if (line > old_line) {
+                    // The separator may close an explicit key whose contents were mapping entries, in
+                    // which case the contents have left their own contexts on the stack:
+                    // ```yaml
+                    // ? e:
+                    // :
+                    //   f: 1
+                    // # -> {{e: null}: {f: 1}}
+                    // ```
+                    // Pop back to the explicit key context so that the separator is handled as the
+                    // explicit key's one. Any deferred properties belong to the omitted value of the
+                    // last entry in the contents.
+                    if (m_context_stack.back().state != context_state_t::BLOCK_MAPPING_EXPLICIT_KEY &&
+                        old_indent < m_context_stack.back().indent) {
+                        const auto is_enclosing_explicit_key = [old_indent](const parse_context& c) {
+                            return c.state == context_state_t::BLOCK_MAPPING_EXPLICIT_KEY &&
+                                   old_indent == c.indent;
+                        };
+                        const bool has_explicit_key_context = std::any_of(
+                            m_context_stack.rbegin(), m_context_stack.rend(), is_enclosing_explicit_key);
+                        if (has_explicit_key_context) {
+                            pop_to_parent_node(old_line, old_indent, is_enclosing_explicit_key);
+                        }
+                    }
+
                     const bool is_explicit_value_begin =
                         m_context_stack.back().state == context_state_t::BLOCK_MAPPING_EXPLICIT_KEY &&
                         (token.type == lexical_token_t::SEQUENCE_BLOCK_PREFIX ||
@@ -8525,15 +8552,28 @@ private:
                         continue;
                     }
 
-                    // A property for an omitted value inside an explicit key is deferred until the
-                    // key context is closed:
+                    // A key separator on a following line may be the value separator of an explicit
+                    // key whose contents were mapping entries, rather than a separator in the current
+                    // mapping:
                     // ```yaml
                     // ? foo: !!str # the tag belongs to this omitted value
                     // : foo: !!str # this separator begins the explicit key's value
                     // ```
-                    // Processing the second separator here would close the explicit key
-                    // with a null value before the tag determines the type of the inner mapping's
-                    // omitted value.
+                    // Defer the properties of the omitted value and leave the separator to the next
+                    // iteration, which closes the explicit key and applies them.
+                    if (token.type == lexical_token_t::KEY_SEPARATOR) {
+                        const auto is_explicit_key_at_indent = [indent](const parse_context& c) {
+                            return c.state == context_state_t::BLOCK_MAPPING_EXPLICIT_KEY && indent == c.indent;
+                        };
+                        const bool closes_explicit_key =
+                            indent < m_context_stack.back().indent &&
+                            std::any_of(m_context_stack.rbegin(), m_context_stack.rend(), is_explicit_key_at_indent);
+                        if (closes_explicit_key) {
+                            defer_node_properties();
+                            continue;
+                        }
+                    }
+
                     const bool is_omitted_mapping_value_without_properties =
                         (token.type != lexical_token_t::KEY_SEPARATOR || !defers_props()) &&
                         indent <= m_context_stack.back().indent;
@@ -9566,6 +9606,9 @@ private:
                 ensure_scalar_tag(tag_type, line, indent);
                 materialize_tagged_empty_node(*mp_current_node, tag_type, line, indent);
             }
+            // The empty node never received the document metainfo, in which an anchor name must be
+            // registered for aliases to resolve it.
+            apply_directive_set(*mp_current_node);
             apply_deferred_properties(*mp_current_node);
         }
 

--- a/tests/unit_test/test_deserializer_class.cpp
+++ b/tests/unit_test/test_deserializer_class.cpp
@@ -4050,6 +4050,128 @@ TEST_CASE("Deserializer_NodeProperties") {
         std::string input = "!!int : bar\n";
         REQUIRE_THROWS_AS(root = deserializer.deserialize(fkyaml::detail::input_adapter(input)), fkyaml::parse_error);
     }
+
+    SUBCASE("anchored empty nodes in various contexts") {
+        std::string input = "&anchor_key1 : &anchor1\n"
+                            "b: {&anchor_key2 : &anchor2}\n"
+                            "c: [&anchor_key3 : &anchor3]\n"
+                            "d:\n"
+                            "- &anchor_key4 : &anchor4\n"
+                            "- &anchor5\n"
+                            "? &anchor_key5 : &anchor6\n"
+                            ": &anchor_key6 : &anchor7\n"
+                            "&anchor_key7 !!str :\n"
+                            "- ? &anchor_key8\n";
+
+        REQUIRE_NOTHROW(root = deserializer.deserialize(fkyaml::detail::input_adapter(input)));
+
+        REQUIRE(root.is_mapping());
+        REQUIRE(root.size() == 6);
+        REQUIRE(root.contains(nullptr));
+        REQUIRE(root.contains("b"));
+        REQUIRE(root.contains("c"));
+        REQUIRE(root.contains("d"));
+        auto map_key = fkyaml::node {{nullptr, nullptr}};
+        REQUIRE(root.contains(map_key));
+        REQUIRE(root.contains(""));
+
+        auto null_key_itr = root.as_map().find(nullptr);
+        const auto& null_key = null_key_itr->first;
+        REQUIRE(null_key.get_anchor_name() == "anchor_key1");
+
+        REQUIRE(root[nullptr].is_null());
+        REQUIRE(root[nullptr].is_anchor());
+        REQUIRE(root[nullptr].get_anchor_name() == "anchor1");
+
+        REQUIRE(root["b"].is_mapping());
+        REQUIRE(root["b"].size() == 1);
+        REQUIRE(root["b"].contains(nullptr));
+
+        auto b_inner_key_itr = root["b"].as_map().find(nullptr);
+        const auto& b_inner_key = b_inner_key_itr->first;
+        REQUIRE(b_inner_key.get_anchor_name() == "anchor_key2");
+
+        REQUIRE(root["b"][nullptr].is_null());
+        REQUIRE(root["b"][nullptr].is_anchor());
+        REQUIRE(root["b"][nullptr].get_anchor_name() == "anchor2");
+
+        REQUIRE(root["c"].is_sequence());
+        REQUIRE(root["c"].size() == 1);
+
+        REQUIRE(root["c"][0].is_mapping());
+        REQUIRE(root["c"][0].size() == 1);
+        REQUIRE(root["c"][0].contains(nullptr));
+
+        auto c_inner_key_itr = root["c"][0].as_map().find(nullptr);
+        const auto& c_inner_key = c_inner_key_itr->first;
+        REQUIRE(c_inner_key.get_anchor_name() == "anchor_key3");
+
+        REQUIRE(root["c"][0][nullptr].is_anchor());
+        REQUIRE(root["c"][0][nullptr].is_null());
+        REQUIRE(root["c"][0][nullptr].get_anchor_name() == "anchor3");
+
+        REQUIRE(root["d"].is_sequence());
+        REQUIRE(root["d"].size() == 2);
+
+        REQUIRE(root["d"][0].is_mapping());
+        REQUIRE(root["d"][0].size() == 1);
+        REQUIRE(root["d"][0].contains(nullptr));
+
+        auto d_inner_key_itr = root["d"][0].as_map().find(nullptr);
+        const auto& d_inner_key = d_inner_key_itr->first;
+        REQUIRE(d_inner_key.get_anchor_name() == "anchor_key4");
+
+        REQUIRE(root["d"][0][nullptr].is_anchor());
+        REQUIRE(root["d"][0][nullptr].is_null());
+        REQUIRE(root["d"][0][nullptr].get_anchor_name() == "anchor4");
+
+        REQUIRE(root["d"][1].is_anchor());
+        REQUIRE(root["d"][1].is_null());
+        REQUIRE(root["d"][1].get_anchor_name() == "anchor5");
+
+        auto map_key_inner_itr = root.as_map().find(map_key);
+        auto map_key_inner = map_key_inner_itr->first;
+        REQUIRE(map_key_inner.is_mapping());
+        REQUIRE(map_key_inner.size() == 1);
+        REQUIRE(map_key_inner.contains(nullptr));
+
+        auto map_key_inner_key_itr = map_key_inner.as_map().find(nullptr);
+        const auto& map_key_inner_key = map_key_inner_key_itr->first;
+        REQUIRE(map_key_inner_key.get_anchor_name() == "anchor_key5");
+
+        REQUIRE(map_key_inner[nullptr].is_anchor());
+        REQUIRE(map_key_inner[nullptr].is_null());
+        REQUIRE(map_key_inner[nullptr].get_anchor_name() == "anchor6");
+
+        REQUIRE(root[map_key].is_mapping());
+        REQUIRE(root[map_key].size() == 1);
+        REQUIRE(root[map_key].contains(nullptr));
+
+        auto map_value_key_itr = root[map_key].as_map().find(nullptr);
+        const auto& map_value_key = map_value_key_itr->first;
+        REQUIRE(map_value_key.get_anchor_name() == "anchor_key6");
+
+        REQUIRE(root[map_key][nullptr].is_anchor());
+        REQUIRE(root[map_key][nullptr].is_null());
+        REQUIRE(root[map_key][nullptr].get_anchor_name() == "anchor7");
+
+        auto empty_str_key_itr = root.as_map().find("");
+        const auto& empty_str_key = empty_str_key_itr->first;
+        REQUIRE(empty_str_key.get_anchor_name() == "anchor_key7");
+        REQUIRE(empty_str_key.get_tag_name() == "!!str");
+
+        REQUIRE(root[""].is_sequence());
+        REQUIRE(root[""].size() == 1);
+        REQUIRE(root[""][0].is_mapping());
+        REQUIRE(root[""][0].size() == 1);
+        REQUIRE(root[""][0].contains(nullptr));
+
+        auto empty_str_inner_key_itr = root[""][0].as_map().find(nullptr);
+        const auto& empty_str_inner_key = empty_str_inner_key_itr->first;
+        REQUIRE(empty_str_inner_key.get_anchor_name() == "anchor_key8");
+
+        REQUIRE(root[""][0][nullptr].is_null());
+    }
 }
 
 TEST_CASE("Deserializer_NoMachingAnchor") {


### PR DESCRIPTION
This pull request improves the handling of node properties and explicit key contexts, especially in edge cases involving anchors, tags, and omitted values.

## Changes

### Explicit Key Context Handling

* Introduced `has_explicit_key_context_at` and `settle_explicit_key_value_with_props` methods to accurately detect and handle explicit key contexts at specific indentation levels, ensuring that properties following a key separator are correctly bound to value nodes, not to the key or deferred incorrectly.
* Updated property application logic to check for explicit key context before deferring or applying node properties, preventing property overwrites and ensuring correct association in complex explicit key/value scenarios.

### Deferred Properties and Directive Application

* Ensured that deferred properties are always applied to the correct node (key or value) depending on context, and that document-level directives (such as anchors) are applied to empty nodes when necessary, improving alias resolution and YAML spec compliance.

### Edge Case Handling for Omitted Values and Key Separators

* Refined logic for omitted mapping values, especially when a key separator on a new line could ambiguously belong to an explicit key or a new mapping entry, by deferring properties and settling explicit keys only when appropriate.

### Robust Context Stack Manipulation

* Improved stack manipulation in `pop_to_parent_node` to repeatedly check for and settle explicit key contexts, ensuring that explicit keys are not dropped and that all deferred properties are applied before popping contexts.

## Testing

* Added a test case which validates the handling of anchors with empty nodes and parse contexts which involves explicit mapping keys. All the test cases pass successfully.
* Fixes `6KGN`, `L94M` and `PW8X` in the YAML test suite where the parser failed to process empty scalars with an anchor. As a result, 56 failing cases has decreased to 53 with no newly failing case.

---

## Pull Request Checklist

Read the [CONTRIBUTING.md](https://github.com/fktn-k/fkYAML/blob/develop/.github/CONTRIBUTING.md) file for detailed information.  

- [x] Changes are described in the pull request or in a referenced [issue](https://github.com/fktn-k/fkYAML/issues).
- [x] The test suite compiles and runs without any error.
- [x] [The code coverage](https://coveralls.io/github/fktn-k/fkYAML) on your branch is 100%.
- [x] The documentation is updated if you added/changed a feature.

## Please don't

- The C++11 support varies between different **compilers** and versions. Please note the [list of supported compilers](https://github.com/fktn-k/fkYAML/blob/develop/README.md#supported-compilers). Some compilers like GCC 4.7 (and earlier), Clang 3.3 (and earlier), or Microsoft Visual Studio 13.0 and earlier are known not to work due to missing or incomplete C++11 support. Please refrain from proposing changes that work around these compiler's limitations with `#ifdef`s or other means.
- Please refrain from proposing changes that would **break [YAML](https://yaml.org/) specifications**. If you propose a conformant extension of YAML to be supported by the library, please motivate this extension.
- Please do not open pull requests that address **multiple issues**.
