### PR TITLE
Fix trailing white spaces not being trimmed when folding flow scalars

### DIFF
--- a/include/fkYAML/detail/input/scalar_parser.hpp
+++ b/include/fkYAML/detail/input/scalar_parser.hpp
@@ -433,11 +433,8 @@ private:
     /// @param newline_pos Position of the target newline code.
     void process_line_folding(str_view& token, std::size_t newline_pos) noexcept {
         // discard trailing white spaces which precedes the line break in the current line.
-        const std::size_t last_non_space_pos = token.substr(0, newline_pos + 1).find_last_not_of(" \t");
-        if (last_non_space_pos == str_view::npos) {
-            m_buffer.append(token.begin(), newline_pos);
-        }
-        else {
+        const std::size_t last_non_space_pos = token.substr(0, newline_pos).find_last_not_of(" \t");
+        if (last_non_space_pos != str_view::npos) {
             m_buffer.append(token.begin(), last_non_space_pos + 1);
         }
         token.remove_prefix(newline_pos + 1); // move next to the LF

--- a/include/fkYAML/detail/str_view.hpp
+++ b/include/fkYAML/detail/str_view.hpp
@@ -648,15 +648,15 @@ public:
     /// @param n The length of `s` character sequence used for comparison.
     /// @return The beginning position of `s` characters, `npos` otherwise.
     size_type find_last_of(const CharT* s, size_type pos, size_type n) const noexcept {
-        if FK_YAML_LIKELY (n <= m_len) {
-            pos = std::min(m_len - n - 1, pos);
+        if FK_YAML_LIKELY (m_len > 0 && n > 0) {
+            pos = std::min(m_len - 1, pos) + 1;
 
             do {
-                const CharT* p_found = traits_type::find(s, n, mp_str[pos]);
+                const CharT* p_found = traits_type::find(s, n, mp_str[--pos]);
                 if (p_found) {
                     return pos;
                 }
-            } while (pos-- != 0);
+            } while (pos > 0);
         }
 
         return npos;
@@ -750,8 +750,8 @@ public:
     /// @param n The length of `s` character sequence used for comparison.
     /// @return The beginning position of non `s` characters, `npos` otherwise.
     size_type find_last_not_of(const CharT* s, size_type pos, size_type n) const noexcept {
-        if FK_YAML_UNLIKELY (n <= m_len) {
-            pos = std::min(m_len - n, pos) + 1;
+        if FK_YAML_LIKELY (m_len > 0) {
+            pos = std::min(m_len - 1, pos) + 1;
 
             do {
                 const CharT* p_found = traits_type::find(s, n, mp_str[--pos]);

--- a/single_include/fkYAML/node.hpp
+++ b/single_include/fkYAML/node.hpp
@@ -2836,15 +2836,15 @@ public:
     /// @param n The length of `s` character sequence used for comparison.
     /// @return The beginning position of `s` characters, `npos` otherwise.
     size_type find_last_of(const CharT* s, size_type pos, size_type n) const noexcept {
-        if FK_YAML_LIKELY (n <= m_len) {
-            pos = std::min(m_len - n - 1, pos);
+        if FK_YAML_LIKELY (m_len > 0 && n > 0) {
+            pos = std::min(m_len - 1, pos) + 1;
 
             do {
-                const CharT* p_found = traits_type::find(s, n, mp_str[pos]);
+                const CharT* p_found = traits_type::find(s, n, mp_str[--pos]);
                 if (p_found) {
                     return pos;
                 }
-            } while (pos-- != 0);
+            } while (pos > 0);
         }
 
         return npos;
@@ -2938,8 +2938,8 @@ public:
     /// @param n The length of `s` character sequence used for comparison.
     /// @return The beginning position of non `s` characters, `npos` otherwise.
     size_type find_last_not_of(const CharT* s, size_type pos, size_type n) const noexcept {
-        if FK_YAML_UNLIKELY (n <= m_len) {
-            pos = std::min(m_len - n, pos) + 1;
+        if FK_YAML_LIKELY (m_len > 0) {
+            pos = std::min(m_len - 1, pos) + 1;
 
             do {
                 const CharT* p_found = traits_type::find(s, n, mp_str[--pos]);
@@ -7405,11 +7405,8 @@ private:
     /// @param newline_pos Position of the target newline code.
     void process_line_folding(str_view& token, std::size_t newline_pos) noexcept {
         // discard trailing white spaces which precedes the line break in the current line.
-        const std::size_t last_non_space_pos = token.substr(0, newline_pos + 1).find_last_not_of(" \t");
-        if (last_non_space_pos == str_view::npos) {
-            m_buffer.append(token.begin(), newline_pos);
-        }
-        else {
+        const std::size_t last_non_space_pos = token.substr(0, newline_pos).find_last_not_of(" \t");
+        if (last_non_space_pos != str_view::npos) {
             m_buffer.append(token.begin(), last_non_space_pos + 1);
         }
         token.remove_prefix(newline_pos + 1); // move next to the LF

--- a/tests/unit_test/test_str_view_class.cpp
+++ b/tests/unit_test/test_str_view_class.cpp
@@ -313,7 +313,11 @@ TEST_CASE("StrView_FindLastOf") {
     REQUIRE(sv.find_last_of('a') == 3);
     REQUIRE(sv.find_last_of("a") == 3);
     REQUIRE(sv.find_last_of("a", 0, 1) == 0);
-    REQUIRE(sv.find_last_of("a", 0, sv.size() + 1) == fkyaml::detail::str_view::npos);
+    REQUIRE(sv.find_last_of("bc", 4, 2) == 4);
+    REQUIRE(sv.find_last_of("d", 6, 1) == fkyaml::detail::str_view::npos);
+    REQUIRE(sv.find_last_of("a", 0, 0) == fkyaml::detail::str_view::npos);
+    fkyaml::detail::str_view empty_sv = "";
+    REQUIRE(empty_sv.find_last_of("a") == fkyaml::detail::str_view::npos);
     REQUIRE(sv.find_last_of(fkyaml::detail::str_view {"aa"}) == 3);
 }
 


### PR DESCRIPTION
This PR fixes trailing white spaces before a line break not being discarded in multiline flow scalars:

```yaml
"2 trailing\t  
    tab"
```

is parsed as `2 trailing\t   tab` (three spaces) instead of `2 trailing\t tab`. Plain and single quoted scalars are affected the same way.

### Cause

The trimming in `process_line_folding()` relies on `str_view::find_last_not_of()`, which never matched. That overload and `find_last_of()` both reuse `rfind()`'s logic, where `n` is the length of the sequence being searched for, but here `n` is the size of the character set, so `std::min(m_len - n, pos)` started the search `n - 1` characters before the end and skipped the last character. `find_last_of()` also read out of bounds when the set was as long as the string (it has no caller in the library today).

Both now start at the last character, and the trimming range stops in front of the line break instead of covering it, otherwise a working search would have kept the break itself in the scalar.

### Tests

`StrView_FindLastOf` no longer passes the string size as the character set size, which read past the literal it searched, and gains an empty string and an empty set. Three more YAML test suite cases pass: `DE56-01`, `DE56-03`, `NAT4`.

---

## Pull Request Checklist

Read the [CONTRIBUTING.md](https://github.com/fktn-k/fkYAML/blob/develop/.github/CONTRIBUTING.md) file for detailed information.  

- [x] Changes are described in the pull request or in a referenced [issue](https://github.com/fktn-k/fkYAML/issues).
- [x] The test suite compiles and runs without any error.
- [x] [The code coverage](https://coveralls.io/github/fktn-k/fkYAML) on your branch is 100%.
- [x] The documentation is updated if you added/changed a feature.

## Please don't

- The C++11 support varies between different **compilers** and versions. Please note the [list of supported compilers](https://github.com/fktn-k/fkYAML/blob/develop/README.md#supported-compilers). Some compilers like GCC 4.7 (and earlier), Clang 3.3 (and earlier), or Microsoft Visual Studio 13.0 and earlier are known not to work due to missing or incomplete C++11 support. Please refrain from proposing changes that work around these compiler's limitations with `#ifdef`s or other means.
- Please refrain from proposing changes that would **break [YAML](https://yaml.org/) specifications**. If you propose a conformant extension of YAML to be supported by the library, please motivate this extension.
- Please do not open pull requests that address **multiple issues**.
