### PR TITLE
Keep the tag name when a node is anchored

### DIFF
--- a/include/fkYAML/node.hpp
+++ b/include/fkYAML/node.hpp
@@ -1221,27 +1221,7 @@ public:
     /// @param[in] anchor_name An anchor name. This should not be empty.
     /// @sa https://fktn-k.github.io/fkYAML/api/basic_node/add_anchor_name/
     void add_anchor_name(const std::string& anchor_name) {
-        if (is_anchor()) {
-            m_attrs &= ~detail::node_attr_mask::anchoring;
-            auto itr = mp_meta->anchor_table.equal_range(anchor_prop()).first;
-            std::advance(itr, detail::node_attr_bits::get_anchor_offset(m_attrs));
-            mp_meta.reset();
-            itr->second.swap(*this);
-            mp_meta->anchor_table.erase(itr);
-        }
-
-        auto p_meta = meta();
-
-        basic_node node;
-        node.swap(*this);
-        p_meta->anchor_table.emplace(anchor_name, std::move(node));
-
-        m_attrs &= ~detail::node_attr_mask::anchoring;
-        m_attrs |= detail::node_attr_bits::anchor_bit;
-        mp_meta = p_meta;
-        const auto offset = static_cast<uint32_t>(mp_meta->anchor_table.count(anchor_name) - 1);
-        detail::node_attr_bits::set_anchor_offset(offset, m_attrs);
-        prop().anchor = anchor_name;
+        anchor_this_node(anchor_name);
     }
 
     /// @brief Add an anchor name to this basic_node object.
@@ -1249,27 +1229,7 @@ public:
     /// @param[in] anchor_name An anchor name. This should not be empty.
     /// @sa https://fktn-k.github.io/fkYAML/api/basic_node/add_anchor_name/
     void add_anchor_name(std::string&& anchor_name) {
-        if (is_anchor()) {
-            m_attrs &= ~detail::node_attr_mask::anchoring;
-            auto itr = mp_meta->anchor_table.equal_range(anchor_prop()).first;
-            std::advance(itr, detail::node_attr_bits::get_anchor_offset(m_attrs));
-            mp_meta.reset();
-            itr->second.swap(*this);
-            mp_meta->anchor_table.erase(itr);
-        }
-
-        auto p_meta = meta();
-
-        basic_node node;
-        node.swap(*this);
-        p_meta->anchor_table.emplace(anchor_name, std::move(node));
-
-        m_attrs &= ~detail::node_attr_mask::anchoring;
-        m_attrs |= detail::node_attr_bits::anchor_bit;
-        mp_meta = p_meta;
-        auto offset = static_cast<uint32_t>(mp_meta->anchor_table.count(anchor_name) - 1);
-        detail::node_attr_bits::set_anchor_offset(offset, m_attrs);
-        prop().anchor = std::move(anchor_name);
+        anchor_this_node(std::move(anchor_name));
     }
 
     /// @brief Check whether this basic_node object has already had any tag name.
@@ -1945,6 +1905,55 @@ private:
             mp_meta = std::make_shared<detail::document_metainfo<basic_node>>();
         }
         return mp_meta;
+    }
+
+    /// @brief Moves the value of this basic_node object into the anchor table and turns it into an
+    /// anchor which refers to that value.
+    /// @param anchor_name An anchor name. This should not be empty.
+    void anchor_this_node(std::string anchor_name) {
+        // A tag which has already been set belongs to the node the caller holds. The value below moves
+        // into the anchor table, so the tag moves onto the anchor which replaces it, where it would have
+        // been stored anyway had it been set after the anchor name. An anchor which is given a new name
+        // carries its tag as well, so the tag is taken before the previous anchor is resolved below.
+        const auto take_tag_name = [this]() {
+            std::string taken;
+            if (mp_prop) {
+                taken = std::move(mp_prop->tag);
+                mp_prop->tag.clear();
+            }
+            return taken;
+        };
+
+        std::string tag_name = take_tag_name();
+
+        if (is_anchor()) {
+            m_attrs &= ~detail::node_attr_mask::anchoring;
+            auto itr = mp_meta->anchor_table.equal_range(anchor_prop()).first;
+            std::advance(itr, detail::node_attr_bits::get_anchor_offset(m_attrs));
+            mp_meta.reset();
+            itr->second.swap(*this);
+            mp_meta->anchor_table.erase(itr);
+
+            if (tag_name.empty()) {
+                tag_name = take_tag_name();
+            }
+        }
+
+        auto p_meta = meta();
+
+        basic_node node;
+        node.swap(*this);
+        p_meta->anchor_table.emplace(anchor_name, std::move(node));
+
+        m_attrs &= ~detail::node_attr_mask::anchoring;
+        m_attrs |= detail::node_attr_bits::anchor_bit;
+        mp_meta = p_meta;
+        const auto offset = static_cast<uint32_t>(mp_meta->anchor_table.count(anchor_name) - 1);
+        detail::node_attr_bits::set_anchor_offset(offset, m_attrs);
+        prop().anchor = std::move(anchor_name);
+        if (!tag_name.empty()) {
+            prop().tag = std::move(tag_name);
+        }
     }
 
     /// @brief Returns the properties of this node, creating them on first use.

--- a/single_include/fkYAML/node.hpp
+++ b/single_include/fkYAML/node.hpp
@@ -15727,27 +15727,7 @@ public:
     /// @param[in] anchor_name An anchor name. This should not be empty.
     /// @sa https://fktn-k.github.io/fkYAML/api/basic_node/add_anchor_name/
     void add_anchor_name(const std::string& anchor_name) {
-        if (is_anchor()) {
-            m_attrs &= ~detail::node_attr_mask::anchoring;
-            auto itr = mp_meta->anchor_table.equal_range(anchor_prop()).first;
-            std::advance(itr, detail::node_attr_bits::get_anchor_offset(m_attrs));
-            mp_meta.reset();
-            itr->second.swap(*this);
-            mp_meta->anchor_table.erase(itr);
-        }
-
-        auto p_meta = meta();
-
-        basic_node node;
-        node.swap(*this);
-        p_meta->anchor_table.emplace(anchor_name, std::move(node));
-
-        m_attrs &= ~detail::node_attr_mask::anchoring;
-        m_attrs |= detail::node_attr_bits::anchor_bit;
-        mp_meta = p_meta;
-        const auto offset = static_cast<uint32_t>(mp_meta->anchor_table.count(anchor_name) - 1);
-        detail::node_attr_bits::set_anchor_offset(offset, m_attrs);
-        prop().anchor = anchor_name;
+        anchor_this_node(anchor_name);
     }
 
     /// @brief Add an anchor name to this basic_node object.
@@ -15755,27 +15735,7 @@ public:
     /// @param[in] anchor_name An anchor name. This should not be empty.
     /// @sa https://fktn-k.github.io/fkYAML/api/basic_node/add_anchor_name/
     void add_anchor_name(std::string&& anchor_name) {
-        if (is_anchor()) {
-            m_attrs &= ~detail::node_attr_mask::anchoring;
-            auto itr = mp_meta->anchor_table.equal_range(anchor_prop()).first;
-            std::advance(itr, detail::node_attr_bits::get_anchor_offset(m_attrs));
-            mp_meta.reset();
-            itr->second.swap(*this);
-            mp_meta->anchor_table.erase(itr);
-        }
-
-        auto p_meta = meta();
-
-        basic_node node;
-        node.swap(*this);
-        p_meta->anchor_table.emplace(anchor_name, std::move(node));
-
-        m_attrs &= ~detail::node_attr_mask::anchoring;
-        m_attrs |= detail::node_attr_bits::anchor_bit;
-        mp_meta = p_meta;
-        auto offset = static_cast<uint32_t>(mp_meta->anchor_table.count(anchor_name) - 1);
-        detail::node_attr_bits::set_anchor_offset(offset, m_attrs);
-        prop().anchor = std::move(anchor_name);
+        anchor_this_node(std::move(anchor_name));
     }
 
     /// @brief Check whether this basic_node object has already had any tag name.
@@ -16451,6 +16411,55 @@ private:
             mp_meta = std::make_shared<detail::document_metainfo<basic_node>>();
         }
         return mp_meta;
+    }
+
+    /// @brief Moves the value of this basic_node object into the anchor table and turns it into an
+    /// anchor which refers to that value.
+    /// @param anchor_name An anchor name. This should not be empty.
+    void anchor_this_node(std::string anchor_name) {
+        // A tag which has already been set belongs to the node the caller holds. The value below moves
+        // into the anchor table, so the tag moves onto the anchor which replaces it, where it would have
+        // been stored anyway had it been set after the anchor name. An anchor which is given a new name
+        // carries its tag as well, so the tag is taken before the previous anchor is resolved below.
+        const auto take_tag_name = [this]() {
+            std::string taken;
+            if (mp_prop) {
+                taken = std::move(mp_prop->tag);
+                mp_prop->tag.clear();
+            }
+            return taken;
+        };
+
+        std::string tag_name = take_tag_name();
+
+        if (is_anchor()) {
+            m_attrs &= ~detail::node_attr_mask::anchoring;
+            auto itr = mp_meta->anchor_table.equal_range(anchor_prop()).first;
+            std::advance(itr, detail::node_attr_bits::get_anchor_offset(m_attrs));
+            mp_meta.reset();
+            itr->second.swap(*this);
+            mp_meta->anchor_table.erase(itr);
+
+            if (tag_name.empty()) {
+                tag_name = take_tag_name();
+            }
+        }
+
+        auto p_meta = meta();
+
+        basic_node node;
+        node.swap(*this);
+        p_meta->anchor_table.emplace(anchor_name, std::move(node));
+
+        m_attrs &= ~detail::node_attr_mask::anchoring;
+        m_attrs |= detail::node_attr_bits::anchor_bit;
+        mp_meta = p_meta;
+        const auto offset = static_cast<uint32_t>(mp_meta->anchor_table.count(anchor_name) - 1);
+        detail::node_attr_bits::set_anchor_offset(offset, m_attrs);
+        prop().anchor = std::move(anchor_name);
+        if (!tag_name.empty()) {
+            prop().tag = std::move(tag_name);
+        }
     }
 
     /// @brief Returns the properties of this node, creating them on first use.

--- a/tests/unit_test/test_node_class.cpp
+++ b/tests/unit_test/test_node_class.cpp
@@ -2935,6 +2935,48 @@ TEST_CASE("Node_GetAnchorName") {
     }
 }
 
+TEST_CASE("Node_AddAnchorNameKeepsTagName") {
+    SUBCASE("a tag set before the anchor name") {
+        // Anchoring moves the value of the node into the anchor table, so a tag which is already set
+        // has to travel with the anchor rather than with the value it refers to.
+        fkyaml::node node(std::string("foo"));
+        node.add_tag_name("!!str");
+        node.add_anchor_name("anchor");
+
+        REQUIRE(node.has_anchor_name());
+        REQUIRE(node.get_anchor_name() == "anchor");
+        REQUIRE(node.has_tag_name());
+        REQUIRE(node.get_tag_name() == "!!str");
+        REQUIRE(node.as_str() == "foo");
+    }
+
+    SUBCASE("a tag set after the anchor name") {
+        fkyaml::node node(std::string("foo"));
+        node.add_anchor_name("anchor");
+        node.add_tag_name("!!str");
+
+        REQUIRE(node.has_anchor_name());
+        REQUIRE(node.get_anchor_name() == "anchor");
+        REQUIRE(node.has_tag_name());
+        REQUIRE(node.get_tag_name() == "!!str");
+        REQUIRE(node.as_str() == "foo");
+    }
+
+    SUBCASE("a tag of a node which is given another anchor name") {
+        // The tag travels with the anchor, so a node which is anchored again keeps it.
+        fkyaml::node node(std::string("foo"));
+        node.add_tag_name("!!str");
+        node.add_anchor_name("first");
+        node.add_anchor_name("second");
+
+        REQUIRE(node.has_anchor_name());
+        REQUIRE(node.get_anchor_name() == "second");
+        REQUIRE(node.has_tag_name());
+        REQUIRE(node.get_tag_name() == "!!str");
+        REQUIRE(node.as_str() == "foo");
+    }
+}
+
 TEST_CASE("Node_AddAnchorName") {
     fkyaml::node node;
     std::string anchor_name = "anchor_name";


### PR DESCRIPTION
This PR fixes the tag name of a node being lost when an anchor name is added to it afterwards:

```cpp
fkyaml::node node(std::string("foo"));
node.add_tag_name("!!str");
node.add_anchor_name("anchor");

node.has_tag_name(); // false
```

Setting the two in the opposite order keeps the tag, so the result depends on the order in which they are set. A node which is already an anchor and is given another anchor name loses its tag as well.

### Cause

`add_anchor_name()` moves the value of the node into the anchor table and leaves behind a reference to it. The node properties travel with the value, so a tag which was set beforehand ends up in the anchor table while the caller holds the reference, which carries the anchor name alone. A tag set after the anchor name lands on that reference and is therefore kept.

The tag is now taken before the value is moved and set on the reference, which is where it would have been stored had it been set after the anchor name. A node which is anchored again has its tag taken before the previous anchor is resolved, so renaming an anchor keeps the tag too.

Both overloads of `add_anchor_name()` were identical apart from moving the anchor name at the end, and now share one implementation, so the fix applies to both.

### Tests

`Node_AddAnchorNameKeepsTagName` covers a tag set before the anchor name, one set after it, and a node which is given another anchor name.

---

## Pull Request Checklist

Read the [CONTRIBUTING.md](https://github.com/fktn-k/fkYAML/blob/develop/.github/CONTRIBUTING.md) file for detailed information.  

- [x] Changes are described in the pull request or in a referenced [issue](https://github.com/fktn-k/fkYAML/issues).
- [x] The test suite compiles and runs without any error.
- [ ] [The code coverage](https://coveralls.io/github/fktn-k/fkYAML) on your branch is 100%.
- [x] The documentation is updated if you added/changed a feature.

## Please don't

- The C++11 support varies between different **compilers** and versions. Please note the [list of supported compilers](https://github.com/fktn-k/fkYAML/blob/develop/README.md#supported-compilers). Some compilers like GCC 4.7 (and earlier), Clang 3.3 (and earlier), or Microsoft Visual Studio 13.0 and earlier are known not to work due to missing or incomplete C++11 support. Please refrain from proposing changes that work around these compiler's limitations with `#ifdef`s or other means.
- Please refrain from proposing changes that would **break [YAML](https://yaml.org/) specifications**. If you propose a conformant extension of YAML to be supported by the library, please motivate this extension.
- Please do not open pull requests that address **multiple issues**.
