### PR TITLE
Fix folded scalar line breaks after empty lines

### DIFF
--- a/include/fkYAML/detail/input/scalar_parser.hpp
+++ b/include/fkYAML/detail/input/scalar_parser.hpp
@@ -312,11 +312,18 @@ private:
         m_use_owned_buffer = true;
         m_buffer.reserve(token.size());
 
-        constexpr str_view white_space_filter {" \t"};
+        constexpr str_view space_filter {" "};
+
+        enum class folding_state_t : std::uint8_t {
+            FOLDABLE,
+            EMPTY_AFTER_FOLDABLE,
+            EMPTY_AFTER_OTHER,
+            OTHER,
+        };
 
         std::size_t cur_line_begin_pos = 0;
         bool has_newline_at_end = true;
-        bool can_be_folded = false;
+        folding_state_t folding_state {folding_state_t::OTHER};
         do {
             std::size_t cur_line_end_pos = token.find('\n', cur_line_begin_pos);
             if (cur_line_end_pos == str_view::npos) {
@@ -324,14 +331,16 @@ private:
                 cur_line_end_pos = token.size();
             }
 
-            const std::size_t line_size = cur_line_end_pos - cur_line_begin_pos;
-            const str_view line = token.substr(cur_line_begin_pos, line_size);
-            const bool is_empty = line.find_first_not_of(white_space_filter) == str_view::npos;
+            const str_view line = token.substr(cur_line_begin_pos, cur_line_end_pos - cur_line_begin_pos);
+            const std::size_t non_space_pos = line.find_first_not_of(space_filter);
+            const bool is_empty = non_space_pos == str_view::npos;
+            const bool is_more_indented =
+                !is_empty &&
+                (non_space_pos > header.indent || (non_space_pos == header.indent && line[non_space_pos] == '\t'));
 
             if (line.size() <= header.indent) {
                 // A less-indented line is turned into a newline.
                 m_buffer.push_back('\n');
-                can_be_folded = false;
             }
             else if (is_empty) {
                 // more-indented empty lines are not folded.
@@ -340,10 +349,7 @@ private:
                 m_buffer.push_back('\n');
             }
             else {
-                const std::size_t non_space_pos = line.find_first_not_of(white_space_filter);
-                const bool is_more_indented = (non_space_pos != str_view::npos) && (non_space_pos > header.indent);
-
-                if (can_be_folded) {
+                if (folding_state == folding_state_t::FOLDABLE) {
                     if (is_more_indented) {
                         // The content line right before more-indented lines is not folded.
                         m_buffer.push_back('\n');
@@ -351,8 +357,18 @@ private:
                     else {
                         m_buffer.push_back(' ');
                     }
-
-                    can_be_folded = false;
+                }
+                else if (
+                    is_more_indented && folding_state == folding_state_t::EMPTY_AFTER_FOLDABLE && has_newline_at_end) {
+                    // Preserve the line break after an empty line before a more-indented line.
+                    // ```yaml
+                    // >
+                    //   foo
+                    //
+                    //    bar
+                    // ```
+                    // is parsed as "foo\n\n bar\n".
+                    m_buffer.push_back('\n');
                 }
 
                 m_buffer.append(line.begin() + header.indent, line.end());
@@ -361,9 +377,19 @@ private:
                     // more-indented lines are not folded.
                     m_buffer.push_back('\n');
                 }
-                else {
-                    can_be_folded = true;
-                }
+            }
+
+            if (is_empty && folding_state == folding_state_t::FOLDABLE) {
+                folding_state = folding_state_t::EMPTY_AFTER_FOLDABLE;
+            }
+            else if (is_empty) {
+                folding_state = folding_state_t::EMPTY_AFTER_OTHER;
+            }
+            else if (!has_newline_at_end || is_more_indented) {
+                folding_state = folding_state_t::OTHER;
+            }
+            else {
+                folding_state = folding_state_t::FOLDABLE;
             }
 
             if (!has_newline_at_end) {
@@ -373,7 +399,7 @@ private:
             cur_line_begin_pos = cur_line_end_pos + 1;
         } while (cur_line_begin_pos < token.size());
 
-        if (has_newline_at_end && can_be_folded) {
+        if (has_newline_at_end && folding_state == folding_state_t::FOLDABLE) {
             // The final content line break are not folded.
             m_buffer.push_back('\n');
         }

--- a/single_include/fkYAML/node.hpp
+++ b/single_include/fkYAML/node.hpp
@@ -7292,11 +7292,18 @@ private:
         m_use_owned_buffer = true;
         m_buffer.reserve(token.size());
 
-        constexpr str_view white_space_filter {" \t"};
+        constexpr str_view space_filter {" "};
+
+        enum class folding_state_t : std::uint8_t {
+            FOLDABLE,
+            EMPTY_AFTER_FOLDABLE,
+            EMPTY_AFTER_OTHER,
+            OTHER,
+        };
 
         std::size_t cur_line_begin_pos = 0;
         bool has_newline_at_end = true;
-        bool can_be_folded = false;
+        folding_state_t folding_state {folding_state_t::OTHER};
         do {
             std::size_t cur_line_end_pos = token.find('\n', cur_line_begin_pos);
             if (cur_line_end_pos == str_view::npos) {
@@ -7304,14 +7311,16 @@ private:
                 cur_line_end_pos = token.size();
             }
 
-            const std::size_t line_size = cur_line_end_pos - cur_line_begin_pos;
-            const str_view line = token.substr(cur_line_begin_pos, line_size);
-            const bool is_empty = line.find_first_not_of(white_space_filter) == str_view::npos;
+            const str_view line = token.substr(cur_line_begin_pos, cur_line_end_pos - cur_line_begin_pos);
+            const std::size_t non_space_pos = line.find_first_not_of(space_filter);
+            const bool is_empty = non_space_pos == str_view::npos;
+            const bool is_more_indented =
+                !is_empty &&
+                (non_space_pos > header.indent || (non_space_pos == header.indent && line[non_space_pos] == '\t'));
 
             if (line.size() <= header.indent) {
                 // A less-indented line is turned into a newline.
                 m_buffer.push_back('\n');
-                can_be_folded = false;
             }
             else if (is_empty) {
                 // more-indented empty lines are not folded.
@@ -7320,10 +7329,7 @@ private:
                 m_buffer.push_back('\n');
             }
             else {
-                const std::size_t non_space_pos = line.find_first_not_of(white_space_filter);
-                const bool is_more_indented = (non_space_pos != str_view::npos) && (non_space_pos > header.indent);
-
-                if (can_be_folded) {
+                if (folding_state == folding_state_t::FOLDABLE) {
                     if (is_more_indented) {
                         // The content line right before more-indented lines is not folded.
                         m_buffer.push_back('\n');
@@ -7331,8 +7337,18 @@ private:
                     else {
                         m_buffer.push_back(' ');
                     }
-
-                    can_be_folded = false;
+                }
+                else if (
+                    is_more_indented && folding_state == folding_state_t::EMPTY_AFTER_FOLDABLE && has_newline_at_end) {
+                    // Preserve the line break after an empty line before a more-indented line.
+                    // ```yaml
+                    // >
+                    //   foo
+                    //
+                    //    bar
+                    // ```
+                    // is parsed as "foo\n\n bar\n".
+                    m_buffer.push_back('\n');
                 }
 
                 m_buffer.append(line.begin() + header.indent, line.end());
@@ -7341,9 +7357,19 @@ private:
                     // more-indented lines are not folded.
                     m_buffer.push_back('\n');
                 }
-                else {
-                    can_be_folded = true;
-                }
+            }
+
+            if (is_empty && folding_state == folding_state_t::FOLDABLE) {
+                folding_state = folding_state_t::EMPTY_AFTER_FOLDABLE;
+            }
+            else if (is_empty) {
+                folding_state = folding_state_t::EMPTY_AFTER_OTHER;
+            }
+            else if (!has_newline_at_end || is_more_indented) {
+                folding_state = folding_state_t::OTHER;
+            }
+            else {
+                folding_state = folding_state_t::FOLDABLE;
             }
 
             if (!has_newline_at_end) {
@@ -7353,7 +7379,7 @@ private:
             cur_line_begin_pos = cur_line_end_pos + 1;
         } while (cur_line_begin_pos < token.size());
 
-        if (has_newline_at_end && can_be_folded) {
+        if (has_newline_at_end && folding_state == folding_state_t::FOLDABLE) {
             // The final content line break are not folded.
             m_buffer.push_back('\n');
         }

--- a/tests/unit_test/test_scalar_parser_class.cpp
+++ b/tests/unit_test/test_scalar_parser_class.cpp
@@ -444,7 +444,7 @@ TEST_CASE("ScalarParser_BlockLiteralScalar") {
         REQUIRE(node.as_str() == "\n");
     }
 
-    SUBCASE("a leading empty line contains a tab") {
+    SUBCASE("a leading tab-indented line") {
         fkyaml::detail::str_view token = "  \t \n"
                                          "  foo";
         header.chomp = fkyaml::detail::chomping_indicator_t::CLIP;
@@ -638,7 +638,18 @@ TEST_CASE("ScalarParser_BlockFoldedScalar") {
 
         REQUIRE_NOTHROW(node = scalar_parser.parse_block(lex_type, tag_type, token, header));
         REQUIRE(node.is_string());
-        REQUIRE(node.as_str() == "\n\t \nfoo");
+        REQUIRE(node.as_str() == "\t \nfoo");
+    }
+
+    SUBCASE("a leading tab line before an implicitly indented content line") {
+        fkyaml::detail::str_view token = " \t\n"
+                                         " detected\n";
+        header.chomp = fkyaml::detail::chomping_indicator_t::CLIP;
+        header.indent = 1;
+
+        REQUIRE_NOTHROW(node = scalar_parser.parse_block(lex_type, tag_type, token, header));
+        REQUIRE(node.is_string());
+        REQUIRE(node.as_str() == "\t\ndetected\n");
     }
 
     SUBCASE("folded string scalar with the first line being more indented than the indicated level") {
@@ -678,6 +689,61 @@ TEST_CASE("ScalarParser_BlockFoldedScalar") {
         REQUIRE_NOTHROW(node = scalar_parser.parse_block(lex_type, tag_type, token, header));
         REQUIRE(node.is_string());
         REQUIRE(node.as_str() == "foo\n\nbar\n");
+    }
+
+    SUBCASE("folded string scalar with an empty line before a tab-indented line") {
+        fkyaml::detail::str_view token = "  foo \n"
+                                         " \n"
+                                         "  \t bar\n"
+                                         "\n"
+                                         "  baz\n";
+
+        header.chomp = fkyaml::detail::chomping_indicator_t::CLIP;
+        header.indent = 2;
+
+        REQUIRE_NOTHROW(node = scalar_parser.parse_block(lex_type, tag_type, token, header));
+        REQUIRE(node.is_string());
+        REQUIRE(node.as_str() == "foo \n\n\t bar\n\nbaz\n");
+    }
+
+    SUBCASE("folded string scalar with a more-indented empty line") {
+        fkyaml::detail::str_view token = "  foo\n"
+                                         "    \n"
+                                         "  bar\n";
+
+        header.chomp = fkyaml::detail::chomping_indicator_t::CLIP;
+        header.indent = 2;
+
+        REQUIRE_NOTHROW(node = scalar_parser.parse_block(lex_type, tag_type, token, header));
+        REQUIRE(node.is_string());
+        REQUIRE(node.as_str() == "foo\n  \nbar\n");
+    }
+
+    SUBCASE("folded string scalar with an empty line after a more-indented line") {
+        fkyaml::detail::str_view token = "    bullet\n"
+                                         "\n"
+                                         "    list\n";
+
+        header.chomp = fkyaml::detail::chomping_indicator_t::CLIP;
+        header.indent = 2;
+
+        REQUIRE_NOTHROW(node = scalar_parser.parse_block(lex_type, tag_type, token, header));
+        REQUIRE(node.is_string());
+        REQUIRE(node.as_str() == "  bullet\n\n  list\n");
+    }
+
+    SUBCASE("folded string scalar with leading empty lines") {
+        fkyaml::detail::str_view token = "\n"
+                                         "\n"
+                                         "   more indented\n"
+                                         "  regular\n";
+
+        header.chomp = fkyaml::detail::chomping_indicator_t::CLIP;
+        header.indent = 2;
+
+        REQUIRE_NOTHROW(node = scalar_parser.parse_block(lex_type, tag_type, token, header));
+        REQUIRE(node.is_string());
+        REQUIRE(node.as_str() == "\n\n more indented\nregular\n");
     }
 
     SUBCASE("folded string scalar with implicit indentation and strip chomping") {


### PR DESCRIPTION
This pull request fixes handling indentation, folding, and line break preservation in the `scalar_parser` class. The changes introduce a more robust state machine to track folding states, which fixes subtle bugs and edge cases in parsing block folded scalars.

## Changes

* Fixes missing line breaks when an empty line is followed by a more-indented line in folded block scalars.
* Replaces can_be_folded with folding_state_t to explicitly track line-folding transitions.
* Treats tabs after the content indent as content, which would otherwise add a extra line break.

## Testing

* Added new test cases in `test_scalar_parser_class.cpp` to cover edge cases such as leading tab-indented lines, empty lines before/after more-indented lines, and combinations of empty and indented lines in folded scalars, ensuring the parser now correctly handles all these scenarios.
* Fixes `6VJK`, `MJS9` and `R4YG` in the YAML test suite which all contains such block folded scalars. As a result, 34 failing cases have decreased to 31 with no newly failing case.

---

## Pull Request Checklist

Read the [CONTRIBUTING.md](https://github.com/fktn-k/fkYAML/blob/develop/.github/CONTRIBUTING.md) file for detailed information.  

- [x] Changes are described in the pull request or in a referenced [issue](https://github.com/fktn-k/fkYAML/issues).
- [x] The test suite compiles and runs without any error.
- [x] [The code coverage](https://coveralls.io/github/fktn-k/fkYAML) on your branch is 100%.
- [x] The documentation is updated if you added/changed a feature.

## Please don't

- The C++11 support varies between different **compilers** and versions. Please note the [list of supported compilers](https://github.com/fktn-k/fkYAML/blob/develop/README.md#supported-compilers). Some compilers like GCC 4.7 (and earlier), Clang 3.3 (and earlier), or Microsoft Visual Studio 13.0 and earlier are known not to work due to missing or incomplete C++11 support. Please refrain from proposing changes that work around these compiler's limitations with `#ifdef`s or other means.
- Please refrain from proposing changes that would **break [YAML](https://yaml.org/) specifications**. If you propose a conformant extension of YAML to be supported by the library, please motivate this extension.
- Please do not open pull requests that address **multiple issues**.
