### PR TITLE
Fix incorrect parse result of scalars which look like a directive end marker

### DIFF
--- a/include/fkYAML/detail/input/lexical_analyzer.hpp
+++ b/include/fkYAML/detail/input/lexical_analyzer.hpp
@@ -322,13 +322,13 @@ private:
             }
 
             if (m_pos_tracker.get_cur_pos_in_line() == 0) {
-                if ((m_end_itr - m_cur_itr) > 2) {
-                    const bool is_dir_end = std::equal(m_token_begin_itr, m_cur_itr + 3, "---");
-                    if (is_dir_end) {
-                        m_cur_itr += 3;
-                        info.token.type = lexical_token_t::END_OF_DIRECTIVES;
-                        return info;
-                    }
+                const str_view sv {m_cur_itr, m_end_itr};
+                const bool is_dir_end =
+                    sv.size() >= 3 && sv.compare(0, 3, "---") == 0 && is_followed_by_white_space(sv, 3);
+                if (is_dir_end) {
+                    m_cur_itr += 3;
+                    info.token.type = lexical_token_t::END_OF_DIRECTIVES;
+                    return info;
                 }
             }
 

--- a/single_include/fkYAML/node.hpp
+++ b/single_include/fkYAML/node.hpp
@@ -3595,13 +3595,13 @@ private:
             }
 
             if (m_pos_tracker.get_cur_pos_in_line() == 0) {
-                if ((m_end_itr - m_cur_itr) > 2) {
-                    const bool is_dir_end = std::equal(m_token_begin_itr, m_cur_itr + 3, "---");
-                    if (is_dir_end) {
-                        m_cur_itr += 3;
-                        info.token.type = lexical_token_t::END_OF_DIRECTIVES;
-                        return info;
-                    }
+                const str_view sv {m_cur_itr, m_end_itr};
+                const bool is_dir_end =
+                    sv.size() >= 3 && sv.compare(0, 3, "---") == 0 && is_followed_by_white_space(sv, 3);
+                if (is_dir_end) {
+                    m_cur_itr += 3;
+                    info.token.type = lexical_token_t::END_OF_DIRECTIVES;
+                    return info;
                 }
             }
 

--- a/tests/unit_test/test_lexical_analyzer_class.cpp
+++ b/tests/unit_test/test_lexical_analyzer_class.cpp
@@ -197,27 +197,36 @@ TEST_CASE("LexicalAnalyzer_EmptyDirective") {
 
 TEST_CASE("LexicalAnalyzer_EndOfDirectives") {
     fkyaml::detail::lexical_token token;
-    fkyaml::detail::lexical_analyzer lexer("%YAML 1.2\n---\nfoo: bar");
-    lexer.set_document_state(true);
 
-    REQUIRE_NOTHROW(token = lexer.get_next_token());
-    REQUIRE(token.type == fkyaml::detail::lexical_token_t::YAML_VER_DIRECTIVE);
-    REQUIRE(lexer.get_yaml_version() == fkyaml::detail::str_view("1.2"));
-    REQUIRE_NOTHROW(token = lexer.get_next_token());
-    REQUIRE(token.type == fkyaml::detail::lexical_token_t::END_OF_DIRECTIVES);
-    REQUIRE_NOTHROW(token = lexer.get_next_token());
+    SUBCASE("valid YAML with directives") {
+        fkyaml::detail::lexical_analyzer lexer("%YAML 1.2\n---\nfoo: bar");
+        lexer.set_document_state(true);
 
-    lexer.set_document_state(false);
+        REQUIRE_NOTHROW(token = lexer.get_next_token());
+        REQUIRE(token.type == fkyaml::detail::lexical_token_t::YAML_VER_DIRECTIVE);
+        REQUIRE(lexer.get_yaml_version() == fkyaml::detail::str_view("1.2"));
+        REQUIRE_NOTHROW(token = lexer.get_next_token());
+        REQUIRE(token.type == fkyaml::detail::lexical_token_t::END_OF_DIRECTIVES);
+        REQUIRE_NOTHROW(token = lexer.get_next_token());
 
-    REQUIRE(token.type == fkyaml::detail::lexical_token_t::PLAIN_SCALAR);
-    REQUIRE(token.str == "foo");
-    REQUIRE_NOTHROW(token = lexer.get_next_token());
-    REQUIRE(token.type == fkyaml::detail::lexical_token_t::KEY_SEPARATOR);
-    REQUIRE_NOTHROW(token = lexer.get_next_token());
-    REQUIRE(token.type == fkyaml::detail::lexical_token_t::PLAIN_SCALAR);
-    REQUIRE(token.str == "bar");
-    REQUIRE_NOTHROW(token = lexer.get_next_token());
-    REQUIRE(token.type == fkyaml::detail::lexical_token_t::END_OF_BUFFER);
+        lexer.set_document_state(false);
+
+        REQUIRE(token.type == fkyaml::detail::lexical_token_t::PLAIN_SCALAR);
+        REQUIRE(token.str == "foo");
+        REQUIRE_NOTHROW(token = lexer.get_next_token());
+        REQUIRE(token.type == fkyaml::detail::lexical_token_t::KEY_SEPARATOR);
+        REQUIRE_NOTHROW(token = lexer.get_next_token());
+        REQUIRE(token.type == fkyaml::detail::lexical_token_t::PLAIN_SCALAR);
+        REQUIRE(token.str == "bar");
+        REQUIRE_NOTHROW(token = lexer.get_next_token());
+        REQUIRE(token.type == fkyaml::detail::lexical_token_t::END_OF_BUFFER);
+    }
+
+    SUBCASE("only end of directives marker") {
+        fkyaml::detail::lexical_analyzer lexer("---");
+        REQUIRE_NOTHROW(token = lexer.get_next_token());
+        REQUIRE(token.type == fkyaml::detail::lexical_token_t::END_OF_DIRECTIVES);
+    }
 }
 
 TEST_CASE("LexicalAnalyzer_EndOfDocuments") {
@@ -482,7 +491,13 @@ TEST_CASE("LexicalAnalyzer_PlainScalar") {
             // "---" and "..." not at the beginning of a line is a scalar
             fkyaml::detail::str_view(" ---"),
             fkyaml::detail::str_view(" ..."),
-            fkyaml::detail::str_view(" ...this is valid"));
+            fkyaml::detail::str_view(" ...this is valid"),
+
+            // plain scalars which look like a directive end marker
+            fkyaml::detail::str_view("--"),
+            fkyaml::detail::str_view("--x"),
+            fkyaml::detail::str_view("-x-"),
+            fkyaml::detail::str_view("---foo"));
 
         fkyaml::detail::lexical_analyzer lexer(input);
 


### PR DESCRIPTION
This pull request improves the detection of the YAML end-of-directives marker (`---`) in the lexical analyzer by making the check more robust and adding new test cases to ensure correct behavior. The main changes involve updating the logic to properly recognize the marker only when it appears at the start of a line and is followed by whitespace, and expanding tests to cover edge cases.

**Lexical analyzer improvements:**

* Updated the logic in `lexical_analyzer` to check that `---` appears at the beginning of a line and is followed by whitespace, making the detection of the end-of-directives marker more accurate.

**Testing enhancements:**

* Added test cases which verify that a directive end marker is detected only when it appears at the start of a line and is followed by a whitespace, a line break, or the end of input.
* Fixes `82AN` and `EXG3` in the YAML test suite which contains a plain scalar which looks like a directive end marker but is not. As a result, 47 failing cases have decreased to 45 with no newly failing case

---

## Pull Request Checklist

Read the [CONTRIBUTING.md](https://github.com/fktn-k/fkYAML/blob/develop/.github/CONTRIBUTING.md) file for detailed information.  

- [x] Changes are described in the pull request or in a referenced [issue](https://github.com/fktn-k/fkYAML/issues).
- [x] The test suite compiles and runs without any error.
- [x] [The code coverage](https://coveralls.io/github/fktn-k/fkYAML) on your branch is 100%.
- [x] The documentation is updated if you added/changed a feature.

## Please don't

- The C++11 support varies between different **compilers** and versions. Please note the [list of supported compilers](https://github.com/fktn-k/fkYAML/blob/develop/README.md#supported-compilers). Some compilers like GCC 4.7 (and earlier), Clang 3.3 (and earlier), or Microsoft Visual Studio 13.0 and earlier are known not to work due to missing or incomplete C++11 support. Please refrain from proposing changes that work around these compiler's limitations with `#ifdef`s or other means.
- Please refrain from proposing changes that would **break [YAML](https://yaml.org/) specifications**. If you propose a conformant extension of YAML to be supported by the library, please motivate this extension.
- Please do not open pull requests that address **multiple issues**.
