### PR TITLE
Ensure tag is valid in a document before application in deserialization

### DIFF
--- a/include/fkYAML/detail/input/deserializer.hpp
+++ b/include/fkYAML/detail/input/deserializer.hpp
@@ -2159,6 +2159,8 @@ private:
         }
 
         if (m_defers_tag) {
+            // Ensure the tag is valid in the current document before applying it.
+            tag_resolver_type::resolve_tag(m_deferred_tag_name, mp_meta);
             node.add_tag_name(std::string(m_deferred_tag_name.begin(), m_deferred_tag_name.end()));
             m_defers_tag = false;
             m_deferred_tag_name = {};
@@ -2175,6 +2177,8 @@ private:
         }
 
         if (m_needs_tag_impl) {
+            // Ensure the tag is valid in the current document before applying it.
+            tag_resolver_type::resolve_tag(m_tag_name, mp_meta);
             node.add_tag_name(std::string(m_tag_name.begin(), m_tag_name.end()));
             m_needs_tag_impl = false;
             m_tag_name = {};

--- a/single_include/fkYAML/node.hpp
+++ b/single_include/fkYAML/node.hpp
@@ -10065,6 +10065,8 @@ private:
         }
 
         if (m_defers_tag) {
+            // Ensure the tag is valid in the current document before applying it.
+            tag_resolver_type::resolve_tag(m_deferred_tag_name, mp_meta);
             node.add_tag_name(std::string(m_deferred_tag_name.begin(), m_deferred_tag_name.end()));
             m_defers_tag = false;
             m_deferred_tag_name = {};
@@ -10081,6 +10083,8 @@ private:
         }
 
         if (m_needs_tag_impl) {
+            // Ensure the tag is valid in the current document before applying it.
+            tag_resolver_type::resolve_tag(m_tag_name, mp_meta);
             node.add_tag_name(std::string(m_tag_name.begin(), m_tag_name.end()));
             m_needs_tag_impl = false;
             m_tag_name = {};

--- a/tests/unit_test/test_deserializer_class.cpp
+++ b/tests/unit_test/test_deserializer_class.cpp
@@ -3266,6 +3266,15 @@ TEST_CASE("Deserializer_TagDirective") {
         REQUIRE_THROWS_AS(deserializer.deserialize(fkyaml::detail::input_adapter(input)), fkyaml::parse_error);
     }
 
+    SUBCASE("named tag handle does not carry over to subsequent documents") {
+        std::string input = "%TAG !prefix! tag:example.com,2011:\n"
+                            "--- !prefix!A\n"
+                            "a: b\n"
+                            "--- !prefix!B\n"
+                            "c: d";
+        REQUIRE_THROWS_AS(deserializer.deserialize_docs(fkyaml::detail::input_adapter(input)), fkyaml::invalid_tag);
+    }
+
     SUBCASE("lacks the end of directives marker after TAG directive") {
         std::string input = "%TAG ! tag:test.com,2000:\n"
                             "foo: bar";


### PR DESCRIPTION
This pull request improves tag handling in the YAML deserialization process by ensuring that tags are validated against the current document, preventing invalid or out-of-scope tags from being applied. It also adds a unit test to verify that named tag handles do not persist across multiple YAML documents.

**Tag validation improvements:**

* Updated `basic_deserializer` to explicitly call `tag_resolver_type::resolve_tag` before applying deferred or needed tags, ensuring tag validity within the current document context.

**Testing enhancements:**

* Added a test case to `test_deserializer_class.cpp` to confirm that named tag handles do not carry over to subsequent documents, and that using them out of scope raises an `invalid_tag` exception.
* Fixed `QLJ7` in the YAML test suite. As a result, 14 failing cases have decreased to 13 with no newly failing case.

---

## Pull Request Checklist

Read the [CONTRIBUTING.md](https://github.com/fktn-k/fkYAML/blob/develop/.github/CONTRIBUTING.md) file for detailed information.  

- [x] Changes are described in the pull request or in a referenced [issue](https://github.com/fktn-k/fkYAML/issues).
- [x] The test suite compiles and runs without any error.
- [x] [The code coverage](https://coveralls.io/github/fktn-k/fkYAML) on your branch is 100%.
- [x] The documentation is updated if you added/changed a feature.

## Please don't

- The C++11 support varies between different **compilers** and versions. Please note the [list of supported compilers](https://github.com/fktn-k/fkYAML/blob/develop/README.md#supported-compilers). Some compilers like GCC 4.7 (and earlier), Clang 3.3 (and earlier), or Microsoft Visual Studio 13.0 and earlier are known not to work due to missing or incomplete C++11 support. Please refrain from proposing changes that work around these compiler's limitations with `#ifdef`s or other means.
- Please refrain from proposing changes that would **break [YAML](https://yaml.org/) specifications**. If you propose a conformant extension of YAML to be supported by the library, please motivate this extension.
- Please do not open pull requests that address **multiple issues**.
