### PR TITLE
Fix key separator detection after a json-like key

### DIFF
--- a/include/fkYAML/detail/input/lexical_analyzer.hpp
+++ b/include/fkYAML/detail/input/lexical_analyzer.hpp
@@ -92,6 +92,7 @@ public:
         m_last_token_begin_pos = info.begin_pos;
         m_last_token_begin_line = info.begin_line;
         m_last_token_begin_itr = info.begin_itr;
+        m_last_token_type = info.token.type;
         return info.token;
     }
 
@@ -237,9 +238,6 @@ private:
                     info.token.type = lexical_token_t::KEY_SEPARATOR;
                     return info;
                 default:
-                    // At least '{' or '[' must precedes this token.
-                    FK_YAML_ASSERT(m_token_begin_itr != m_begin_itr);
-
                     // if a key inside a flow mapping is JSON-like (surrounded by indicators, see below), YAML allows
                     // the following value to be specified adjacent to the ":" mapping value indicator.
                     // ```yaml
@@ -251,11 +249,11 @@ private:
                     //   {[1,2,3]:null}:"baz"
                     // }
                     // ```
-                    switch (*(m_token_begin_itr - 1)) {
-                    case '\'':
-                    case '\"':
-                    case ']':
-                    case '}':
+                    switch (m_last_token_type) {
+                    case lexical_token_t::SINGLE_QUOTED_SCALAR:
+                    case lexical_token_t::DOUBLE_QUOTED_SCALAR:
+                    case lexical_token_t::SEQUENCE_FLOW_END:
+                    case lexical_token_t::MAPPING_FLOW_END:
                         info.token.type = lexical_token_t::KEY_SEPARATOR;
                         return info;
                     default:
@@ -1692,6 +1690,8 @@ private:
     uint32_t m_last_token_begin_pos {0};
     /// The beginning line of the last lexical token. (zero origin)
     uint32_t m_last_token_begin_line {0};
+    /// The type of the last lexical token.
+    lexical_token_t m_last_token_type {lexical_token_t::END_OF_BUFFER};
     /// The current depth of flow context.
     uint32_t m_state {0};
     /// The queue of pending tokens.

--- a/single_include/fkYAML/node.hpp
+++ b/single_include/fkYAML/node.hpp
@@ -3365,6 +3365,7 @@ public:
         m_last_token_begin_pos = info.begin_pos;
         m_last_token_begin_line = info.begin_line;
         m_last_token_begin_itr = info.begin_itr;
+        m_last_token_type = info.token.type;
         return info.token;
     }
 
@@ -3510,9 +3511,6 @@ private:
                     info.token.type = lexical_token_t::KEY_SEPARATOR;
                     return info;
                 default:
-                    // At least '{' or '[' must precedes this token.
-                    FK_YAML_ASSERT(m_token_begin_itr != m_begin_itr);
-
                     // if a key inside a flow mapping is JSON-like (surrounded by indicators, see below), YAML allows
                     // the following value to be specified adjacent to the ":" mapping value indicator.
                     // ```yaml
@@ -3524,11 +3522,11 @@ private:
                     //   {[1,2,3]:null}:"baz"
                     // }
                     // ```
-                    switch (*(m_token_begin_itr - 1)) {
-                    case '\'':
-                    case '\"':
-                    case ']':
-                    case '}':
+                    switch (m_last_token_type) {
+                    case lexical_token_t::SINGLE_QUOTED_SCALAR:
+                    case lexical_token_t::DOUBLE_QUOTED_SCALAR:
+                    case lexical_token_t::SEQUENCE_FLOW_END:
+                    case lexical_token_t::MAPPING_FLOW_END:
                         info.token.type = lexical_token_t::KEY_SEPARATOR;
                         return info;
                     default:
@@ -4965,6 +4963,8 @@ private:
     uint32_t m_last_token_begin_pos {0};
     /// The beginning line of the last lexical token. (zero origin)
     uint32_t m_last_token_begin_line {0};
+    /// The type of the last lexical token.
+    lexical_token_t m_last_token_type {lexical_token_t::END_OF_BUFFER};
     /// The current depth of flow context.
     uint32_t m_state {0};
     /// The queue of pending tokens.

--- a/tests/unit_test/test_lexical_analyzer_class.cpp
+++ b/tests/unit_test/test_lexical_analyzer_class.cpp
@@ -2134,7 +2134,8 @@ TEST_CASE("LexicalAnalyzer_FlowMapping") {
 
     SUBCASE("\':\' is preceded by JSON-like keys and followed by values adjacent to it") {
         fkyaml::detail::str_view input = "{\n"
-                                         "  \"foo\":123,\n"
+                                         "  \"foo\"\n"
+                                         "  :123,\n"
                                          "  \'bar\':true,\n"
                                          "  [baz]:3.14,\n"
                                          "  {\"qux\":false}:null\n"


### PR DESCRIPTION
This PR fixes parsing of flow mappings where a JSON-like key and an adjacent value indicator are separated by whitespace or a line break.

## Cause

The lexer recognized an adjacent `:` as a flow-mapping value indicator only when it immediately followed a JSON-like key. It failed when separation whitespace, including a line break, appeared between the key and the `:`.

Consequently, this valid YAML Test Suite case (5MUD) was tokenized incorrectly and produced a parse error:

```yaml
{ "foo"
  :bar }
```

## Resolution

Track the previous token type in the lexical analyzer. In a flow context, recognize : as a key separator when the preceding token is a JSON-like flow node, including quoted scalars and closed flow collections, even when whitespace or line breaks separate them.

## Testing

* Added regression coverage for the 5MUD layout and updated the lexer test for multiline JSON-like keys.
* Fixed `5MUD` and `5U3A` in the YAML test suite. As a result, 29 failing cases has decreased to 27 with no newly failing case.

---

## Pull Request Checklist

Read the [CONTRIBUTING.md](https://github.com/fktn-k/fkYAML/blob/develop/.github/CONTRIBUTING.md) file for detailed information.  

- [x] Changes are described in the pull request or in a referenced [issue](https://github.com/fktn-k/fkYAML/issues).
- [x] The test suite compiles and runs without any error.
- [x] [The code coverage](https://coveralls.io/github/fktn-k/fkYAML) on your branch is 100%.
- [x] The documentation is updated if you added/changed a feature.

## Please don't

- The C++11 support varies between different **compilers** and versions. Please note the [list of supported compilers](https://github.com/fktn-k/fkYAML/blob/develop/README.md#supported-compilers). Some compilers like GCC 4.7 (and earlier), Clang 3.3 (and earlier), or Microsoft Visual Studio 13.0 and earlier are known not to work due to missing or incomplete C++11 support. Please refrain from proposing changes that work around these compiler's limitations with `#ifdef`s or other means.
- Please refrain from proposing changes that would **break [YAML](https://yaml.org/) specifications**. If you propose a conformant extension of YAML to be supported by the library, please motivate this extension.
- Please do not open pull requests that address **multiple issues**.
