### PR TITLE
Allow a newline after an explicit key prefix

### DIFF
--- a/include/fkYAML/detail/input/lexical_analyzer.hpp
+++ b/include/fkYAML/detail/input/lexical_analyzer.hpp
@@ -204,7 +204,7 @@ private:
 
             // Any separation white space may follow the explicit key indicator, just like the block
             // sequence entry indicator. https://yaml.org/spec/1.2.2/#rule-c-l-block-map-explicit-key
-            if (*m_cur_itr == ' ' || *m_cur_itr == '\t') {
+            if (*m_cur_itr == ' ' || *m_cur_itr == '\t' || *m_cur_itr == '\n') {
                 info.token.type = lexical_token_t::EXPLICIT_KEY_PREFIX;
                 return info;
             }

--- a/single_include/fkYAML/node.hpp
+++ b/single_include/fkYAML/node.hpp
@@ -3477,7 +3477,7 @@ private:
 
             // Any separation white space may follow the explicit key indicator, just like the block
             // sequence entry indicator. https://yaml.org/spec/1.2.2/#rule-c-l-block-map-explicit-key
-            if (*m_cur_itr == ' ' || *m_cur_itr == '\t') {
+            if (*m_cur_itr == ' ' || *m_cur_itr == '\t' || *m_cur_itr == '\n') {
                 info.token.type = lexical_token_t::EXPLICIT_KEY_PREFIX;
                 return info;
             }

--- a/tests/unit_test/test_lexical_analyzer_class.cpp
+++ b/tests/unit_test/test_lexical_analyzer_class.cpp
@@ -313,6 +313,41 @@ TEST_CASE("LexicalAnalyzer_Comment") {
     }
 }
 
+TEST_CASE("LexicalAnalyzer_ExplicitKey") {
+    fkyaml::detail::lexical_token token;
+
+    SUBCASE("explicit mapping key followed by a whitespace") {
+        fkyaml::detail::str_view input =
+            GENERATE(fkyaml::detail::str_view("? foo"), fkyaml::detail::str_view("?\tfoo"));
+        fkyaml::detail::lexical_analyzer lexer(input);
+
+        REQUIRE_NOTHROW(token = lexer.get_next_token());
+        REQUIRE(token.type == fkyaml::detail::lexical_token_t::EXPLICIT_KEY_PREFIX);
+
+        REQUIRE_NOTHROW(token = lexer.get_next_token());
+        REQUIRE(token.type == fkyaml::detail::lexical_token_t::PLAIN_SCALAR);
+        REQUIRE(token.str.begin() == input.begin() + 2);
+        REQUIRE(token.str.end() == input.end());
+    }
+
+    SUBCASE("explicit mapping key followed by a newline") {
+        fkyaml::detail::str_view input = "?\n"
+                                         "- foo";
+        fkyaml::detail::lexical_analyzer lexer(input);
+
+        REQUIRE_NOTHROW(token = lexer.get_next_token());
+        REQUIRE(token.type == fkyaml::detail::lexical_token_t::EXPLICIT_KEY_PREFIX);
+
+        REQUIRE_NOTHROW(token = lexer.get_next_token());
+        REQUIRE(token.type == fkyaml::detail::lexical_token_t::SEQUENCE_BLOCK_PREFIX);
+
+        REQUIRE_NOTHROW(token = lexer.get_next_token());
+        REQUIRE(token.type == fkyaml::detail::lexical_token_t::PLAIN_SCALAR);
+        REQUIRE(token.str.begin() == input.begin() + 4);
+        REQUIRE(token.str.end() == input.end());
+    }
+}
+
 TEST_CASE("LexicalAnalyzer_Colon") {
     fkyaml::detail::lexical_token token;
 


### PR DESCRIPTION
This PR improves the handling of explicit mapping keys in the lexer by allowing newlines as valid separation after the explicit key indicator (`?`). It also adds new unit tests to ensure this behavior is correctly handled.

## Changes

* Updated the `lexical_analyzer` to treat a newline (`\n`) as valid separation after an explicit key indicator, in addition to space and tab.

## Testing

* Added a new test case `LexicalAnalyzer_ExplicitKey` in `tests/unit_test/test_lexical_analyzer_class.cpp` to verify that explicit mapping keys followed by whitespace or a newline are correctly tokenized.
* Fixed `6PBE` in the YAML test suite. As a result, 24 failing cases have decreased to 23 with no newly failing case.

---

## Pull Request Checklist

Read the [CONTRIBUTING.md](https://github.com/fktn-k/fkYAML/blob/develop/.github/CONTRIBUTING.md) file for detailed information.  

- [x] Changes are described in the pull request or in a referenced [issue](https://github.com/fktn-k/fkYAML/issues).
- [x] The test suite compiles and runs without any error.
- [x] [The code coverage](https://coveralls.io/github/fktn-k/fkYAML) on your branch is 100%.
- [x] The documentation is updated if you added/changed a feature.

## Please don't

- The C++11 support varies between different **compilers** and versions. Please note the [list of supported compilers](https://github.com/fktn-k/fkYAML/blob/develop/README.md#supported-compilers). Some compilers like GCC 4.7 (and earlier), Clang 3.3 (and earlier), or Microsoft Visual Studio 13.0 and earlier are known not to work due to missing or incomplete C++11 support. Please refrain from proposing changes that work around these compiler's limitations with `#ifdef`s or other means.
- Please refrain from proposing changes that would **break [YAML](https://yaml.org/) specifications**. If you propose a conformant extension of YAML to be supported by the library, please motivate this extension.
- Please do not open pull requests that address **multiple issues**.
