### PR TITLE
End a plain scalar at flow separator

### DIFF
--- a/include/fkYAML/detail/input/lexical_analyzer.hpp
+++ b/include/fkYAML/detail/input/lexical_analyzer.hpp
@@ -459,11 +459,12 @@ private:
     }
 
     /// @brief Checks if the given position begins something a plain scalar cannot continue into.
+    /// @note Must not be static, as flow indicators only end a plain scalar within a flow context.
     /// @param sv The buffer contents being scanned.
     /// @param pos The position of the first non-space character in a line.
     /// @param is_first_column Whether the position is at the beginning of its line.
     /// @return true if a document marker or a block structure indicator begins there.
-    static bool begins_non_scalar_content(str_view sv, std::size_t pos, bool is_first_column) noexcept {
+    bool begins_non_scalar_content(str_view sv, std::size_t pos, bool is_first_column) const noexcept {
         switch (sv[pos]) {
         case ':':
         case '?':
@@ -477,6 +478,10 @@ private:
         case '}':
             // A flow collection beginning a line starts a node of its own.
             return true;
+        case ',':
+            // A separator beginning a line ends the preceding entry of a flow collection, while in a
+            // block context it is just an ordinary plain scalar character.
+            return (m_state & flow_context_bit) != 0;
         default:
             break;
         }

--- a/single_include/fkYAML/node.hpp
+++ b/single_include/fkYAML/node.hpp
@@ -3732,11 +3732,12 @@ private:
     }
 
     /// @brief Checks if the given position begins something a plain scalar cannot continue into.
+    /// @note Must not be static, as flow indicators only end a plain scalar within a flow context.
     /// @param sv The buffer contents being scanned.
     /// @param pos The position of the first non-space character in a line.
     /// @param is_first_column Whether the position is at the beginning of its line.
     /// @return true if a document marker or a block structure indicator begins there.
-    static bool begins_non_scalar_content(str_view sv, std::size_t pos, bool is_first_column) noexcept {
+    bool begins_non_scalar_content(str_view sv, std::size_t pos, bool is_first_column) const noexcept {
         switch (sv[pos]) {
         case ':':
         case '?':
@@ -3750,6 +3751,10 @@ private:
         case '}':
             // A flow collection beginning a line starts a node of its own.
             return true;
+        case ',':
+            // A separator beginning a line ends the preceding entry of a flow collection, while in a
+            // block context it is just an ordinary plain scalar character.
+            return (m_state & flow_context_bit) != 0;
         default:
             break;
         }

--- a/tests/unit_test/test_deserializer_class.cpp
+++ b/tests/unit_test/test_deserializer_class.cpp
@@ -2415,6 +2415,17 @@ TEST_CASE("Deserializer_FlowMapping") {
         REQUIRE(test_pi_node.get_value<double>() == 3.14);
     }
 
+    SUBCASE("value separator beginning a line") {
+        std::string input = "{ foo: 1\n"
+                            "  , bar: 2 }";
+        REQUIRE_NOTHROW(root = deserializer.deserialize(fkyaml::detail::input_adapter(input)));
+
+        REQUIRE(root.is_mapping());
+        REQUIRE(root.size() == 2);
+        REQUIRE(root["foo"].get_value<int>() == 1);
+        REQUIRE(root["bar"].get_value<int>() == 2);
+    }
+
     SUBCASE("Correct traversal after deserializing flow mapping value") {
         REQUIRE_NOTHROW(
             root = deserializer.deserialize(fkyaml::detail::input_adapter("test: { foo: bar }\n"


### PR DESCRIPTION
This PR is a follow up to #610 and fixes another case where a scalar is not terminated where it should be. A plain scalar in a flow context is not terminated by a value separator (`,`) beginning the line that follows it, so it absorbs the separator and the entries after it and the flow collection loses its structure:

```yaml
[ a
, b ]
```

The above input is deserialized into `["a , b"]`, a sequence of one entry, instead of `["a", "b"]`. The same shape in a flow mapping:

```yaml
{ a: 1
, b: 2 }
```

is rejected with `Detected invalid indentation.`, since the plain scalar `1 , b` leaves the following `:` without a key. Beginning a continuation line with the separator is a common way to format multi-line flow collections and is valid YAML in both cases.

The cause is in `determine_plain_scalar_range()`. When the scan reaches a line break it moves to the first non-space character of the continuation line, but the loop then advances past that character with `find_first_of(filter, pos + 1)` before the switch inspects it. The only place that character is examined is the `begins_non_scalar_content()` call in the line break handler, which recognized `:`, `?` and the flow collection delimiters but not the value separator.

## Changes

* Added `,` to `begins_non_scalar_content()` so that a value separator which begins a line ends the preceding plain scalar in a flow context, as required by [the YAML specification](https://yaml.org/spec/1.2.2/#733-plain-style). In a block context a comma is an ordinary plain scalar character and is left as it is.
* `begins_non_scalar_content()` is no longer static, as the new check depends on whether the lexer is currently in a flow context.

## Testing

* Added a unit test to `test_deserializer_class.cpp` which verifies that a value separator beginning a line separates the entries of a flow mapping.
* `LP6E` in the YAML test suite is now deserialized correctly. As a result, 53 failing cases has decreased to 52 with no newly failing case.

---

## Pull Request Checklist

Read the [CONTRIBUTING.md](https://github.com/fktn-k/fkYAML/blob/develop/.github/CONTRIBUTING.md) file for detailed information.  

- [x] Changes are described in the pull request or in a referenced [issue](https://github.com/fktn-k/fkYAML/issues).
- [x] The test suite compiles and runs without any error.
- [x] [The code coverage](https://coveralls.io/github/fktn-k/fkYAML) on your branch is 100%.
- [x] The documentation is updated if you added/changed a feature.

## Please don't

- The C++11 support varies between different **compilers** and versions. Please note the [list of supported compilers](https://github.com/fktn-k/fkYAML/blob/develop/README.md#supported-compilers). Some compilers like GCC 4.7 (and earlier), Clang 3.3 (and earlier), or Microsoft Visual Studio 13.0 and earlier are known not to work due to missing or incomplete C++11 support. Please refrain from proposing changes that work around these compiler's limitations with `#ifdef`s or other means.
- Please refrain from proposing changes that would **break [YAML](https://yaml.org/) specifications**. If you propose a conformant extension of YAML to be supported by the library, please motivate this extension.
- Please do not open pull requests that address **multiple issues**.
