### PR TITLE
Fix the handling of flow collections used as mapping keys

### DIFF
--- a/include/fkYAML/detail/input/deserializer.hpp
+++ b/include/fkYAML/detail/input/deserializer.hpp
@@ -82,7 +82,8 @@ class basic_deserializer {
             : line(line),
               indent(indent),
               state(state),
-              p_node(p_node) {
+              p_node(p_node),
+              is_explicit_key(state == context_state_t::BLOCK_MAPPING_EXPLICIT_KEY) {
         }
 
         /// @brief Construct a new parse_context object which owns its node.
@@ -96,7 +97,8 @@ class basic_deserializer {
               indent(indent),
               state(state),
               p_node(node.get()),
-              owned_node(std::move(node)) {
+              owned_node(std::move(node)),
+              is_explicit_key(state == context_state_t::BLOCK_MAPPING_EXPLICIT_KEY) {
         }
 
         // Parse contexts are move-only so that the ownership of an owned node cannot be duplicated.
@@ -116,6 +118,8 @@ class basic_deserializer {
         basic_node_type* p_node {nullptr};
         /// The node owned by this context, if any. Empty if p_node is owned by the result tree.
         std::unique_ptr<basic_node_type> owned_node {};
+        /// Whether this context originated as an explicit mapping key.
+        bool is_explicit_key {false};
     };
 
     /// @brief Definitions of state types for expected flow token hints.
@@ -1032,7 +1036,11 @@ private:
                 // keep the last state for later processing.
                 parse_context& last_context = m_context_stack.back();
                 mp_current_node = last_context.p_node;
-                indent = last_context.indent;
+                const uint32_t collection_begin_line = last_context.line;
+                const uint32_t collection_begin_indent = last_context.indent;
+                indent = collection_begin_indent;
+                const bool is_multiline_collection = collection_begin_line != lexer.get_lines_processed();
+                const bool is_explicit_key = last_context.is_explicit_key;
                 // The node stays alive until its value is either moved into the tree below or dropped here.
                 std::unique_ptr<basic_node_type> owned_node = std::move(last_context.owned_node);
                 m_context_stack.pop_back();
@@ -1041,6 +1049,24 @@ private:
                 // while that node is a key which has not been added to its parent mapping yet.
 
                 if (!m_context_stack.empty() && owned_node != nullptr) {
+                    if (is_explicit_key) {
+                        restore_explicit_flow_collection_key(
+                            lexer,
+                            std::move(owned_node),
+                            collection_begin_line,
+                            collection_begin_indent,
+                            is_multiline_collection,
+                            token,
+                            line,
+                            indent);
+                        continue;
+                    }
+                    if FK_YAML_UNLIKELY (is_multiline_collection) {
+                        throw parse_error(
+                            "An implicit mapping key cannot span multiple lines.",
+                            lexer.get_lines_processed(),
+                            lexer.get_last_token_begin_pos());
+                    }
                     if (m_expects_root_flow_key_separator) {
                         const lexical_token_t next_type = lexer.peek_next_token().type;
                         if FK_YAML_UNLIKELY (next_type != lexical_token_t::KEY_SEPARATOR) {
@@ -1060,6 +1086,12 @@ private:
 
                 token = lexer.get_next_token();
                 if (token.type == lexical_token_t::KEY_SEPARATOR) {
+                    if FK_YAML_UNLIKELY (is_multiline_collection) {
+                        throw parse_error(
+                            "An implicit mapping key cannot span multiple lines.",
+                            lexer.get_lines_processed(),
+                            lexer.get_last_token_begin_pos());
+                    }
                     basic_node_type key_node = basic_node_type::mapping();
                     apply_directive_set(key_node);
                     mp_current_node->swap(key_node);
@@ -1175,7 +1207,11 @@ private:
                 // keep the last state for later processing.
                 parse_context& last_context = m_context_stack.back();
                 mp_current_node = last_context.p_node;
-                indent = last_context.indent;
+                const uint32_t collection_begin_line = last_context.line;
+                const uint32_t collection_begin_indent = last_context.indent;
+                indent = collection_begin_indent;
+                const bool is_multiline_collection = collection_begin_line != lexer.get_lines_processed();
+                const bool is_explicit_key = last_context.is_explicit_key;
                 // The node stays alive until its value is either moved into the tree below or dropped here.
                 std::unique_ptr<basic_node_type> owned_node = std::move(last_context.owned_node);
                 m_context_stack.pop_back();
@@ -1184,6 +1220,24 @@ private:
                 // while that node is a key which has not been added to its parent mapping yet.
 
                 if (!m_context_stack.empty() && owned_node != nullptr) {
+                    if (is_explicit_key) {
+                        restore_explicit_flow_collection_key(
+                            lexer,
+                            std::move(owned_node),
+                            collection_begin_line,
+                            collection_begin_indent,
+                            is_multiline_collection,
+                            token,
+                            line,
+                            indent);
+                        continue;
+                    }
+                    if FK_YAML_UNLIKELY (is_multiline_collection) {
+                        throw parse_error(
+                            "An implicit mapping key cannot span multiple lines.",
+                            lexer.get_lines_processed(),
+                            lexer.get_last_token_begin_pos());
+                    }
                     if (m_expects_root_flow_key_separator) {
                         const lexical_token_t next_type = lexer.peek_next_token().type;
                         if FK_YAML_UNLIKELY (next_type != lexical_token_t::KEY_SEPARATOR) {
@@ -1203,6 +1257,12 @@ private:
 
                 token = lexer.get_next_token();
                 if (token.type == lexical_token_t::KEY_SEPARATOR) {
+                    if FK_YAML_UNLIKELY (is_multiline_collection) {
+                        throw parse_error(
+                            "An implicit mapping key cannot span multiple lines.",
+                            lexer.get_lines_processed(),
+                            lexer.get_last_token_begin_pos());
+                    }
                     basic_node_type key_node = basic_node_type::mapping();
                     apply_directive_set(key_node);
                     mp_current_node->swap(key_node);
@@ -1441,10 +1501,6 @@ private:
             });
         }
         else {
-            if FK_YAML_UNLIKELY (m_flow_token_state != flow_token_state_t::NEEDS_VALUE_OR_SUFFIX) {
-                throw parse_error("Flow mapping entry is found without separated with a comma.", line, indent);
-            }
-
             if (mp_current_node->is_sequence()) {
                 mp_current_node->as_seq().emplace_back(basic_node_type::mapping());
                 mp_current_node = &(mp_current_node->operator[](mp_current_node->size() - 1));
@@ -1461,6 +1517,46 @@ private:
         const parse_context& key_context = current_context(line, indent);
         m_context_stack.emplace_back(
             key_context.line, key_context.indent, context_state_t::MAPPING_VALUE, mp_current_node);
+    }
+
+    void restore_explicit_flow_collection_key(
+        lexer_type& lexer, std::unique_ptr<basic_node_type>&& owned_node, const uint32_t collection_begin_line,
+        const uint32_t collection_begin_indent, const bool is_multiline_collection, lexical_token& token,
+        uint32_t& line, uint32_t& indent) {
+        m_context_stack.emplace_back(
+            collection_begin_line,
+            collection_begin_indent,
+            context_state_t::BLOCK_MAPPING_EXPLICIT_KEY,
+            std::move(owned_node));
+        mp_current_node = m_context_stack.back().p_node;
+
+        const uint32_t collection_end_line = lexer.get_lines_processed();
+        token = lexer.get_next_token();
+        line = lexer.get_lines_processed();
+        indent = lexer.get_last_token_begin_pos();
+
+        const bool begins_compact_mapping = token.type == lexical_token_t::KEY_SEPARATOR && line == collection_end_line;
+        if (!begins_compact_mapping) {
+            return;
+        }
+        if FK_YAML_UNLIKELY (is_multiline_collection) {
+            throw parse_error(
+                "An implicit mapping key cannot span multiple lines.",
+                lexer.get_lines_processed(),
+                lexer.get_last_token_begin_pos());
+        }
+
+        basic_node_type collection_key = std::move(*mp_current_node);
+        *mp_current_node = basic_node_type::mapping();
+        apply_directive_set(*mp_current_node);
+        auto itr = mp_current_node->as_map().emplace(std::move(collection_key), basic_node_type());
+        mp_current_node = &(itr.first->second);
+        apply_directive_set(*mp_current_node);
+        m_context_stack.emplace_back(line, indent, context_state_t::MAPPING_VALUE, mp_current_node);
+
+        token = lexer.get_next_token();
+        line = lexer.get_lines_processed();
+        indent = lexer.get_last_token_begin_pos();
     }
 
     /// @brief Assign node value to the current node.

--- a/include/fkYAML/detail/input/lexical_analyzer.hpp
+++ b/include/fkYAML/detail/input/lexical_analyzer.hpp
@@ -480,6 +480,8 @@ private:
             // A separator beginning a line ends the preceding entry of a flow collection, while in a
             // block context it is just an ordinary plain scalar character.
             return (m_state & flow_context_bit) != 0;
+        case '#':
+            return true;
         default:
             break;
         }
@@ -1176,7 +1178,7 @@ private:
                     indent = get_current_indent_level(&sv[pos]);
                     // The scalar begins a line of its own if its column is the indentation of that line.
                     // Only meaningful in a block context: in a flow context the surrounding collection
-                    // owns the following lines, so a scalar must not extend into them.
+                    // determines the required indentation of continuation lines.
                     begins_own_line =
                         ((m_state & flow_context_bit) == 0) && (m_pos_tracker.get_cur_pos_in_line() == indent);
                 }
@@ -1195,7 +1197,13 @@ private:
                 // ```
                 // One which follows a key on the same line must be continued by more indented lines,
                 // because a line at the key's indentation belongs to the parent mapping instead.
-                const uint32_t min_continuation_indent = begins_own_line ? indent : indent + 1;
+                uint32_t min_continuation_indent = 0;
+                if (m_state & flow_context_bit) {
+                    min_continuation_indent = m_flow_required_indent;
+                }
+                else {
+                    min_continuation_indent = begins_own_line ? indent : indent + 1;
+                }
 
                 if (non_space_pos == str_view::npos) {
                     if (trailing_white_space_pos != str_view::npos) {

--- a/single_include/fkYAML/node.hpp
+++ b/single_include/fkYAML/node.hpp
@@ -3753,6 +3753,8 @@ private:
             // A separator beginning a line ends the preceding entry of a flow collection, while in a
             // block context it is just an ordinary plain scalar character.
             return (m_state & flow_context_bit) != 0;
+        case '#':
+            return true;
         default:
             break;
         }
@@ -4449,7 +4451,7 @@ private:
                     indent = get_current_indent_level(&sv[pos]);
                     // The scalar begins a line of its own if its column is the indentation of that line.
                     // Only meaningful in a block context: in a flow context the surrounding collection
-                    // owns the following lines, so a scalar must not extend into them.
+                    // determines the required indentation of continuation lines.
                     begins_own_line =
                         ((m_state & flow_context_bit) == 0) && (m_pos_tracker.get_cur_pos_in_line() == indent);
                 }
@@ -4468,7 +4470,13 @@ private:
                 // ```
                 // One which follows a key on the same line must be continued by more indented lines,
                 // because a line at the key's indentation belongs to the parent mapping instead.
-                const uint32_t min_continuation_indent = begins_own_line ? indent : indent + 1;
+                uint32_t min_continuation_indent = 0;
+                if (m_state & flow_context_bit) {
+                    min_continuation_indent = m_flow_required_indent;
+                }
+                else {
+                    min_continuation_indent = begins_own_line ? indent : indent + 1;
+                }
 
                 if (non_space_pos == str_view::npos) {
                     if (trailing_white_space_pos != str_view::npos) {
@@ -7980,7 +7988,8 @@ class basic_deserializer {
             : line(line),
               indent(indent),
               state(state),
-              p_node(p_node) {
+              p_node(p_node),
+              is_explicit_key(state == context_state_t::BLOCK_MAPPING_EXPLICIT_KEY) {
         }
 
         /// @brief Construct a new parse_context object which owns its node.
@@ -7994,7 +8003,8 @@ class basic_deserializer {
               indent(indent),
               state(state),
               p_node(node.get()),
-              owned_node(std::move(node)) {
+              owned_node(std::move(node)),
+              is_explicit_key(state == context_state_t::BLOCK_MAPPING_EXPLICIT_KEY) {
         }
 
         // Parse contexts are move-only so that the ownership of an owned node cannot be duplicated.
@@ -8014,6 +8024,8 @@ class basic_deserializer {
         basic_node_type* p_node {nullptr};
         /// The node owned by this context, if any. Empty if p_node is owned by the result tree.
         std::unique_ptr<basic_node_type> owned_node {};
+        /// Whether this context originated as an explicit mapping key.
+        bool is_explicit_key {false};
     };
 
     /// @brief Definitions of state types for expected flow token hints.
@@ -8930,7 +8942,11 @@ private:
                 // keep the last state for later processing.
                 parse_context& last_context = m_context_stack.back();
                 mp_current_node = last_context.p_node;
-                indent = last_context.indent;
+                const uint32_t collection_begin_line = last_context.line;
+                const uint32_t collection_begin_indent = last_context.indent;
+                indent = collection_begin_indent;
+                const bool is_multiline_collection = collection_begin_line != lexer.get_lines_processed();
+                const bool is_explicit_key = last_context.is_explicit_key;
                 // The node stays alive until its value is either moved into the tree below or dropped here.
                 std::unique_ptr<basic_node_type> owned_node = std::move(last_context.owned_node);
                 m_context_stack.pop_back();
@@ -8939,6 +8955,24 @@ private:
                 // while that node is a key which has not been added to its parent mapping yet.
 
                 if (!m_context_stack.empty() && owned_node != nullptr) {
+                    if (is_explicit_key) {
+                        restore_explicit_flow_collection_key(
+                            lexer,
+                            std::move(owned_node),
+                            collection_begin_line,
+                            collection_begin_indent,
+                            is_multiline_collection,
+                            token,
+                            line,
+                            indent);
+                        continue;
+                    }
+                    if FK_YAML_UNLIKELY (is_multiline_collection) {
+                        throw parse_error(
+                            "An implicit mapping key cannot span multiple lines.",
+                            lexer.get_lines_processed(),
+                            lexer.get_last_token_begin_pos());
+                    }
                     if (m_expects_root_flow_key_separator) {
                         const lexical_token_t next_type = lexer.peek_next_token().type;
                         if FK_YAML_UNLIKELY (next_type != lexical_token_t::KEY_SEPARATOR) {
@@ -8958,6 +8992,12 @@ private:
 
                 token = lexer.get_next_token();
                 if (token.type == lexical_token_t::KEY_SEPARATOR) {
+                    if FK_YAML_UNLIKELY (is_multiline_collection) {
+                        throw parse_error(
+                            "An implicit mapping key cannot span multiple lines.",
+                            lexer.get_lines_processed(),
+                            lexer.get_last_token_begin_pos());
+                    }
                     basic_node_type key_node = basic_node_type::mapping();
                     apply_directive_set(key_node);
                     mp_current_node->swap(key_node);
@@ -9073,7 +9113,11 @@ private:
                 // keep the last state for later processing.
                 parse_context& last_context = m_context_stack.back();
                 mp_current_node = last_context.p_node;
-                indent = last_context.indent;
+                const uint32_t collection_begin_line = last_context.line;
+                const uint32_t collection_begin_indent = last_context.indent;
+                indent = collection_begin_indent;
+                const bool is_multiline_collection = collection_begin_line != lexer.get_lines_processed();
+                const bool is_explicit_key = last_context.is_explicit_key;
                 // The node stays alive until its value is either moved into the tree below or dropped here.
                 std::unique_ptr<basic_node_type> owned_node = std::move(last_context.owned_node);
                 m_context_stack.pop_back();
@@ -9082,6 +9126,24 @@ private:
                 // while that node is a key which has not been added to its parent mapping yet.
 
                 if (!m_context_stack.empty() && owned_node != nullptr) {
+                    if (is_explicit_key) {
+                        restore_explicit_flow_collection_key(
+                            lexer,
+                            std::move(owned_node),
+                            collection_begin_line,
+                            collection_begin_indent,
+                            is_multiline_collection,
+                            token,
+                            line,
+                            indent);
+                        continue;
+                    }
+                    if FK_YAML_UNLIKELY (is_multiline_collection) {
+                        throw parse_error(
+                            "An implicit mapping key cannot span multiple lines.",
+                            lexer.get_lines_processed(),
+                            lexer.get_last_token_begin_pos());
+                    }
                     if (m_expects_root_flow_key_separator) {
                         const lexical_token_t next_type = lexer.peek_next_token().type;
                         if FK_YAML_UNLIKELY (next_type != lexical_token_t::KEY_SEPARATOR) {
@@ -9101,6 +9163,12 @@ private:
 
                 token = lexer.get_next_token();
                 if (token.type == lexical_token_t::KEY_SEPARATOR) {
+                    if FK_YAML_UNLIKELY (is_multiline_collection) {
+                        throw parse_error(
+                            "An implicit mapping key cannot span multiple lines.",
+                            lexer.get_lines_processed(),
+                            lexer.get_last_token_begin_pos());
+                    }
                     basic_node_type key_node = basic_node_type::mapping();
                     apply_directive_set(key_node);
                     mp_current_node->swap(key_node);
@@ -9339,10 +9407,6 @@ private:
             });
         }
         else {
-            if FK_YAML_UNLIKELY (m_flow_token_state != flow_token_state_t::NEEDS_VALUE_OR_SUFFIX) {
-                throw parse_error("Flow mapping entry is found without separated with a comma.", line, indent);
-            }
-
             if (mp_current_node->is_sequence()) {
                 mp_current_node->as_seq().emplace_back(basic_node_type::mapping());
                 mp_current_node = &(mp_current_node->operator[](mp_current_node->size() - 1));
@@ -9359,6 +9423,46 @@ private:
         const parse_context& key_context = current_context(line, indent);
         m_context_stack.emplace_back(
             key_context.line, key_context.indent, context_state_t::MAPPING_VALUE, mp_current_node);
+    }
+
+    void restore_explicit_flow_collection_key(
+        lexer_type& lexer, std::unique_ptr<basic_node_type>&& owned_node, const uint32_t collection_begin_line,
+        const uint32_t collection_begin_indent, const bool is_multiline_collection, lexical_token& token,
+        uint32_t& line, uint32_t& indent) {
+        m_context_stack.emplace_back(
+            collection_begin_line,
+            collection_begin_indent,
+            context_state_t::BLOCK_MAPPING_EXPLICIT_KEY,
+            std::move(owned_node));
+        mp_current_node = m_context_stack.back().p_node;
+
+        const uint32_t collection_end_line = lexer.get_lines_processed();
+        token = lexer.get_next_token();
+        line = lexer.get_lines_processed();
+        indent = lexer.get_last_token_begin_pos();
+
+        const bool begins_compact_mapping = token.type == lexical_token_t::KEY_SEPARATOR && line == collection_end_line;
+        if (!begins_compact_mapping) {
+            return;
+        }
+        if FK_YAML_UNLIKELY (is_multiline_collection) {
+            throw parse_error(
+                "An implicit mapping key cannot span multiple lines.",
+                lexer.get_lines_processed(),
+                lexer.get_last_token_begin_pos());
+        }
+
+        basic_node_type collection_key = std::move(*mp_current_node);
+        *mp_current_node = basic_node_type::mapping();
+        apply_directive_set(*mp_current_node);
+        auto itr = mp_current_node->as_map().emplace(std::move(collection_key), basic_node_type());
+        mp_current_node = &(itr.first->second);
+        apply_directive_set(*mp_current_node);
+        m_context_stack.emplace_back(line, indent, context_state_t::MAPPING_VALUE, mp_current_node);
+
+        token = lexer.get_next_token();
+        line = lexer.get_lines_processed();
+        indent = lexer.get_last_token_begin_pos();
     }
 
     /// @brief Assign node value to the current node.

--- a/tests/unit_test/test_deserializer_class.cpp
+++ b/tests/unit_test/test_deserializer_class.cpp
@@ -2093,6 +2093,24 @@ TEST_CASE("Deserializer_ExplicitBlockMapping") {
         REQUIRE(root[key].is_null());
     }
 
+    SUBCASE("explicit mapping key containing a compact mapping with a flow collection key") {
+        REQUIRE_NOTHROW(root = deserializer.deserialize(fkyaml::detail::input_adapter("? []: x")));
+
+        REQUIRE(root.is_mapping());
+        REQUIRE(root.size() == 1);
+        REQUIRE(root.begin().key().is_mapping());
+        REQUIRE(root.begin().key().size() == 1);
+        REQUIRE(root.begin().key().begin().key().is_sequence());
+        REQUIRE(root.begin().key().begin().key().empty());
+        REQUIRE(root.begin().key().begin().value().as_str() == "x");
+        REQUIRE(root.begin().value().is_null());
+    }
+
+    SUBCASE("explicit mapping key containing a multiline implicit collection key") {
+        auto input = GENERATE(std::string("? [foo,\n    bar]: baz"), std::string("? {foo: bar,\n    baz: qux}: value"));
+        REQUIRE_THROWS_AS(root = deserializer.deserialize(fkyaml::detail::input_adapter(input)), fkyaml::parse_error);
+    }
+
     SUBCASE("explicit mapping key with an empty key and its own value") {
         std::string input = "? :\n"
                             ": baz\n";
@@ -2390,6 +2408,17 @@ TEST_CASE("Deserializer_FlowSequence") {
         REQUIRE(root_1_b_node.as_str() == "bar");
     }
 
+    SUBCASE("comment between a plain scalar and a value separator") {
+        std::string input = "[ word1\n"
+                            "# comment\n"
+                            ", word2]";
+        REQUIRE_NOTHROW(root = deserializer.deserialize(fkyaml::detail::input_adapter(input)));
+        REQUIRE(root.is_sequence());
+        REQUIRE(root.size() == 2);
+        REQUIRE(root[0].as_str() == "word1");
+        REQUIRE(root[1].as_str() == "word2");
+    }
+
     SUBCASE("missing value separators") {
         // White space alone does not separate entries, since it may appear within a plain scalar. A
         // missing separator is only detectable where the next entry cannot continue the current one.
@@ -2510,6 +2539,24 @@ TEST_CASE("Deserializer_FlowMapping") {
         fkyaml::node& test_pi_node = test_node["pi"];
         REQUIRE(test_pi_node.is_float_number());
         REQUIRE(test_pi_node.get_value<double>() == 3.14);
+    }
+
+    SUBCASE("plain scalar key continued by a percent sign in a flow mapping") {
+        const std::string input = "---\n"
+                                  "{ matches\n"
+                                  "% : 20 }\n"
+                                  "...\n"
+                                  "---\n"
+                                  "# Empty\n"
+                                  "...\n";
+        std::vector<fkyaml::node> docs;
+
+        REQUIRE_NOTHROW(docs = fkyaml::node::deserialize_docs(input));
+        REQUIRE(docs.size() == 2);
+        REQUIRE(docs[0].is_mapping());
+        REQUIRE(docs[0].size() == 1);
+        REQUIRE(docs[0]["matches %"].get_value<int>() == 20);
+        REQUIRE(docs[1].is_null());
     }
 
     SUBCASE("value separator beginning a line") {
@@ -2725,22 +2772,13 @@ TEST_CASE("Deserializer_FlowMapping") {
         REQUIRE(root_mapkey_node.as_str() == "bar");
     }
 
-    SUBCASE("flow mapping key of a flow mapping (not compact)") {
+    SUBCASE("multiline flow mapping as an implicit mapping key") {
         std::string input = "{\n"
                             "  {\n"
                             "    \"foo\": true\n"
                             "  }: \"bar\"\n"
                             "}";
-        REQUIRE_NOTHROW(root = deserializer.deserialize(fkyaml::detail::input_adapter(input)));
-
-        REQUIRE(root.is_mapping());
-        REQUIRE(root.size() == 1);
-        fkyaml::node mapkey = {{"foo", true}};
-        REQUIRE(root.contains(mapkey));
-
-        fkyaml::node& root_mapkey_node = root[std::move(mapkey)];
-        REQUIRE(root_mapkey_node.is_string());
-        REQUIRE(root_mapkey_node.as_str() == "bar");
+        REQUIRE_THROWS_AS(root = deserializer.deserialize(fkyaml::detail::input_adapter(input)), fkyaml::parse_error);
     }
 
     SUBCASE("flow sequence key of a flow mapping (compact)") {
@@ -2757,23 +2795,33 @@ TEST_CASE("Deserializer_FlowMapping") {
         REQUIRE(root_seqkey_node.as_str() == "bar");
     }
 
-    SUBCASE("flow sequence key of a flow mapping (not compact)") {
+    SUBCASE("multiline flow sequence as an implicit mapping key") {
         std::string input = "{\n"
                             "  [\n"
                             "    \"foo\",\n"
                             "    true\n"
                             "  ]: \"bar\"\n"
                             "}";
-        REQUIRE_NOTHROW(root = deserializer.deserialize(fkyaml::detail::input_adapter(input)));
+        REQUIRE_THROWS_AS(root = deserializer.deserialize(fkyaml::detail::input_adapter(input)), fkyaml::parse_error);
+    }
 
+    SUBCASE("root multiline flow sequence as an implicit mapping key") {
+        std::string input = "[23\n]: 42";
+        REQUIRE_THROWS_AS(root = deserializer.deserialize(fkyaml::detail::input_adapter(input)), fkyaml::parse_error);
+    }
+
+    SUBCASE("root multiline flow mapping as an implicit mapping key") {
+        std::string input = "{foo: 23\n}: 42";
+        REQUIRE_THROWS_AS(root = deserializer.deserialize(fkyaml::detail::input_adapter(input)), fkyaml::parse_error);
+    }
+
+    SUBCASE("multiline flow collections as explicit mapping keys") {
+        auto input = GENERATE(
+            std::string("? [ foo,\n    true ]\n: bar"), std::string("? { foo: true,\n    bar: false }\n: bar"));
+        REQUIRE_NOTHROW(root = deserializer.deserialize(fkyaml::detail::input_adapter(input)));
         REQUIRE(root.is_mapping());
         REQUIRE(root.size() == 1);
-        fkyaml::node seqkey = {"foo", true};
-        REQUIRE(root.contains(seqkey));
-
-        fkyaml::node& root_seqkey_node = root[std::move(seqkey)];
-        REQUIRE(root_seqkey_node.is_string());
-        REQUIRE(root_seqkey_node.as_str() == "bar");
+        REQUIRE(root.begin().value().as_str() == "bar");
     }
 
     SUBCASE("missing value separators") {

--- a/tests/unit_test/test_fuzz_regression.cpp
+++ b/tests/unit_test/test_fuzz_regression.cpp
@@ -185,7 +185,7 @@ TEST_CASE("FuzzRegression") {
     }
 
     SUBCASE("key node owned by a parse context is released on an error path") {
-        const char input[] = "? []";
+        const char input[] = "? [] ]";
         p_begin = input;
         p_end = input + sizeof(input) - 1;
         REQUIRE_THROWS_AS(root = fkyaml::node::deserialize(p_begin, p_end), fkyaml::parse_error);


### PR DESCRIPTION
This PR fixes the handling of flow collections used as mapping keys, while correcting multiline plain-scalar parsing in flow contexts.  

## Cause

The parser lost information about whether a flow collection originated from an explicit mapping key after its parsing state changed. As a result:

- Multiline flow collections could be accepted as implicit mapping keys.
- Valid multiline explicit keys could be rejected.
- A same-line `:` following a flow collection inside an explicit key was mistaken for the outer value separator.
- Some multiline plain scalars were terminated incorrectly or consumed comment lines.

## Resolution

- Preserve explicit-key context while parsing flow collections.
- Reject implicit mapping keys that span multiple lines.
- Continue allowing multiline explicit mapping keys.
- Distinguish compact mappings inside explicit keys from outer value separators using separator line positions.
- Correct multiline plain-scalar continuation and comment termination.

## Testing

- Add regression tests for the affected valid and invalid YAML structures. All unit test cases pass successfully.
- Fix `C2SP`, `M2N8-01`, `M5DY` and `UT92` in the YAML test suite. As a result, 23 failing cases have decreased to 19 with no newly failing case.

---

## Pull Request Checklist

Read the [CONTRIBUTING.md](https://github.com/fktn-k/fkYAML/blob/develop/.github/CONTRIBUTING.md) file for detailed information.  

- [x] Changes are described in the pull request or in a referenced [issue](https://github.com/fktn-k/fkYAML/issues).
- [x] The test suite compiles and runs without any error.
- [x] [The code coverage](https://coveralls.io/github/fktn-k/fkYAML) on your branch is 100%.
- [x] The documentation is updated if you added/changed a feature.

## Please don't

- The C++11 support varies between different **compilers** and versions. Please note the [list of supported compilers](https://github.com/fktn-k/fkYAML/blob/develop/README.md#supported-compilers). Some compilers like GCC 4.7 (and earlier), Clang 3.3 (and earlier), or Microsoft Visual Studio 13.0 and earlier are known not to work due to missing or incomplete C++11 support. Please refrain from proposing changes that work around these compiler's limitations with `#ifdef`s or other means.
- Please refrain from proposing changes that would **break [YAML](https://yaml.org/) specifications**. If you propose a conformant extension of YAML to be supported by the library, please motivate this extension.
- Please do not open pull requests that address **multiple issues**.
