### PR TITLE
Fix incorrect parse result of multiline plain scalars

### DIFF
--- a/include/fkYAML/detail/input/lexical_analyzer.hpp
+++ b/include/fkYAML/detail/input/lexical_analyzer.hpp
@@ -1164,6 +1164,7 @@ private:
         bool ends_loop = false;
         uint32_t indent = std::numeric_limits<uint32_t>::max();
         bool begins_own_line = false;
+        std::size_t trailing_white_space_pos = str_view::npos;
         do {
             FK_YAML_ASSERT(pos < sv.size());
             switch (sv[pos]) {
@@ -1194,6 +1195,9 @@ private:
                 const uint32_t min_continuation_indent = begins_own_line ? indent : indent + 1;
 
                 if (non_space_pos == str_view::npos) {
+                    if (trailing_white_space_pos != str_view::npos) {
+                        pos = trailing_white_space_pos;
+                    }
                     ends_loop = true;
                     break;
                 }
@@ -1201,10 +1205,14 @@ private:
                 const std::size_t cur_line_indent = non_space_pos - last_newline_pos - 1;
                 const bool ends_scalar = begins_non_scalar_content(sv, non_space_pos, cur_line_indent == 0);
                 if (cur_line_indent < min_continuation_indent || ends_scalar) {
+                    if (trailing_white_space_pos != str_view::npos) {
+                        pos = trailing_white_space_pos;
+                    }
                     ends_loop = true;
                     break;
                 }
 
+                trailing_white_space_pos = str_view::npos;
                 pos = non_space_pos;
                 break;
             }
@@ -1224,6 +1232,11 @@ private:
                 // indicators are not allowed to follow it in a flow context.
                 switch (sv[next_pos]) {
                 case '\n':
+                    // The following line decides whether these white spaces are trailing or precede
+                    // a continuation line. Let the newline handler make that decision.
+                    trailing_white_space_pos = pos;
+                    pos = next_pos;
+                    continue;
                 case '#':
                     ends_loop = true;
                     break;

--- a/single_include/fkYAML/node.hpp
+++ b/single_include/fkYAML/node.hpp
@@ -4437,6 +4437,7 @@ private:
         bool ends_loop = false;
         uint32_t indent = std::numeric_limits<uint32_t>::max();
         bool begins_own_line = false;
+        std::size_t trailing_white_space_pos = str_view::npos;
         do {
             FK_YAML_ASSERT(pos < sv.size());
             switch (sv[pos]) {
@@ -4467,6 +4468,9 @@ private:
                 const uint32_t min_continuation_indent = begins_own_line ? indent : indent + 1;
 
                 if (non_space_pos == str_view::npos) {
+                    if (trailing_white_space_pos != str_view::npos) {
+                        pos = trailing_white_space_pos;
+                    }
                     ends_loop = true;
                     break;
                 }
@@ -4474,10 +4478,14 @@ private:
                 const std::size_t cur_line_indent = non_space_pos - last_newline_pos - 1;
                 const bool ends_scalar = begins_non_scalar_content(sv, non_space_pos, cur_line_indent == 0);
                 if (cur_line_indent < min_continuation_indent || ends_scalar) {
+                    if (trailing_white_space_pos != str_view::npos) {
+                        pos = trailing_white_space_pos;
+                    }
                     ends_loop = true;
                     break;
                 }
 
+                trailing_white_space_pos = str_view::npos;
                 pos = non_space_pos;
                 break;
             }
@@ -4497,6 +4505,11 @@ private:
                 // indicators are not allowed to follow it in a flow context.
                 switch (sv[next_pos]) {
                 case '\n':
+                    // The following line decides whether these white spaces are trailing or precede
+                    // a continuation line. Let the newline handler make that decision.
+                    trailing_white_space_pos = pos;
+                    pos = next_pos;
+                    continue;
                 case '#':
                     ends_loop = true;
                     break;

--- a/tests/unit_test/test_deserializer_class.cpp
+++ b/tests/unit_test/test_deserializer_class.cpp
@@ -560,6 +560,19 @@ TEST_CASE("Deserializer_MultilinePlainScalarInBlockContext") {
         REQUIRE(root["bar"].as_str() == "baz");
     }
 
+    SUBCASE("a root scalar includes lines with trailing spaces before a line break") {
+        std::string input = "a\n"
+                            "b  \n"
+                            "  c\n"
+                            "d\n"
+                            "\n"
+                            "e";
+        REQUIRE_NOTHROW(root = deserializer.deserialize(fkyaml::detail::input_adapter(input)));
+
+        REQUIRE(root.is_string());
+        REQUIRE(root.as_str() == "a b c d\ne");
+    }
+
     SUBCASE("a document marker ends the scalar") {
         // The marker may be followed by a space, a tab or a line break alike.
         auto input = GENERATE(

--- a/tests/unit_test/test_lexical_analyzer_class.cpp
+++ b/tests/unit_test/test_lexical_analyzer_class.cpp
@@ -742,6 +742,32 @@ TEST_CASE("LexicalAnalyzer_PlainScalar") {
         REQUIRE(token.str.begin() == input.begin() + 2);
         REQUIRE(token.str.end() == input.end());
     }
+
+    SUBCASE("multiline with trailing spaces before a line break") {
+        fkyaml::detail::str_view input = "a\n"
+                                         "b  \n"
+                                         "  c\n"
+                                         "d\n"
+                                         "\n"
+                                         "e";
+        fkyaml::detail::lexical_analyzer lexer(input);
+
+        REQUIRE_NOTHROW(token = lexer.get_next_token());
+        REQUIRE(token.type == fkyaml::detail::lexical_token_t::PLAIN_SCALAR);
+        REQUIRE(token.str.begin() == input.begin());
+        REQUIRE(token.str.end() == input.end());
+    }
+
+    SUBCASE("trailing spaces before a line break are excluded when the scalar ends") {
+        fkyaml::detail::str_view input = "  foo  \n"
+                                         " bar";
+        fkyaml::detail::lexical_analyzer lexer(input);
+
+        REQUIRE_NOTHROW(token = lexer.get_next_token());
+        REQUIRE(token.type == fkyaml::detail::lexical_token_t::PLAIN_SCALAR);
+        REQUIRE(token.str.begin() == input.begin() + 2);
+        REQUIRE(token.str.end() == input.begin() + 5);
+    }
 }
 
 TEST_CASE("LexicalAnalyzer_SingleQuotedScalar") {


### PR DESCRIPTION
This pull request improves the handling of trailing whitespace in plain scalar YAML values, ensuring that spaces before a line break are correctly managed according to the YAML specification.

## Changes

* Updated the `lexical_analyzer` class to track and correctly handle trailing whitespace before line breaks, ensuring these spaces are only included or excluded as appropriate when parsing multiline scalars.

## Testing

* Added new unit tests in `test_deserializer_class.cpp` and `test_lexical_analyzer_class.cpp` to verify that trailing spaces before line breaks are handled correctly in multiline plain scalars, and that such spaces are excluded when the scalar ends.
* Fixed `9YRD`, `EX5H` and `HS5T` in the YAML test suite all of which contain trailing whitespaces before a line break. As a result, 45 failing cases have decreased to 42 with no newly failing case.

---

## Pull Request Checklist

Read the [CONTRIBUTING.md](https://github.com/fktn-k/fkYAML/blob/develop/.github/CONTRIBUTING.md) file for detailed information.  

- [x] Changes are described in the pull request or in a referenced [issue](https://github.com/fktn-k/fkYAML/issues).
- [x] The test suite compiles and runs without any error.
- [x] [The code coverage](https://coveralls.io/github/fktn-k/fkYAML) on your branch is 100%.
- [x] The documentation is updated if you added/changed a feature.

## Please don't

- The C++11 support varies between different **compilers** and versions. Please note the [list of supported compilers](https://github.com/fktn-k/fkYAML/blob/develop/README.md#supported-compilers). Some compilers like GCC 4.7 (and earlier), Clang 3.3 (and earlier), or Microsoft Visual Studio 13.0 and earlier are known not to work due to missing or incomplete C++11 support. Please refrain from proposing changes that work around these compiler's limitations with `#ifdef`s or other means.
- Please refrain from proposing changes that would **break [YAML](https://yaml.org/) specifications**. If you propose a conformant extension of YAML to be supported by the library, please motivate this extension.
- Please do not open pull requests that address **multiple issues**.
