### PR TITLE
Fix trailing spaces in implicit mapping keys

### DIFF
--- a/include/fkYAML/detail/input/lexical_analyzer.hpp
+++ b/include/fkYAML/detail/input/lexical_analyzer.hpp
@@ -1240,10 +1240,33 @@ private:
                 case '#':
                     ends_loop = true;
                     break;
-                case ':':
-                    // " :" is permitted in a plain style string token, but not when followed by a space.
-                    ends_loop = (next_pos + 1 < sv.size()) && (sv[next_pos + 1] == ' ');
+                case ':': {
+                    // " :" is permitted in a plain style string token, but not when the ":" is a mapping
+                    // value indicator, that is, when it is followed by a white space, a line break or the
+                    // end of the input. In a flow context, a flow indicator is not safe to follow it either.
+                    if (next_pos + 1 == sv.size()) {
+                        ends_loop = true;
+                        break;
+                    }
+
+                    switch (sv[next_pos + 1]) {
+                    case ' ':
+                    case '\t':
+                    case '\n':
+                        ends_loop = true;
+                        break;
+                    case ',':
+                    case '[':
+                    case ']':
+                    case '{':
+                    case '}':
+                        ends_loop = ((m_state & flow_context_bit) != 0);
+                        break;
+                    default:
+                        break;
+                    }
                     break;
+                }
                 case '{':
                 case '}':
                 case '[':

--- a/single_include/fkYAML/node.hpp
+++ b/single_include/fkYAML/node.hpp
@@ -4513,10 +4513,33 @@ private:
                 case '#':
                     ends_loop = true;
                     break;
-                case ':':
-                    // " :" is permitted in a plain style string token, but not when followed by a space.
-                    ends_loop = (next_pos + 1 < sv.size()) && (sv[next_pos + 1] == ' ');
+                case ':': {
+                    // " :" is permitted in a plain style string token, but not when the ":" is a mapping
+                    // value indicator, that is, when it is followed by a white space, a line break or the
+                    // end of the input. In a flow context, a flow indicator is not safe to follow it either.
+                    if (next_pos + 1 == sv.size()) {
+                        ends_loop = true;
+                        break;
+                    }
+
+                    switch (sv[next_pos + 1]) {
+                    case ' ':
+                    case '\t':
+                    case '\n':
+                        ends_loop = true;
+                        break;
+                    case ',':
+                    case '[':
+                    case ']':
+                    case '{':
+                    case '}':
+                        ends_loop = ((m_state & flow_context_bit) != 0);
+                        break;
+                    default:
+                        break;
+                    }
                     break;
+                }
                 case '{':
                 case '}':
                 case '[':

--- a/tests/unit_test/test_deserializer_class.cpp
+++ b/tests/unit_test/test_deserializer_class.cpp
@@ -1076,6 +1076,39 @@ TEST_CASE("Deserializer_BlockMapping") {
         REQUIRE(pi_node.get_value<double>() == 3.14);
     }
 
+    SUBCASE("white spaces in front of the mapping value indicator") {
+        // The white spaces which separate a key from the ":" indicator belong to neither of them, no
+        // matter whether the value follows on the same line or on the next one.
+        std::string input = "foo :\n"
+                            "  bar\n"
+                            "baz : qux\n";
+
+        REQUIRE_NOTHROW(root = deserializer.deserialize(fkyaml::detail::input_adapter(input)));
+        REQUIRE(root.is_mapping());
+        REQUIRE(root.size() == 2);
+        REQUIRE(root.contains("foo"));
+        REQUIRE(root["foo"].as_str() == "bar");
+        REQUIRE(root.contains("baz"));
+        REQUIRE(root["baz"].as_str() == "qux");
+    }
+
+    SUBCASE("white spaces in front of the mapping value indicator followed by a tab or the end of input") {
+        auto input = GENERATE(std::string("foo :\tbar\n"), std::string("foo :"));
+
+        REQUIRE_NOTHROW(root = deserializer.deserialize(fkyaml::detail::input_adapter(input)));
+        REQUIRE(root.is_mapping());
+        REQUIRE(root.size() == 1);
+        REQUIRE(root.contains("foo"));
+    }
+
+    SUBCASE("a colon followed by a flow indicator outside flow collections") {
+        // Flow indicators have no special meaning outside flow collections, so the ":" is not a mapping
+        // value indicator here.
+        REQUIRE_NOTHROW(root = deserializer.deserialize(fkyaml::detail::input_adapter("foo :,bar")));
+        REQUIRE(root.is_string());
+        REQUIRE(root.as_str() == "foo :,bar");
+    }
+
     // regression test for https://github.com/fktn-k/fkYAML/pull/437
     SUBCASE("indented block mapping beginning with a newline") {
         std::string input = R"(
@@ -2439,6 +2472,16 @@ TEST_CASE("Deserializer_SinglePairMappingInFlowSequence") {
 TEST_CASE("Deserializer_FlowMapping") {
     fkyaml::detail::basic_deserializer<fkyaml::node> deserializer;
     fkyaml::node root;
+
+    SUBCASE("white spaces in front of the mapping value indicator followed by a flow indicator") {
+        std::string input = "{foo :, bar :}";
+
+        REQUIRE_NOTHROW(root = deserializer.deserialize(fkyaml::detail::input_adapter(input)));
+        REQUIRE(root.is_mapping());
+        REQUIRE(root.size() == 2);
+        REQUIRE(root.contains("foo"));
+        REQUIRE(root.contains("bar"));
+    }
 
     SUBCASE("simple flow mapping") {
         std::string input = "test: { bool: true, foo: bar, pi: 3.14 }";


### PR DESCRIPTION
This PR fixes the white spaces in front of a mapping value indicator being kept in an implicit key when the indicator is not followed by a space:

```yaml
foo :
  bar
```

is parsed with the key `"foo "` instead of `"foo"`. The same happens with a tab after the indicator (`foo :<TAB>bar`) and with a flow indicator after it in a flow collection (`{foo :, bar :}`), and `foo :` at the end of the input is parsed as the scalar `"foo :"` instead of a mapping.

### Cause

When scanning a plain scalar, `determine_plain_scalar_range()` ended the scalar in front of ` :` only if the `:` was followed by a space. A `:` followed by a tab, a line break or the end of the input is a mapping value indicator as well, and so is a `:` followed by a flow indicator inside a flow collection (see [7.3.3. Plain Style](https://yaml.org/spec/1.2.2/#733-plain-style)). The scalar now ends in all of these cases, while a `:` followed by a flow indicator outside flow collections (`foo :,bar`) is still part of the scalar.

### Tests

`Deserializer_BlockMapping` gains subcases for a line break, a tab and the end of the input after the indicator, and for
`foo :,bar` staying a scalar. `Deserializer_FlowMapping` gains a subcase for flow indicators after the indicator. One more YAML test suite case passes: `7FWL` (31 failing cases decreased to 30 with no newly failing case).

---

## Pull Request Checklist

Read the [CONTRIBUTING.md](https://github.com/fktn-k/fkYAML/blob/develop/.github/CONTRIBUTING.md) file for detailed information.  

- [x] Changes are described in the pull request or in a referenced [issue](https://github.com/fktn-k/fkYAML/issues).
- [x] The test suite compiles and runs without any error.
- [x] [The code coverage](https://coveralls.io/github/fktn-k/fkYAML) on your branch is 100%.
- [x] The documentation is updated if you added/changed a feature.

## Please don't

- The C++11 support varies between different **compilers** and versions. Please note the [list of supported compilers](https://github.com/fktn-k/fkYAML/blob/develop/README.md#supported-compilers). Some compilers like GCC 4.7 (and earlier), Clang 3.3 (and earlier), or Microsoft Visual Studio 13.0 and earlier are known not to work due to missing or incomplete C++11 support. Please refrain from proposing changes that work around these compiler's limitations with `#ifdef`s or other means.
- Please refrain from proposing changes that would **break [YAML](https://yaml.org/) specifications**. If you propose a conformant extension of YAML to be supported by the library, please motivate this extension.
- Please do not open pull requests that address **multiple issues**.
