### PR TITLE
Skip YAML test suite cases which contain duplicate mapping keys

### DIFF
--- a/tests/yaml_test_suite_runner/test_deserialize.cpp
+++ b/tests/yaml_test_suite_runner/test_deserialize.cpp
@@ -81,6 +81,22 @@ std::vector<std::unique_ptr<yaml_test_suite_runner::validator<fkyaml::node>>> lo
     return compositor.take_document_validators();
 }
 
+bool should_skip_yaml_case(const std::string& test_id, std::string& reason) {
+    static const char* const duplicate_key_cases[] = {
+        "2JQS",
+        "X38W",
+    };
+
+    for (std::size_t i = 0; i < sizeof(duplicate_key_cases) / sizeof(duplicate_key_cases[0]); ++i) {
+        if (test_id == duplicate_key_cases[i]) {
+            reason = "duplicate key in YAML mapping.";
+            return true;
+        }
+    }
+
+    return false;
+}
+
 bool should_skip_json_case(const std::string& test_id, std::string& reason) {
     static const char* const malformed_input_cases[] = {
         "35KP",
@@ -135,6 +151,14 @@ void run_yaml_test_suite_case(const char* relative_case_dir, const char* test_id
     if (format == input_format::JSON) {
         std::string reason;
         if (should_skip_json_case(suite_case_id, reason)) {
+            INFO("Skipped: " << reason);
+            CHECK(true);
+            return;
+        }
+    }
+    else {
+        std::string reason;
+        if (should_skip_yaml_case(suite_case_id, reason)) {
             INFO("Skipped: " << reason);
             CHECK(true);
             return;


### PR DESCRIPTION
This pull request adds logic to skip YAML test cases (`2JQS` and `X38W`) which contain duplicate keys, similar to how malformed JSON cases are handled.  
As a result, 16 failing cases have decreased to 14, obviously with no newly failing case.

---

## Pull Request Checklist

Read the [CONTRIBUTING.md](https://github.com/fktn-k/fkYAML/blob/develop/.github/CONTRIBUTING.md) file for detailed information.  

- [x] Changes are described in the pull request or in a referenced [issue](https://github.com/fktn-k/fkYAML/issues).
- [x] The test suite compiles and runs without any error.
- [x] [The code coverage](https://coveralls.io/github/fktn-k/fkYAML) on your branch is 100%.
- [x] The documentation is updated if you added/changed a feature.

## Please don't

- The C++11 support varies between different **compilers** and versions. Please note the [list of supported compilers](https://github.com/fktn-k/fkYAML/blob/develop/README.md#supported-compilers). Some compilers like GCC 4.7 (and earlier), Clang 3.3 (and earlier), or Microsoft Visual Studio 13.0 and earlier are known not to work due to missing or incomplete C++11 support. Please refrain from proposing changes that work around these compiler's limitations with `#ifdef`s or other means.
- Please refrain from proposing changes that would **break [YAML](https://yaml.org/) specifications**. If you propose a conformant extension of YAML to be supported by the library, please motivate this extension.
- Please do not open pull requests that address **multiple issues**.
