### PR TITLE
Fix handling multiline anchors and tags

### DIFF
--- a/include/fkYAML/detail/input/deserializer.hpp
+++ b/include/fkYAML/detail/input/deserializer.hpp
@@ -197,6 +197,7 @@ private:
         lexical_token token {};
 
         m_has_document = false;
+        m_expects_root_flow_key_separator = false;
 
         basic_node_type root;
         mp_current_node = &root;
@@ -307,6 +308,8 @@ private:
         case lexical_token_t::SINGLE_QUOTED_SCALAR:
         case lexical_token_t::DOUBLE_QUOTED_SCALAR:
         case lexical_token_t::ALIAS_PREFIX:
+        case lexical_token_t::ANCHOR_PREFIX:
+        case lexical_token_t::TAG_PREFIX:
             // Defer handling the above token events until the next call on the deserialize_scalar() function since the
             // meaning depends on subsequent events.
             if (found_props && line < lexer.get_lines_processed()) {
@@ -943,7 +946,14 @@ private:
                     lexer.set_context_state(true);
 
                     if FK_YAML_UNLIKELY (m_context_stack.empty()) {
-                        throw parse_error("invalid flow sequence beginning is found.", line, indent);
+                        if (!defers_props()) {
+                            throw parse_error("invalid flow sequence beginning is found.", line, indent);
+                        }
+                        *mp_current_node = basic_node_type::mapping();
+                        apply_directive_set(*mp_current_node);
+                        apply_deferred_properties(*mp_current_node);
+                        m_context_stack.emplace_back(line, indent, context_state_t::BLOCK_MAPPING, mp_current_node);
+                        m_expects_root_flow_key_separator = true;
                     }
 
                     if (indent <= m_context_stack.back().indent) {
@@ -1031,6 +1041,14 @@ private:
                 // while that node is a key which has not been added to its parent mapping yet.
 
                 if (!m_context_stack.empty() && owned_node != nullptr) {
+                    if (m_expects_root_flow_key_separator) {
+                        const lexical_token_t next_type = lexer.peek_next_token().type;
+                        if FK_YAML_UNLIKELY (next_type != lexical_token_t::KEY_SEPARATOR) {
+                            throw parse_error(
+                                "A flow collection key must be followed by a key separator.", line, indent);
+                        }
+                        m_expects_root_flow_key_separator = false;
+                    }
                     basic_node_type key_node = std::move(*owned_node);
                     owned_node.reset();
                     mp_current_node = m_context_stack.back().p_node;
@@ -1069,7 +1087,14 @@ private:
                     lexer.set_context_state(true);
 
                     if FK_YAML_UNLIKELY (m_context_stack.empty()) {
-                        throw parse_error("invalid flow mapping beginning is found.", line, indent);
+                        if (!defers_props()) {
+                            throw parse_error("invalid flow mapping beginning is found.", line, indent);
+                        }
+                        *mp_current_node = basic_node_type::mapping();
+                        apply_directive_set(*mp_current_node);
+                        apply_deferred_properties(*mp_current_node);
+                        m_context_stack.emplace_back(line, indent, context_state_t::BLOCK_MAPPING, mp_current_node);
+                        m_expects_root_flow_key_separator = true;
                     }
 
                     if (indent <= m_context_stack.back().indent) {
@@ -1159,6 +1184,14 @@ private:
                 // while that node is a key which has not been added to its parent mapping yet.
 
                 if (!m_context_stack.empty() && owned_node != nullptr) {
+                    if (m_expects_root_flow_key_separator) {
+                        const lexical_token_t next_type = lexer.peek_next_token().type;
+                        if FK_YAML_UNLIKELY (next_type != lexical_token_t::KEY_SEPARATOR) {
+                            throw parse_error(
+                                "A flow collection key must be followed by a key separator.", line, indent);
+                        }
+                        m_expects_root_flow_key_separator = false;
+                    }
                     basic_node_type key_node = std::move(*owned_node);
                     owned_node.reset();
                     mp_current_node = m_context_stack.back().p_node;
@@ -1251,7 +1284,6 @@ private:
 
                 basic_node_type node = scalar_parser_type(line, indent).parse_flow(token.type, tag_type, token.str);
                 apply_directive_set(node);
-                apply_node_properties(node);
 
                 deserialize_scalar(lexer, std::move(node), indent, line, token);
                 continue;
@@ -1264,7 +1296,6 @@ private:
                     scalar_parser_type(line, indent)
                         .parse_block(token.type, tag_type, token.str, lexer.get_block_scalar_header());
                 apply_directive_set(node);
-                apply_node_properties(node);
 
                 deserialize_scalar(lexer, std::move(node), indent, line, token);
                 continue;
@@ -1480,6 +1511,21 @@ private:
     void deserialize_scalar(
         lexer_type& lexer, basic_node_type&& node, uint32_t& indent, uint32_t& line, lexical_token& token) {
         token = lexer.get_next_token();
+        const bool is_mapping_key = mp_current_node->is_mapping() || token.type == lexical_token_t::KEY_SEPARATOR;
+        if (is_mapping_key) {
+            apply_node_properties(node);
+        }
+        else if (!node.is_alias()) {
+            if FK_YAML_UNLIKELY (m_defers_anchor && m_needs_anchor_impl) {
+                throw parse_error("anchor name cannot be specified more than once to the same node.", line, indent);
+            }
+            if FK_YAML_UNLIKELY (m_defers_tag && m_needs_tag_impl) {
+                throw parse_error("tag name cannot be specified more than once to the same node.", line, indent);
+            }
+            apply_deferred_properties(node);
+            apply_node_properties(node);
+        }
+
         if (mp_current_node->is_mapping()) {
             // An implicit key in the block context must be followed by the ":" indicator on the same line, while in
             // the flow context the two can be separated by line breaks.
@@ -1637,14 +1683,10 @@ private:
         }
         else {
             if (defers_props()) {
-                // No key separator follows, so the node is a value and owns the deferred properties.
-                // An alias node must not carry any, which is only known once it turns out not to be a
-                // key of the mapping the properties belong to.
+                // Non-alias values consume deferred properties before reaching this point. An alias
+                // cannot carry properties, which is only known once it turns out not to be a key.
                 // https://yaml.org/spec/1.2.2/#71-alias-nodes
-                if FK_YAML_UNLIKELY (node.is_alias()) {
-                    throw parse_error("Node properties cannot be specified to an alias node.", line, indent);
-                }
-                apply_deferred_properties(node);
+                throw parse_error("Node properties cannot be specified to an alias node.", line, indent);
             }
             assign_node_value(std::move(node), line, indent);
         }
@@ -2056,6 +2098,8 @@ private:
     std::shared_ptr<doc_metainfo_type> mp_meta {};
     /// Whether the document being parsed exists at all: it has contents or an explicit "---".
     bool m_has_document {false};
+    /// Whether a provisional root mapping still requires a separator after its flow collection key.
+    bool m_expects_root_flow_key_separator {false};
     /// Whether the pending node properties precede their node and are not bound yet.
     bool m_defers_anchor {false};
     /// Whether a tag which precedes its node is waiting to be bound.

--- a/single_include/fkYAML/node.hpp
+++ b/single_include/fkYAML/node.hpp
@@ -8095,6 +8095,7 @@ private:
         lexical_token token {};
 
         m_has_document = false;
+        m_expects_root_flow_key_separator = false;
 
         basic_node_type root;
         mp_current_node = &root;
@@ -8205,6 +8206,8 @@ private:
         case lexical_token_t::SINGLE_QUOTED_SCALAR:
         case lexical_token_t::DOUBLE_QUOTED_SCALAR:
         case lexical_token_t::ALIAS_PREFIX:
+        case lexical_token_t::ANCHOR_PREFIX:
+        case lexical_token_t::TAG_PREFIX:
             // Defer handling the above token events until the next call on the deserialize_scalar() function since the
             // meaning depends on subsequent events.
             if (found_props && line < lexer.get_lines_processed()) {
@@ -8841,7 +8844,14 @@ private:
                     lexer.set_context_state(true);
 
                     if FK_YAML_UNLIKELY (m_context_stack.empty()) {
-                        throw parse_error("invalid flow sequence beginning is found.", line, indent);
+                        if (!defers_props()) {
+                            throw parse_error("invalid flow sequence beginning is found.", line, indent);
+                        }
+                        *mp_current_node = basic_node_type::mapping();
+                        apply_directive_set(*mp_current_node);
+                        apply_deferred_properties(*mp_current_node);
+                        m_context_stack.emplace_back(line, indent, context_state_t::BLOCK_MAPPING, mp_current_node);
+                        m_expects_root_flow_key_separator = true;
                     }
 
                     if (indent <= m_context_stack.back().indent) {
@@ -8929,6 +8939,14 @@ private:
                 // while that node is a key which has not been added to its parent mapping yet.
 
                 if (!m_context_stack.empty() && owned_node != nullptr) {
+                    if (m_expects_root_flow_key_separator) {
+                        const lexical_token_t next_type = lexer.peek_next_token().type;
+                        if FK_YAML_UNLIKELY (next_type != lexical_token_t::KEY_SEPARATOR) {
+                            throw parse_error(
+                                "A flow collection key must be followed by a key separator.", line, indent);
+                        }
+                        m_expects_root_flow_key_separator = false;
+                    }
                     basic_node_type key_node = std::move(*owned_node);
                     owned_node.reset();
                     mp_current_node = m_context_stack.back().p_node;
@@ -8967,7 +8985,14 @@ private:
                     lexer.set_context_state(true);
 
                     if FK_YAML_UNLIKELY (m_context_stack.empty()) {
-                        throw parse_error("invalid flow mapping beginning is found.", line, indent);
+                        if (!defers_props()) {
+                            throw parse_error("invalid flow mapping beginning is found.", line, indent);
+                        }
+                        *mp_current_node = basic_node_type::mapping();
+                        apply_directive_set(*mp_current_node);
+                        apply_deferred_properties(*mp_current_node);
+                        m_context_stack.emplace_back(line, indent, context_state_t::BLOCK_MAPPING, mp_current_node);
+                        m_expects_root_flow_key_separator = true;
                     }
 
                     if (indent <= m_context_stack.back().indent) {
@@ -9057,6 +9082,14 @@ private:
                 // while that node is a key which has not been added to its parent mapping yet.
 
                 if (!m_context_stack.empty() && owned_node != nullptr) {
+                    if (m_expects_root_flow_key_separator) {
+                        const lexical_token_t next_type = lexer.peek_next_token().type;
+                        if FK_YAML_UNLIKELY (next_type != lexical_token_t::KEY_SEPARATOR) {
+                            throw parse_error(
+                                "A flow collection key must be followed by a key separator.", line, indent);
+                        }
+                        m_expects_root_flow_key_separator = false;
+                    }
                     basic_node_type key_node = std::move(*owned_node);
                     owned_node.reset();
                     mp_current_node = m_context_stack.back().p_node;
@@ -9149,7 +9182,6 @@ private:
 
                 basic_node_type node = scalar_parser_type(line, indent).parse_flow(token.type, tag_type, token.str);
                 apply_directive_set(node);
-                apply_node_properties(node);
 
                 deserialize_scalar(lexer, std::move(node), indent, line, token);
                 continue;
@@ -9162,7 +9194,6 @@ private:
                     scalar_parser_type(line, indent)
                         .parse_block(token.type, tag_type, token.str, lexer.get_block_scalar_header());
                 apply_directive_set(node);
-                apply_node_properties(node);
 
                 deserialize_scalar(lexer, std::move(node), indent, line, token);
                 continue;
@@ -9378,6 +9409,21 @@ private:
     void deserialize_scalar(
         lexer_type& lexer, basic_node_type&& node, uint32_t& indent, uint32_t& line, lexical_token& token) {
         token = lexer.get_next_token();
+        const bool is_mapping_key = mp_current_node->is_mapping() || token.type == lexical_token_t::KEY_SEPARATOR;
+        if (is_mapping_key) {
+            apply_node_properties(node);
+        }
+        else if (!node.is_alias()) {
+            if FK_YAML_UNLIKELY (m_defers_anchor && m_needs_anchor_impl) {
+                throw parse_error("anchor name cannot be specified more than once to the same node.", line, indent);
+            }
+            if FK_YAML_UNLIKELY (m_defers_tag && m_needs_tag_impl) {
+                throw parse_error("tag name cannot be specified more than once to the same node.", line, indent);
+            }
+            apply_deferred_properties(node);
+            apply_node_properties(node);
+        }
+
         if (mp_current_node->is_mapping()) {
             // An implicit key in the block context must be followed by the ":" indicator on the same line, while in
             // the flow context the two can be separated by line breaks.
@@ -9535,14 +9581,10 @@ private:
         }
         else {
             if (defers_props()) {
-                // No key separator follows, so the node is a value and owns the deferred properties.
-                // An alias node must not carry any, which is only known once it turns out not to be a
-                // key of the mapping the properties belong to.
+                // Non-alias values consume deferred properties before reaching this point. An alias
+                // cannot carry properties, which is only known once it turns out not to be a key.
                 // https://yaml.org/spec/1.2.2/#71-alias-nodes
-                if FK_YAML_UNLIKELY (node.is_alias()) {
-                    throw parse_error("Node properties cannot be specified to an alias node.", line, indent);
-                }
-                apply_deferred_properties(node);
+                throw parse_error("Node properties cannot be specified to an alias node.", line, indent);
             }
             assign_node_value(std::move(node), line, indent);
         }
@@ -9954,6 +9996,8 @@ private:
     std::shared_ptr<doc_metainfo_type> mp_meta {};
     /// Whether the document being parsed exists at all: it has contents or an explicit "---".
     bool m_has_document {false};
+    /// Whether a provisional root mapping still requires a separator after its flow collection key.
+    bool m_expects_root_flow_key_separator {false};
     /// Whether the pending node properties precede their node and are not bound yet.
     bool m_defers_anchor {false};
     /// Whether a tag which precedes its node is waiting to be bound.

--- a/tests/unit_test/test_deserializer_class.cpp
+++ b/tests/unit_test/test_deserializer_class.cpp
@@ -3546,6 +3546,25 @@ TEST_CASE("Deserializer_Anchor") {
         REQUIRE(root_0_foo_node.as_str() == "bar");
     }
 
+    SUBCASE("anchors for the root mapping and its flow collection key") {
+        auto input =
+            GENERATE(std::string("&mapping\n&key [a, b, c]: value"), std::string("&mapping\n&key {a: b}: value"));
+        REQUIRE_NOTHROW(root = deserializer.deserialize(fkyaml::detail::input_adapter(input)));
+
+        REQUIRE(root.is_mapping());
+        REQUIRE(root.size() == 1);
+        REQUIRE(root.is_anchor());
+        REQUIRE(root.get_anchor_name() == "mapping");
+        REQUIRE(root.begin().key().is_anchor());
+        REQUIRE(root.begin().key().get_anchor_name() == "key");
+        REQUIRE(root.begin().value().as_str() == "value");
+    }
+
+    SUBCASE("multiple anchors on separate lines before a root flow collection") {
+        auto input = GENERATE(std::string("&anchor\n&anchor2 [foo]"), std::string("&anchor\n&anchor2 {foo: bar}"));
+        REQUIRE_THROWS_AS(root = deserializer.deserialize(fkyaml::detail::input_adapter(input)), fkyaml::parse_error);
+    }
+
     SUBCASE("multiple anchors specified") {
         auto input =
             GENERATE(std::string("foo: &anchor &anchor2\n  bar: baz"), std::string("&anchor &anchor2 foo: bar"));
@@ -3844,6 +3863,32 @@ TEST_CASE("Deserializer_Tag") {
 TEST_CASE("Deserializer_NodeProperties") {
     fkyaml::detail::basic_deserializer<fkyaml::node> deserializer;
     fkyaml::node root;
+
+    SUBCASE("anchor and tag split across lines on a root scalar") {
+        auto input = GENERATE(std::string("&anchor\n!!str value"), std::string("!!str\n&anchor\nvalue"));
+        REQUIRE_NOTHROW(root = deserializer.deserialize(fkyaml::detail::input_adapter(input)));
+
+        REQUIRE(root.is_string());
+        REQUIRE(root.as_str() == "value");
+        REQUIRE(root.is_anchor());
+        REQUIRE(root.get_anchor_name() == "anchor");
+        REQUIRE(root.has_tag_name());
+        REQUIRE(root.get_tag_name() == "!!str");
+    }
+
+    SUBCASE("duplicate anchors split across lines on a scalar value") {
+        std::string input = "top1: &node1\n"
+                            "  &key1 key1: value1\n"
+                            "top2: &node2\n"
+                            "  &value2 value2\n";
+        REQUIRE_THROWS_AS(deserializer.deserialize(fkyaml::detail::input_adapter(input)), fkyaml::parse_error);
+    }
+
+    SUBCASE("duplicate tags split across lines on a scalar value") {
+        std::string input = "!!str\n"
+                            "!!str value\n";
+        REQUIRE_THROWS_AS(deserializer.deserialize(fkyaml::detail::input_adapter(input)), fkyaml::parse_error);
+    }
 
     SUBCASE("both tag and anchor specified") {
         auto input = GENERATE(


### PR DESCRIPTION
This PR fixes YAML parsing failures involving node properties split across multiple lines.

## Cause

Deferred anchors and tags were applied before the parser knew whether a scalar represented a mapping key or value. This caused:

* Flow collection keys at the document root to lack a valid parsing context.
* Tags to be lost when anchors and tags were split across lines.
* Duplicate anchors or tags on separate lines to bypass validation.
* An unreachable deferred-property branch to remain in the parser.

## Resolution

* Added root mapping context handling for flow collection keys preceded by deferred properties.
* Delayed scalar property application until key/value ownership is determined.
* Preserved anchors and tags across line breaks.
* Added validation for duplicate anchors and tags split across lines.
* Removed the unreachable branch.
* Added regression tests and regenerated the single-header distribution.

## Testing

* Added unit test cases which verify that anchors and tags spanning on multiple lines are associated to a proper node. All unit test cases pass successfully
* Fixed `4JVG`, `6BFJ`, `9KAX` in the YAML test suite. As a result, 27 failing cases have decreased to 24 with no newly failing case.

---

## Pull Request Checklist

Read the [CONTRIBUTING.md](https://github.com/fktn-k/fkYAML/blob/develop/.github/CONTRIBUTING.md) file for detailed information.  

- [x] Changes are described in the pull request or in a referenced [issue](https://github.com/fktn-k/fkYAML/issues).
- [x] The test suite compiles and runs without any error.
- [x] [The code coverage](https://coveralls.io/github/fktn-k/fkYAML) on your branch is 100%.
- [x] The documentation is updated if you added/changed a feature.

## Please don't

- The C++11 support varies between different **compilers** and versions. Please note the [list of supported compilers](https://github.com/fktn-k/fkYAML/blob/develop/README.md#supported-compilers). Some compilers like GCC 4.7 (and earlier), Clang 3.3 (and earlier), or Microsoft Visual Studio 13.0 and earlier are known not to work due to missing or incomplete C++11 support. Please refrain from proposing changes that work around these compiler's limitations with `#ifdef`s or other means.
- Please refrain from proposing changes that would **break [YAML](https://yaml.org/) specifications**. If you propose a conformant extension of YAML to be supported by the library, please motivate this extension.
- Please do not open pull requests that address **multiple issues**.
