### PR TITLE
Fix a block scalar whose first content line holds a single character

### DIFF
--- a/include/fkYAML/detail/input/lexical_analyzer.hpp
+++ b/include/fkYAML/detail/input/lexical_analyzer.hpp
@@ -1340,7 +1340,9 @@ private:
             emit_error("The first non-empty line in the block scalar is less indented.");
         }
 
-        std::size_t last_newline_pos = sv.find('\n', cur_itr - m_token_begin_itr + 1);
+        // cur_itr already points past the first character of the first non-empty line, so the newline
+        // which ends that line is at that very position when the line holds a single character.
+        std::size_t last_newline_pos = sv.find('\n', cur_itr - m_token_begin_itr);
         if (last_newline_pos == str_view::npos) {
             last_newline_pos = remain_input_len;
         }

--- a/single_include/fkYAML/node.hpp
+++ b/single_include/fkYAML/node.hpp
@@ -4613,7 +4613,9 @@ private:
             emit_error("The first non-empty line in the block scalar is less indented.");
         }
 
-        std::size_t last_newline_pos = sv.find('\n', cur_itr - m_token_begin_itr + 1);
+        // cur_itr already points past the first character of the first non-empty line, so the newline
+        // which ends that line is at that very position when the line holds a single character.
+        std::size_t last_newline_pos = sv.find('\n', cur_itr - m_token_begin_itr);
         if (last_newline_pos == str_view::npos) {
             last_newline_pos = remain_input_len;
         }

--- a/tests/unit_test/test_deserializer_class.cpp
+++ b/tests/unit_test/test_deserializer_class.cpp
@@ -323,6 +323,20 @@ TEST_CASE("Deserializer_BlockLiteralScalar") {
         REQUIRE(foo_node.as_str() == "first sentence.\nsecond sentence.\nlast sentence.\n");
     }
 
+    SUBCASE("single character on the first content line") {
+        std::string input = "foo: |\n"
+                            "  a\n"
+                            "bar: 1\n";
+
+        REQUIRE_NOTHROW(root = deserializer.deserialize(fkyaml::detail::input_adapter(input)));
+        REQUIRE(root.is_mapping());
+        REQUIRE(root.size() == 2);
+        REQUIRE(root.contains("foo"));
+        REQUIRE(root["foo"].as_str() == "a\n");
+        REQUIRE(root.contains("bar"));
+        REQUIRE(root["bar"].get_value<int>() == 1);
+    }
+
     SUBCASE("tagged") {
         std::string input = "foo: !!str |\n"
                             "  first sentence.\n"


### PR DESCRIPTION
This PR fixes a block scalar whose first content line consists of a single character. Such a scalar absorbs the line which follows it, so the contents of that line are lost and the scalar itself gets a wrong value:

```yaml
foo: |
  a
bar: 1
```

The above input is deserialized into `{foo: "a\nr: 1\n"}` and the `bar` entry disappears entirely. The same happens in a block sequence, where:

```yaml
- |
  x
- 2
```

yields `["x\n2\n"]` instead of two entries. A block scalar with two or more content lines is not affected, which is why this has gone unnoticed so far.

## Changes

* Fixed the search for the newline which ends the first content line in `determine_block_scalar_content_range()`. The search started one character after the cursor, which already points past the first character of that line, so the newline was skipped whenever the line holds just a single character. The scan then continued into the following line and the block scalar absorbed it.

## Testing

* Added a unit test to `test_deserializer_class.cpp` which verifies that a block scalar with a single character on its first content line ends at that line and that the following entry is preserved.
* `KK5P` and `M6YH` in the YAML test suite are now deserialized correctly. As a result, 53 failing cases has decreased to 51 with no newly failing case.

---

## Pull Request Checklist

Read the [CONTRIBUTING.md](https://github.com/fktn-k/fkYAML/blob/develop/.github/CONTRIBUTING.md) file for detailed information.  

- [x] Changes are described in the pull request or in a referenced [issue](https://github.com/fktn-k/fkYAML/issues).
- [x] The test suite compiles and runs without any error.
- [x] [The code coverage](https://coveralls.io/github/fktn-k/fkYAML) on your branch is 100%.
- [x] The documentation is updated if you added/changed a feature.

## Please don't

- The C++11 support varies between different **compilers** and versions. Please note the [list of supported compilers](https://github.com/fktn-k/fkYAML/blob/develop/README.md#supported-compilers). Some compilers like GCC 4.7 (and earlier), Clang 3.3 (and earlier), or Microsoft Visual Studio 13.0 and earlier are known not to work due to missing or incomplete C++11 support. Please refrain from proposing changes that work around these compiler's limitations with `#ifdef`s or other means.
- Please refrain from proposing changes that would **break [YAML](https://yaml.org/) specifications**. If you propose a conformant extension of YAML to be supported by the library, please motivate this extension.
- Please do not open pull requests that address **multiple issues**.
