### PR TITLE
Accept the YAML 1.x minor versions which the library does not know

### DIFF
--- a/include/fkYAML/detail/input/lexical_analyzer.hpp
+++ b/include/fkYAML/detail/input/lexical_analyzer.hpp
@@ -800,8 +800,13 @@ private:
 
         m_yaml_version = str_view {m_token_begin_itr, m_cur_itr};
 
-        if FK_YAML_UNLIKELY (m_yaml_version.compare("1.1") != 0 && m_yaml_version.compare("1.2") != 0) {
-            emit_error("Only 1.1 and 1.2 can be specified as the YAML version.");
+        // A YAML processor must reject a different major version, but should only warn about a minor
+        // version it does not know and keep parsing the document.
+        // See https://yaml.org/spec/1.2.2/#681-yaml-directives for more details.
+        const bool is_yaml_1_x = m_yaml_version.size() > 2 && m_yaml_version.substr(0, 2).compare("1.") == 0 &&
+                                 m_yaml_version.find_first_not_of("0123456789", 2) == str_view::npos;
+        if FK_YAML_UNLIKELY (!is_yaml_1_x) {
+            emit_error("Only the 1.x versions can be specified as the YAML version.");
         }
 
         return lexical_token_t::YAML_VER_DIRECTIVE;

--- a/single_include/fkYAML/node.hpp
+++ b/single_include/fkYAML/node.hpp
@@ -4073,8 +4073,13 @@ private:
 
         m_yaml_version = str_view {m_token_begin_itr, m_cur_itr};
 
-        if FK_YAML_UNLIKELY (m_yaml_version.compare("1.1") != 0 && m_yaml_version.compare("1.2") != 0) {
-            emit_error("Only 1.1 and 1.2 can be specified as the YAML version.");
+        // A YAML processor must reject a different major version, but should only warn about a minor
+        // version it does not know and keep parsing the document.
+        // See https://yaml.org/spec/1.2.2/#681-yaml-directives for more details.
+        const bool is_yaml_1_x = m_yaml_version.size() > 2 && m_yaml_version.substr(0, 2).compare("1.") == 0 &&
+                                 m_yaml_version.find_first_not_of("0123456789", 2) == str_view::npos;
+        if FK_YAML_UNLIKELY (!is_yaml_1_x) {
+            emit_error("Only the 1.x versions can be specified as the YAML version.");
         }
 
         return lexical_token_t::YAML_VER_DIRECTIVE;

--- a/tests/unit_test/test_lexical_analyzer_class.cpp
+++ b/tests/unit_test/test_lexical_analyzer_class.cpp
@@ -52,14 +52,25 @@ TEST_CASE("LexicalAnalyzer_YamlVersionDirective") {
         REQUIRE(token.type == fkyaml::detail::lexical_token_t::END_OF_BUFFER);
     }
 
-    SUBCASE("invalid YAML directive value") {
+    SUBCASE("unknown YAML 1.x minor version") {
+        // An unknown minor version must not stop the parsing of the document.
+        // See https://yaml.org/spec/1.2.2/#681-yaml-directives for more details.
         auto buffer = GENERATE(
             fkyaml::detail::str_view("%YAML 1.3\n"),
+            fkyaml::detail::str_view("%YAML 1.23"),
+            fkyaml::detail::str_view("%YAML 1.11"));
+
+        fkyaml::detail::lexical_analyzer lexer(buffer);
+        lexer.set_document_state(true);
+        REQUIRE(lexer.get_next_token().type == fkyaml::detail::lexical_token_t::YAML_VER_DIRECTIVE);
+    }
+
+    SUBCASE("invalid YAML directive value") {
+        auto buffer = GENERATE(
             fkyaml::detail::str_view("%YAML 2.0\n"),
             fkyaml::detail::str_view("%YAML 12"),
             fkyaml::detail::str_view("%YAML 123"),
-            fkyaml::detail::str_view("%YAML 1.23"),
-            fkyaml::detail::str_view("%YAML 1.11"),
+            fkyaml::detail::str_view("%YAML 1."),
             fkyaml::detail::str_view("%YAML 1.A"),
             fkyaml::detail::str_view("%YAML AbC"));
 


### PR DESCRIPTION
This PR fixes documents being rejected when their `%YAML` directive names a minor version other than 1.1 or 1.2:

```yaml
%YAML 1.3
---
foo
```

throws `parse_error: Only 1.1 and 1.2 can be specified as the YAML version.` instead of being parsed.

### Cause

The lexer accepted exactly `1.1` and `1.2` and rejected everything else. The spec says a processor should reject a document with a different major version, but only warn about a higher minor version and keep parsing it (see [6.8.1. "YAML" Directives](https://yaml.org/spec/1.2.2/#681-yaml-directives)).

The lexer now accepts `1.` followed by one or more digits. A different major version (`2.0`) and malformed values (`1.`, `1.A`, `12`) are still rejected. An unknown minor version is handled as 1.2, which is what `convert_yaml_version()` already falls back to, so `get_yaml_version_type()` returns `VERSION_1_2` for such a document. The library has no way to emit a warning, so none is emitted.

### Tests

`LexicalAnalyzer_YamlVersionDirective` gains a subcase for unknown minor versions (`1.3`, `1.23`, `1.11`), which were moved out of the invalid-value subcase, and the invalid-value subcase gains `1.`. One more YAML test suite case passes: `BEC7` (31 failing cases decreased to 30 with no newly failing case).

---

## Pull Request Checklist

Read the [CONTRIBUTING.md](https://github.com/fktn-k/fkYAML/blob/develop/.github/CONTRIBUTING.md) file for detailed information.  

- [x] Changes are described in the pull request or in a referenced [issue](https://github.com/fktn-k/fkYAML/issues).
- [x] The test suite compiles and runs without any error.
- [x] [The code coverage](https://coveralls.io/github/fktn-k/fkYAML) on your branch is 100%.
- [x] The documentation is updated if you added/changed a feature.

## Please don't

- The C++11 support varies between different **compilers** and versions. Please note the [list of supported compilers](https://github.com/fktn-k/fkYAML/blob/develop/README.md#supported-compilers). Some compilers like GCC 4.7 (and earlier), Clang 3.3 (and earlier), or Microsoft Visual Studio 13.0 and earlier are known not to work due to missing or incomplete C++11 support. Please refrain from proposing changes that work around these compiler's limitations with `#ifdef`s or other means.
- Please refrain from proposing changes that would **break [YAML](https://yaml.org/) specifications**. If you propose a conformant extension of YAML to be supported by the library, please motivate this extension.
- Please do not open pull requests that address **multiple issues**.
