### PR TITLE
Remove installing git and unzip

### DIFF
--- a/.github/workflows/ubuntu.yml
+++ b/.github/workflows/ubuntu.yml
@@ -210,10 +210,11 @@ jobs:
         sed -i s/security.debian.org/archive.debian.org/g /etc/apt/sources.list
       if: ${{ matrix.compiler == '3.4' || matrix.compiler == '3.5' || matrix.compiler == '3.6' || matrix.compiler == '3.7' || matrix.compiler == '3.8' || matrix.compiler == '3.9' || matrix.compiler == '7' || matrix.compiler == '8' || matrix.compiler == '9' || matrix.compiler == '10' }}
 
-    - name: Install git and unzip
+    - name: install git
+      if: ${{ matrix.compiler > 6 }}
       run: |
-        apt-get update
-        apt-get install -y git unzip
+        apt-get -o Acquire::Check-Valid-Until=false update
+        apt-get -o Acquire::Check-Valid-Until=false install -y git
         git --version
 
     - uses: actions/checkout@v7
@@ -251,12 +252,6 @@ jobs:
         sed -i s/deb.debian.org/archive.debian.org/g /etc/apt/sources.list
         sed -i s/security.debian.org/archive.debian.org/g /etc/apt/sources.list
       if: ${{ matrix.compiler == '7' || matrix.compiler == '8' }}
-
-    - name: Install git and unzip
-      run: |
-        apt-get update
-        apt-get install -y git unzip
-        git --version
 
     - uses: actions/checkout@v7
 


### PR DESCRIPTION
This pull request makes a small change to the GitHub Actions workflow configuration by removing redundant steps that installed `git` and `unzip` in the `.github/workflows/ubuntu.yml` file. If I remember correctly, they were required to be installed to use Git submodules with Docker images with older gcc/clang compilers, but Git submodules are not used currently, so no installation should be needed anymore.

---

## Pull Request Checklist

Read the [CONTRIBUTING.md](https://github.com/fktn-k/fkYAML/blob/develop/.github/CONTRIBUTING.md) file for detailed information.  

- [ ] Changes are described in the pull request or in a referenced [issue](https://github.com/fktn-k/fkYAML/issues).
- [ ] The test suite compiles and runs without any error.
- [ ] [The code coverage](https://coveralls.io/github/fktn-k/fkYAML) on your branch is 100%.
- [ ] The documentation is updated if you added/changed a feature.

## Please don't

- The C++11 support varies between different **compilers** and versions. Please note the [list of supported compilers](https://github.com/fktn-k/fkYAML/blob/develop/README.md#supported-compilers). Some compilers like GCC 4.7 (and earlier), Clang 3.3 (and earlier), or Microsoft Visual Studio 13.0 and earlier are known not to work due to missing or incomplete C++11 support. Please refrain from proposing changes that work around these compiler's limitations with `#ifdef`s or other means.
- Please refrain from proposing changes that would **break [YAML](https://yaml.org/) specifications**. If you propose a conformant extension of YAML to be supported by the library, please motivate this extension.
- Please do not open pull requests that address **multiple issues**.
