### PR TITLE
Fix empty documents being dropped

### DIFF
--- a/include/fkYAML/detail/input/deserializer.hpp
+++ b/include/fkYAML/detail/input/deserializer.hpp
@@ -212,8 +212,15 @@ private:
         uint32_t indent = lexer.get_last_token_begin_pos();
         const bool found_props = deserialize_node_properties(lexer, token, line, indent);
 
-        // A stream which only holds comments, white spaces or a bare "..." contains no document.
-        if (token.type != lexical_token_t::END_OF_BUFFER && token.type != lexical_token_t::END_OF_DOCUMENT) {
+        // A stream which only holds comments, white spaces or a bare "..." contains no document. Node
+        // properties on their own, however, do make up one: they belong to an empty scalar.
+        // ```yaml
+        // !
+        // # -> one document holding an empty scalar tagged with the non-specific tag
+        // ```
+        const bool has_contents =
+            token.type != lexical_token_t::END_OF_BUFFER && token.type != lexical_token_t::END_OF_DOCUMENT;
+        if (has_contents || found_props) {
             m_has_document = true;
         }
 
@@ -438,6 +445,19 @@ private:
                 // TODO: should output a warning log. Currently just ignore this case.
                 break;
             case lexical_token_t::END_OF_DIRECTIVES:
+                if (m_has_document) {
+                    // A "---" which follows another one ends the document that one began and begins the
+                    // next, even though the document it ends holds no node at all.
+                    // ```yaml
+                    // ---
+                    // ---
+                    // # -> two documents, both empty
+                    // ```
+                    last_token = token;
+                    lexer.set_document_state(false);
+                    return;
+                }
+
                 lacks_end_of_directives_marker = false;
                 m_has_document = true;
                 break;

--- a/single_include/fkYAML/node.hpp
+++ b/single_include/fkYAML/node.hpp
@@ -8048,8 +8048,15 @@ private:
         uint32_t indent = lexer.get_last_token_begin_pos();
         const bool found_props = deserialize_node_properties(lexer, token, line, indent);
 
-        // A stream which only holds comments, white spaces or a bare "..." contains no document.
-        if (token.type != lexical_token_t::END_OF_BUFFER && token.type != lexical_token_t::END_OF_DOCUMENT) {
+        // A stream which only holds comments, white spaces or a bare "..." contains no document. Node
+        // properties on their own, however, do make up one: they belong to an empty scalar.
+        // ```yaml
+        // !
+        // # -> one document holding an empty scalar tagged with the non-specific tag
+        // ```
+        const bool has_contents =
+            token.type != lexical_token_t::END_OF_BUFFER && token.type != lexical_token_t::END_OF_DOCUMENT;
+        if (has_contents || found_props) {
             m_has_document = true;
         }
 
@@ -8274,6 +8281,19 @@ private:
                 // TODO: should output a warning log. Currently just ignore this case.
                 break;
             case lexical_token_t::END_OF_DIRECTIVES:
+                if (m_has_document) {
+                    // A "---" which follows another one ends the document that one began and begins the
+                    // next, even though the document it ends holds no node at all.
+                    // ```yaml
+                    // ---
+                    // ---
+                    // # -> two documents, both empty
+                    // ```
+                    last_token = token;
+                    lexer.set_document_state(false);
+                    return;
+                }
+
                 lacks_end_of_directives_marker = false;
                 m_has_document = true;
                 break;

--- a/tests/unit_test/test_deserializer_class.cpp
+++ b/tests/unit_test/test_deserializer_class.cpp
@@ -4257,6 +4257,31 @@ TEST_CASE("Deserializer_MultipleDocuments") {
     fkyaml::node root;
     std::vector<fkyaml::node> docs;
 
+    SUBCASE("consecutive directives end markers") {
+        // Each "---" begins a document, so the one which the previous marker began ends here without
+        // holding any node.
+        std::string input = "---\n"
+                            "---\n"
+                            "foo\n";
+
+        REQUIRE_NOTHROW(docs = deserializer.deserialize_docs(fkyaml::detail::input_adapter(input)));
+        REQUIRE(docs.size() == 2);
+        REQUIRE(docs[0].is_null());
+        REQUIRE(docs[1].is_string());
+        REQUIRE(docs[1].as_str() == "foo");
+    }
+
+    SUBCASE("a document which holds nothing but node properties") {
+        // The properties belong to an empty scalar, which is a node and therefore a document, even
+        // without a "---" marker which begins it.
+        std::string input = "!!str\n";
+
+        REQUIRE_NOTHROW(docs = deserializer.deserialize_docs(fkyaml::detail::input_adapter(input)));
+        REQUIRE(docs.size() == 1);
+        REQUIRE(docs[0].has_tag_name());
+        REQUIRE(docs[0].get_tag_name() == "!!str");
+    }
+
     SUBCASE("both directives/document end markers") {
         std::string input = "%YAML 1.1\n"
                             "---\n"


### PR DESCRIPTION
This PR fixes documents which hold no node being dropped from the parse result:

```yaml
---
---
foo
```

is parsed as a single document `foo` instead of two documents (`null` and `foo`), and a document made of node properties alone, such as:

```yaml
!!str
```

produces no document at all instead of one holding an empty scalar tagged with `!!str`.

### Cause

`deserialize_directives()` handles `---` by marking the document as begun and keeps reading, so a second `---` right after the first one is consumed as part of the same directives section and the empty document the first one began is never emitted. A `---` found once a document has been begun now ends that document instead.

`deserialize_document()` only counts a document when some token other than the end of the buffer or of the document follows. Node properties are consumed before that check, so a stream holding nothing but properties yields no document, even though the properties belong to an empty scalar. Found properties now count as well, attaching them to the root node was already handled.

### Tests

`Deserializer_MultipleDocuments` gains two subcases: consecutive `---` markers and a document holding nothing but a tag. Two more YAML test suite cases pass: `6XDY`, `UKK6-02` (38 failing cases decreased to 36 with no newly failing case).

---

## Pull Request Checklist

Read the [CONTRIBUTING.md](https://github.com/fktn-k/fkYAML/blob/develop/.github/CONTRIBUTING.md) file for detailed information.  

- [x] Changes are described in the pull request or in a referenced [issue](https://github.com/fktn-k/fkYAML/issues).
- [x] The test suite compiles and runs without any error.
- [x] [The code coverage](https://coveralls.io/github/fktn-k/fkYAML) on your branch is 100%.
- [x] The documentation is updated if you added/changed a feature.

## Please don't

- The C++11 support varies between different **compilers** and versions. Please note the [list of supported compilers](https://github.com/fktn-k/fkYAML/blob/develop/README.md#supported-compilers). Some compilers like GCC 4.7 (and earlier), Clang 3.3 (and earlier), or Microsoft Visual Studio 13.0 and earlier are known not to work due to missing or incomplete C++11 support. Please refrain from proposing changes that work around these compiler's limitations with `#ifdef`s or other means.
- Please refrain from proposing changes that would **break [YAML](https://yaml.org/) specifications**. If you propose a conformant extension of YAML to be supported by the library, please motivate this extension.
- Please do not open pull requests that address **multiple issues**.
