### PR TITLE
Reject multiple root nodes in a document

### DIFF
--- a/include/fkYAML/detail/input/deserializer.hpp
+++ b/include/fkYAML/detail/input/deserializer.hpp
@@ -1784,6 +1784,12 @@ private:
                 // https://yaml.org/spec/1.2.2/#71-alias-nodes
                 throw parse_error("Node properties cannot be specified to an alias node.", line, indent);
             }
+            const bool ends_document = token.type == lexical_token_t::END_OF_BUFFER ||
+                                       token.type == lexical_token_t::END_OF_DIRECTIVES ||
+                                       token.type == lexical_token_t::END_OF_DOCUMENT;
+            if FK_YAML_UNLIKELY (m_context_stack.empty() && !ends_document) {
+                throw parse_error("Multiple root nodes are not allowed in the same document.", line, indent);
+            }
             assign_node_value(std::move(node), line, indent);
         }
 

--- a/single_include/fkYAML/node.hpp
+++ b/single_include/fkYAML/node.hpp
@@ -9690,6 +9690,12 @@ private:
                 // https://yaml.org/spec/1.2.2/#71-alias-nodes
                 throw parse_error("Node properties cannot be specified to an alias node.", line, indent);
             }
+            const bool ends_document = token.type == lexical_token_t::END_OF_BUFFER ||
+                                       token.type == lexical_token_t::END_OF_DIRECTIVES ||
+                                       token.type == lexical_token_t::END_OF_DOCUMENT;
+            if FK_YAML_UNLIKELY (m_context_stack.empty() && !ends_document) {
+                throw parse_error("Multiple root nodes are not allowed in the same document.", line, indent);
+            }
             assign_node_value(std::move(node), line, indent);
         }
 

--- a/tests/unit_test/test_deserializer_class.cpp
+++ b/tests/unit_test/test_deserializer_class.cpp
@@ -181,6 +181,26 @@ TEST_CASE("Deserializer_InvalidStructureAfterRootScalar") {
     REQUIRE_THROWS_AS(root = deserializer.deserialize(fkyaml::detail::input_adapter(input_str)), fkyaml::parse_error);
 }
 
+TEST_CASE("Deserializer_InvalidStructureAfterRootFlowCollection") {
+    const auto input = GENERATE(
+        std::string("[]\n? foo"), std::string("[]\n- foo"), std::string("[]\n[foo]"), std::string("[]\n{foo}"));
+
+    REQUIRE_THROWS_AS(fkyaml::node::deserialize(input), fkyaml::parse_error);
+}
+
+TEST_CASE("Deserializer_UnmatchedFlowMappingEnd") {
+    REQUIRE_THROWS_AS(fkyaml::node::deserialize("}"), fkyaml::parse_error);
+}
+
+TEST_CASE("Deserializer_MultipleRootScalars") {
+    const auto input = GENERATE(
+        std::string("!foo \"bar\"\n%TAG ! tag:example.com,2000:app/\n---\n!foo \"bar\"\n"),
+        std::string("word1  # comment\nword2\n"),
+        std::string("---\nscalar1 # comment\n%YAML 1.2\n---\nscalar2\n"));
+
+    REQUIRE_THROWS_AS(fkyaml::node::deserialize_docs(input), fkyaml::parse_error);
+}
+
 TEST_CASE("Deserializer_NullValue") {
     fkyaml::detail::basic_deserializer<fkyaml::node> deserializer;
     fkyaml::node root;


### PR DESCRIPTION
This PR fixes the deserializer to reject YAML documents that contain multiple root-level nodes without an explicit document boundary.

## Cause

After completing a root scalar, the deserializer continued processing subsequent tokens as part of the same document.  
This allowed another root-level scalar or structure to appear without a document-end or document-start marker.

## Resolution

Validate the token following a completed root scalar.  
Only the end of input or an explicit document boundary is accepted when no parent parsing context exists; otherwise, a parse error is raised.

## Testing

- Added regression tests for the followings. All the unit test cases pass successfully.
  - Multiple root scalars separated by comments or directives
  - Block and flow structures following a completed root flow collection
  - An unmatched flow mapping terminator
- Fixed `9HCY`, `BS4K` and `EB22` in the YAML test suite. As a result, 19 failing cases have decreased to 16 with no newly failing case.

---

## Pull Request Checklist

Read the [CONTRIBUTING.md](https://github.com/fktn-k/fkYAML/blob/develop/.github/CONTRIBUTING.md) file for detailed information.  

- [x] Changes are described in the pull request or in a referenced [issue](https://github.com/fktn-k/fkYAML/issues).
- [x] The test suite compiles and runs without any error.
- [x] [The code coverage](https://coveralls.io/github/fktn-k/fkYAML) on your branch is 100%.
- [x] The documentation is updated if you added/changed a feature.

## Please don't

- The C++11 support varies between different **compilers** and versions. Please note the [list of supported compilers](https://github.com/fktn-k/fkYAML/blob/develop/README.md#supported-compilers). Some compilers like GCC 4.7 (and earlier), Clang 3.3 (and earlier), or Microsoft Visual Studio 13.0 and earlier are known not to work due to missing or incomplete C++11 support. Please refrain from proposing changes that work around these compiler's limitations with `#ifdef`s or other means.
- Please refrain from proposing changes that would **break [YAML](https://yaml.org/) specifications**. If you propose a conformant extension of YAML to be supported by the library, please motivate this extension.
- Please do not open pull requests that address **multiple issues**.
