### PR TITLE
Fix false duplicate-key detection with anchored explicit keys

### DIFF
--- a/include/fkYAML/detail/input/deserializer.hpp
+++ b/include/fkYAML/detail/input/deserializer.hpp
@@ -1762,8 +1762,8 @@ private:
         basic_node_type key_node = std::move(*m_context_stack.back().p_node);
         m_context_stack.pop_back();
         basic_node_type* p_parent_node = current_context(line, indent).p_node;
-        p_parent_node->as_map().emplace(key_node, basic_node_type());
-        mp_current_node = &(p_parent_node->operator[](std::move(key_node)));
+        auto itr = p_parent_node->as_map().emplace(std::move(key_node), basic_node_type());
+        mp_current_node = &(itr.first->second);
         m_context_stack.emplace_back(line, indent, context_state_t::BLOCK_MAPPING_EXPLICIT_VALUE, mp_current_node);
     }
 

--- a/single_include/fkYAML/node.hpp
+++ b/single_include/fkYAML/node.hpp
@@ -9601,8 +9601,8 @@ private:
         basic_node_type key_node = std::move(*m_context_stack.back().p_node);
         m_context_stack.pop_back();
         basic_node_type* p_parent_node = current_context(line, indent).p_node;
-        p_parent_node->as_map().emplace(key_node, basic_node_type());
-        mp_current_node = &(p_parent_node->operator[](std::move(key_node)));
+        auto itr = p_parent_node->as_map().emplace(std::move(key_node), basic_node_type());
+        mp_current_node = &(itr.first->second);
         m_context_stack.emplace_back(line, indent, context_state_t::BLOCK_MAPPING_EXPLICIT_VALUE, mp_current_node);
     }
 


### PR DESCRIPTION
This PR fixes false duplicate-key detection with anchored explicit keys which was introduced by the changes in the previous PR #609.  

## Cause

When settling an explicit mapping key, the parser inserted the key with `emplace`, then used `operator[]` with the same key to obtain the inserted value node.

For anchored keys, this redundant lookup created and later destroyed a temporary `basic_node` carrying the anchor metadata. Destroying that temporary cleared the corresponding anchor-table entry, causing the stored key to resolve as a null node.

Subsequently, when parsing a valid empty key entry, the parser compared the new null key against the corrupted anchored key and incorrectly reported a duplicate key.

## Fix

Use the iterator returned by `emplace` to access the inserted value node directly. This avoids the redundant `operator[]` lookup and the temporary anchored node, preserving the anchor-table entry.

## Testing

* All the unit test cases pass successfully.
* Fixes `6M2F` in the YAML test suite. As a result, 42 failing cases have decreased to 41 with no newly failing case.

---

## Pull Request Checklist

Read the [CONTRIBUTING.md](https://github.com/fktn-k/fkYAML/blob/develop/.github/CONTRIBUTING.md) file for detailed information.  

- [x] Changes are described in the pull request or in a referenced [issue](https://github.com/fktn-k/fkYAML/issues).
- [x] The test suite compiles and runs without any error.
- [x] [The code coverage](https://coveralls.io/github/fktn-k/fkYAML) on your branch is 100%.
- [x] The documentation is updated if you added/changed a feature.

## Please don't

- The C++11 support varies between different **compilers** and versions. Please note the [list of supported compilers](https://github.com/fktn-k/fkYAML/blob/develop/README.md#supported-compilers). Some compilers like GCC 4.7 (and earlier), Clang 3.3 (and earlier), or Microsoft Visual Studio 13.0 and earlier are known not to work due to missing or incomplete C++11 support. Please refrain from proposing changes that work around these compiler's limitations with `#ifdef`s or other means.
- Please refrain from proposing changes that would **break [YAML](https://yaml.org/) specifications**. If you propose a conformant extension of YAML to be supported by the library, please motivate this extension.
- Please do not open pull requests that address **multiple issues**.
