### PR TITLE
Reject document markers in the quoted scalar content

### DIFF
--- a/include/fkYAML/detail/input/lexical_analyzer.hpp
+++ b/include/fkYAML/detail/input/lexical_analyzer.hpp
@@ -1056,9 +1056,19 @@ private:
     str_view determine_single_quoted_scalar_range() {
         const str_view sv {m_token_begin_itr, m_end_itr};
 
-        std::size_t pos = sv.find('\'');
+        const str_view filter {"\'\n"};
+        std::size_t pos = sv.find_first_of(filter);
         while (pos != str_view::npos) {
             FK_YAML_ASSERT(pos < sv.size());
+            if (sv[pos] == '\n') {
+                if FK_YAML_UNLIKELY (begins_document_marker(sv, pos + 1)) {
+                    m_cur_itr = &sv[pos + 1];
+                    emit_error("Document marker found in the scalar content.");
+                }
+                pos = sv.find_first_of(filter, pos + 1);
+                continue;
+            }
+
             if FK_YAML_LIKELY (pos == sv.size() - 1 || sv[pos + 1] != '\'') {
                 // closing single quote is found.
                 m_cur_itr = m_token_begin_itr + (pos + 1);
@@ -1071,7 +1081,7 @@ private:
             // If single quotation marks are repeated twice in a single quoted scalar, they are considered as an
             // escaped single quotation mark. Skip the second one which would otherwise be detected as a closing
             // single quotation mark in the next loop.
-            pos = sv.find('\'', pos + 2);
+            pos = sv.find_first_of(filter, pos + 2);
         }
 
         m_cur_itr = m_end_itr; // update for error information
@@ -1083,9 +1093,19 @@ private:
     str_view determine_double_quoted_scalar_range() {
         const str_view sv {m_token_begin_itr, m_end_itr};
 
-        std::size_t pos = sv.find('\"');
+        const str_view filter {"\"\n"};
+        std::size_t pos = sv.find_first_of(filter);
         while (pos != str_view::npos) {
             FK_YAML_ASSERT(pos < sv.size());
+
+            if (sv[pos] == '\n') {
+                if FK_YAML_UNLIKELY (begins_document_marker(sv, pos + 1)) {
+                    m_cur_itr = &sv[pos + 1];
+                    emit_error("Document marker found in the scalar content.");
+                }
+                pos = sv.find_first_of(filter, pos + 1);
+                continue;
+            }
 
             bool is_closed = true;
             if FK_YAML_LIKELY (pos > 0) {
@@ -1120,7 +1140,7 @@ private:
                 return double_quoted_scalar;
             }
 
-            pos = sv.find('\"', pos + 1);
+            pos = sv.find_first_of(filter, pos + 1);
         }
 
         m_cur_itr = m_end_itr; // update for error information

--- a/single_include/fkYAML/node.hpp
+++ b/single_include/fkYAML/node.hpp
@@ -4329,9 +4329,19 @@ private:
     str_view determine_single_quoted_scalar_range() {
         const str_view sv {m_token_begin_itr, m_end_itr};
 
-        std::size_t pos = sv.find('\'');
+        const str_view filter {"\'\n"};
+        std::size_t pos = sv.find_first_of(filter);
         while (pos != str_view::npos) {
             FK_YAML_ASSERT(pos < sv.size());
+            if (sv[pos] == '\n') {
+                if FK_YAML_UNLIKELY (begins_document_marker(sv, pos + 1)) {
+                    m_cur_itr = &sv[pos + 1];
+                    emit_error("Document marker found in the scalar content.");
+                }
+                pos = sv.find_first_of(filter, pos + 1);
+                continue;
+            }
+
             if FK_YAML_LIKELY (pos == sv.size() - 1 || sv[pos + 1] != '\'') {
                 // closing single quote is found.
                 m_cur_itr = m_token_begin_itr + (pos + 1);
@@ -4344,7 +4354,7 @@ private:
             // If single quotation marks are repeated twice in a single quoted scalar, they are considered as an
             // escaped single quotation mark. Skip the second one which would otherwise be detected as a closing
             // single quotation mark in the next loop.
-            pos = sv.find('\'', pos + 2);
+            pos = sv.find_first_of(filter, pos + 2);
         }
 
         m_cur_itr = m_end_itr; // update for error information
@@ -4356,9 +4366,19 @@ private:
     str_view determine_double_quoted_scalar_range() {
         const str_view sv {m_token_begin_itr, m_end_itr};
 
-        std::size_t pos = sv.find('\"');
+        const str_view filter {"\"\n"};
+        std::size_t pos = sv.find_first_of(filter);
         while (pos != str_view::npos) {
             FK_YAML_ASSERT(pos < sv.size());
+
+            if (sv[pos] == '\n') {
+                if FK_YAML_UNLIKELY (begins_document_marker(sv, pos + 1)) {
+                    m_cur_itr = &sv[pos + 1];
+                    emit_error("Document marker found in the scalar content.");
+                }
+                pos = sv.find_first_of(filter, pos + 1);
+                continue;
+            }
 
             bool is_closed = true;
             if FK_YAML_LIKELY (pos > 0) {
@@ -4393,7 +4413,7 @@ private:
                 return double_quoted_scalar;
             }
 
-            pos = sv.find('\"', pos + 1);
+            pos = sv.find_first_of(filter, pos + 1);
         }
 
         m_cur_itr = m_end_itr; // update for error information

--- a/tests/unit_test/test_lexical_analyzer_class.cpp
+++ b/tests/unit_test/test_lexical_analyzer_class.cpp
@@ -730,64 +730,86 @@ TEST_CASE("LexicalAnalyzer_PlainScalar") {
 }
 
 TEST_CASE("LexicalAnalyzer_SingleQuotedScalar") {
-    using value_pair_t = std::pair<fkyaml::detail::str_view, uint32_t /*end offset*/>;
-    auto value_pair = GENERATE(
-        value_pair_t("\'\'", 1),
-        value_pair_t("\'foo\"bar\'", 1),
-        value_pair_t("\'foo bar\'", 1),
-        value_pair_t("\'foo\'\'bar\'", 1),
-        value_pair_t("\'foo\'\'bar\' ", 2),
-        value_pair_t("\'foo,bar\'", 1),
-        value_pair_t("\'foo]bar\'", 1),
-        value_pair_t("\'foo}bar\'", 1),
-        value_pair_t("\'foo\"bar\'", 1),
-        value_pair_t("\'foo:bar\'", 1),
-        value_pair_t("\'foo\\bar\'", 1),
-
-        value_pair_t("\'foo\nbar\'", 1),
-        value_pair_t("\'foo \t\n \tbar\'", 1),
-        value_pair_t("\'foo\n\n \t\nbar\'", 1),
-        value_pair_t("\'\nfoo\n\n \t\nbar\'", 1),
-        value_pair_t("\'foo\nbar\n\'", 1));
-
-    fkyaml::detail::lexical_analyzer lexer(value_pair.first);
     fkyaml::detail::lexical_token token;
 
-    REQUIRE_NOTHROW(token = lexer.get_next_token());
-    REQUIRE(token.type == fkyaml::detail::lexical_token_t::SINGLE_QUOTED_SCALAR);
-    REQUIRE(token.str.begin() == value_pair.first.begin() + 1);
-    REQUIRE(token.str.end() == value_pair.first.end() - value_pair.second);
+    SUBCASE("valid single quoted scalars") {
+        using value_pair_t = std::pair<fkyaml::detail::str_view, uint32_t /*end offset*/>;
+        auto value_pair = GENERATE(
+            value_pair_t("\'\'", 1),
+            value_pair_t("\'foo\"bar\'", 1),
+            value_pair_t("\'foo bar\'", 1),
+            value_pair_t("\'foo\'\'bar\'", 1),
+            value_pair_t("\'foo\'\'bar\' ", 2),
+            value_pair_t("\'foo,bar\'", 1),
+            value_pair_t("\'foo]bar\'", 1),
+            value_pair_t("\'foo}bar\'", 1),
+            value_pair_t("\'foo\"bar\'", 1),
+            value_pair_t("\'foo:bar\'", 1),
+            value_pair_t("\'foo\\bar\'", 1),
+
+            value_pair_t("\'foo\nbar\'", 1),
+            value_pair_t("\'foo \t\n \tbar\'", 1),
+            value_pair_t("\'foo\n\n \t\nbar\'", 1),
+            value_pair_t("\'\nfoo\n\n \t\nbar\'", 1),
+            value_pair_t("\'foo\nbar\n\'", 1));
+
+        fkyaml::detail::lexical_analyzer lexer(value_pair.first);
+
+        REQUIRE_NOTHROW(token = lexer.get_next_token());
+        REQUIRE(token.type == fkyaml::detail::lexical_token_t::SINGLE_QUOTED_SCALAR);
+        REQUIRE(token.str.begin() == value_pair.first.begin() + 1);
+        REQUIRE(token.str.end() == value_pair.first.end() - value_pair.second);
+    }
+
+    SUBCASE("single quoted scalar contains a document marker") {
+        auto input =
+            GENERATE(fkyaml::detail::str_view("\'foo\n---\nbar\'"), fkyaml::detail::str_view("\'foo\n...\nbar\'"));
+
+        fkyaml::detail::lexical_analyzer lexer(input);
+        REQUIRE_THROWS_AS(token = lexer.get_next_token(), fkyaml::parse_error);
+    }
 }
 
 TEST_CASE("LexicalAnalyzer_DoubleQuotedScalar") {
-    auto input = GENERATE(
-        fkyaml::detail::str_view("\"\""),
-        fkyaml::detail::str_view("\"\\\"\""),
-        fkyaml::detail::str_view("\"foo bar\""),
-        fkyaml::detail::str_view("\"foo\tbar\""),
-        fkyaml::detail::str_view("\"foo's bar\""),
-        fkyaml::detail::str_view("\"foo:bar\""),
-        fkyaml::detail::str_view("\"foo,bar\""),
-        fkyaml::detail::str_view("\"foo]bar\""),
-        fkyaml::detail::str_view("\"foo}bar\""),
-        fkyaml::detail::str_view("\"\\x30\\x2B\\x6d\""),
-
-        fkyaml::detail::str_view("\"foo\nbar\""),
-        fkyaml::detail::str_view("\"foo \t\n \tbar\""),
-        fkyaml::detail::str_view("\"foo\n\n \t\nbar\""),
-        fkyaml::detail::str_view("\"\nfoo\n\n \t\nbar\""),
-        fkyaml::detail::str_view("\"foo\nbar\n\""),
-        fkyaml::detail::str_view("\"foo\\\nbar\""),
-        fkyaml::detail::str_view("\"foo \t\\\nbar\""),
-        fkyaml::detail::str_view("\"\\\n  foo \t\\\n\tbar\t  \t\\\n\""));
-
-    fkyaml::detail::lexical_analyzer lexer(input);
     fkyaml::detail::lexical_token token;
 
-    REQUIRE_NOTHROW(token = lexer.get_next_token());
-    REQUIRE(token.type == fkyaml::detail::lexical_token_t::DOUBLE_QUOTED_SCALAR);
-    REQUIRE(token.str.begin() == input.begin() + 1);
-    REQUIRE(token.str.end() == input.end() - 1);
+    SUBCASE("valid double quoted scalars") {
+        auto input = GENERATE(
+            fkyaml::detail::str_view("\"\""),
+            fkyaml::detail::str_view("\"\\\"\""),
+            fkyaml::detail::str_view("\"foo bar\""),
+            fkyaml::detail::str_view("\"foo\tbar\""),
+            fkyaml::detail::str_view("\"foo's bar\""),
+            fkyaml::detail::str_view("\"foo:bar\""),
+            fkyaml::detail::str_view("\"foo,bar\""),
+            fkyaml::detail::str_view("\"foo]bar\""),
+            fkyaml::detail::str_view("\"foo}bar\""),
+            fkyaml::detail::str_view("\"\\x30\\x2B\\x6d\""),
+
+            fkyaml::detail::str_view("\"foo\nbar\""),
+            fkyaml::detail::str_view("\"foo \t\n \tbar\""),
+            fkyaml::detail::str_view("\"foo\n\n \t\nbar\""),
+            fkyaml::detail::str_view("\"\nfoo\n\n \t\nbar\""),
+            fkyaml::detail::str_view("\"foo\nbar\n\""),
+            fkyaml::detail::str_view("\"foo\\\nbar\""),
+            fkyaml::detail::str_view("\"foo \t\\\nbar\""),
+            fkyaml::detail::str_view("\"\\\n  foo \t\\\n\tbar\t  \t\\\n\""));
+
+        fkyaml::detail::lexical_analyzer lexer(input);
+
+        REQUIRE_NOTHROW(token = lexer.get_next_token());
+        REQUIRE(token.type == fkyaml::detail::lexical_token_t::DOUBLE_QUOTED_SCALAR);
+        REQUIRE(token.str.begin() == input.begin() + 1);
+        REQUIRE(token.str.end() == input.end() - 1);
+    }
+
+    SUBCASE("double quoted scalar contains a document marker") {
+        auto input =
+            GENERATE(fkyaml::detail::str_view("\"foo\n---\nbar\""), fkyaml::detail::str_view("\"foo\n...\nbar\""));
+
+        fkyaml::detail::lexical_analyzer lexer(input);
+        REQUIRE_THROWS_AS(token = lexer.get_next_token(), fkyaml::parse_error);
+    }
 }
 
 TEST_CASE("LexicalAnalyzer_MultiByteCharString") {


### PR DESCRIPTION
This pull request improves the handling of quoted scalars in the YAML lexical analyzer by ensuring that document markers within single- or double-quoted scalars are detected and reported as errors. It also updates the unit tests to cover these cases and refactors the code for more efficient character searching.

## Changes

* Updated `determine_single_quoted_scalar_range` and `determine_double_quoted_scalar_range` to detect document markers (`---` or `...`) appearing after a newline inside quoted scalars and emit a parse error. The search now uses `find_first_of` to look for both the quote character and newline simultaneously, improving efficiency.

## Testing

* Added new test cases in `tests/unit_test/test_lexical_analyzer_class.cpp` to verify that a parse error is thrown when a document marker is found inside single- or double-quoted scalars.
* Fixes `5TRB`, `9MQT-01` and `RXY3` in the YAML test suite all of which contains a document marker in a quoted scalar. As a result, 50 failing cases has decreased to 47 with no newly failing case.

---

## Pull Request Checklist

Read the [CONTRIBUTING.md](https://github.com/fktn-k/fkYAML/blob/develop/.github/CONTRIBUTING.md) file for detailed information.  

- [x] Changes are described in the pull request or in a referenced [issue](https://github.com/fktn-k/fkYAML/issues).
- [x] The test suite compiles and runs without any error.
- [x] [The code coverage](https://coveralls.io/github/fktn-k/fkYAML) on your branch is 100%.
- [x] The documentation is updated if you added/changed a feature.

## Please don't

- The C++11 support varies between different **compilers** and versions. Please note the [list of supported compilers](https://github.com/fktn-k/fkYAML/blob/develop/README.md#supported-compilers). Some compilers like GCC 4.7 (and earlier), Clang 3.3 (and earlier), or Microsoft Visual Studio 13.0 and earlier are known not to work due to missing or incomplete C++11 support. Please refrain from proposing changes that work around these compiler's limitations with `#ifdef`s or other means.
- Please refrain from proposing changes that would **break [YAML](https://yaml.org/) specifications**. If you propose a conformant extension of YAML to be supported by the library, please motivate this extension.
- Please do not open pull requests that address **multiple issues**.
