### PR TITLE
Fix bug in parsing empty block scalars before a mapping entry

### DIFF
--- a/include/fkYAML/detail/input/lexical_analyzer.hpp
+++ b/include/fkYAML/detail/input/lexical_analyzer.hpp
@@ -1334,6 +1334,9 @@ private:
                 stop_increment = true;
                 continue;
             case '\n':
+                if FK_YAML_UNLIKELY (!is_document_root && stop_increment && cur_indent <= base_indent) {
+                    emit_error("A tab character cannot be used as indentation.");
+                }
                 max_leading_indent = std::max(cur_indent, max_leading_indent);
                 cur_indent = 0;
                 stop_increment = false;
@@ -1357,6 +1360,14 @@ private:
             return sv;
         }
 
+        // A non-empty line at or below the parent indentation ends an otherwise empty block scalar.
+        if (!is_document_root && cur_indent <= base_indent) {
+            const auto content_end_pos = static_cast<std::size_t>(cur_itr - m_token_begin_itr - 1);
+            m_cur_itr = m_token_begin_itr + content_end_pos;
+            content_indent = indicated_indent == 0 ? max_leading_indent : base_indent + indicated_indent;
+            return sv.substr(0, content_end_pos);
+        }
+
         // Any leading empty line must not contain more spaces than the first non-empty line.
         if FK_YAML_UNLIKELY (cur_indent < max_leading_indent) {
             emit_error("Any leading empty line must not be more indented than the first non-empty line.");
@@ -1369,9 +1380,6 @@ private:
             // --- >
             // line1
             // ```
-            if FK_YAML_UNLIKELY (!is_document_root && base_indent >= cur_indent) {
-                emit_error("The first non-empty line in the block scalar is less indented.");
-            }
             indicated_indent = cur_indent - base_indent;
         }
         else if FK_YAML_UNLIKELY (cur_indent < base_indent + indicated_indent) {

--- a/single_include/fkYAML/node.hpp
+++ b/single_include/fkYAML/node.hpp
@@ -4607,6 +4607,9 @@ private:
                 stop_increment = true;
                 continue;
             case '\n':
+                if FK_YAML_UNLIKELY (!is_document_root && stop_increment && cur_indent <= base_indent) {
+                    emit_error("A tab character cannot be used as indentation.");
+                }
                 max_leading_indent = std::max(cur_indent, max_leading_indent);
                 cur_indent = 0;
                 stop_increment = false;
@@ -4630,6 +4633,14 @@ private:
             return sv;
         }
 
+        // A non-empty line at or below the parent indentation ends an otherwise empty block scalar.
+        if (!is_document_root && cur_indent <= base_indent) {
+            const auto content_end_pos = static_cast<std::size_t>(cur_itr - m_token_begin_itr - 1);
+            m_cur_itr = m_token_begin_itr + content_end_pos;
+            content_indent = indicated_indent == 0 ? max_leading_indent : base_indent + indicated_indent;
+            return sv.substr(0, content_end_pos);
+        }
+
         // Any leading empty line must not contain more spaces than the first non-empty line.
         if FK_YAML_UNLIKELY (cur_indent < max_leading_indent) {
             emit_error("Any leading empty line must not be more indented than the first non-empty line.");
@@ -4642,9 +4653,6 @@ private:
             // --- >
             // line1
             // ```
-            if FK_YAML_UNLIKELY (!is_document_root && base_indent >= cur_indent) {
-                emit_error("The first non-empty line in the block scalar is less indented.");
-            }
             indicated_indent = cur_indent - base_indent;
         }
         else if FK_YAML_UNLIKELY (cur_indent < base_indent + indicated_indent) {

--- a/tests/unit_test/test_deserializer_class.cpp
+++ b/tests/unit_test/test_deserializer_class.cpp
@@ -337,6 +337,33 @@ TEST_CASE("Deserializer_BlockLiteralScalar") {
         REQUIRE(root["bar"].get_value<int>() == 1);
     }
 
+    SUBCASE("a leading empty line can begin with a tab at the root level") {
+        std::string input = "|\n"
+                            "\t\n"
+                            "content line.\n";
+
+        REQUIRE_NOTHROW(root = deserializer.deserialize(fkyaml::detail::input_adapter(input)));
+        REQUIRE(root.is_scalar());
+        REQUIRE(root.as_str() == "\t\ncontent line.\n");
+    }
+
+    SUBCASE("a leading empty line cannot begin with a tab") {
+        std::string input = "foo: |\n"
+                            "\t\n"
+                            "bar: 1\n";
+
+        REQUIRE_THROWS_AS(root = deserializer.deserialize(fkyaml::detail::input_adapter(input)), fkyaml::parse_error);
+    }
+
+    SUBCASE("a leading empty line cannot contain a tab in the parent indentation") {
+        std::string input = "foo:\n"
+                            "  bar: |\n"
+                            "  \t\n"
+                            "  baz: 1\n";
+
+        REQUIRE_THROWS_AS(root = deserializer.deserialize(fkyaml::detail::input_adapter(input)), fkyaml::parse_error);
+    }
+
     SUBCASE("tagged") {
         std::string input = "foo: !!str |\n"
                             "  first sentence.\n"


### PR DESCRIPTION
This pull request adds stricter error checking for invalid tab usage, ensures correct block scalar termination based on indentation, and updates the test suite to verify these behaviors.

## Changes

* Added a check to emit an error if a tab character is used as indentation in a non-root block scalar when the current indentation is less than or equal to the base indentation.
* Improved block scalar parsing to end the scalar when a non-empty line is detected at or below the parent indentation.
* Removed redundant error check for the first non-empty line's indentation in block scalars.

## Testing

* Added tests to ensure the followings. All the test cases pass successfully.
  - Leading empty lines with tabs are allowed at the root level but not within mappings.
  - Using a tab as indentation in block scalars at non-root levels correctly raises a parse error.
* Fixed `K858` and `Y79Y/001` in the YAML test suite which contain a empty block scalar followed by a mapping entry. As a result, 36 failing cases have decreased to 34 with no newly failing case.

---

## Pull Request Checklist

Read the [CONTRIBUTING.md](https://github.com/fktn-k/fkYAML/blob/develop/.github/CONTRIBUTING.md) file for detailed information.  

- [x] Changes are described in the pull request or in a referenced [issue](https://github.com/fktn-k/fkYAML/issues).
- [x] The test suite compiles and runs without any error.
- [x] [The code coverage](https://coveralls.io/github/fktn-k/fkYAML) on your branch is 100%.
- [x] The documentation is updated if you added/changed a feature.

## Please don't

- The C++11 support varies between different **compilers** and versions. Please note the [list of supported compilers](https://github.com/fktn-k/fkYAML/blob/develop/README.md#supported-compilers). Some compilers like GCC 4.7 (and earlier), Clang 3.3 (and earlier), or Microsoft Visual Studio 13.0 and earlier are known not to work due to missing or incomplete C++11 support. Please refrain from proposing changes that work around these compiler's limitations with `#ifdef`s or other means.
- Please refrain from proposing changes that would **break [YAML](https://yaml.org/) specifications**. If you propose a conformant extension of YAML to be supported by the library, please motivate this extension.
- Please do not open pull requests that address **multiple issues**.
